### PR TITLE
[nt] Add progress bar to cell and simple datatable

### DIFF
--- a/mage_ai/frontend/components/datasets/overview/index.tsx
+++ b/mage_ai/frontend/components/datasets/overview/index.tsx
@@ -236,7 +236,7 @@ function DatasetOverview({
             <Flex flex={1}>
               {metricSample && (
                 <SimpleDataTable
-                  columnFlexNumbers={[1, 1]}
+                  columnFlexNumbers={[2, 1, 2 ]}
                   columnHeaders={[{ label: 'Quality Metrics' }]}
                   rowGroupData={[metricSample]}
                 />

--- a/mage_ai/frontend/components/datasets/overview/utils.ts
+++ b/mage_ai/frontend/components/datasets/overview/utils.ts
@@ -16,14 +16,16 @@ export function createMetricsSample(statistics) {
   stats.map((key) => {
     if (METRICS_KEYS.includes(key)) {
       let value = statistics[key].toPrecision(2);
+      let bar = [false];
       const order = HUMAN_READABLE_MAPPING[key];
       const index = METRICS_SORTED_MAPPING[key];
       if (PERCENTAGE_KEYS.includes(key)) {
         value *= 100;
+        bar = [true, value];
         value = `${value}%`;
       }
       metricRows[index] = {
-        columnValues: [order, value],
+        columnValues: [order, value, bar],
       };
     }
   });

--- a/mage_ai/frontend/oracle/components/Table/Cell.tsx
+++ b/mage_ai/frontend/oracle/components/Table/Cell.tsx
@@ -15,7 +15,7 @@ type CellProps = {
   rowIndex: number;
   selected: boolean;
   small: boolean;
-  showProgress
+  showProgress?: boolean;
   value: any;
 };
 

--- a/mage_ai/frontend/oracle/components/Table/Cell.tsx
+++ b/mage_ai/frontend/oracle/components/Table/Cell.tsx
@@ -6,6 +6,7 @@ import { ArrowDown, ArrowRight } from '@oracle/icons';
 import { RowCellStyle } from './index.style';
 import { UNIT } from '@oracle/styles/units/spacing';
 import ProgressBar from '../ProgressBar';
+import FlexContainer from '../FlexContainer';
 
 type CellProps = {
   cellIndex: number;
@@ -83,7 +84,9 @@ function Cell({
     );
   } else if (showProgress) {
     cellEl = (
-      <ProgressBar danger={value < 75} progress={value} />
+      <FlexContainer alignItems={'center'}>
+        <ProgressBar danger={value < 75} progress={value} />
+      </FlexContainer>
     );
   }
   else {

--- a/mage_ai/frontend/oracle/components/Table/Cell.tsx
+++ b/mage_ai/frontend/oracle/components/Table/Cell.tsx
@@ -5,6 +5,7 @@ import Text from '@oracle/elements/Text';
 import { ArrowDown, ArrowRight } from '@oracle/icons';
 import { RowCellStyle } from './index.style';
 import { UNIT } from '@oracle/styles/units/spacing';
+import ProgressBar from '../ProgressBar';
 
 type CellProps = {
   cellIndex: number;
@@ -14,6 +15,7 @@ type CellProps = {
   rowIndex: number;
   selected: boolean;
   small: boolean;
+  showProgress
   value: any;
 };
 
@@ -25,6 +27,7 @@ function Cell({
   rowIndex,
   selected,
   small,
+  showProgress,
   value,
 }: CellProps) {
   const [collapsed, setCollapsed] = useState(false);
@@ -78,7 +81,12 @@ function Cell({
         </Link>
       </Flex>
     );
-  } else {
+  } else if (showProgress) {
+    cellEl = (
+      <ProgressBar danger={value < 75} progress={value} />
+    );
+  }
+  else {
     cellEl = (
       <Text
         small={small}

--- a/mage_ai/frontend/oracle/components/Table/SimpleDataTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/SimpleDataTable.tsx
@@ -5,7 +5,6 @@ import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
 import Link from '@oracle/elements/Link';
 import Text from '@oracle/elements/Text';
-import { PERCENTAGE_KEYS } from '@components/datasets/constants';
 import {
   ColumnHeaderCellStyle,
   ColumnHeaderRowStyle,
@@ -152,9 +151,9 @@ function SimpleDataTable({
                   selected={isSelected}
                   showProgress={value[0]}
                   small={small}
-                  value={value[1]}  
+                  value={value[1]}
                 />,
-              );  
+              );
             } else {
               cells.push(
                 <Cell

--- a/mage_ai/frontend/oracle/components/Table/SimpleDataTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/SimpleDataTable.tsx
@@ -5,6 +5,7 @@ import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
 import Link from '@oracle/elements/Link';
 import Text from '@oracle/elements/Text';
+import { PERCENTAGE_KEYS } from '@components/datasets/constants';
 import {
   ColumnHeaderCellStyle,
   ColumnHeaderRowStyle,
@@ -30,7 +31,7 @@ export type ColumnHeaderType = {
 export type RowGroupDataType = {
   title?: string;
   rowData: {
-    columnValues: (string | number | any)[];
+    columnValues: (string | number | boolean | any)[];
     uuid?: string | number;
   }[];
 };
@@ -139,20 +140,36 @@ function SimpleDataTable({
 
           columnValues?.forEach((value: any, cellIndex: number) => {
             const renderFunc = renderRowCellByIndex?.[cellIndex];
-
-            cells.push(
-              <Cell
-                cellIndex={cellIndex}
-                flex={columnFlexNumbers[cellIndex]}
-                key={cellIndex}
-                render={renderFunc}
-                rowGroupIndex={rowGroupIndex}
-                rowIndex={rowIndex}
-                selected={isSelected}
-                small={small}
-                value={value}
-              />,
-            );
+            if (Array.isArray(value)) {
+              cells.push(
+                <Cell
+                  cellIndex={cellIndex}
+                  flex={columnFlexNumbers[cellIndex]}
+                  key={cellIndex}
+                  render={renderFunc}
+                  rowGroupIndex={rowGroupIndex}
+                  rowIndex={rowIndex}
+                  selected={isSelected}
+                  showProgress={value[0]}
+                  small={small}
+                  value={value[1]}  
+                />,
+              );  
+            } else {
+              cells.push(
+                <Cell
+                  cellIndex={cellIndex}
+                  flex={columnFlexNumbers[cellIndex]}
+                  key={cellIndex}
+                  render={renderFunc}
+                  rowGroupIndex={rowGroupIndex}
+                  rowIndex={rowIndex}
+                  selected={isSelected}
+                  small={small}
+                  value={value}
+                />,
+              );
+            }
           });
 
           const cellEls = (


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
### Add progress bar display to certain charts
- If a table is given a list inside it, it'll look for a pair. The first being a boolean to determine whether to include a progress bar, followed by the value.
- Updates cell file to display progress bars using the "showProgress" prop.
- Change default flex values to get the table to closer match figma, though the cell's padding makes it difficult for the chart to be exactly like Figma where the progress bar and percentage are both closer to each other.

# Tests
<!-- How did you test your change? -->
Ran on localhost 

### Max progress
<img width="588" alt="image" src="https://user-images.githubusercontent.com/90282975/172019238-b3131e16-c44d-4a52-9ea5-d5ec953306f7.png">

### Good progress
<img width="573" alt="image" src="https://user-images.githubusercontent.com/90282975/172019434-20be1d07-dd4f-4c0f-9cae-a0d358e191de.png">

### Bad progress
<img width="595" alt="image" src="https://user-images.githubusercontent.com/90282975/172019596-aab81b35-260c-4974-bb9b-a94986618f82.png">

# Known issues/Improvements
* The progress bar is off center... I think this is due to how it renders inside a cell. 
* I also added the danger property for the red version of the progress bar when it's below average (C = 75%). We can extend this with a constant in the future when we do good/bad/average.

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@johnson-mage @dy46 @tommydangerous 