### PR TITLE
[xy] Add package_dir to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setuptools.setup(
     author_email="sales@mage.ai",
     description='Mage data cleaning tool',
     url='https://github.com/mage-ai/mage-ai',
+    package_dir={"": "mage_ai"},
     packages=setuptools.find_packages('./mage_ai'),
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Add package_dir to setup.py. This fixes the error of `error: package directory 'xxx' does not exist`.

ref: https://packaging.python.org/en/latest/tutorials/packaging-projects/

# Tests
<!-- How did you test your change? -->
tested locally
<img width="1265" alt="image" src="https://user-images.githubusercontent.com/80284865/170802108-3268309f-993f-4191-9f0d-57d449c093f0.png">

cc:
<!-- Optionally mention someone to let them know about this pull request -->
