### PR TITLE
[nt]  oracle basetable polish

### DIFF
--- a/mage_ai/frontend/components/datasets/overview/index.tsx
+++ b/mage_ai/frontend/components/datasets/overview/index.tsx
@@ -61,7 +61,9 @@ function DatasetOverview({
   const {
     column_types: colTypes,
   } = featureSet?.metadata || {};
-
+  const {
+    header_types: headerTypes,
+  } = featureSet?.metadata?.column_types || {};
   const features: FeatureType[] = Object.entries(featureSet?.metadata?.column_types || {})
     .map(([k, v]: [string, ColumnTypeEnum]) => ({ columnType: v, uuid: k }));
 
@@ -218,9 +220,10 @@ function DatasetOverview({
         <Tab key="data" label="Data">
           <Spacing mb={3} mt={3} />
           <BaseTable
-            columnHeaders={columnHeaderSample}
-            columnTitles={columns}
-            rowGroupData={rows}
+            columns={columnHeaderSample}
+            data={rows}
+            datatype={headerTypes}
+            titles={columns}
           />
         </Tab>
         <Tab key="reports" label="Reports">

--- a/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
@@ -138,7 +138,7 @@ import { cutTextSize, getColumnWidth } from './helpers';
                 >
                   {/* <RowCellStyle width={totalColumnsWidth}> */}
                   <TextStyle>
-                    <Text bold>
+                    <Text bold leftAligned>
                       {column.render('Header')}
                     </Text>
                   </TextStyle>

--- a/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
@@ -26,6 +26,7 @@ import { cutTextSize, getColumnWidth } from './helpers';
 
   const [column, setColumn] = useState([]);
   const [row, setRow] = useState([]);
+  let stripes = true;
 
   // Keep these samples in due to undefined errors.
   const dataSample = useMemo(
@@ -151,8 +152,9 @@ import { cutTextSize, getColumnWidth } from './helpers';
         </thead>
         {/* Rows: relative, overflow, black text, borders on everything but bottom except for last, skip bg */}
         <tbody {...getTableBodyProps()}>
-          {rows.map(row => {
+          { rows.map(row => {
               prepareRow(row);
+              stripes = !stripes;
               return (
                 // eslint-disable-next-line react/jsx-key
                 <tr {...row.getRowProps()}>
@@ -161,7 +163,7 @@ import { cutTextSize, getColumnWidth } from './helpers';
                     <td
                       {...cell.getCellProps()}
                       style={{
-                        background: '#FBFCFD',
+                        background: stripes ? '#F9FAFC' : '#FBFCFD',
                         border: 'solid 1px #FBFCFD',
                         borderLeft: 'none',
                         borderRight: 'none',

--- a/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
@@ -12,6 +12,8 @@ import { cutTextSize, getColumnWidth } from './helpers';
     children?: any;
     columns: DataTableColumn[];
     data: DataTableRow<any>[];
+    titles: string[];
+    datatype: string[];
   };
 
   export type rowMapping = {
@@ -19,9 +21,10 @@ import { cutTextSize, getColumnWidth } from './helpers';
   };
 
   function BaseTable({
-    columnHeaders,
-    rowGroupData,
-    columnTitles,
+    columns,
+    data,
+    titles,
+    datatype,
   }: any) {
 
   const [column, setColumn] = useState([]);
@@ -62,28 +65,28 @@ import { cutTextSize, getColumnWidth } from './helpers';
   );
 
   useEffect(() => {
-    if (columnHeaders) {
+    if (columns) {
       const headers = [];
-      columnHeaders.map(({ label='none' }: any, i: string | number) => {
+      columns.map(({ label='none' }: any, i: string | number) => {
         const rowValues =
           {
-            Header: cutTextSize(label),
-            accessor: columnTitles[i],
+            Header: (datatype) ? `${cutTextSize(label)} (${datatype[i]})` : cutTextSize(label),
+            accessor: titles[i],
           };
         headers.push(rowValues);
       });
       setColumn(headers);
     }
-  }, [columnHeaders, columnTitles]);
+  }, [columns, titles, datatype]);
 
     useEffect(() => {
-      if (rowGroupData) {
+      if (data) {
         const values = [];
-        rowGroupData.map((rows: any[]) => {
+        data.map((rows: any[]) => {
 
           const rowValues:rowMapping = {};
           rows.map((cell, j) => {
-            const key = columnTitles[j];
+            const key = titles[j];
             !(key in rowValues) && (rowValues.key = {});
             rowValues[key] = cutTextSize(cell);
           });
@@ -91,7 +94,7 @@ import { cutTextSize, getColumnWidth } from './helpers';
         });
         setRow(values);
       }
-    }, [columnTitles, rowGroupData]);
+    }, [titles, data]);
 
   const {
     getTableProps,
@@ -135,6 +138,7 @@ import { cutTextSize, getColumnWidth } from './helpers';
                     maxWidth: `${getColumnWidth(rows, column.id)}px`,
                     minWidth: column.minWidth,
                     padding: '14px',
+                    position: 'sticky',
                   }}
                 >
                   {/* <RowCellStyle width={totalColumnsWidth}> */}

--- a/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
@@ -29,7 +29,6 @@ import { cutTextSize, getColumnWidth } from './helpers';
 
   const [column, setColumn] = useState([]);
   const [row, setRow] = useState([]);
-  let stripes = true;
 
   // Keep these samples in due to undefined errors.
   const dataSample = useMemo(
@@ -156,9 +155,8 @@ import { cutTextSize, getColumnWidth } from './helpers';
         </thead>
         {/* Rows: relative, overflow, black text, borders on everything but bottom except for last, skip bg */}
         <tbody {...getTableBodyProps()}>
-          { rows.map(row => {
+          {rows.map((row, i) => {
               prepareRow(row);
-              stripes = !stripes;
               return (
                 // eslint-disable-next-line react/jsx-key
                 <tr {...row.getRowProps()}>
@@ -167,7 +165,7 @@ import { cutTextSize, getColumnWidth } from './helpers';
                     <td
                       {...cell.getCellProps()}
                       style={{
-                        background: stripes ? '#F9FAFC' : '#FBFCFD',
+                        background: (i % 2 === 1) ? '#F9FAFC' : '#FBFCFD',
                         border: 'solid 1px #FBFCFD',
                         borderLeft: 'none',
                         borderRight: 'none',

--- a/mage_ai/frontend/oracle/components/Table/Table.style.tsx
+++ b/mage_ai/frontend/oracle/components/Table/Table.style.tsx
@@ -8,6 +8,7 @@ export const TableStyle = styled.div<any>`
   width: 100%;
   max-width: 100vw;
   overflow: auto;
+  padding: 4px;
   ${props => props.table &&`
     background-color: ${(props.theme.background || light.background).page};
   `}

--- a/mage_ai/frontend/oracle/components/Table/helpers.tsx
+++ b/mage_ai/frontend/oracle/components/Table/helpers.tsx
@@ -1,7 +1,7 @@
 import { UNIT } from '@oracle/styles/units/spacing';
 import { DataTableRow } from './types';
 // TODO: Update with official numbers and import from units/spacing.ts
-export const WIDTH_OF_SINGLE_CHARACTER = 2;
+export const WIDTH_OF_SINGLE_CHARACTER = 10;
 export const CHARACTER_LIMIT = 45;
 
 export const cutTextSize = (


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
### Address P0 Polish Items
- Adds left Align to the column header
- Adds striped look to match Figma
- Fix bug with certain column headers not stretching enough

# Tests
<!-- How did you test your change? -->
### Localhost on a long dataset
<img width="1216" alt="image" src="https://user-images.githubusercontent.com/90282975/171912993-1050f22a-9998-4a53-8d64-271ec7db5112.png">

### Localhost on a short dataset
<img width="1209" alt="image" src="https://user-images.githubusercontent.com/90282975/171913223-39173d0b-80d9-40e0-8987-2b2fdd50a2c1.png">

### More things to add on for the future
- Fix bottom border not showing up bug
- Refactor/create a new component that calls the api given the dataset version. (Currently is done on page level)
- Change px to rem and em, find another way to style that works with the react-table without passing in a style prop.
- Display the datatype on top of the column
- Add a sticky column header.

<!-- Optionally mention someone to let them know about this pull request -->
cc:
@johnson-mage @dy46 @tommydangerous 