### PR TITLE
[nt] Add all page titles for existing pages

### DIFF
--- a/mage_ai/frontend/components/datasets/columns/ColumnDetail.tsx
+++ b/mage_ai/frontend/components/datasets/columns/ColumnDetail.tsx
@@ -251,6 +251,7 @@ function ColumnDetail({
   return (
     <Layout
       centerAlign
+      pageTitle="Column Details"
     >
       <Spacing mt={UNIT}>
         {actionType && (

--- a/mage_ai/frontend/components/datasets/columns/ColumnList.tsx
+++ b/mage_ai/frontend/components/datasets/columns/ColumnList.tsx
@@ -60,6 +60,7 @@ const ColumnList = ({
     <Layout
       centerAlign
       header={<Spacing mt={UNIT} />}
+      pageTitle="Column List"
     >
       {headEl}
       <Spacing pt={3}>

--- a/mage_ai/frontend/components/datasets/overview/index.tsx
+++ b/mage_ai/frontend/components/datasets/overview/index.tsx
@@ -205,6 +205,7 @@ function DatasetOverview({
       <Layout
         centerAlign
         footer={<Spacing mt={UNIT} />}
+        pageTitle="Dataset Overview"
       >
         <Spacing mt={UNIT} />
         {headEl}

--- a/mage_ai/frontend/oracle/components/Layout/index.tsx
+++ b/mage_ai/frontend/oracle/components/Layout/index.tsx
@@ -5,6 +5,7 @@ import { BREAKPOINT_X_LARGE } from '@styles/theme';
 import { UNIT } from '@oracle/styles/units/spacing';
 import light from '@oracle/styles/themes/light';
 import Spacing from '@oracle/elements/Spacing';
+import Head from '@oracle/elements/Head';
 
 export type AsideProps = {
   after?: React.ReactNode;
@@ -18,6 +19,7 @@ export type LayoutProps = {
   footer?: React.ReactNode;
   header?: any;
   minHeight?: number | string;
+  pageTitle?: string;
 };
 
 export type MainContentProps = {
@@ -75,11 +77,13 @@ function Layout({
   footer,
   header,
   minHeight,
+  pageTitle,
 }: LayoutProps & AsideProps) {
   return (
     <WrapperStyle
       minHeight={minHeight}
     >
+      <Head title={pageTitle} />
       {header}
       <LayoutContainerStyle>
         {before}

--- a/mage_ai/frontend/oracle/elements/Head/index.tsx
+++ b/mage_ai/frontend/oracle/elements/Head/index.tsx
@@ -1,0 +1,23 @@
+import NextHead from 'next/head';
+
+type HeadProps = {
+  children?: any;
+  defaultTitle?: string;
+  title?: string;
+};
+
+const Head = ({
+  children,
+  defaultTitle = 'Mage',
+  title,
+}: HeadProps) => (
+  <NextHead>
+    <title>
+      {title ? `${title} | ${defaultTitle}` : defaultTitle}
+    </title>
+
+    {children}
+  </NextHead>
+);
+
+export default Head;

--- a/mage_ai/frontend/pages/datasets/index.tsx
+++ b/mage_ai/frontend/pages/datasets/index.tsx
@@ -28,6 +28,7 @@ const Dashboard: NextPage = () => {
     <Layout
       centerAlign
       header={<Spacing mt={UNIT} />}
+      pageTitle="Dataset Dashboard"
     >
       <Tabs bold defaultKey="datasets" large>
         <Tab key="datasets" label="Datasets">


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
### Add page titles to the app
- Adds a new element called Head to contain the page title, can be later extended for a page description for search/SEO.
- Integrates the head component with the layout (i.e you can now set titles within the layout component)
- Adds basic names based on file names to the pages. (see video)

# Tests
<!-- How did you test your change? -->
### Localhost went and browsed through pages
https://user-images.githubusercontent.com/90282975/171983112-454f0e44-de0b-4b00-871d-6b6a145b0465.mov

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@johnson-mage @dy46 