### PR TITLE
[nt] component panel

### DIFF
--- a/mage_ai/frontend/oracle/components/Panel/index.tsx
+++ b/mage_ai/frontend/oracle/components/Panel/index.tsx
@@ -34,7 +34,7 @@ const PanelStyle = styled.div`
 const HeaderStyle = styled.div<any>`
   ${props => `
     background-color: ${(props.theme.background || light.background).header};
-    border: 1px solid ${(props.theme.interactive || light.interactive).defaultBorder};
+    border-bottom: 1px solid ${(props.theme.interactive || light.interactive).defaultBorder};
   `}
 
   ${props => props.height && `
@@ -69,8 +69,8 @@ export type PanelProps = {
   headerTitle?: string;
   footer?: JSX.Element;
   fullHeight?: boolean;
-  inverted?: boolean;
-  keyboardShortcut?: JSX.Element;
+  items?: JSX.Element;
+  subtitle?: JSX.Element;
 };
 
 const PANEL_HEADER_HEIGHT = 6.5 * UNIT;
@@ -86,6 +86,8 @@ function Panel({
   headerHeight,
   headerIcon,
   headerTitle,
+  items,
+  subtitle,
 }: PanelProps) {
   let contentSectionHeight = HEADERS_HEIGHT_OFFSET;
 
@@ -111,7 +113,20 @@ function Panel({
                   </Text>
                 </Spacing>
               </FlexContainer>
+              { items &&
+                <>
+                  {items}
+                </> 
+              }
             </FlexContainer>
+          }
+          { subtitle &&
+          <>
+            <Spacing mb={2}/>
+            <FlexContainer alignItems="right">
+              {subtitle}
+            </FlexContainer>
+          </>
           }
         </HeaderStyle>
       }

--- a/mage_ai/frontend/stories/oracle/components/Panel.stories.tsx
+++ b/mage_ai/frontend/stories/oracle/components/Panel.stories.tsx
@@ -27,3 +27,11 @@ Regular.args = {
   headerIcon: <Check />,
   headerTitle: 'Define features',
 };
+
+export const Subtitle = Template.bind({});
+Subtitle.args = {
+  children: <Text> 1.00 </Text>,
+  headerTitle: 'Quality Metrics',
+  items: <Check />,
+  subtitle: <Text disabled large> Good </Text>,
+};


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
### Adds the Panel component from Figma
- Add a subtitle and items props
- Removes all unrelated components, but kept in footer in case.
# Tests
<!-- How did you test your change? -->
- Recreated stories to match charts we'll want

### Example Report Panel
<img width="1148" alt="image" src="https://user-images.githubusercontent.com/90282975/170091918-eaa22e75-9a6f-4bea-b5a5-4119a3e4d0fc.png">

cc: @johnson-mage 
<!-- Optionally mention someone to let them know about this pull request -->
