### PR TITLE
[xy] Reduce duplicate clean for timeseries charts.

### DIFF
--- a/mage_ai/data_cleaner/analysis/calculator.py
+++ b/mage_ai/data_cleaner/analysis/calculator.py
@@ -47,8 +47,8 @@ class AnalysisCalculator():
         else:
             df_clean = df
 
-        arr_args_1 = [df_clean for _ in features_to_use]
-        arr_args_2 = features_to_use
+        arr_args_1 = [df_clean for _ in features_to_use],
+        arr_args_2 = features_to_use,
 
         data_for_columns = \
             [d for d in run_parallel(self.calculate_column, arr_args_1, arr_args_2)]

--- a/mage_ai/data_cleaner/analysis/charts.py
+++ b/mage_ai/data_cleaner/analysis/charts.py
@@ -145,7 +145,7 @@ def build_time_series_data(df, feature, datetime_column, column_type):
 
     # print(feature, datetime_column)
 
-    datetimes = pd.to_datetime(clean_series(df[datetime_column], DATETIME), errors='coerce')
+    datetimes = df[datetime_column].dropna()
     if datetimes.size <= 1:
         return
 
@@ -180,7 +180,8 @@ def build_time_series_data(df, feature, datetime_column, column_type):
             min=min_value,
         ))
 
-        series_cleaned = clean_series(series, column_type, dropna=False)
+        # series_cleaned = clean_series(series, column_type, dropna=False)
+        series_cleaned = series
         df_value_counts = series_cleaned.value_counts(dropna=False)
         series_non_null = series_cleaned.dropna()
         count_unique = len(df_value_counts.index)
@@ -240,10 +241,10 @@ def build_overview_data(df, datetime_features):
         tags = dict(datetime_column=datetime_column)
         increment(f'{DD_KEY}.build_overview_time_series.start', tags)
 
-        if clean_series(df_copy[datetime_column], DATETIME).size <= 1:
+        if df_copy[datetime_column].count() <= 1:
             continue
 
-        df_copy[datetime_column] = pd.to_datetime(df[datetime_column], errors='coerce').apply(
+        df_copy[datetime_column] = df[datetime_column].apply(
             lambda x: x if pd.isnull(x) else x.timestamp()
         )
 


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Reduce duplicate clean methods for timeseries charts.

# Tests
<!-- How did you test your change? -->
tested locally. It reduces insights calculator time from 14s to 11s.
<img width="561" alt="image" src="https://user-images.githubusercontent.com/80284865/171134914-0f314e5b-7b74-41f4-b045-4fa390750690.png">
<img width="548" alt="image" src="https://user-images.githubusercontent.com/80284865/171134949-1ee033c5-62a0-45c0-8445-242fdc0c6de6.png">


cc:
<!-- Optionally mention someone to let them know about this pull request -->
