### PR TITLE
[sk] Write pipeline to file only after action is successfully applied

### DIFF
--- a/mage_ai/server/app.py
+++ b/mage_ai/server/app.py
@@ -218,6 +218,8 @@ def update_pipeline(id):
         result = clean_data(df_transformed, transform=False)
         pipeline.pipeline = clean_pipeline
         feature_set.write_files(result)
+    else:
+        pipeline.pipeline = clean_pipeline
 
     response = app.response_class(
         response=json.dumps(pipeline.to_dict(), cls=NumpyEncoder),

--- a/mage_ai/server/app.py
+++ b/mage_ai/server/app.py
@@ -209,7 +209,6 @@ def update_pipeline(id):
     actions = request_data.get('actions', [])
     actions = generate_action_titles(actions)
     clean_pipeline = BasePipeline(actions=actions)
-    pipeline.pipeline = clean_pipeline
     # 1. Transform the data
     # 2. Recalculate stats and suggestions
     feature_set_id = pipeline.metadata.get('feature_set_id')
@@ -217,6 +216,7 @@ def update_pipeline(id):
         feature_set = FeatureSet(id=feature_set_id)
         df_transformed = clean_pipeline.transform(feature_set.data_orig, auto=False)
         result = clean_data(df_transformed, transform=False)
+        pipeline.pipeline = clean_pipeline
         feature_set.write_files(result)
 
     response = app.response_class(


### PR DESCRIPTION
# Summary
Previously, the cleaning pipeline sent by the client frontend would get directly written to file, even if the contained cleaning actions failed to execute due to some error. This PR updates the backend so the new pipeline is written to file only if the action is successfully applied without any error. If the action throws an error then the cleaning step has not been fully executed, and so the action should not be written to file as if it has been completed.

If no feature set ID is given (that is, the pipeline exists separately from a feature set to apply the action to), then always write the pipeline to file. This is for the case when users are building their own custom pipeline to apply on any data.

# Tests
Local tests were performed by manually throwing errors in the cleaning step and asserting that the pipeline is not correctly written to file in that instance.

cc:
@wangxiaoyou1993, @dy46 
