### PR TITLE
[nt] component layout

### DIFF
--- a/mage_ai/frontend/oracle/components/Layout/index.tsx
+++ b/mage_ai/frontend/oracle/components/Layout/index.tsx
@@ -79,7 +79,6 @@ function Layout({
       {header}
       <LayoutContainerStyle>
         {before}
-
         <MainStyle role="main">
           <MainContentStyle
             centerAlign={centerAlign}
@@ -89,7 +88,6 @@ function Layout({
             {children}
           </MainContentStyle>
         </MainStyle>
-
         {after}
       </LayoutContainerStyle>
       {footer}

--- a/mage_ai/frontend/stories/oracle/components/Layout.stories.tsx
+++ b/mage_ai/frontend/stories/oracle/components/Layout.stories.tsx
@@ -5,6 +5,7 @@ import Layout, { LayoutProps } from '@oracle/components/Layout';
 import Text from '@oracle/elements/Text';
 import Spacing from '@oracle/elements/Spacing';
 import ThemeBlock from 'stories/ThemeBlock';
+import { ArrowDown, ArrowRight } from '@oracle/icons';
 
 export default {
   component: Layout,
@@ -13,20 +14,26 @@ export default {
 
 const TemplateWithTheme = ({ ...props }) => (
   <ThemeBlock>
-    <Layout {...props} >
-      <Text>
-      Hello world!
-      What do I put in here exactly?
-      </Text>
-      <Spacing/>
-      <Text>
-      How do I test this?
-      </Text>
-      <Spacing/>
-      <Text>
-      Try resizing the screen!
-      </Text>      
-      <Spacing/>
+    <Layout {...props}
+      after={ <Text> This comes after the content <ArrowRight /> </Text> }
+      before={ <Text> This comes before the real content <ArrowDown/> </Text>}
+      footer={ <Text> This is a footer </Text>}
+      header={ <Text> This is a header </Text>}
+    >
+      <>
+        <Text>
+          This is the main content. It can be shifted by props unlike the content above.
+        </Text>
+        <Spacing/>
+        <Text>
+          How do I test this?
+        </Text>
+        <Spacing/>
+        <Text>
+          Try resizing the screen!
+        </Text>      
+        <Spacing/>
+      </>
     </Layout>
   </ThemeBlock>
 );


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
### Add the Layout component
- Contains a wrapper to help with resizing, test by dragging the storybook page.
- Adds a static header that can be used for all pages.
- Adds a static footer that can be used for a CTA or repeated component.
- Adds a flexible before prop that can be used to contain something below the header.
- Adds an flexible after prop that displays it's contents at the end of the content body.
# Tests
<!-- How did you test your change? -->
- Storybook and wrote messages on how to test by flexing the page.
<img width="1330" alt="image" src="https://user-images.githubusercontent.com/90282975/169919584-c494147a-3cc3-49b9-95db-42ecb360243e.png">

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@johnson-mage

After some playing around I found out the purpose of each prop and it's flex behavior so I kept them all in. Note: Fluid says it's supposed to assist in the flex, but I couldn't find the difference between the default and fluid true.