### PR TITLE
[sk] Backend reports internal server errors to the client

### DIFF
--- a/mage_ai/data_cleaner/pipelines/base.py
+++ b/mage_ai/data_cleaner/pipelines/base.py
@@ -2,16 +2,15 @@ from mage_ai.data_cleaner.cleaning_rules.base import STATUS_COMPLETED
 from mage_ai.data_cleaner.cleaning_rules.clean_column_names import CleanColumnNames
 from mage_ai.data_cleaner.cleaning_rules.impute_values import ImputeValues
 from mage_ai.data_cleaner.cleaning_rules.reformat_values import ReformatValues
-from mage_ai.data_cleaner.cleaning_rules.remove_collinear_columns \
-    import RemoveCollinearColumns
-from mage_ai.data_cleaner.cleaning_rules.remove_columns_with_high_empty_rate \
-    import RemoveColumnsWithHighEmptyRate
-from mage_ai.data_cleaner.cleaning_rules.remove_columns_with_single_value \
-    import RemoveColumnsWithSingleValue
-from mage_ai.data_cleaner.cleaning_rules.remove_duplicate_rows \
-    import RemoveDuplicateRows
-from mage_ai.data_cleaner.cleaning_rules.remove_outliers \
-    import RemoveOutliers
+from mage_ai.data_cleaner.cleaning_rules.remove_collinear_columns import RemoveCollinearColumns
+from mage_ai.data_cleaner.cleaning_rules.remove_columns_with_high_empty_rate import (
+    RemoveColumnsWithHighEmptyRate,
+)
+from mage_ai.data_cleaner.cleaning_rules.remove_columns_with_single_value import (
+    RemoveColumnsWithSingleValue,
+)
+from mage_ai.data_cleaner.cleaning_rules.remove_duplicate_rows import RemoveDuplicateRows
+from mage_ai.data_cleaner.cleaning_rules.remove_outliers import RemoveOutliers
 from mage_ai.data_cleaner.column_type_detector import infer_column_types
 from mage_ai.data_cleaner.transformer_actions.base import BaseAction
 from mage_ai.data_cleaner.statistics.calculator import StatisticsCalculator
@@ -28,8 +27,7 @@ DEFAULT_RULES = [
 ]
 
 
-class BasePipeline():
-
+class BasePipeline:
     def __init__(self, actions=[]):
         self.actions = actions
         self.rules = DEFAULT_RULES

--- a/mage_ai/server/app.py
+++ b/mage_ai/server/app.py
@@ -11,6 +11,7 @@ import json
 import simplejson
 import sys
 import threading
+import traceback
 
 
 log = logging.getLogger('werkzeug')
@@ -25,12 +26,37 @@ CORS(app, resources={r'/*': {'origins': '*'}})
 thread = None
 
 
-@app.route('/')
+def rescue_errors(endpoint):
+    def handler(*args, **kwargs):
+        try:
+            return endpoint(*args, **kwargs)
+        except Exception as err:
+            exception = traceback.format_exc()
+            stack_trace = traceback.format_stack()
+            response_obj = {
+                'error_code': 500,
+                'error_msg': str(err),
+                'error_stack_trace': exception,
+                'full_stack_trace': stack_trace,
+            }
+            response = app.response_class(
+                response=simplejson.dumps(response_obj),
+                status=200,
+                mimetype='application/json',
+            )
+            return response
+
+    return handler
+
+
+@app.route('/', endpoint='index')
+@rescue_errors
 def index():
     return render_template('index.html')
 
 
-@app.route('/process', methods=['POST'])
+@app.route('/process', methods=['POST'], endpoint='process')
+@rescue_errors
 def process():
     """
     request: {
@@ -79,7 +105,8 @@ def process():
     return response
 
 
-@app.route('/feature_sets')
+@app.route('/feature_sets', endpoint='feature_sets')
+@rescue_errors
 def feature_sets():
     """
     response: [
@@ -103,7 +130,8 @@ def feature_sets():
     return response
 
 
-@app.route('/feature_sets/<id>')
+@app.route('/feature_sets/<id>', endpoint='feature_sets_get')
+@rescue_errors
 def feature_set(id):
     """
     response: [
@@ -125,7 +153,8 @@ def feature_set(id):
     return response
 
 
-@app.route('/feature_sets/<id>', methods=['PUT'])
+@app.route('/feature_sets/<id>', methods=['PUT'], endpoint='feature_sets_put')
+@rescue_errors
 def update_feature_set(id):
     """
     request: {
@@ -156,7 +185,8 @@ def update_feature_set(id):
     return response
 
 
-@app.route('/pipelines')
+@app.route('/pipelines', endpoint='pipelines')
+@rescue_errors
 def pipelines():
     """
     response: [
@@ -173,7 +203,8 @@ def pipelines():
     return response
 
 
-@app.route('/pipelines/<id>')
+@app.route('/pipelines/<id>', endpoint='piplines_get')
+@rescue_errors
 def pipeline(id):
     """
     response: {
@@ -192,7 +223,8 @@ def pipeline(id):
     return response
 
 
-@app.route('/pipelines/<id>', methods=['PUT'])
+@app.route('/pipelines/<id>', methods=['PUT'], endpoint='pipelines_put')
+@rescue_errors
 def update_pipeline(id):
     """
     request: {

--- a/mage_ai/server/app.py
+++ b/mage_ai/server/app.py
@@ -29,23 +29,22 @@ thread = None
 def rescue_errors(endpoint):
     def handler(*args, **kwargs):
         try:
-            return endpoint(*args, **kwargs)
+            response = endpoint(*args, **kwargs)
         except Exception as err:
             exception = traceback.format_exc()
-            stack_trace = traceback.format_stack()
             response_obj = {
                 'error_code': 500,
                 'error_msg': str(err),
                 'error_stack_trace': exception,
-                'full_stack_trace': stack_trace,
+                'full_stack_trace': traceback.format_stack(),
             }
             response = app.response_class(
-                response=simplejson.dumps(response_obj),
+                response=json.dumps(response_obj),
                 status=200,
                 mimetype='application/json',
             )
             log.error(exception)
-            return response
+        return response
 
     return handler
 

--- a/mage_ai/server/app.py
+++ b/mage_ai/server/app.py
@@ -26,14 +26,14 @@ CORS(app, resources={r'/*': {'origins': '*'}})
 thread = None
 
 
-def rescue_errors(endpoint):
+def rescue_errors(endpoint, error_code=500):
     def handler(*args, **kwargs):
         try:
             response = endpoint(*args, **kwargs)
         except Exception as err:
             exception = traceback.format_exc()
             response_obj = {
-                'error_code': 500,
+                'error_code': error_code,
                 'error_msg': str(err),
                 'error_stack_trace': exception,
                 'full_stack_trace': traceback.format_stack(),
@@ -43,6 +43,7 @@ def rescue_errors(endpoint):
                 status=200,
                 mimetype='application/json',
             )
+            log.error('An error was caught and reported to the client: ')
             log.error(exception)
         return response
 

--- a/mage_ai/server/app.py
+++ b/mage_ai/server/app.py
@@ -44,6 +44,7 @@ def rescue_errors(endpoint):
                 status=200,
                 mimetype='application/json',
             )
+            log.error(exception)
             return response
 
     return handler


### PR DESCRIPTION
# Summary
Backend now rescues all internal server errors thrown and sends a response with the error message and stack trace back to the client. All endpoint functions are wrapped with the `rescue_errors` decorator which catch all exceptions thrown and reroute them to the client through a JSON response. This response object contains
- `error_code`: The error code (default is currently 500)
- `error_msg`: The message reported by the error object
- `error_stack_trace`: The formatted error message with stack trace (as usually printed by Python)
- `full_stack_trace`: A list of the entire stack trace up to the point of the error being thrown

**Note**: As decorators wrap all inner functions with the same outer function, Flask natively will detect duplicate endpoints and fail to run (Flask by default uses function name as a unique endpoint identifier; with a decorator function all the endpoints have the same function name). 

To solve this, I manually named all the endpoints to be unique regardless of the wrapping decorator function. This will not change the URL of the endpoints, but only how Flask maps the URLs to Python functions. The endpoint names can be changed.

# Tests
Tests were run locally by sending both properly formatted and ill formatted requests to the backend server and evaluating that the right response is returned in each case.

cc:
@wangxiaoyou1993, @nathaniel-mage 
