### PR TITLE
[nt] Change route to dataset instead of list and clean up code styling.

### DIFF
--- a/mage_ai/frontend/pages/datasets/[slug]/features/[column].tsx
+++ b/mage_ai/frontend/pages/datasets/[slug]/features/[column].tsx
@@ -39,7 +39,7 @@ function Feature() {
   const featureData = featureMapping[featureIndex];
   const featureUUID = featureData?.uuid;
   const columnType = featureData?.column_type;
-  const sampleRowData = featureSet?.sample_data?.rows?.map(row => ({
+  const sampleRowData = featureSet?.sample_data?.rows?.map((row: any[]) => ({
     columnValues: [row[featureIndex]],
   }));
 
@@ -110,15 +110,16 @@ function Feature() {
   );
 
   const [tab, setTab] = useState('data');
-  const viewColumns = (e) => {
+  const viewDataset = (e: { preventDefault: () => void; }) => {
     e.preventDefault();
-    Router.push('/datasets');
+    Router.push(`/datasets/${featureSetId}`);
   };
 
   const headEl = (
-    <FlexContainer alignItems="center" justifyContent="space-between">
-      <PageBreadcrumbs featureSet={featureSet} />
-      <Button onClick={viewColumns}>
+    <FlexContainer alignItems="justify-right" flexDirection="row-reverse" >
+      <Button 
+        onClick={viewDataset}
+      >
         <Text bold> Datasets view </Text>
       </Button>
     </FlexContainer>
@@ -147,14 +148,7 @@ function Feature() {
   const dataEl = (
     <FlexContainer justifyContent={'center'}>
       <Flex flex={1}>
-        <SimpleDataTable
-          columnFlexNumbers={[1, 1]}
-          columnHeaders={[{ label: 'Column values' }]}
-          rowGroupData={[{
-            rowData: sampleRowData,
-            title: `${featureUUID} (${columnType})`,
-          }]}
-        />
+        {columnValuesTableEl}
       </Flex>
       <Spacing ml={UNIT} />
       <Flex flex={1}>
@@ -219,7 +213,7 @@ function Feature() {
 
   const [actionPayload, setActionPayload] = useState<TransformerActionType>();
   const actionType = actionPayload?.action_type;
-  const saveAction = (data) => {
+  const saveAction = (data: TransformerActionType) => {
     const updatedAction = {
       action_arguments: [
         featureUUID,


### PR DESCRIPTION

# Summary
<!-- Brief summary of what your code does -->
Column view button goes to the dataset details view instead of the dataset list.

# Tests
<!-- How did you test your change? -->
### Localhost (Development)
https://user-images.githubusercontent.com/90282975/171523219-401a15ce-21de-490a-b369-4066f08c86e6.mov

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@tommydangerous @johnson-mage @dy46 