### PR TITLE
[nt]  Basetable polish p2

### DIFF
--- a/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
@@ -150,7 +150,7 @@ import { cutTextSize } from './helpers';
               return (
                 // eslint-disable-next-line react/jsx-key
                 <tr {...row.getRowProps()}>
-                  {row.cells.map((cell) => (
+                  {row.cells.map(cell => (
                     // eslint-disable-next-line react/jsx-key
                     <td
                       {...cell.getCellProps()}

--- a/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
@@ -119,17 +119,14 @@ import { cutTextSize } from './helpers';
           { headerGroups.map(headerGroup => (
             // eslint-disable-next-line react/jsx-key
             <tr {...headerGroup.getHeaderGroupProps()}>
-              {headerGroup.headers.map((column, i, cols) => (
+              {headerGroup.headers.map(column => (
                 // eslint-disable-next-line react/jsx-key
                 <th
                   {...column.getHeaderProps()}
                   style={{
                     background: '#F9FAFC',
                     border: 'solid 1px #D8DCE3',
-                    borderLeft: (i === 0) && 'none',
-                    borderRight: (i === cols.length - 1) && 'none',
-                    borderTop: 'none',
-                    padding: '14px',
+                    padding: '4px',
                   }}
                 >
                   <TextStyle>
@@ -145,7 +142,7 @@ import { cutTextSize } from './helpers';
         </thead>
         {/* Rows: relative, overflow, black text, borders on everything but bottom except for last, skip bg */}
         <tbody {...getTableBodyProps()}>
-          {rows.map((row, i) => {
+          {rows.map((row, i, arr) => {
               prepareRow(row);
               return (
                 // eslint-disable-next-line react/jsx-key
@@ -156,8 +153,12 @@ import { cutTextSize } from './helpers';
                       {...cell.getCellProps()}
                       style={{
                         background: (i % 2 === 1) ? '#F9FAFC' : '#FBFCFD',
+                        borderBottom: (i === arr.length - 1) ? 'solid 1px #D8DCE3' : 'none',
+                        borderLeft: 'solid 1px #D8DCE3',
+                        borderRight: 'solid 1px #D8DCE3',
                         borderSpacing: 0,
-                        padding: '14px',
+                        borderTop: 'none',
+                        padding: '4px',
                       }}
                     >
                       <TextStyle>

--- a/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useAbsoluteLayout, useBlockLayout, useFlexLayout, useTable } from 'react-table';
+import { useTable } from 'react-table';
 import { TextStyle } from './index.style';
 import Text from '@oracle/elements/Text';
 
 import { DataTableColumn, DataTableRow } from './types';
-import { BORDER_RADIUS_LARGE } from '@oracle/styles/units/borders';
-import { TableStyle, RowCellStyle, CellStyled } from './Table.style';
-import { cutTextSize, getColumnWidth } from './helpers';
+import { TableStyle} from './Table.style';
+import { cutTextSize } from './helpers';
 
   export type DataTableProps = {
     children?: any;
@@ -29,7 +28,6 @@ import { cutTextSize, getColumnWidth } from './helpers';
 
   const [column, setColumn] = useState([]);
   const [row, setRow] = useState([]);
-  let lengths = [];
 
   // Keep these samples in due to undefined errors.
   const dataSample = useMemo(
@@ -102,51 +100,43 @@ import { cutTextSize, getColumnWidth } from './helpers';
     headerGroups,
     rows,
     prepareRow,
-    totalColumnsWidth,
   } = useTable(
     {
       columns: column || columnSample,
       data: row || dataSample,
     },
-    useAbsoluteLayout,
     );
 
   // TODO: Base template, add styling later. Cell styling is only for selected. Skip for now.
   return (
     // Table: Relative, no overflow, outline in silver
     <TableStyle>
-      <table 
+      <table
           {...getTableProps()}
-          style={{
-            // border: 'solid 1px #D8DCE3',
-            borderRadius: `${BORDER_RADIUS_LARGE}px`,
-            width: totalColumnsWidth,
-          }}
         >
         {/* Column: sticky. overflow y only, bold, silver, borders on everything but bottom. Filled background */}
         <thead>
           { headerGroups.map(headerGroup => (
             // eslint-disable-next-line react/jsx-key
             <tr {...headerGroup.getHeaderGroupProps()}>
-              {headerGroup.headers.map(column => (
+              {headerGroup.headers.map((column, i, cols) => (
                 // eslint-disable-next-line react/jsx-key
                 <th
                   {...column.getHeaderProps()}
                   style={{
                     background: '#F9FAFC',
                     border: 'solid 1px #D8DCE3',
-                    // width: `${getColumnWidth(rows, column.id)}px`,
+                    borderLeft: (i === 0) && 'none',
+                    borderRight: (i === cols.length - 1) && 'none',
+                    borderTop: 'none',
                     padding: '14px',
-                    // minWidth: `${column.width}px`,
                   }}
                 >
-                  {/* <RowCellStyle width={totalColumnsWidth}> */}
                   <TextStyle>
                     <Text bold leftAligned>
                       {column.render('Header')}
                     </Text>
                   </TextStyle>
-                  {/* </RowCellStyle> */}
                 </th>
                   ))}
             </tr>
@@ -160,27 +150,21 @@ import { cutTextSize, getColumnWidth } from './helpers';
               return (
                 // eslint-disable-next-line react/jsx-key
                 <tr {...row.getRowProps()}>
-                  {row.cells.map(cell => (
+                  {row.cells.map((cell) => (
                     // eslint-disable-next-line react/jsx-key
                     <td
                       {...cell.getCellProps()}
                       style={{
                         background: (i % 2 === 1) ? '#F9FAFC' : '#FBFCFD',
-                        border: 'solid 1px #FBFCFD',
-                        borderLeft: 'none',
-                        borderRight: 'none',
-                        // maxWidth: `${getColumnWidth(rows, cell.column.id)}px`,
-                        minWidth: cell.column.width,
+                        borderSpacing: 0,
                         padding: '14px',
                       }}
                     >
-                      {/* <CellStyled> */}
                       <TextStyle>
                         <Text>
                           {cell.render('Cell')}
                         </Text>
                       </TextStyle>
-                      {/* </CellStyled> */}
                     </td>
                     ))}
                 </tr>

--- a/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
@@ -29,6 +29,7 @@ import { cutTextSize, getColumnWidth } from './helpers';
 
   const [column, setColumn] = useState([]);
   const [row, setRow] = useState([]);
+  let lengths = [];
 
   // Keep these samples in due to undefined errors.
   const dataSample = useMemo(
@@ -117,7 +118,7 @@ import { cutTextSize, getColumnWidth } from './helpers';
       <table 
           {...getTableProps()}
           style={{
-            border: 'solid 1px #D8DCE3',
+            // border: 'solid 1px #D8DCE3',
             borderRadius: `${BORDER_RADIUS_LARGE}px`,
             width: totalColumnsWidth,
           }}
@@ -134,10 +135,9 @@ import { cutTextSize, getColumnWidth } from './helpers';
                   style={{
                     background: '#F9FAFC',
                     border: 'solid 1px #D8DCE3',
-                    maxWidth: `${getColumnWidth(rows, column.id)}px`,
-                    minWidth: column.minWidth,
+                    // width: `${getColumnWidth(rows, column.id)}px`,
                     padding: '14px',
-                    position: 'sticky',
+                    // minWidth: `${column.width}px`,
                   }}
                 >
                   {/* <RowCellStyle width={totalColumnsWidth}> */}
@@ -169,7 +169,7 @@ import { cutTextSize, getColumnWidth } from './helpers';
                         border: 'solid 1px #FBFCFD',
                         borderLeft: 'none',
                         borderRight: 'none',
-                        maxWidth: `${getColumnWidth(rows, cell.column.id)}px`,
+                        // maxWidth: `${getColumnWidth(rows, cell.column.id)}px`,
                         minWidth: cell.column.width,
                         padding: '14px',
                       }}

--- a/mage_ai/frontend/oracle/components/Table/SimpleDataTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/SimpleDataTable.tsx
@@ -15,8 +15,6 @@ import {
 } from './index.style';
 import { Check } from '@oracle/icons';
 import Spacing from '@oracle/elements/Spacing';
-import ProgressBar from '../ProgressBar';
-import { PERCENTAGE_KEYS } from '@components/datasets/constants';
 
 export type OnClickRowProps = {
   rowGroupIndex: number;

--- a/mage_ai/frontend/oracle/components/Table/SimpleDataTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/SimpleDataTable.tsx
@@ -15,6 +15,8 @@ import {
 } from './index.style';
 import { Check } from '@oracle/icons';
 import Spacing from '@oracle/elements/Spacing';
+import ProgressBar from '../ProgressBar';
+import { PERCENTAGE_KEYS } from '@components/datasets/constants';
 
 export type OnClickRowProps = {
   rowGroupIndex: number;
@@ -25,6 +27,7 @@ export type OnClickRowProps = {
 export type ColumnHeaderType = {
   Icon?: any;
   label: string;
+  progress?: number;
 };
 
 export type RowGroupDataType = {

--- a/mage_ai/frontend/oracle/components/Table/Table.style.tsx
+++ b/mage_ai/frontend/oracle/components/Table/Table.style.tsx
@@ -2,15 +2,19 @@ import styled from 'styled-components';
 
 import light from '@oracle/styles/themes/light';
 import { UNIT, PADDING_UNITS } from '@oracle/styles/units/spacing';
+import { BORDER_RADIUS_LARGE } from '@oracle/styles/units/borders';
 
 export const TableStyle = styled.div<any>`
   position: relative;
-  height: 80%;
-  max-height: 80vh;
+  text-align: left;
+  position: relative;
+  border: solid 1px #D8DCE3;
+  border-collapse: collapse;
+  border-radius: ${BORDER_RADIUS_LARGE}px;
+  max-height: 50vh;
   width: 100%;
   max-width: 100vw;
   overflow: auto;
-  padding: 4px;
   ${props => props.table &&`
     background-color: ${(props.theme.background || light.background).page};
   `}
@@ -25,7 +29,6 @@ export const TableStyle = styled.div<any>`
 
 // TODO: Update these hardcoded values
 export const RowCellStyle = styled.div<any>`
-  
   max-height: 80px;
   flex-shrink: 0;
   ${props => !props.first && `

--- a/mage_ai/frontend/oracle/components/Table/Table.style.tsx
+++ b/mage_ai/frontend/oracle/components/Table/Table.style.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 import light from '@oracle/styles/themes/light';
 import { UNIT, PADDING_UNITS } from '@oracle/styles/units/spacing';
-import { BORDER_RADIUS_LARGE } from '@oracle/styles/units/borders';
 
 export const TableStyle = styled.div<any>`
   max-height: 50vh;
@@ -11,9 +10,7 @@ export const TableStyle = styled.div<any>`
   position: relative;
 
   ${props => props && `
-    border: solid 1px ${(props.theme.interactive || light.interactive).defaultBorder};
     border-collapse: collapse;
-    border-radius: ${BORDER_RADIUS_LARGE}px;
   `}
   ${props => props.table && `
     background-color: ${(props.theme.background || light.background).page};

--- a/mage_ai/frontend/oracle/components/Table/Table.style.tsx
+++ b/mage_ai/frontend/oracle/components/Table/Table.style.tsx
@@ -5,17 +5,17 @@ import { UNIT, PADDING_UNITS } from '@oracle/styles/units/spacing';
 import { BORDER_RADIUS_LARGE } from '@oracle/styles/units/borders';
 
 export const TableStyle = styled.div<any>`
-  position: relative;
-  text-align: left;
-  position: relative;
-  border: solid 1px #D8DCE3;
-  border-collapse: collapse;
-  border-radius: ${BORDER_RADIUS_LARGE}px;
   max-height: 50vh;
-  width: 100%;
   max-width: 100vw;
   overflow: auto;
-  ${props => props.table &&`
+  position: relative;
+
+  ${props => props && `
+    border: solid 1px ${(props.theme.interactive || light.interactive).defaultBorder};
+    border-collapse: collapse;
+    border-radius: ${BORDER_RADIUS_LARGE}px;
+  `}
+  ${props => props.table && `
     background-color: ${(props.theme.background || light.background).page};
   `}
   ${props => props.height && `

--- a/mage_ai/frontend/oracle/components/Table/Table.style.tsx
+++ b/mage_ai/frontend/oracle/components/Table/Table.style.tsx
@@ -5,6 +5,8 @@ import { UNIT, PADDING_UNITS } from '@oracle/styles/units/spacing';
 
 export const TableStyle = styled.div<any>`
   position: relative;
+  height: 80%;
+  max-height: 80vh;
   width: 100%;
   max-width: 100vw;
   overflow: auto;

--- a/mage_ai/frontend/oracle/components/Table/helpers.tsx
+++ b/mage_ai/frontend/oracle/components/Table/helpers.tsx
@@ -1,8 +1,8 @@
 import { UNIT } from '@oracle/styles/units/spacing';
 import { DataTableRow } from './types';
 // TODO: Update with official numbers and import from units/spacing.ts
-export const WIDTH_OF_SINGLE_CHARACTER = 10;
-export const CHARACTER_LIMIT = 45;
+export const WIDTH_OF_SINGLE_CHARACTER = 8;
+export const CHARACTER_LIMIT = 20;
 
 export const cutTextSize = (
   label: string,
@@ -12,13 +12,17 @@ export const getColumnWidth = (
   rows: DataTableRow<any>[],
   headerText: string,
 ) => {
-  const toFieldLength = (row: any) => (row?.toString() ?? '').length;
+  const toFieldLength = (row: any) => {
+    (row?.toString() ?? '').length;
+  };
 
   // Use the largest length between the rows and columns.
+  console.log("Rows:", ...rows);
   const cellLength = Math.max(
     // TODO: could short circuit here if a single item length > MAX_COL_WIDTH
     ...rows.map(toFieldLength),
     headerText.length,
   );
-  return cellLength * WIDTH_OF_SINGLE_CHARACTER;
+  // console.log(Math.max(...rows.map(toFieldLength)), headerText.length, headerText);
+  return (cellLength)  * WIDTH_OF_SINGLE_CHARACTER;
 };

--- a/mage_ai/frontend/oracle/components/Table/helpers.tsx
+++ b/mage_ai/frontend/oracle/components/Table/helpers.tsx
@@ -1,28 +1,5 @@
-import { UNIT } from '@oracle/styles/units/spacing';
-import { DataTableRow } from './types';
-// TODO: Update with official numbers and import from units/spacing.ts
-export const WIDTH_OF_SINGLE_CHARACTER = 8;
 export const CHARACTER_LIMIT = 20;
 
 export const cutTextSize = (
   label: string,
 ) => (label?.length > CHARACTER_LIMIT) ? `${label?.slice(0, CHARACTER_LIMIT - 3)}...` : (label);
-
-export const getColumnWidth = (
-  rows: DataTableRow<any>[],
-  headerText: string,
-) => {
-  const toFieldLength = (row: any) => {
-    (row?.toString() ?? '').length;
-  };
-
-  // Use the largest length between the rows and columns.
-  console.log("Rows:", ...rows);
-  const cellLength = Math.max(
-    // TODO: could short circuit here if a single item length > MAX_COL_WIDTH
-    ...rows.map(toFieldLength),
-    headerText.length,
-  );
-  // console.log(Math.max(...rows.map(toFieldLength)), headerText.length, headerText);
-  return (cellLength)  * WIDTH_OF_SINGLE_CHARACTER;
-};


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
### BaseTable polishing
- Add rounded corners
- Removed fancy layout hooks
- Improved styling on the inside of the table
- Shrunk the size of table down for more apparent vertical scrolling

# Tests
<!-- How did you test your change? -->
Localhost 

### Ugly dataset with long values
<img width="1210" alt="image" src="https://user-images.githubusercontent.com/90282975/172023191-abfbaa09-fdb5-4aa9-bd6a-87a93ad06ba4.png">

### Dataset with long column names
<img width="1219" alt="image" src="https://user-images.githubusercontent.com/90282975/172023211-31ea2ca7-ec0d-4180-a9ca-6a9f1385ae00.png">

### Small dataset
<img width="1248" alt="image" src="https://user-images.githubusercontent.com/90282975/172023454-c0c47b81-d0e1-4390-915c-d8f3a7232036.png">

**Doesn't look that good since the borders don't align**

### Additions & improvements
- Change px to rem and em, 
- Find another way to style that works with the react-table without passing in a style prop.
- Display the datatype on top of the column
- Add a sticky column header.
- There is a bug where if the table is at max scroll it will scroll the page by the direction. Can be annoying at times.

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@johnson-mage @dy46 @tommydangerous 