### PR TITLE
[xy] Calculate correlation for number types.

### DIFF
--- a/mage_ai/data_cleaner/analysis/calculator.py
+++ b/mage_ai/data_cleaner/analysis/calculator.py
@@ -16,6 +16,7 @@ from mage_ai.data_cleaner.column_type_detector import (
     NUMBER_WITH_DECIMALS,
     TRUE_OR_FALSE,
 )
+from pandas.api.types import is_numeric_dtype
 
 DD_KEY = 'lambda.analysis_calculator'
 
@@ -112,7 +113,7 @@ class AnalysisCalculator():
         correlation = []
         time_series = []
 
-        if column_type in [NUMBER, NUMBER_WITH_DECIMALS]:
+        if column_type in [NUMBER, NUMBER_WITH_DECIMALS] or is_numeric_dtype(df[col]):
             with timer(
                 'analysis.calculate_column.build_histogram_data',
                 dict(feature=feature),


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Calculate correlation for number types. For some number columns with 2 values, the columns are detected as type true_or_false. Thus, the correlation was not calculated. This PR fixes this issue.

# Tests
<!-- How did you test your change? -->
tested locally
<img width="481" alt="image" src="https://user-images.githubusercontent.com/80284865/171812113-c7f03db3-bd0f-4f07-ad47-df8e5ec4d4c3.png">


cc:
<!-- Optionally mention someone to let them know about this pull request -->
