### PR TITLE
[xy] Support killing a flask app.

### DIFF
--- a/mage_ai/__init__.py
+++ b/mage_ai/__init__.py
@@ -1,6 +1,11 @@
 from IPython import get_ipython
 from IPython.display import IFrame, Javascript, display
-from mage_ai.server.app import clean_df, connect_df, launch as launch_flask
+from mage_ai.server.app import (
+    clean_df,
+    connect_df,
+    kill as kill_flask,
+    launch as launch_flask,
+)
 from mage_ai.server.constants import SERVER_PORT
 
 IFRAME_HEIGHT = 1000
@@ -8,8 +13,13 @@ MAX_NUM_OF_ROWS = 100_000
 
 
 def launch():
-    launch_flask()
+    thread = launch_flask()
     display_inline_iframe()
+    return thread
+
+
+def kill():
+    kill_flask()
 
 
 def display_inline_iframe():


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Support killing a flask app.

```
import mage_ai

# Launch server
mage_ai.launch()

# Kill server
mage_ai.kill()
```
Reference: https://www.geeksforgeeks.org/python-different-ways-to-kill-a-thread/

# Tests
<!-- How did you test your change? -->
tested locally
<img width="431" alt="image" src="https://user-images.githubusercontent.com/80284865/171694719-1e74f8fb-831d-4d86-94ac-dad5a7112731.png">


cc:
<!-- Optionally mention someone to let them know about this pull request -->
