### PR TITLE
[sk] Added default impute value

### DIFF
--- a/mage_ai/data_cleaner/cleaning_rules/impute_values.py
+++ b/mage_ai/data_cleaner/cleaning_rules/impute_values.py
@@ -91,7 +91,7 @@ class CategoricalImputeSubRule(TypeImputeSubRule):
         1. If there are no null entries, no suggestion
         2. If the dataset was identified as timeseries, suggest sequential imputation
         3. Else, if more than MODE_PROP_LB of nonnull entries are a single value, use
-           imputation with mode 
+           imputation with mode
         4. Else, if less than RAND_EMPTY_UB ratio of entries are null, use random imputation
         5. Else suggest no imputation (no good fit)
         """
@@ -144,7 +144,7 @@ class StringImputeSubRule(TypeImputeSubRule):
         1. If there are no null entries, no suggestion
         2. If the dataset was identified as timeseries, suggest sequential imputation
         3. Else, if more than MODE_PROP_LB of nonnull entries are a single value, use
-           imputation with mode 
+           imputation with mode
         4. Else, if less than RAND_EMPTY_UB ratio of entries are null, use random imputation
         5. Else suggest no imputation (no good fit)
         """

--- a/mage_ai/data_cleaner/pipelines/base.py
+++ b/mage_ai/data_cleaner/pipelines/base.py
@@ -30,6 +30,7 @@ DEFAULT_RULES = [
 
 
 class BasePipeline():
+
     def __init__(self, actions=[]):
         self.actions = actions
         self.rules = DEFAULT_RULES
@@ -37,7 +38,7 @@ class BasePipeline():
     def create_actions(self, df, column_types, statistics):
         if not statistics or len(statistics) == 0:
             calculator = StatisticsCalculator(column_types)
-            statistics = calculator.calculate_statistics_overview(df, True)
+            statistics = calculator.calculate_statistics_overview(df, False)
         self.column_types = column_types
         all_suggestions = []
         for rule in self.rules:

--- a/mage_ai/data_cleaner/shared/utils.py
+++ b/mage_ai/data_cleaner/shared/utils.py
@@ -1,8 +1,4 @@
-from mage_ai.data_cleaner.column_type_detector import (
-    NUMBER,
-    NUMBER_WITH_DECIMALS,
-    DATETIME
-)
+from mage_ai.data_cleaner.column_type_detector import (NUMBER, NUMBER_WITH_DECIMALS, DATETIME)
 from mage_ai.data_cleaner.column_type_detector import DATETIME
 from mage_ai.data_cleaner.transformer_actions.constants import CURRENCY_SYMBOLS
 import pandas as pd
@@ -12,14 +8,13 @@ import numpy as np
 def clean_series(series, column_type, dropna=True):
     series_cleaned = series.apply(lambda x: x.strip(' \'\"') if type(x) is str else x)
     series_cleaned = series_cleaned.map(
-        lambda x: x if (not isinstance(x, str) or (len(x) > 0 and not x.isspace())) else np.nan,
-    )
+        lambda x: x if (not isinstance(x, str) or (len(x) > 0 and not x.isspace())) else np.nan,)
     if dropna:
         series_cleaned = series_cleaned.dropna()
-    
+
     if series_cleaned.count() == 0:
         return series_cleaned
-    
+
     first_item = series_cleaned.dropna().iloc[0]
     if column_type == NUMBER or column_type == NUMBER_WITH_DECIMALS:
         is_percent = False
@@ -37,11 +32,10 @@ def clean_series(series, column_type, dropna=True):
             series_cleaned = series_cleaned.astype(float)
         if is_percent:
             series_cleaned /= 100
+    if column_type == DATETIME:
+        series_cleaned = pd.to_datetime(series_cleaned, infer_datetime_format=True, errors='coerce')
     return series_cleaned
 
 
 def clean_dataframe(df, column_types, dropna=True):
-    return df.apply(
-        lambda col: clean_series(col, column_types[col.name], dropna=dropna), 
-        axis=0
-    )
+    return df.apply(lambda col: clean_series(col, column_types[col.name], dropna=dropna), axis=0)

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -168,7 +168,7 @@ class StatisticsCalculator:
         data = {
             f'{col}/count': series_non_null.size,
             f'{col}/count_distinct': count_unique - 1
-            if np.nan in df_value_counts
+            if np.nan in df_top_value_counts_raw
             else count_unique,
             f'{col}/null_value_rate': 0
             if series.size == 0

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -20,8 +20,7 @@ def increment(metric, tags):
     pass
 
 
-class StatisticsCalculator():
-
+class StatisticsCalculator:
     def __init__(
         self,
         # s3_client,
@@ -49,12 +48,14 @@ class StatisticsCalculator():
             if not is_clean:
                 df = clean_dataframe(df, self.column_types, dropna=False)
             timeseries_metadata = self.__evaluate_timeseries(df)
-            data = dict(count=len(df.index),
-                        is_timeseries=timeseries_metadata['is_timeseries'],
-                        timeseries_index=timeseries_metadata['timeseries_index'])
+            data = dict(
+                count=len(df.index),
+                is_timeseries=timeseries_metadata['is_timeseries'],
+                timeseries_index=timeseries_metadata['timeseries_index'],
+            )
 
-            arr_args_1 = [df[col] for col in df.columns],
-            arr_args_2 = [col for col in df.columns],
+            arr_args_1 = ([df[col] for col in df.columns],)
+            arr_args_2 = ([col for col in df.columns],)
 
             dicts = run_parallel(self.statistics_overview, arr_args_1, arr_args_2)
 
@@ -63,20 +64,26 @@ class StatisticsCalculator():
 
             # Aggregated stats
             column_count = len(df.columns)
-            data['total_null_value_count'] = \
-                sum(data[f'{col}/null_value_count'] for col in df.columns)
+            data['total_null_value_count'] = sum(
+                data[f'{col}/null_value_count'] for col in df.columns
+            )
             data['avg_null_value_count'] = data['total_null_value_count'] / column_count
-            data['avg_invalid_value_count'] = \
+            data['avg_invalid_value_count'] = (
                 sum(data.get(f'{col}/invalid_value_count', 0) for col in df.columns) / column_count
-            data['completeness'] = \
+            )
+            data['completeness'] = (
                 1 - data['avg_null_value_count'] / data['count'] if data['count'] > 0 else 0
-            data['validity'] = \
-                data['completeness'] - data['avg_invalid_value_count'] / data['count'] \
-                if data['count'] > 0 else 0
+            )
+            data['validity'] = (
+                data['completeness'] - data['avg_invalid_value_count'] / data['count']
+                if data['count'] > 0
+                else 0
+            )
             df_dedupe = df.drop_duplicates()
             data['duplicate_row_count'] = df.shape[0] - df_dedupe.shape[0]
-            data['empty_column_count'] = \
-                len([col for col in df.columns if data[f'{col}/count'] == 0])
+            data['empty_column_count'] = len(
+                [col for col in df.columns if data[f'{col}/count'] == 0]
+            )
 
             # object_key = s3_paths.path_statistics_overview(self.object_key_prefix)
             # s3_data.upload_json_sorted(self.s3_client, object_key, data)
@@ -106,10 +113,13 @@ class StatisticsCalculator():
         except Exception as err:
             increment(
                 'statistics.calculate_statistics_overview.column.failed',
-                merge_dict(self.data_tags, {
-                    'col': col,
-                    'error': err.__class__.__name__,
-                }),
+                merge_dict(
+                    self.data_tags,
+                    {
+                        'col': col,
+                        'error': err.__class__.__name__,
+                    },
+                ),
             )
             traceback.print_exc()
             return {}
@@ -156,18 +166,16 @@ class StatisticsCalculator():
         count_unique = len(df_value_counts.index)
 
         data = {
-            f'{col}/count':
-                series_non_null.size,
-            f'{col}/count_distinct':
-                count_unique - 1 if np.nan in df_value_counts else count_unique,
-            f'{col}/null_value_rate':
-                0 if series.size == 0 else series.isnull().sum() / series.size,
-            f'{col}/null_value_count':
-                series.isnull().sum(),
-            f'{col}/max_null_seq':
-                self.get_longest_null_seq(series),
-            f'{col}/value_counts':
-                df_top_value_counts.to_dict(),
+            f'{col}/count': series_non_null.size,
+            f'{col}/count_distinct': count_unique - 1
+            if np.nan in df_value_counts
+            else count_unique,
+            f'{col}/null_value_rate': 0
+            if series.size == 0
+            else series.isnull().sum() / series.size,
+            f'{col}/null_value_count': series.isnull().sum(),
+            f'{col}/max_null_seq': self.get_longest_null_seq(series),
+            f'{col}/value_counts': df_top_value_counts.to_dict(),
         }
 
         if len(series_non_null) > 0:
@@ -185,15 +193,18 @@ class StatisticsCalculator():
                 if data[f'{col}/std'] == 0:
                     data[f'{col}/outlier_count'] = 0
                 else:
-                    series_z_score = ((series_non_null - data[f'{col}/average']) /
-                                      data[f'{col}/std']).abs()
-                    data[f'{col}/outlier_count'] = (series_z_score >=
-                                                    OUTLIER_ZSCORE_THRESHOLD).sum()
+                    series_z_score = (
+                        (series_non_null - data[f'{col}/average']) / data[f'{col}/std']
+                    ).abs()
+                    data[f'{col}/outlier_count'] = (
+                        series_z_score >= OUTLIER_ZSCORE_THRESHOLD
+                    ).sum()
             elif column_type == DATETIME:
                 dates = pd.to_datetime(series_non_null, utc=True, errors='coerce').dropna()
                 data[f'{col}/max'] = dates.max().isoformat()
-                data[f'{col}/median'] = dates.sort_values().iloc[math.floor(len(dates) /
-                                                                            2)].isoformat()
+                data[f'{col}/median'] = (
+                    dates.sort_values().iloc[math.floor(len(dates) / 2)].isoformat()
+                )
                 data[f'{col}/min'] = dates.min().isoformat()
 
             if column_type not in NUMBER_TYPES:
@@ -213,8 +224,9 @@ class StatisticsCalculator():
 
         # Detect mismatched formats for some column types
         data[f'{col}/invalid_value_count'] = get_mismatched_row_count(series_non_null, column_type)
-        data[f'{col}/invalid_value_rate'] = 0 if series.size == 0 else \
-            data[f'{col}/invalid_value_count'] / series.size
+        data[f'{col}/invalid_value_rate'] = (
+            0 if series.size == 0 else data[f'{col}/invalid_value_count'] / series.size
+        )
 
         # Calculate quality metrics
         data[f'{col}/completeness'] = 1 - data[f'{col}/null_value_rate']

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -194,8 +194,7 @@ class StatisticsCalculator():
                     data[f'{col}/outlier_count'] = (series_z_score >=
                                                     OUTLIER_ZSCORE_THRESHOLD).sum()
             elif column_type == DATETIME:
-                dates = pd.to_datetime(series_non_null, utc=True, errors='coerce',
-                                       unit='ns').dropna()
+                dates = pd.to_datetime(series_non_null, utc=True, errors='coerce').dropna()
                 data[f'{col}/max'] = dates.max().isoformat()
                 data[f'{col}/median'] = dates.sort_values().iloc[math.floor(len(dates) /
                                                                             2)].isoformat()

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -7,10 +7,6 @@ from mage_ai.data_cleaner.column_type_detector import (
     NUMBER_TYPES,
     get_mismatched_row_count,
 )
-from mage_ai.data_cleaner.shared.hash import merge_dict
-from mage_ai.data_cleaner.shared.multi import run_parallel
-from mage_ai.data_cleaner.shared.logger import timer
-from mage_ai.data_cleaner.shared.utils import clean_dataframe
 import math
 import numpy as np
 import pandas as pd

--- a/mage_ai/data_cleaner/transformer_actions/column.py
+++ b/mage_ai/data_cleaner/transformer_actions/column.py
@@ -1,9 +1,11 @@
 from mage_ai.data_cleaner.column_type_detector import DATETIME, NUMBER_TYPES, REGEX_NUMBER
 from mage_ai.data_cleaner.transformer_actions.action_code import query_with_action_code
-from mage_ai.data_cleaner.transformer_actions.constants import (CONSTANT_IMPUTATION_DEFAULTS,
-                                                                CURRENCY_SYMBOLS,
-                                                                ImputationStrategy,
-                                                                NameConventionPatterns)
+from mage_ai.data_cleaner.transformer_actions.constants import (
+    CONSTANT_IMPUTATION_DEFAULTS,
+    CURRENCY_SYMBOLS,
+    ImputationStrategy,
+    NameConventionPatterns,
+)
 from mage_ai.data_cleaner.transformer_actions.helpers import (
     convert_col_type,
     get_column_type,
@@ -106,7 +108,8 @@ def impute(df, action, **kwargs):
             valid_idx = df[df[column].notna()].index
             if len(invalid_idx) == len(df[column]):
                 raise Exception(
-                    f'Random impute has no values to sample from in column \'{column}\'')
+                    f'Random impute has no values to sample from in column \'{column}\''
+                )
             sample = df.loc[valid_idx, column].sample(len(invalid_idx), replace=True)
             sample.index = invalid_idx
             df.loc[invalid_idx, column] = sample
@@ -158,12 +161,13 @@ def reformat(df, action, **kwargs):
             exact_dtype = type(dropped.iloc[0]) if len(dropped) > 0 else None
             if exact_dtype is str:
                 clean_col = clean_col.str.replace(r'[\,\s\t]+', ' ')
-                clean_col = clean_col.str.replace(r'\s*([\/\\\-\.]+)\s*',
-                                                  lambda group: group.group(1)[0])
+                clean_col = clean_col.str.replace(
+                    r'\s*([\/\\\-\.]+)\s*', lambda group: group.group(1)[0]
+                )
                 clean_col = clean_col.str.lower()
-            df.loc[:, column] = pd.to_datetime(clean_col,
-                                               infer_datetime_format=True,
-                                               errors='coerce')
+            df.loc[:, column] = pd.to_datetime(
+                clean_col, infer_datetime_format=True, errors='coerce'
+            )
 
     return df
 
@@ -248,15 +252,18 @@ def __filter_df_with_time_window(df, action):
     time_window_keys = ['timestamp_feature_a', 'timestamp_feature_b', 'window']
     if all(k in action_options for k in time_window_keys):
         window_in_seconds = action_options['window']
-        df_time_diff = \
-            (pd.to_datetime(df[action_options['timestamp_feature_a']], utc=True) - \
-                pd.to_datetime(df[action_options['timestamp_feature_b']], utc=True)).dt.total_seconds()
+        df_time_diff = (
+            pd.to_datetime(df[action_options['timestamp_feature_a']], utc=True)
+            - pd.to_datetime(df[action_options['timestamp_feature_b']], utc=True)
+        ).dt.total_seconds()
         if window_in_seconds > 0:
-            df_time_diff_filtered = \
-                df_time_diff[(df_time_diff <= window_in_seconds) & (df_time_diff >= 0)]
+            df_time_diff_filtered = df_time_diff[
+                (df_time_diff <= window_in_seconds) & (df_time_diff >= 0)
+            ]
         else:
-            df_time_diff_filtered = \
-                df_time_diff[(df_time_diff >= window_in_seconds) & (df_time_diff <= 0)]
+            df_time_diff_filtered = df_time_diff[
+                (df_time_diff >= window_in_seconds) & (df_time_diff <= 0)
+            ]
         df_filtered = df.loc[df_time_diff_filtered.index]
         time_window = get_time_window_str(window_in_seconds)
     else:
@@ -269,12 +276,11 @@ def __groupby_agg(df, action, agg_method):
     df_filtered, _ = __filter_df_with_time_window(df, action)
     action_code = action.get('action_code')
     if action_code is not None and action_code != '':
-        df_filtered = query_with_action_code(df_filtered, action_code, {
-            'original_df': df_filtered,
-        })
+        df_filtered = query_with_action_code(df_filtered, action_code, {'original_df': df_filtered})
     action_options = action['action_options']
-    df_agg = df_filtered.groupby(
-        action_options['groupby_columns'],)[action['action_arguments']].agg(agg_method)
+    df_agg = df_filtered.groupby(action_options['groupby_columns'])[action['action_arguments']].agg(
+        agg_method
+    )
     return df.merge(
         df_agg.rename(columns=__column_mapping(action)),
         on=action_options['groupby_columns'],

--- a/mage_ai/data_cleaner/transformer_actions/column.py
+++ b/mage_ai/data_cleaner/transformer_actions/column.py
@@ -75,17 +75,20 @@ def impute(df, action, **kwargs):
     if strategy == ImputationStrategy.AVERAGE:
         df[columns] = df[columns].fillna(df[columns].astype(float).mean(axis=0))
     elif strategy == ImputationStrategy.CONSTANT:
-        col_by_type = {}
-        for column in columns:
-            dtype = action_variables[column]['feature']['column_type']
-            key = 'object'
-            if dtype == DATETIME:
-                key = 'datetime'
-            elif dtype in NUMBER_TYPES:
-                key = 'number'
-            col_by_type.setdefault(key, []).append(column)
-        for key, column_set in col_by_type.items():
-            df[column_set] = df[column_set].fillna(CONSTANT_IMPUTATION_DEFAULTS[key])
+        if value is None:
+            col_by_type = {}
+            for column in columns:
+                dtype = action_variables[column]['feature']['column_type']
+                key = 'object'
+                if dtype == DATETIME:
+                    key = 'datetime'
+                elif dtype in NUMBER_TYPES:
+                    key = 'number'
+                col_by_type.setdefault(key, []).append(column)
+            for key, column_set in col_by_type.items():
+                df[column_set] = df[column_set].fillna(CONSTANT_IMPUTATION_DEFAULTS[key])
+        else:
+            df[columns] = df[columns].fillna(value)
     elif strategy == ImputationStrategy.MEDIAN:
         df[columns] = df[columns].fillna(df[columns].astype(float).median(axis=0))
     elif strategy == ImputationStrategy.MODE:

--- a/mage_ai/data_cleaner/transformer_actions/column.py
+++ b/mage_ai/data_cleaner/transformer_actions/column.py
@@ -1,10 +1,9 @@
-from mage_ai.data_cleaner.column_type_detector import REGEX_NUMBER
+from mage_ai.data_cleaner.column_type_detector import DATETIME, NUMBER_TYPES, REGEX_NUMBER
 from mage_ai.data_cleaner.transformer_actions.action_code import query_with_action_code
-from mage_ai.data_cleaner.transformer_actions.constants import (
-    CURRENCY_SYMBOLS,
-    ImputationStrategy,
-    NameConventionPatterns
-)
+from mage_ai.data_cleaner.transformer_actions.constants import (CONSTANT_IMPUTATION_DEFAULTS,
+                                                                CURRENCY_SYMBOLS,
+                                                                ImputationStrategy,
+                                                                NameConventionPatterns)
 from mage_ai.data_cleaner.transformer_actions.helpers import (
     convert_col_type,
     get_column_type,
@@ -34,29 +33,37 @@ def add_column(df, action, **kwargs):
     df_copy[col] = convert_col_type(df_copy[col], col_type)
     return df_copy
 
+
 def average(df, action, **kwargs):
     return __agg(df, action, 'mean')
+
 
 def count(df, action, **kwargs):
     return __groupby_agg(df, action, 'count')
 
+
 def count_distinct(df, action, **kwargs):
     return __groupby_agg(df, action, 'nunique')
 
+
 def clean_column_names(df, action, **kwargs):
     columns = action['action_arguments']
-    mapping = {col : __clean_column_name(col) for col in columns}
+    mapping = {col: __clean_column_name(col) for col in columns}
     return df.rename(columns=mapping)
+
 
 def diff(df, action, **kwargs):
     output_col = action['outputs'][0]['uuid']
     df[output_col] = df[action['action_arguments'][0]].diff()
     return df
 
+
 def first(df, action, **kwargs):
     return __agg(df, action, 'first')
 
+
 def impute(df, action, **kwargs):
+    action_variables = action['action_variables']
     columns = action['action_arguments']
     action_options = action['action_options']
     strategy = action_options.get('strategy')
@@ -67,6 +74,18 @@ def impute(df, action, **kwargs):
 
     if strategy == ImputationStrategy.AVERAGE:
         df[columns] = df[columns].fillna(df[columns].astype(float).mean(axis=0))
+    elif strategy == ImputationStrategy.CONSTANT:
+        col_by_type = {}
+        for column in columns:
+            dtype = action_variables[column]['feature']['column_type']
+            key = 'object'
+            if dtype == DATETIME:
+                key = 'datetime'
+            elif dtype in NUMBER_TYPES:
+                key = 'number'
+            col_by_type.setdefault(key, []).append(column)
+        for key, column_set in col_by_type.items():
+            df[column_set] = df[column_set].fillna(CONSTANT_IMPUTATION_DEFAULTS[key])
     elif strategy == ImputationStrategy.MEDIAN:
         df[columns] = df[columns].fillna(df[columns].astype(float).median(axis=0))
     elif strategy == ImputationStrategy.MODE:
@@ -84,8 +103,7 @@ def impute(df, action, **kwargs):
             valid_idx = df[df[column].notna()].index
             if len(invalid_idx) == len(df[column]):
                 raise Exception(
-                    f'Random impute has no values to sample from in column \'{column}\''
-                )
+                    f'Random impute has no values to sample from in column \'{column}\'')
             sample = df.loc[valid_idx, column].sample(len(invalid_idx), replace=True)
             sample.index = invalid_idx
             df.loc[invalid_idx, column] = sample
@@ -99,14 +117,18 @@ def impute(df, action, **kwargs):
         df[col] = convert_col_type(df[col], col_type)
     return df
 
+
 def max(df, action, **kwargs):
     return __agg(df, action, 'max')
+
 
 def median(df, action, **kwargs):
     return __agg(df, action, 'median')
 
+
 def min(df, action, **kwargs):
     return __agg(df, action, 'min')
+
 
 def reformat(df, action, **kwargs):
     columns = action['action_arguments']
@@ -133,18 +155,15 @@ def reformat(df, action, **kwargs):
             exact_dtype = type(dropped.iloc[0]) if len(dropped) > 0 else None
             if exact_dtype is str:
                 clean_col = clean_col.str.replace(r'[\,\s\t]+', ' ')
-                clean_col = clean_col.str.replace(
-                    r'\s*([\/\\\-\.]+)\s*',
-                    lambda group: group.group(1)[0]
-                )
+                clean_col = clean_col.str.replace(r'\s*([\/\\\-\.]+)\s*',
+                                                  lambda group: group.group(1)[0])
                 clean_col = clean_col.str.lower()
-            df.loc[:, column] = pd.to_datetime(
-                clean_col, 
-                infer_datetime_format=True, 
-                errors='coerce'
-            )
-    
+            df.loc[:, column] = pd.to_datetime(clean_col,
+                                               infer_datetime_format=True,
+                                               errors='coerce')
+
     return df
+
 
 def remove_column(df, action, **kwargs):
     cols = action['action_arguments']
@@ -153,11 +172,14 @@ def remove_column(df, action, **kwargs):
 
     return df.drop(columns=drop_columns)
 
+
 def last(df, action, **kwargs):
     return __agg(df, action, 'last')
 
+
 def select(df, action, **kwargs):
     return df[action['action_arguments']]
+
 
 def shift_down(df, action, **kwargs):
     output_col = action['outputs'][0]['uuid']
@@ -170,13 +192,16 @@ def shift_down(df, action, **kwargs):
         df[output_col] = df[action['action_arguments'][0]].shift(periods)
     return df
 
+
 def shift_up(df, action, **kwargs):
     output_col = action['outputs'][0]['uuid']
     df[output_col] = df[action['action_arguments'][0]].shift(-1)
     return df
 
+
 def sum(df, action, **kwargs):
     return __agg(df, action, 'sum')
+
 
 def __agg(df, action, agg_method):
     if action['action_options'].get('groupby_columns'):
@@ -186,8 +211,10 @@ def __agg(df, action, agg_method):
         df[output_col] = df[action['action_arguments'][0]].agg(agg_method)
         return df
 
+
 def __column_mapping(action):
     return dict(zip(action['action_arguments'], [o['uuid'] for o in action['outputs']]))
+
 
 def __clean_column_name(name):
     if iskeyword(name):
@@ -211,6 +238,7 @@ def __clean_column_name(name):
         name = '_'.join(components)
     return name.lower()
 
+
 # Filter by timestamp_feature_a - window <= timestamp_feature_b <= timestamp_feature_a
 def __filter_df_with_time_window(df, action):
     action_options = action['action_options']
@@ -233,6 +261,7 @@ def __filter_df_with_time_window(df, action):
         time_window = None
     return df_filtered, time_window
 
+
 def __groupby_agg(df, action, agg_method):
     df_filtered, _ = __filter_df_with_time_window(df, action)
     action_code = action.get('action_code')
@@ -242,8 +271,7 @@ def __groupby_agg(df, action, agg_method):
         })
     action_options = action['action_options']
     df_agg = df_filtered.groupby(
-        action_options['groupby_columns'],
-    )[action['action_arguments']].agg(agg_method)
+        action_options['groupby_columns'],)[action['action_arguments']].agg(agg_method)
     return df.merge(
         df_agg.rename(columns=__column_mapping(action)),
         on=action_options['groupby_columns'],

--- a/mage_ai/data_cleaner/transformer_actions/constants.py
+++ b/mage_ai/data_cleaner/transformer_actions/constants.py
@@ -1,5 +1,7 @@
+import pandas as pd
 import re
 
+CONSTANT_IMPUTATION_DEFAULTS = dict(object='missing', datetime=pd.NaT, number=0)
 CURRENCY_SYMBOLS = re.compile(r'(?:[\$\€\¥\₹\元\£]|(?:Rs)|(?:CAD))')
 
 
@@ -58,15 +60,18 @@ class Operator():
     LESS_THAN = '<'
     LESS_THAN_OR_EQUALS = '<='
 
+
 class ImputationStrategy():
     AVERAGE = 'average'
     COLUMN = 'column'
+    CONSTANT = 'constant'
     MEDIAN = 'median'
     MODE = 'mode'
     NOOP = 'no_action'
     RANDOM = 'random'
     ROW_RM = 'remove_rows'
     SEQ = 'sequential'
+
 
 class NameConventionPatterns():
     SNAKE = re.compile(r'^[a-z]+(?:\_[a-z0-9]+)*$')

--- a/mage_ai/data_cleaner/transformer_actions/constants.py
+++ b/mage_ai/data_cleaner/transformer_actions/constants.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import re
 
-CONSTANT_IMPUTATION_DEFAULTS = dict(object='missing', datetime=pd.NaT, number=0)
+CONSTANT_IMPUTATION_DEFAULTS = dict(object='missing', datetime=pd.Timestamp.min, number=0)
 CURRENCY_SYMBOLS = re.compile(r'(?:[\$\€\¥\₹\元\£]|(?:Rs)|(?:CAD))')
 
 

--- a/mage_ai/tests/data_cleaner/cleaning_rules/test_impute_values.py
+++ b/mage_ai/tests/data_cleaner/cleaning_rules/test_impute_values.py
@@ -6,34 +6,33 @@ import pandas as pd
 
 
 class ImputeValuesTest(TestCase):
+
     def setUp(self):
         self.rng = np.random.default_rng(42)
         return super().setUp()
 
     def test_mean(self):
-        df = pd.DataFrame(
-            [
-                [10, 3],
-                [None, None],
-                [21, None],
-                [25, None],
-                [None, None],
-                [np.NaN, None],
-                [31, None],
-                [25, 9],
-                [21, 99],
-                [10, 2],
-            ],
-            columns=['age', 'number_of_years']
-        )
+        df = pd.DataFrame([
+            [10, 3],
+            [None, None],
+            [21, None],
+            [25, None],
+            [None, None],
+            [np.NaN, None],
+            [31, None],
+            [25, 9],
+            [21, 99],
+            [10, 2],
+        ],
+                          columns=['age', 'number_of_years'])
         column_types = {'age': 'number', 'number_of_years': 'number'}
         statistics = {
             'age/count': 7,
             'age/count_distinct': 4,
-            'age/null_value_rate': 3/10,
+            'age/null_value_rate': 3 / 10,
             'number_of_years/count': 4,
             'number_of_years/count_distinct': 4,
-            'number_of_years/null_value_rate': 6/10,
+            'number_of_years/null_value_rate': 6 / 10,
             'is_timeseries': False
         }
         expected_suggestions = [
@@ -63,7 +62,33 @@ class ImputeValuesTest(TestCase):
                     outputs=[]
                 ),
                 status='not_applied'
-            )
+            ),
+            dict(
+                title='Fill in missing values',
+                message='The following columns have many missing entries: '\
+                      '[\'number_of_years\']. ' \
+                      'Suggested: fill null values with a placeholder to mark them as missing',
+                action_payload=dict(
+                    action_type='impute',
+                    action_arguments=['number_of_years'],
+                    action_options=dict(
+                        strategy='constant'
+                    ),
+                    action_variables=dict(
+                        number_of_years=dict(
+                            feature=dict(
+                                column_type='number',
+                                uuid='number_of_years'
+                            ),
+                            type='feature'
+                        )
+                    ),
+                    action_code='',
+                    axis='column',
+                    outputs=[]
+                ),
+                status='not_applied'
+            ),
         ]
         suggestions = ImputeValues(
             df,
@@ -81,9 +106,7 @@ class ImputeValuesTest(TestCase):
         num_years_arr = self.rng.integers(0, 110, size=(150,)).astype(float)
         self.rng.shuffle(indices)
         num_years_arr[indices[:50]] = np.NaN
-        df = pd.DataFrame(
-            {'age':age_arr, 'number_of_years':num_years_arr}
-        )
+        df = pd.DataFrame({'age': age_arr, 'number_of_years': num_years_arr})
         column_types = {'age': 'number', 'number_of_years': 'number'}
         statistics = {
             'age/count': df['age'].count(),
@@ -91,29 +114,41 @@ class ImputeValuesTest(TestCase):
             'age/null_value_rate': 1 - df['age'].count() / len(df['age']),
             'number_of_years/count': df['number_of_years'].count(),
             'number_of_years/count_distinct': df['number_of_years'].nunique(),
-            'number_of_years/null_value_rate': (
-                1 - df['number_of_years'].count() / len(df['number_of_years'])
-            ),
+            'number_of_years/null_value_rate':
+                (1 - df['number_of_years'].count() / len(df['number_of_years'])),
             'is_timeseries': False
         }
         expected_suggestions = [
-            dict(
-                title='Fill in missing values',
-                message='The following columns have null-valued entries and '
-                      'the distribution of remaining values is approximately symmetric: '
-                      '[\'age\']. '
-                      'Suggested: fill null values with the average value from each column.',
+            dict(title='Fill in missing values',
+                 message='The following columns have null-valued entries and '
+                 'the distribution of remaining values is approximately symmetric: '
+                 '[\'age\']. '
+                 'Suggested: fill null values with the average value from each column.',
+                 action_payload=dict(
+                     action_type='impute',
+                     action_arguments=['age'],
+                     action_options=dict(strategy='average'),
+                     action_variables=dict(
+                         age=dict(feature=dict(column_type='number', uuid='age'), type='feature')),
+                     action_code='',
+                     axis='column',
+                     outputs=[]),
+                 status='not_applied'),
+            dict(title='Fill in missing values',
+                message='The following columns have many missing entries: '\
+                      '[\'number_of_years\']. ' \
+                      'Suggested: fill null values with a placeholder to mark them as missing',
                 action_payload=dict(
                     action_type='impute',
-                    action_arguments=['age'],
+                    action_arguments=['number_of_years'],
                     action_options=dict(
-                        strategy='average'
+                        strategy='constant'
                     ),
                     action_variables=dict(
-                        age=dict(
+                        number_of_years=dict(
                             feature=dict(
                                 column_type='number',
-                                uuid='age'
+                                uuid='number_of_years'
                             ),
                             type='feature'
                         )
@@ -123,7 +158,7 @@ class ImputeValuesTest(TestCase):
                     outputs=[]
                 ),
                 status='not_applied'
-            )
+            ),
         ]
         suggestions = ImputeValues(
             df,
@@ -133,21 +168,19 @@ class ImputeValuesTest(TestCase):
         self.assertEqual(expected_suggestions, suggestions)
 
     def test_median(self):
-        df = pd.DataFrame(
-            [
-                [90.5, 3],
-                [None, None],
-                [52.3, None],
-                [-2.3, None],
-                [None, None],
-                [np.NaN, None],
-                [-1.4, None],
-                [-1.6, 9],
-                [-4.3, 9],
-                [-3.4, 9],
-            ],
-            columns=['profit', 'number_of_years']
-        )
+        df = pd.DataFrame([
+            [90.5, 3],
+            [None, None],
+            [52.3, None],
+            [-2.3, None],
+            [None, None],
+            [np.NaN, None],
+            [-1.4, None],
+            [-1.6, 9],
+            [-4.3, 9],
+            [-3.4, 9],
+        ],
+                          columns=['profit', 'number_of_years'])
         column_types = {'profit': 'number_with_decimals', 'number_of_years': 'number'}
         statistics = {
             'profit/count': 7,
@@ -161,15 +194,96 @@ class ImputeValuesTest(TestCase):
         expected_suggestions = [
             dict(
                 title='Fill in missing values',
+                message='The following columns have many missing entries: '\
+                      '[\'number_of_years\']. ' \
+                      'Suggested: fill null values with a placeholder to mark them as missing',
+                action_payload=dict(
+                    action_type='impute',
+                    action_arguments=['number_of_years'],
+                    action_options=dict(
+                        strategy='constant'
+                    ),
+                    action_variables=dict(
+                        number_of_years=dict(
+                            feature=dict(
+                                column_type='number',
+                                uuid='number_of_years'
+                            ),
+                            type='feature'
+                        )
+                    ),
+                    action_code='',
+                    axis='column',
+                    outputs=[]
+                ),
+                status='not_applied'
+            ),
+            dict(
+                title='Fill in missing values',
                 message='The following columns have null-valued entries and '
-                      'the distribution of remaining values is skewed: '
-                      '[\'profit\']. '
-                      'Suggested: fill null values with the median value from each column.',
+                'the distribution of remaining values is skewed: '
+                '[\'profit\']. '
+                'Suggested: fill null values with the median value from each column.',
+                action_payload=dict(
+                    action_type='impute',
+                    action_arguments=['profit'],
+                    action_options=dict(strategy='median'),
+                    action_variables=dict(
+                        profit=dict(feature=dict(column_type='number_with_decimals', uuid='profit'),
+                                    type='feature')),
+                    action_code='',
+                    axis='column',
+                    outputs=[]),
+                status='not_applied'),
+        ]
+        suggestions = ImputeValues(
+            df,
+            column_types,
+            statistics,
+        ).evaluate()
+        self.assertEqual(expected_suggestions, suggestions)
+
+    def test_mode(self):
+        df = pd.DataFrame([
+            [90.5, 'one', 34934],
+            [np.nan, None, np.nan],
+            [667, 'one', 10010],
+            [np.nan, 'one', 34934],
+            [-234, None, np.nan],
+            [np.nan, None, 34934],
+            [-1.4, 'one', np.nan],
+            [-1.6, 'None', 10010],
+        ],
+                          columns=['profit', 'company', 'industry'])
+        column_types = {
+            'profit': 'number_with_decimals',
+            'company': 'category',
+            'industry': 'zip_code'
+        }
+        statistics = {
+            'profit/count': 5,
+            'profit/null_value_rate': 3 / 8,
+            'company/count': 5,
+            'company/null_value_rate': 3 / 8,
+            'company/mode': 'one',
+            'company/mode_ratio': 4 / 5,
+            'industry/count': 5,
+            'industry/null_value_rate': 3 / 8,
+            'industry/mode': 34934,
+            'industry/mode_ratio': 3 / 5,
+            'is_timeseries': False
+        }
+        expected_suggestions = [
+            dict(
+                title='Fill in missing values',
+                message='The following columns have many missing entries: '\
+                      '[\'profit\']. ' \
+                      'Suggested: fill null values with a placeholder to mark them as missing',
                 action_payload=dict(
                     action_type='impute',
                     action_arguments=['profit'],
                     action_options=dict(
-                        strategy='median'
+                        strategy='constant'
                     ),
                     action_variables=dict(
                         profit=dict(
@@ -185,7 +299,28 @@ class ImputeValuesTest(TestCase):
                     outputs=[]
                 ),
                 status='not_applied'
-            )
+            ),
+            dict(title='Fill in missing values',
+                 message='The following columns have null valued entries and '
+                 'a large proportion of entries are a single value: '
+                 '[\'company\', \'industry\']. '
+                 'Suggested: fill null values with this most frequent value.',
+                 action_payload=dict(
+                    action_type='impute',
+                    action_arguments=['company', 'industry'],
+                    action_options=dict(strategy='mode'),
+                    action_variables=dict(
+                        company=dict(feature=dict(column_type='category',
+                                                uuid='company'),
+                                    type='feature'),
+                        industry=dict(feature=dict(column_type='zip_code',
+                                                uuid='industry'),
+                                    type='feature')),
+                    action_code='',
+                    axis='column',
+                    outputs=[]),
+                 status='not_applied'
+            ),
         ]
         suggestions = ImputeValues(
             df,
@@ -194,63 +329,52 @@ class ImputeValuesTest(TestCase):
         ).evaluate()
         self.assertEqual(expected_suggestions, suggestions)
 
-    def test_mode(self):
-        df = pd.DataFrame(
-            [
-                [90.5, 'one', 34934],
-                [np.nan, None, np.nan],
-                [667, 'one', 10010],
-                [np.nan, 'one', 34934],
-                [-234, None, np.nan],
-                [np.nan, None, 34934],
-                [-1.4, 'one', np.nan],
-                [-1.6, 'None', 10010],
-            ],
-            columns=['profit', 'company', 'industry']
-        )
-        column_types = {
-            'profit': 'number_with_decimals', 
-            'company': 'category',
-            'industry': 'zip_code'
-        }
+    def test_no_numerical(self):
+        df = pd.DataFrame([
+            [90.5, 3],
+            [None, ''],
+            ['', None],
+            [np.NaN, None],
+            [None, None],
+            [np.NaN, None],
+            [-1.4, None],
+            [-1.6, 9],
+        ],
+                          columns=['profit', 'number_of_years'])
+        column_types = {'profit': 'number_with_decimals', 'number_of_years': 'number'}
         statistics = {
-            'profit/count': 5,
-            'profit/null_value_rate': 3/8,
-            'company/count': 5,
-            'company/null_value_rate': 3/8,
-            'company/mode': 'one',
-            'company/mode_ratio': 4/5,
-            'industry/count': 5,
-            'industry/null_value_rate': 3/8,
-            'industry/mode': 34934,
-            'industry/mode_ratio': 3/5,
+            'profit/count': 3,
+            'profit/count_distinct': 3,
+            'profit/null_value_rate': 5 / 8,
+            'number_of_years/count': 2,
+            'number_of_years/count_distinct': 2,
+            'number_of_years/null_value_rate': 6 / 8,
             'is_timeseries': False
         }
         expected_suggestions = [
             dict(
                 title='Fill in missing values',
-                message='The following columns have null valued entries and '
-                      'a large proportion of entries are a single value: '
-                      '[\'company\', \'industry\']. '
-                      'Suggested: fill null values with this most frequent value.',
+                message='The following columns have many missing entries: '\
+                      '[\'profit\', \'number_of_years\']. ' \
+                      'Suggested: fill null values with a placeholder to mark them as missing',
                 action_payload=dict(
                     action_type='impute',
-                    action_arguments=['company', 'industry'],
+                    action_arguments=['profit', 'number_of_years'],
                     action_options=dict(
-                        strategy='mode'
+                        strategy='constant'
                     ),
                     action_variables=dict(
-                        company=dict(
+                        profit=dict(
                             feature=dict(
-                                column_type='category',
-                                uuid='company'
+                                column_type='number_with_decimals',
+                                uuid='profit'
                             ),
                             type='feature'
                         ),
-                        industry=dict(
+                        number_of_years=dict(
                             feature=dict(
-                                column_type='zip_code',
-                                uuid='industry'
+                                column_type='number',
+                                uuid='number_of_years'
                             ),
                             type='feature'
                         )
@@ -260,40 +384,8 @@ class ImputeValuesTest(TestCase):
                     outputs=[]
                 ),
                 status='not_applied'
-            )
+            ),
         ]
-        suggestions = ImputeValues(
-            df,
-            column_types,
-            statistics,
-        ).evaluate()
-        self.assertEqual(expected_suggestions, suggestions)
-    
-    def test_no_numerical(self):
-        df = pd.DataFrame(
-            [
-                [90.5, 3],
-                [None, ''],
-                ['', None],
-                [np.NaN, None],
-                [None, None],
-                [np.NaN, None],
-                [-1.4, None],
-                [-1.6, 9],
-            ],
-            columns=['profit', 'number_of_years']
-        )
-        column_types = {'profit': 'number_with_decimals', 'number_of_years': 'number'}
-        statistics = {
-            'profit/count': 3,
-            'profit/count_distinct': 3,
-            'profit/null_value_rate': 5/8,
-            'number_of_years/count': 2,
-            'number_of_years/count_distinct': 2,
-            'number_of_years/null_value_rate': 6/8,
-            'is_timeseries': False
-        }
-        expected_suggestions = []
         suggestions = ImputeValues(
             df,
             column_types,
@@ -303,67 +395,85 @@ class ImputeValuesTest(TestCase):
 
     def test_random(self):
         source_ids = np.concatenate(
-            [self.rng.integers(10000, 99999, size=(20,)).astype(str) for _ in range(10)]
-        )
-        source_idxs = self.rng.integers(0,100,size=(60,))
+            [self.rng.integers(10000, 99999, size=(20,)).astype(str) for _ in range(10)])
+        source_idxs = self.rng.integers(0, 100, size=(60,))
         source_ids[source_idxs] = ''
         dest_ids = np.concatenate(
-            [self.rng.integers(10000, 99999, size=(20,)).astype(str) for _ in range(10)]
-        )
+            [self.rng.integers(10000, 99999, size=(20,)).astype(str) for _ in range(10)])
         dest_idxs_seq = np.arange(0, 199, 8)
-        dest_idxs_rand = self.rng.integers(0,99,size=(70))
+        dest_idxs_rand = self.rng.integers(0, 99, size=(70))
         dest_ids[dest_idxs_seq] = ''
         dest_ids[dest_idxs_rand] = ''
-        df = pd.DataFrame({
-            'source': source_ids,
-            'dest': dest_ids
-        })
+        df = pd.DataFrame({'source': source_ids, 'dest': dest_ids})
         cleaned_df = df.applymap(lambda x: x if (not isinstance(x, str) or
-                                (len(x) > 0 and not x.isspace())) else np.nan)
-        
+                                                 (len(x) > 0 and not x.isspace())) else np.nan)
+
         column_types = {'source': 'category_high_cardinality', 'dest': 'category_high_cardinality'}
         statistics = {
-            'source/count': cleaned_df['source'].count(),
-            'source/count_distinct': len(cleaned_df['source'].value_counts().index)-1,
-            'source/null_value_rate': 1 - cleaned_df['source'].count()/len(df),
-            'source/mode': cleaned_df['source'].mode(),
-            'source/mode_ratio': cleaned_df['source'].value_counts().max() / 
-                                 cleaned_df['source'].count(),
-            'dest/count': cleaned_df['dest'].count(),
-            'dest/count_distinct': len(cleaned_df['dest'].value_counts().index)-1,
-            'dest/null_value_rate': 1 - cleaned_df['dest'].count()/len(df),
-            'dest/mode': cleaned_df['dest'].mode(),
-            'dest/mode_ratio': cleaned_df['dest'].value_counts().max()  / 
-                               cleaned_df['dest'].count(),
-            'is_timeseries': False
+            'source/count':
+                cleaned_df['source'].count(),
+            'source/count_distinct':
+                len(cleaned_df['source'].value_counts().index) - 1,
+            'source/null_value_rate':
+                1 - cleaned_df['source'].count() / len(df),
+            'source/mode':
+                cleaned_df['source'].mode(),
+            'source/mode_ratio':
+                cleaned_df['source'].value_counts().max() / cleaned_df['source'].count(),
+            'dest/count':
+                cleaned_df['dest'].count(),
+            'dest/count_distinct':
+                len(cleaned_df['dest'].value_counts().index) - 1,
+            'dest/null_value_rate':
+                1 - cleaned_df['dest'].count() / len(df),
+            'dest/mode':
+                cleaned_df['dest'].mode(),
+            'dest/mode_ratio':
+                cleaned_df['dest'].value_counts().max() / cleaned_df['dest'].count(),
+            'is_timeseries':
+                False
         }
         expected_suggestions = [
             dict(
                 title='Fill in missing values',
-                message='The following columns have null-valued entries and are categorical: '
-                      '[\'source\']. '
-                      'Suggested: fill null values with a randomly sampled not null value.',
+                message='The following columns have many missing entries: '\
+                      '[\'dest\']. ' \
+                      'Suggested: fill null values with a placeholder to mark them as missing',
                 action_payload=dict(
                     action_type='impute',
-                    action_arguments=['source'],
+                    action_arguments=['dest'],
                     action_options=dict(
-                        strategy='random'
+                        strategy='constant'
                     ),
                     action_variables=dict(
-                        source=dict(
+                        dest=dict(
                             feature=dict(
                                 column_type='category_high_cardinality',
-                                uuid='source'
+                                uuid='dest'
                             ),
                             type='feature'
-                        )
+                        ),
                     ),
                     action_code='',
                     axis='column',
                     outputs=[]
                 ),
                 status='not_applied'
-            )
+            ),
+            dict(title='Fill in missing values',
+                 message='The following columns have null-valued entries and are categorical: '
+                 '[\'source\']. '
+                 'Suggested: fill null values with a randomly sampled not null value.',
+                 action_payload=dict(action_type='impute',
+                                     action_arguments=['source'],
+                                     action_options=dict(strategy='random'),
+                                     action_variables=dict(source=dict(feature=dict(
+                                         column_type='category_high_cardinality', uuid='source'),
+                                                                       type='feature')),
+                                     action_code='',
+                                     axis='column',
+                                     outputs=[]),
+                 status='not_applied'),
         ]
         df = clean_dataframe(df, column_types, dropna=False)
         suggestions = ImputeValues(
@@ -375,20 +485,9 @@ class ImputeValuesTest(TestCase):
 
     def test_row_rm(self):
         df = pd.DataFrame(
-            [
-                ['CT', '06902'],
-                ['NY', '10001'],
-                ['MI', '48841'],
-                ['CA', '95001'],
-                ['', None],
-                [None, '23456'],
-                ['CA', None],
-                ['MA', '12214'],
-                ['PA', '37821'],
-                ['TX', '75001']
-            ],
-            columns=['state', 'location']
-        )
+            [['CT', '06902'], ['NY', '10001'], ['MI', '48841'], ['CA', '95001'], ['', None],
+             [None, '23456'], ['CA', None], ['MA', '12214'], ['PA', '37821'], ['TX', '75001']],
+            columns=['state', 'location'])
         column_types = {'state': 'category', 'location': 'zip_code'}
         statistics = {
             'state/count': 8,
@@ -400,36 +499,24 @@ class ImputeValuesTest(TestCase):
             'is_timeseries': False
         }
         expected_suggestions = [
-            dict(
-                title='Remove rows with missing entries',
-                message='There are 3 rows containing null values. '
-                        'Suggested: remove these rows to remove null values from the dataset.',
-                action_payload=dict(
-                    action_type='filter',
-                    action_arguments=['state', 'location'],
-                    action_options={},
-                    action_variables=dict(
-                        state=dict(
-                            feature=dict(
-                                column_type='category',
-                                uuid='state'
-                            ),
-                            type='feature'
-                        ),
-                        location=dict(
-                            feature=dict(
-                                column_type='zip_code',
-                                uuid='location'
-                            ),
-                            type='feature'
-                        ),
-                    ),
-                    action_code='state != null and location != null',
-                    axis='row',
-                    outputs=[]
-                ),
-                status='not_applied'
-            )
+            dict(title='Remove rows with missing entries',
+                 message='There are 3 rows containing null values. '
+                 'Suggested: remove these rows to remove null values from the dataset.',
+                 action_payload=dict(action_type='filter',
+                                     action_arguments=['state', 'location'],
+                                     action_options={},
+                                     action_variables=dict(
+                                         state=dict(feature=dict(column_type='category',
+                                                                 uuid='state'),
+                                                    type='feature'),
+                                         location=dict(feature=dict(column_type='zip_code',
+                                                                    uuid='location'),
+                                                       type='feature'),
+                                     ),
+                                     action_code='state != null and location != null',
+                                     axis='row',
+                                     outputs=[]),
+                 status='not_applied')
         ]
         suggestions = ImputeValues(
             df,
@@ -439,21 +526,11 @@ class ImputeValuesTest(TestCase):
         self.assertEqual(expected_suggestions, suggestions)
 
     def test_seq(self):
-        df = pd.DataFrame(
-            [
-                ['CT', '06902', '12-24-2022'],
-                ['NY', '10001', '12-25-2022'],
-                [None, '', None],
-                ['CA', '', '12-28-2022'],
-                [None, '', '12-30-2022'],
-                ['CA', None, '12-30-2022'],
-                ['MA', '12214', '12-31-2022'],
-                ['PA', '', '1-2-2023'],
-                ['TX', '75001', '1-2-2023'],
-                ['', None, '']
-            ],
-            columns=['state', 'location', 'timestamp']
-        )
+        df = pd.DataFrame([['CT', '06902', '12-24-2022'], ['NY', '10001', '12-25-2022'],
+                           [None, '', None], ['CA', '', '12-28-2022'], [None, '', '12-30-2022'],
+                           ['CA', None, '12-30-2022'], ['MA', '12214', '12-31-2022'],
+                           ['PA', '', '1-2-2023'], ['TX', '75001', '1-2-2023'], ['', None, '']],
+                          columns=['state', 'location', 'timestamp'])
         column_types = {'state': 'category', 'location': 'zip_code', 'timestamp': 'datetime'}
         statistics = {
             'state/count': 7,
@@ -464,55 +541,36 @@ class ImputeValuesTest(TestCase):
             'location/count_distinct': 4,
             'location/null_value_rate': 0.6,
             'location/max_null_seq': 4,
-            'timestamp/null_value_rate': 1/10,
+            'timestamp/null_value_rate': 1 / 10,
             'timestamp/max_null_seq': 1,
             'is_timeseries': True,
             'timeseries_index': ['timestamp']
         }
         expected_suggestions = [
-            dict(
-                title='Fill in missing values',
-                message='The following columns have null-valued entries which '
-                        'may be part of timeseries data: '
-                        '[\'state\', \'location\', \'timestamp\']. '
-                        'Suggested: fill null values with previously occurring '
-                        'value in timeseries.',
-                action_payload=dict(
-                    action_type='impute',
-                    action_arguments=['state', 'location', 'timestamp'],
-                    action_options=dict(
-                        strategy='sequential',
-                        timeseries_index=['timestamp']
-                    ),
-                    action_variables=dict(
-                        state=dict(
-                            feature=dict(
-                                column_type='category',
-                                uuid='state'
-                            ),
-                            type='feature'
-                        ),
-                        location=dict(
-                            feature=dict(
-                                column_type='zip_code',
-                                uuid='location'
-                            ),
-                            type='feature'
-                        ),
-                        timestamp=dict(
-                            feature=dict(
-                                column_type='datetime',
-                                uuid='timestamp'
-                            ),
-                            type='feature'
-                        )
-                    ),
-                    action_code='',
-                    axis='column',
-                    outputs=[]
-                ),
-                status='not_applied'
-            )
+            dict(title='Fill in missing values',
+                 message='The following columns have null-valued entries which '
+                 'may be part of timeseries data: '
+                 '[\'state\', \'location\', \'timestamp\']. '
+                 'Suggested: fill null values with previously occurring '
+                 'value in timeseries.',
+                 action_payload=dict(action_type='impute',
+                                     action_arguments=['state', 'location', 'timestamp'],
+                                     action_options=dict(strategy='sequential',
+                                                         timeseries_index=['timestamp']),
+                                     action_variables=dict(
+                                         state=dict(feature=dict(column_type='category',
+                                                                 uuid='state'),
+                                                    type='feature'),
+                                         location=dict(feature=dict(column_type='zip_code',
+                                                                    uuid='location'),
+                                                       type='feature'),
+                                         timestamp=dict(feature=dict(column_type='datetime',
+                                                                     uuid='timestamp'),
+                                                        type='feature')),
+                                     action_code='',
+                                     axis='column',
+                                     outputs=[]),
+                 status='not_applied')
         ]
         suggestions = ImputeValues(
             df,
@@ -523,74 +581,50 @@ class ImputeValuesTest(TestCase):
 
     def test_seq_edge(self):
         df = pd.DataFrame(
-            [
-                ['MI', '32453', '12-26-2022'],
-                ['CA', '', '12-28-2022'],
-                ['', None, '12-28-2022'],
-                ['MA', '12214', '12-31-2022'],
-                ['PA', '', '1-2-2023'],
-                ['TX', '75001', '1-2-2023'],
-                ['CT', '06902', '12-24-2022'],
-                ['NY', '10001', '12-25-2022'],
-                [None, '', '12-30-2022'],
-                ['CA', None, '12-30-2022']
-            ],
-            columns=['state', 'location', 'timestamp']
-        )
+            [['MI', '32453', '12-26-2022'], ['CA', '', '12-28-2022'], ['', None, '12-28-2022'],
+             ['MA', '12214', '12-31-2022'], ['PA', '', '1-2-2023'], ['TX', '75001', '1-2-2023'],
+             ['CT', '06902', '12-24-2022'], ['NY', '10001', '12-25-2022'], [None, '', '12-30-2022'],
+             ['CA', None, '12-30-2022']],
+            columns=['state', 'location', 'timestamp'])
         column_types = {'state': 'category', 'location': 'zip_code', 'timestamp': 'datetime'}
         statistics = {
             'state/count': 7,
             'state/count_distinct': 6,
             'state/null_value_rate': 0.4,
             'state/max_null_seq': 1,
-            'state/mode_ratio': 2/7,
+            'state/mode_ratio': 2 / 7,
             'location/count': 4,
             'location/count_distinct': 4,
             'location/null_value_rate': 0.6,
             'location/max_null_seq': 3,
-            'location/mode_ratio': 1/4,
+            'location/mode_ratio': 1 / 4,
             'timestamp/null_value_rate': 0,
             'timestamp/max_null_seq': 0,
-            'timestamp/mode_ratio': 1/10,
+            'timestamp/mode_ratio': 1 / 10,
             'is_timeseries': True,
             'timeseries_index': ['timestamp']
         }
         expected_suggestions = [
-            dict(
-                title='Fill in missing values',
-                message='The following columns have null-valued entries which '
-                        'may be part of timeseries data: [\'state\', \'location\']. '
-                        'Suggested: fill null values with previously occurring '
-                        'value in timeseries.',
-                action_payload=dict(
-                    action_type='impute',
-                    action_arguments=['state', 'location'],
-                    action_options=dict(
-                        strategy='sequential',
-                        timeseries_index=['timestamp']
-                    ),
-                    action_variables=dict(
-                        state=dict(
-                            feature=dict(
-                                column_type='category',
-                                uuid='state'
-                            ),
-                            type='feature'
-                        ),
-                        location=dict(
-                            feature=dict(
-                                column_type='zip_code',
-                                uuid='location'
-                            ),
-                            type='feature'
-                        )
-                    ),
-                    action_code='',
-                    axis='column',
-                    outputs=[]
-                ),
-                status='not_applied'
-            )
+            dict(title='Fill in missing values',
+                 message='The following columns have null-valued entries which '
+                 'may be part of timeseries data: [\'state\', \'location\']. '
+                 'Suggested: fill null values with previously occurring '
+                 'value in timeseries.',
+                 action_payload=dict(action_type='impute',
+                                     action_arguments=['state', 'location'],
+                                     action_options=dict(strategy='sequential',
+                                                         timeseries_index=['timestamp']),
+                                     action_variables=dict(
+                                         state=dict(feature=dict(column_type='category',
+                                                                 uuid='state'),
+                                                    type='feature'),
+                                         location=dict(feature=dict(column_type='zip_code',
+                                                                    uuid='location'),
+                                                       type='feature')),
+                                     action_code='',
+                                     axis='column',
+                                     outputs=[]),
+                 status='not_applied')
         ]
         df = clean_dataframe(df, column_types, dropna=False)
         suggestions = ImputeValues(

--- a/mage_ai/tests/data_cleaner/statistics/test_calculator.py
+++ b/mage_ai/tests/data_cleaner/statistics/test_calculator.py
@@ -4,26 +4,29 @@ import pandas as pd
 
 
 class StatisticsCalculatorTest(TestCase):
-
     def test_calculate_statistics_overview(self):
-        calculator = StatisticsCalculator(column_types=dict(
-            age='number',
-            country='category',
-            date_joined='datetime',
-            id='number',
-            cancelled='true_or_false',
-        ),)
+        calculator = StatisticsCalculator(
+            column_types=dict(
+                age='number',
+                country='category',
+                date_joined='datetime',
+                id='number',
+                cancelled='true_or_false',
+            )
+        )
 
-        df = pd.DataFrame([
-            [1, 'JP', '2000-01-01', '1', False],
-            [2, 'KO', '2000-12-01', '2', False],
-            [1, 'US', '2000-07-01 00:00:00+00:00', '3', False],
-            [' ', 'US', '2000-07-01 00:00:00+00:00', '4', False],
-            [1, None, '2000-07-01 00:00:00+00:00', '5', False],
-            ['', None, '899-07-01 00:00:00+00:00', '6', False],
-            [3, 'US', None, '7', True],
-        ],
-                          columns=['age', 'country', 'date_joined', 'id', 'cancelled'])
+        df = pd.DataFrame(
+            [
+                [1, 'JP', '2000-01-01', '1', False],
+                [2, 'KO', '2000-12-01', '2', False],
+                [1, 'US', '2000-07-01 00:00:00+00:00', '3', False],
+                [' ', 'US', '2000-07-01 00:00:00+00:00', '4', False],
+                [1, None, '2000-07-01 00:00:00+00:00', '5', False],
+                ['', None, '899-07-01 00:00:00+00:00', '6', False],
+                [3, 'US', None, '7', True],
+            ],
+            columns=['age', 'country', 'date_joined', 'id', 'cancelled'],
+        )
 
         data = calculator.calculate_statistics_overview(df, is_clean=False)
 
@@ -70,7 +73,7 @@ class StatisticsCalculatorTest(TestCase):
         self.assertEqual(data['cancelled/quality'], 'Good')
 
     def test_calculate_statistics_overview_divide_by_zero(self):
-        calculator = StatisticsCalculator(column_types=dict(age='number',),)
+        calculator = StatisticsCalculator(column_types=dict(age='number'))
 
         df = pd.DataFrame([], columns=['age'])
         data = calculator.calculate_statistics_overview(df, is_clean=False)

--- a/mage_ai/tests/data_cleaner/statistics/test_calculator.py
+++ b/mage_ai/tests/data_cleaner/statistics/test_calculator.py
@@ -48,15 +48,15 @@ class StatisticsCalculatorTest(TestCase):
         self.assertEqual(data['country/completeness'], 1 - data['country/null_value_rate'])
         self.assertEqual(data['country/quality'], 'Bad')
 
-        self.assertEqual(data['date_joined/count'], 6)
+        self.assertEqual(data['date_joined/count'], 5)
         self.assertEqual(data['date_joined/count_distinct'], 4)
         self.assertEqual(data['date_joined/max'], '2000-12-01T00:00:00+00:00')
         self.assertEqual(data['date_joined/median'], '2000-07-01T00:00:00+00:00')
         self.assertEqual(data['date_joined/min'], '2000-01-01T00:00:00+00:00')
         self.assertEqual(data['date_joined/mode'], '2000-07-01T00:00:00+00:00')
-        self.assertEqual(data['date_joined/null_value_rate'], 1/7)
+        self.assertEqual(data['date_joined/null_value_rate'], 2/7)
         self.assertEqual(data['date_joined/completeness'], 1 - data['date_joined/null_value_rate'])
-        self.assertEqual(data['date_joined/quality'], 'Good')
+        self.assertEqual(data['date_joined/quality'], 'Bad')
 
         self.assertEqual(data['id/count'], 7)
         self.assertEqual(data['id/count_distinct'], 7)

--- a/mage_ai/tests/data_cleaner/statistics/test_calculator.py
+++ b/mage_ai/tests/data_cleaner/statistics/test_calculator.py
@@ -1,6 +1,7 @@
 from mage_ai.data_cleaner.statistics.calculator import StatisticsCalculator
 from mage_ai.tests.base_test import TestCase
 import pandas as pd
+import numpy as np
 
 
 class StatisticsCalculatorTest(TestCase):
@@ -12,7 +13,7 @@ class StatisticsCalculatorTest(TestCase):
                 date_joined='datetime',
                 id='number',
                 cancelled='true_or_false',
-            )
+            ),
         )
 
         df = pd.DataFrame(
@@ -52,7 +53,7 @@ class StatisticsCalculatorTest(TestCase):
         self.assertEqual(data['country/quality'], 'Bad')
 
         self.assertEqual(data['date_joined/count'], 5)
-        self.assertEqual(data['date_joined/count_distinct'], 4)
+        self.assertEqual(data['date_joined/count_distinct'], 3)
         self.assertEqual(data['date_joined/max'], '2000-12-01T00:00:00+00:00')
         self.assertEqual(data['date_joined/median'], '2000-07-01T00:00:00+00:00')
         self.assertEqual(data['date_joined/min'], '2000-01-01T00:00:00+00:00')
@@ -72,8 +73,80 @@ class StatisticsCalculatorTest(TestCase):
         self.assertEqual(data['cancelled/completeness'], 1)
         self.assertEqual(data['cancelled/quality'], 'Good')
 
+    def test_calculate_statistics_overview_no_cleaning(self):
+        calculator = StatisticsCalculator(
+            column_types=dict(
+                age='number',
+                country='category',
+                date_joined='datetime',
+                id='number',
+                cancelled='true_or_false',
+            ),
+        )
+
+        df = pd.DataFrame(
+            [
+                [1, 'JP', '2000-01-01', 1, False],
+                [2, 'KO', '2000-12-01', 2, False],
+                [1, 'US', '2000-07-01 00:00:00+00:00', 3, False],
+                [np.nan, 'US', '2000-07-01 00:00:00+00:00', 4, False],
+                [1, None, '2000-07-01 00:00:00+00:00', 5, False],
+                [np.nan, None, '899-07-01 00:00:00+00:00', 6, False],
+                [3, 'US', None, 7, True],
+            ],
+            columns=['age', 'country', 'date_joined', 'id', 'cancelled'],
+        )
+
+        data = calculator.calculate_statistics_overview(df, is_clean=True)
+
+        self.assertEqual(data['count'], 7)
+        self.assertEqual(data['total_null_value_count'], 5)
+
+        self.assertEqual(data['age/average'], 8 / 5)
+        self.assertEqual(data['age/count'], 5)
+        self.assertEqual(data['age/count_distinct'], 3)
+        self.assertEqual(data['age/max'], 3)
+        self.assertEqual(data['age/median'], 1)
+        self.assertEqual(data['age/min'], 1)
+        self.assertEqual(data['age/sum'], 8)
+        self.assertEqual(data['age/null_value_rate'], 2 / 7)
+        self.assertEqual(data['age/completeness'], 1 - data['age/null_value_rate'])
+        self.assertEqual(data['age/quality'], 'Bad')
+
+        self.assertEqual(data['country/count'], 5)
+        self.assertEqual(data['country/count_distinct'], 3)
+        self.assertEqual(data['country/mode'], 'US')
+        self.assertEqual(data['country/null_value_rate'], 2 / 7)
+        self.assertEqual(data['country/completeness'], 1 - data['country/null_value_rate'])
+        self.assertEqual(data['country/quality'], 'Bad')
+
+        self.assertEqual(data['date_joined/count'], 6)
+        self.assertEqual(data['date_joined/count_distinct'], 4)
+        self.assertEqual(data['date_joined/max'], '2000-12-01T00:00:00+00:00')
+        self.assertEqual(data['date_joined/median'], '2000-07-01T00:00:00+00:00')
+        self.assertEqual(data['date_joined/min'], '2000-01-01T00:00:00+00:00')
+        self.assertEqual(data['date_joined/mode'], '2000-07-01T00:00:00+00:00')
+        self.assertEqual(data['date_joined/null_value_rate'], 1 / 7)
+        self.assertEqual(data['date_joined/completeness'], 1 - data['date_joined/null_value_rate'])
+        self.assertEqual(data['date_joined/quality'], 'Good')
+
+        self.assertEqual(data['id/count'], 7)
+        self.assertEqual(data['id/count_distinct'], 7)
+        self.assertEqual(data['id/null_value_rate'], 0)
+        self.assertEqual(data['id/completeness'], 1)
+        self.assertEqual(data['id/quality'], 'Good')
+
+        self.assertEqual(data['cancelled/mode'], False)
+        self.assertEqual(data['cancelled/null_value_rate'], 0)
+        self.assertEqual(data['cancelled/completeness'], 1)
+        self.assertEqual(data['cancelled/quality'], 'Good')
+
     def test_calculate_statistics_overview_divide_by_zero(self):
-        calculator = StatisticsCalculator(column_types=dict(age='number'))
+        calculator = StatisticsCalculator(
+            column_types=dict(
+                age='number',
+            ),
+        )
 
         df = pd.DataFrame([], columns=['age'])
         data = calculator.calculate_statistics_overview(df, is_clean=False)

--- a/mage_ai/tests/data_cleaner/statistics/test_calculator.py
+++ b/mage_ai/tests/data_cleaner/statistics/test_calculator.py
@@ -4,16 +4,15 @@ import pandas as pd
 
 
 class StatisticsCalculatorTest(TestCase):
+
     def test_calculate_statistics_overview(self):
-        calculator = StatisticsCalculator(
-            column_types=dict(
-                age='number',
-                country='category',
-                date_joined='datetime',
-                id='number',
-                cancelled='true_or_false',
-            ),
-        )
+        calculator = StatisticsCalculator(column_types=dict(
+            age='number',
+            country='category',
+            date_joined='datetime',
+            id='number',
+            cancelled='true_or_false',
+        ),)
 
         df = pd.DataFrame([
             [1, 'JP', '2000-01-01', '1', False],
@@ -23,12 +22,13 @@ class StatisticsCalculatorTest(TestCase):
             [1, None, '2000-07-01 00:00:00+00:00', '5', False],
             ['', None, '899-07-01 00:00:00+00:00', '6', False],
             [3, 'US', None, '7', True],
-        ], columns=['age', 'country', 'date_joined', 'id', 'cancelled'])
+        ],
+                          columns=['age', 'country', 'date_joined', 'id', 'cancelled'])
 
         data = calculator.calculate_statistics_overview(df, is_clean=False)
 
         self.assertEqual(data['count'], 7)
-        self.assertEqual(data['total_null_value_count'], 5)
+        self.assertEqual(data['total_null_value_count'], 6)
 
         self.assertEqual(data['age/average'], 8 / 5)
         self.assertEqual(data['age/count'], 5)
@@ -37,14 +37,14 @@ class StatisticsCalculatorTest(TestCase):
         self.assertEqual(data['age/median'], 1)
         self.assertEqual(data['age/min'], 1)
         self.assertEqual(data['age/sum'], 8)
-        self.assertEqual(data['age/null_value_rate'], 2/7)
+        self.assertEqual(data['age/null_value_rate'], 2 / 7)
         self.assertEqual(data['age/completeness'], 1 - data['age/null_value_rate'])
         self.assertEqual(data['age/quality'], 'Bad')
 
         self.assertEqual(data['country/count'], 5)
         self.assertEqual(data['country/count_distinct'], 3)
         self.assertEqual(data['country/mode'], 'US')
-        self.assertEqual(data['country/null_value_rate'], 2/7)
+        self.assertEqual(data['country/null_value_rate'], 2 / 7)
         self.assertEqual(data['country/completeness'], 1 - data['country/null_value_rate'])
         self.assertEqual(data['country/quality'], 'Bad')
 
@@ -54,7 +54,7 @@ class StatisticsCalculatorTest(TestCase):
         self.assertEqual(data['date_joined/median'], '2000-07-01T00:00:00+00:00')
         self.assertEqual(data['date_joined/min'], '2000-01-01T00:00:00+00:00')
         self.assertEqual(data['date_joined/mode'], '2000-07-01T00:00:00+00:00')
-        self.assertEqual(data['date_joined/null_value_rate'], 2/7)
+        self.assertEqual(data['date_joined/null_value_rate'], 2 / 7)
         self.assertEqual(data['date_joined/completeness'], 1 - data['date_joined/null_value_rate'])
         self.assertEqual(data['date_joined/quality'], 'Bad')
 
@@ -70,11 +70,7 @@ class StatisticsCalculatorTest(TestCase):
         self.assertEqual(data['cancelled/quality'], 'Good')
 
     def test_calculate_statistics_overview_divide_by_zero(self):
-        calculator = StatisticsCalculator(
-            column_types=dict(
-                age='number',
-            ),
-        )
+        calculator = StatisticsCalculator(column_types=dict(age='number',),)
 
         df = pd.DataFrame([], columns=['age'])
         data = calculator.calculate_statistics_overview(df, is_clean=False)

--- a/mage_ai/tests/data_cleaner/transformer_actions/test_column.py
+++ b/mage_ai/tests/data_cleaner/transformer_actions/test_column.py
@@ -1695,6 +1695,52 @@ class ColumnTests(TestCase):
         df_new['group_churned_at'] = df_new['group_churned_at'].astype(np.datetime64)
         assert_frame_equal(df_new, df_expected)
 
+    def test_impute_constant_with_value(self):
+        from mage_ai.data_cleaner.transformer_actions.column import impute
+        df = pd.DataFrame([
+            [1, 1.000, '2021-10-01', 'Store 1', 23023],
+            [1, None, '2021-10-01', 'Store 2', np.nan],
+            [np.nan, 1100, '', '', 90233],
+            [2, None, None, 'Store 1', 23920],
+            [2, 12.00, '2021-09-01', None, np.nan],
+            [2, 125.0, '2021-09-01', 'Store 3', 49833]
+        ], columns=[
+            'group_id',
+            'price',
+            'group_churned_at',
+            'store',
+            'zip_code',
+        ])
+        action = dict(
+            action_arguments=['group_id',
+                'price',
+                'group_churned_at',
+                'store',
+                'zip_code'
+            ],
+            action_options={
+                'strategy': 'constant',
+                'value': 'test'
+            },
+            action_variables={},
+        )
+        df_expected = pd.DataFrame([
+            [1, 1.000, '2021-10-01', 'Store 1', 23023],
+            [1, 'test', '2021-10-01', 'Store 2', 'test'],
+            ['test', 1100, 'test', 'test', 90233],
+            [2, 'test', 'test', 'Store 1', 23920],
+            [2, 12.00, '2021-09-01', 'test', 'test'],
+            [2, 125.0, '2021-09-01', 'Store 3', 49833],
+        ], columns=[
+            'group_id',
+            'price',
+            'group_churned_at',
+            'store',
+            'zip_code',
+        ])
+        df_new = impute(df, action).reset_index(drop=True)
+        assert_frame_equal(df_new, df_expected)
+
     def test_impute_sequential_two_idx(self):
         from mage_ai.data_cleaner.transformer_actions.column import impute
         df = pd.DataFrame([

--- a/mage_ai/tests/data_cleaner/transformer_actions/test_column.py
+++ b/mage_ai/tests/data_cleaner/transformer_actions/test_column.py
@@ -1678,8 +1678,8 @@ class ColumnTests(TestCase):
         df_expected = pd.DataFrame([
             [1, 1.000, '2021-10-01', 'Store 1', 23023],
             [1, 0.0, '2021-10-01', 'Store 2', 'missing'],
-            [0, 1100, pd.NaT, 'missing', 90233],
-            [2, 0.0, pd.NaT, 'Store 1', 23920],
+            [0, 1100, pd.Timestamp.min, 'missing', 90233],
+            [2, 0.0, pd.Timestamp.min, 'Store 1', 23920],
             [2, 12.00, '2021-09-01', 'missing', 'missing'],
             [2, 125.0, '2021-09-01', 'Store 3', 49833],
         ], columns=[

--- a/mage_ai/tests/data_cleaner/transformer_actions/test_column.py
+++ b/mage_ai/tests/data_cleaner/transformer_actions/test_column.py
@@ -1273,14 +1273,14 @@ class ColumnTests(TestCase):
                 'value': '0',
             },
             action_variables={
-                '0': {
+                'sold': {
                     'feature': {
                         'column_type': 'number',
                         'uuid': 'sold',
                     },
                     'type': 'feature',
                 },
-                '1': {
+                'curr_profit': {
                     'feature': {
                         'column_type': 'number',
                         'uuid': 'curr_profit',
@@ -1295,10 +1295,17 @@ class ColumnTests(TestCase):
                 'value': '0',
             },
             action_variables={
-                '0': {
+                'sold': {
                     'feature': {
                         'column_type': 'number',
                         'uuid': 'sold',
+                    },
+                    'type': 'feature',
+                },
+                'curr_profit': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'curr_profit',
                     },
                     'type': 'feature',
                 },
@@ -1309,11 +1316,43 @@ class ColumnTests(TestCase):
             action_options={
                 'strategy': 'average',
             },
+            action_variables={
+                'sold': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'sold',
+                    },
+                    'type': 'feature',
+                },
+                'curr_profit': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'curr_profit',
+                    },
+                    'type': 'feature',
+                },
+            },
         )
         action4 = dict(
             action_arguments=['sold', 'curr_profit'],
             action_options={
                 'strategy': 'median',
+            },
+            action_variables={
+                'sold': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'sold',
+                    },
+                    'type': 'feature',
+                },
+                'curr_profit': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'curr_profit',
+                    },
+                    'type': 'feature',
+                },
             },
         )
         action5 = dict(
@@ -1322,6 +1361,22 @@ class ColumnTests(TestCase):
                 'strategy': 'column',
                 'value': 'prev_sold',
             },
+            action_variables={
+                'sold': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'sold',
+                    },
+                    'type': 'feature',
+                },
+                'curr_profit': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'curr_profit',
+                    },
+                    'type': 'feature',
+                },
+            },
         )
         action6 = dict(
             action_arguments=['sold', 'curr_profit'],
@@ -1329,11 +1384,43 @@ class ColumnTests(TestCase):
                 'strategy': 'sequential',
                 'timeseries_index': ['date']
             },
+            action_variables={
+                'sold': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'sold',
+                    },
+                    'type': 'feature',
+                },
+                'curr_profit': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'curr_profit',
+                    },
+                    'type': 'feature',
+                },
+            },
         )
         action7 = dict(
             action_arguments=['sold', 'curr_profit'],
             action_options={
                 'strategy': 'random'
+            },
+            action_variables={
+                'sold': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'sold',
+                    },
+                    'type': 'feature',
+                },
+                'curr_profit': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'curr_profit',
+                    },
+                    'type': 'feature',
+                },
             },
         )
         action8 = dict(
@@ -1341,11 +1428,43 @@ class ColumnTests(TestCase):
             action_options={
                 'strategy': 'mode'
             },
+            action_variables={
+                'sold': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'sold',
+                    },
+                    'type': 'feature',
+                },
+                'curr_profit': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'curr_profit',
+                    },
+                    'type': 'feature',
+                },
+            },
         )
         action_invalid = dict(
             action_arguments=['sold', 'curr_profit'],
             action_options={
                 'strategy': 'knn',
+            },
+            action_variables={
+                'sold': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'sold',
+                    },
+                    'type': 'feature',
+                },
+                'curr_profit': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'curr_profit',
+                    },
+                    'type': 'feature',
+                },
             },
         )
         df_new1 = impute(df.copy(), action1)
@@ -1418,8 +1537,8 @@ class ColumnTests(TestCase):
             'prev_sold',
         ])
         df_expected6 = pd.DataFrame([
-            ['2020-01-01', 1000, None, 800],
-            ['2020-01-02', 1000, None, 700],
+            ['2020-01-01', 1000, 0, 800],
+            ['2020-01-02', 1000, 0, 700],
             ['2020-01-03', 1000, 1200, 700],
             ['2020-01-04', 1700, 1300, 800],
             ['2020-01-05', 1200, 1300, 900],
@@ -1441,7 +1560,7 @@ class ColumnTests(TestCase):
             'curr_profit',
             'prev_sold',
         ])
-        
+
         df_new1['sold'] = df_new1['sold'].astype(int)
         df_new1['curr_profit'] = df_new1['curr_profit'].astype(int)
         df_new2['sold'] = df_new2['sold'].astype(int)
@@ -1465,7 +1584,7 @@ class ColumnTests(TestCase):
         assert_frame_equal(df_new6, df_expected6)
         assert_frame_equal(df_new7, df_new7.dropna(axis=0))
         assert_frame_equal(df_new8, df_expected8)
-        
+
         with self.assertRaises(Exception):
             _ = impute(df.copy(), action_invalid)
 
@@ -1492,6 +1611,90 @@ class ColumnTests(TestCase):
         with self.assertRaises(Exception):
             _ = impute(df.copy(), action)
 
+    def test_impute_constant(self):
+        from mage_ai.data_cleaner.transformer_actions.column import impute
+        df = pd.DataFrame([
+            [1, 1.000, '2021-10-01', 'Store 1', 23023],
+            [1, None, '2021-10-01', 'Store 2', np.nan],
+            [np.nan, 1100, '', '', 90233],
+            [2, None, None, 'Store 1', 23920],
+            [2, 12.00, '2021-09-01', None, np.nan],
+            [2, 125.0, '2021-09-01', 'Store 3', 49833]
+        ], columns=[
+            'group_id',
+            'price',
+            'group_churned_at',
+            'store',
+            'zip_code',
+        ])
+        action = dict(
+            action_arguments=['group_id',
+                'price',
+                'group_churned_at',
+                'store',
+                'zip_code'
+            ],
+            action_options={
+                'strategy': 'constant',
+            },
+            action_variables={
+                'group_id': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'group_id',
+                    },
+                    'type': 'feature',
+                },
+                'price': {
+                    'feature': {
+                        'column_type': 'number_with_decimals',
+                        'uuid': 'price',
+                    },
+                    'type': 'feature',
+                },
+                'group_churned_at': {
+                    'feature': {
+                        'column_type': 'datetime',
+                        'uuid': 'group_churned_at',
+                    },
+                    'type': 'feature',
+                },
+                'store': {
+                    'feature': {
+                        'column_type': 'category',
+                        'uuid': 'store',
+                    },
+                    'type': 'feature',
+                },
+                'zip_code': {
+                    'feature': {
+                        'column_type': 'zip_code',
+                        'uuid': 'zip_code',
+                    },
+                    'type': 'feature',
+                },
+            },
+        )
+        df_expected = pd.DataFrame([
+            [1, 1.000, '2021-10-01', 'Store 1', 23023],
+            [1, 0.0, '2021-10-01', 'Store 2', 'missing'],
+            [0, 1100, pd.NaT, 'missing', 90233],
+            [2, 0.0, pd.NaT, 'Store 1', 23920],
+            [2, 12.00, '2021-09-01', 'missing', 'missing'],
+            [2, 125.0, '2021-09-01', 'Store 3', 49833],
+        ], columns=[
+            'group_id',
+            'price',
+            'group_churned_at',
+            'store',
+            'zip_code',
+        ])
+        df_new = impute(df, action).reset_index(drop=True)
+        df_new['group_id'] = df_new['group_id'].astype(int)
+        df_new['price'] = df_new['price'].astype(float)
+        df_new['group_churned_at'] = df_new['group_churned_at'].astype(np.datetime64)
+        assert_frame_equal(df_new, df_expected)
+
     def test_impute_sequential_two_idx(self):
         from mage_ai.data_cleaner.transformer_actions.column import impute
         df = pd.DataFrame([
@@ -1514,9 +1717,46 @@ class ColumnTests(TestCase):
                 'strategy': 'sequential',
                 'timeseries_index': ['group_churned_at', 'order_created_at']
             },
+            action_variables={
+                'group_id': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'group_id',
+                    },
+                    'type': 'feature',
+                },
+                'order_id': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'order_id',
+                    },
+                    'type': 'feature',
+                },
+                'group_churned_at': {
+                    'feature': {
+                        'column_type': 'datetime',
+                        'uuid': 'group_churned_at',
+                    },
+                    'type': 'feature',
+                },
+                'order_created_at': {
+                    'feature': {
+                        'column_type': 'datetime',
+                        'uuid': 'order_created_at',
+                    },
+                    'type': 'feature',
+                },
+                'order_count': {
+                    'feature': {
+                        'column_type': 'number',
+                        'uuid': 'order_count',
+                    },
+                    'type': 'feature',
+                },
+            },
         )
         df_expected = pd.DataFrame([
-            [2, None, '2021-09-01', '2021-08-01', 2],
+            [2, 0, '2021-09-01', '2021-08-01', 2],
             [2, 1250, '2021-09-01', '2021-08-14', 2],
             [2, 1200, '2021-09-01', '2021-08-16', 2],
             [2, 1100, '2021-10-01', '2021-01-01', 2],


### PR DESCRIPTION
# Summary
Default imputation strategy is to now fill missing entries with some non-null marker that represents the missing value. By type, these markers are:
- Category/String: `'missing'`
- Datetime: `pd.Timestamp.min` (1677-09-21 00:12:43.145224193)
- Number: `0`

Along with these changes relevant bug fixes were made to other parts of the program.

# Tests
Changes were tested locally against unit tests alongside more rigorous testing on sample testing datasets.

cc:
@wangxiaoyou1993 
