### PR TITLE
[sk] Fixed Flask resource loading bugs

### DIFF
--- a/mage_ai/server/app.py
+++ b/mage_ai/server/app.py
@@ -8,12 +8,10 @@ from mage_ai.server.data.models import FeatureSet, Pipeline
 from numpyencoder import NumpyEncoder
 import logging
 import json
-import os
 import simplejson
 import sys
 import threading
 
-RESOURCE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data/files'))
 
 log = logging.getLogger('werkzeug')
 log.setLevel(logging.ERROR)
@@ -92,13 +90,13 @@ def feature_sets():
     ]
     """
     feature_sets = list(map(lambda fs: fs.to_dict(detailed=False), FeatureSet.objects()))
-    valid_feture_sets = [
+    valid_feature_sets = [
         f
         for f in feature_sets
         if set(['column_types', 'statistics']).issubset(f['metadata'].keys())
     ]
     response = app.response_class(
-        response=simplejson.dumps(valid_feture_sets, ignore_nan=True),
+        response=simplejson.dumps(valid_feature_sets, ignore_nan=True),
         status=200,
         mimetype='application/json',
     )

--- a/mage_ai/server/app.py
+++ b/mage_ai/server/app.py
@@ -115,13 +115,8 @@ def feature_set(id):
         }
     ]
     """
-    path = RESOURCE_PATH + '/FeatureSet'
-    try:
-        opts = os.listdir(path)
-        if id not in opts:
-            raise RuntimeError(f'Unknown feature set id: {id}')
-    except OSError:
-        pass
+    if not FeatureSet.is_valid_id(id):
+        raise RuntimeError(f'Unknown feature set id: {id}')
     feature_set = FeatureSet(id=id)
     query_column = request.args.get('column')
     response = app.response_class(
@@ -188,13 +183,8 @@ def pipeline(id):
         actions,
     }
     """
-    path = RESOURCE_PATH + '/Pipelines'
-    try:
-        opts = os.listdir(path)
-        if id not in opts:
-            raise RuntimeError(f'Unknown pipeline id: {id}')
-    except OSError:
-        pass
+    if not Pipeline.is_valid_id(id):
+        raise RuntimeError(f'Unknown pipeline id: {id}')
     pipeline = Pipeline(id=id)
     response = app.response_class(
         response=json.dumps(pipeline.to_dict(), cls=NumpyEncoder),

--- a/mage_ai/server/data/base.py
+++ b/mage_ai/server/data/base.py
@@ -1,4 +1,3 @@
-from multiprocessing.sharedctypes import Value
 from numpyencoder import NumpyEncoder
 import json
 import os
@@ -61,8 +60,8 @@ class Model:
 
     @classmethod
     def is_valid_id(cls, id):
-        opts = os.listdir(cls.path_name())
-        return id in opts
+        opts = Model.gen_integer_dir_list(cls.path_name())
+        return int(id) in opts
 
     @classmethod
     def path_name(cls):

--- a/mage_ai/server/data/base.py
+++ b/mage_ai/server/data/base.py
@@ -82,6 +82,6 @@ class Model:
             except ValueError:
                 raise RuntimeError(
                     f'Invalid ID generated for model: {dirname}. '
-                    'Remove this folder and restarting the application.'
+                    'Remove this folder and restart the application.'
                 )
         return dirs

--- a/mage_ai/server/data/base.py
+++ b/mage_ai/server/data/base.py
@@ -20,10 +20,10 @@ class Model:
             os.mkdir(self.path)
 
         if id is None:
-            dirs = [name for name in os.listdir(self.path)]
-            max_id = 0
+            dirs = Model.gen_integer_dir_list(self.path)
+            max_id = -1
             if len(dirs) > 0:
-                max_id = sorted([int(dir) for dir in dirs], reverse=True)[0]
+                max_id = sorted(dirs, reverse=True)[0]
             self.id = max_id + 1
         else:
             self.id = id
@@ -66,17 +66,22 @@ class Model:
     @classmethod
     def objects(cls):
         arr = []
-        string_dirs = [int(name) for name in os.listdir(cls.path_name())]
-        dirs = []
-        for dirname in string_dirs:
-            try:
-                dirs.append(int(dirname))
-            except ValueError:
-                raise ValueError(f'Invalid id generated for model: {dirname}')
-        dirs = sorted([int(name) for name in os.listdir(cls.path_name())], reverse=True)
-        for id in dirs:
+        for id in Model.gen_integer_dir_list(cls.path_name()):
             try:
                 arr.append(cls(id=id))
             except Exception:
                 print(f'Fail to load {cls.__name__} with id {id}')
         return arr
+
+    @staticmethod
+    def gen_integer_dir_list(pathname):
+        dirs = []
+        for dirname in os.listdir(pathname):
+            try:
+                dirs.append(int(dirname))
+            except ValueError:
+                raise RuntimeError(
+                    f'Invalid ID generated for model: {dirname}. '
+                    'Remove this folder and restarting the application.'
+                )
+        return dirs

--- a/mage_ai/server/data/base.py
+++ b/mage_ai/server/data/base.py
@@ -1,3 +1,4 @@
+from multiprocessing.sharedctypes import Value
 from numpyencoder import NumpyEncoder
 import json
 import os
@@ -8,7 +9,7 @@ import pandas as pd
 DATA_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), 'files'))
 
 
-class Model():
+class Model:
     def __init__(self, id=None):
         # TODO: figure out a good directory to store the files
         if not os.path.isdir(DATA_PATH):
@@ -26,7 +27,7 @@ class Model():
             self.id = max_id + 1
         else:
             self.id = id
-        
+
         self.dir = os.path.join(self.path, str(self.id))
         if not os.path.isdir(self.dir):
             os.mkdir(self.dir)
@@ -46,14 +47,14 @@ class Model():
         file_path = os.path.join(self.dir, file_name)
         if not os.path.exists(file_path):
             return pd.DataFrame()
-        return pd.read_parquet(file_path, engine='pyarrow',)
+        return pd.read_parquet(file_path, engine='pyarrow')
 
     def write_parquet_file(self, file_name, df):
         df.to_parquet(os.path.join(self.dir, file_name))
 
     def to_dict(self, detailed):
         pass
-    
+
     @classmethod
     def folder_name(cls):
         return cls.__name__
@@ -65,8 +66,14 @@ class Model():
     @classmethod
     def objects(cls):
         arr = []
-        dirs = sorted([int(name) for name in os.listdir(cls.path_name()) if name.isnumeric()],
-                      reverse=True)
+        string_dirs = [int(name) for name in os.listdir(cls.path_name())]
+        dirs = []
+        for dirname in string_dirs:
+            try:
+                dirs.append(int(dirname))
+            except ValueError:
+                raise ValueError(f'Invalid id generated for model: {dirname}')
+        dirs = sorted([int(name) for name in os.listdir(cls.path_name())], reverse=True)
         for id in dirs:
             try:
                 arr.append(cls(id=id))

--- a/mage_ai/server/data/base.py
+++ b/mage_ai/server/data/base.py
@@ -60,6 +60,15 @@ class Model:
         return cls.__name__
 
     @classmethod
+    def is_valid_id(cls, id):
+        try:
+            opts = os.listdir(cls.path_name())
+            if id not in opts:
+                raise RuntimeError(f'Unknown feature set id: {id}')
+        except OSError:
+            pass
+
+    @classmethod
     def path_name(cls):
         return os.path.join(DATA_PATH, cls.folder_name())
 
@@ -80,8 +89,5 @@ class Model:
             try:
                 dirs.append(int(dirname))
             except ValueError:
-                raise RuntimeError(
-                    f'Invalid ID generated for model: {os.path.abspath(pathname) + "/" + dirname}. '
-                    'Remove this folder and restart the application.'
-                )
+                continue
         return dirs

--- a/mage_ai/server/data/base.py
+++ b/mage_ai/server/data/base.py
@@ -61,12 +61,8 @@ class Model:
 
     @classmethod
     def is_valid_id(cls, id):
-        try:
-            opts = os.listdir(cls.path_name())
-            if id not in opts:
-                raise RuntimeError(f'Unknown feature set id: {id}')
-        except OSError:
-            pass
+        opts = os.listdir(cls.path_name())
+        return id in opts
 
     @classmethod
     def path_name(cls):

--- a/mage_ai/server/data/base.py
+++ b/mage_ai/server/data/base.py
@@ -81,7 +81,7 @@ class Model:
                 dirs.append(int(dirname))
             except ValueError:
                 raise RuntimeError(
-                    f'Invalid ID generated for model: {dirname}. '
+                    f'Invalid ID generated for model: {os.path.abspath(pathname) + "/" + dirname}. '
                     'Remove this folder and restart the application.'
                 )
         return dirs

--- a/mage_ai/server/data/base.py
+++ b/mage_ai/server/data/base.py
@@ -20,7 +20,7 @@ class Model:
 
         if id is None:
             dirs = Model.gen_integer_dir_list(self.path)
-            max_id = -1
+            max_id = 0
             if len(dirs) > 0:
                 max_id = sorted(dirs, reverse=True)[0]
             self.id = max_id + 1

--- a/mage_ai/server/data/models.py
+++ b/mage_ai/server/data/models.py
@@ -47,7 +47,7 @@ class FeatureSet(Model):
     def data(self, df):
         df.to_parquet(os.path.join(self.dir, 'data.parquet'))
         self._data = df
-    
+
     @property
     def data_orig(self):
         if self._data_orig is None:
@@ -62,7 +62,7 @@ class FeatureSet(Model):
     @property
     def metadata(self):
         return self.read_json_file('metadata.json', {})
-    
+
     @metadata.setter
     def metadata(self, metadata):
         return self.write_json_file('metadata.json', metadata)
@@ -70,7 +70,7 @@ class FeatureSet(Model):
     @property
     def statistics(self):
         return self.read_json_file('statistics.json', {})
-    
+
     @statistics.setter
     def statistics(self, metadata):
         return self.write_json_file('statistics.json', metadata)
@@ -90,7 +90,7 @@ class FeatureSet(Model):
     @suggestions.setter
     def suggestions(self, metadata):
         return self.write_json_file('suggestions.json', metadata)
-    
+
     @property
     def pipeline(self):
         pipeline_id = self.metadata.get('pipeline_id')
@@ -157,17 +157,21 @@ class FeatureSet(Model):
             # Filter suggestions
             suggestions = self.suggestions
             if column is not None:
-                suggestions = [s for s in suggestions
-                               if column in s['action_payload']['action_arguments']]
+                suggestions = [
+                    s for s in suggestions if column in s['action_payload']['action_arguments']
+                ]
                 for s in suggestions:
                     s['action_payload']['action_arguments'] = [column]
-            obj = merge_dict(obj, dict(
-                pipeline=self.pipeline.to_dict(),
-                sample_data=sample_data_dict,
-                statistics=self.statistics,
-                insights=self.insights,
-                suggestions=suggestions,
-            ))
+            obj = merge_dict(
+                obj,
+                dict(
+                    pipeline=self.pipeline.to_dict(),
+                    sample_data=sample_data_dict,
+                    statistics=self.statistics,
+                    insights=self.insights,
+                    suggestions=suggestions,
+                ),
+            )
         return obj
 
 
@@ -192,7 +196,7 @@ class Pipeline(Model):
     @property
     def metadata(self):
         return self.read_json_file('metadata.json', {})
-    
+
     @metadata.setter
     def metadata(self, metadata):
         return self.write_json_file('metadata.json', metadata)


### PR DESCRIPTION
# Summary
Fixed a couple of bugs in Flask endpoints:
- When a non-integer id is used for a pipeline, originally it would try to be converted to an integer and throw a hard to find error. Now the error is raised directly, letting the user know that someone an invalid id had been created.
     ![image](https://user-images.githubusercontent.com/71106771/171918138-859c288d-67dd-4041-b20c-acf71fbc9dfd.png)
    Usually the error is raised when the user manually adds in their own feature set or pipeline incorrectly to the files folder.
- When a dataset with some id xx does not exist, accessing the Flask GET endpoint (feature_sets/xx or pipelines/xx) with creates an empty pipeline and feature set in files (a ghost storage model). Now when this is attempted an internal server error gets raised. The PUT endpoint is not modified.
    <img width="451" alt="image" src="https://user-images.githubusercontent.com/71106771/171918414-5c1fcecc-0ee7-483a-9276-f149f9a4f06a.png">
   This is the error now generated when accessing http://localhost:3000/datasets/329423 when the feature set and pipeline with id 329423 don't exist.


# Tests
Errors were tested locally through accessing the endpoints to check for intended behavior.

cc:
@wangxiaoyou1993, @dy46 
