### PR TITLE
[xy] Speed up reformat values

### DIFF
--- a/mage_ai/data_cleaner/cleaning_rules/reformat_values.py
+++ b/mage_ai/data_cleaner/cleaning_rules/reformat_values.py
@@ -215,7 +215,7 @@ class ConvertCurrencySubRule(ReformatValuesSubRule):
 
 class ReformatDateSubRule(ReformatValuesSubRule):
     DATE_MATCHES_LB = 0.3
-    DATE_TYPES = frozenset((DATETIME, CATEGORY, CATEGORY_HIGH_CARDINALITY, TEXT))
+    DATE_TYPES = frozenset((DATETIME))
 
     def evaluate(self, column):
         """

--- a/mage_ai/data_cleaner/cleaning_rules/reformat_values.py
+++ b/mage_ai/data_cleaner/cleaning_rules/reformat_values.py
@@ -215,7 +215,7 @@ class ConvertCurrencySubRule(ReformatValuesSubRule):
 
 class ReformatDateSubRule(ReformatValuesSubRule):
     DATE_MATCHES_LB = 0.3
-    DATE_TYPES = frozenset((DATETIME))
+    DATE_TYPES = frozenset((DATETIME,))
 
     def evaluate(self, column):
         """

--- a/mage_ai/tests/data_cleaner/cleaning_rules/test_reformat_values.py
+++ b/mage_ai/tests/data_cleaner/cleaning_rules/test_reformat_values.py
@@ -1,6 +1,7 @@
-from mage_ai.data_cleaner.cleaning_rules.reformat_values import ReformatValues
-from mage_ai.tests.base_test import TestCase
 from datetime import datetime as dt
+from mage_ai.data_cleaner.cleaning_rules.reformat_values import ReformatValues
+from mage_ai.data_cleaner.column_type_detector import infer_column_types
+from mage_ai.tests.base_test import TestCase
 import numpy as np
 import pandas as pd
 
@@ -243,13 +244,10 @@ class ReformatValuesCleaningRuleTests(TestCase):
                 'date5',
             ],
         )
-        column_types = {
-            'date1': 'datetime',
-            'date2': 'datetime',
-            'date3': 'category',
-            'date4': 'category',
-            'date5': 'text',
-        }
+        # date3 and date4 are detected as text type.
+        # TODO: Update column_type_detector to detect date3 and date4 as datetime type.
+        column_types = infer_column_types(df)
+        print(column_types)
         statistics = {
             'date1/count': 5,
             'date2/count': 4,
@@ -263,11 +261,11 @@ class ReformatValuesCleaningRuleTests(TestCase):
             dict(
                 title='Reformat values',
                 message='The following columns have date values: '
-                '[\'date2\', \'date3\', \'date4\', \'date5\']. '
+                '[\'date2\', \'date5\']. '
                 'Reformat these columns as datetime objects to improve data quality.',
                 action_payload=dict(
                     action_type='reformat',
-                    action_arguments=['date2', 'date3', 'date4', 'date5'],
+                    action_arguments=['date2', 'date5'],
                     axis='column',
                     action_options={
                         'reformat': 'date_format_conversion',
@@ -299,13 +297,7 @@ class ReformatValuesCleaningRuleTests(TestCase):
                 'date5',
             ],
         )
-        column_types = {
-            'date1': 'datetime',
-            'date2': 'datetime',
-            'notdate': 'text',
-            'mostlydate': 'category_high_cardinality',
-            'date5': 'number',
-        }
+        column_types = infer_column_types(df)
         statistics = {
             'date1/count': 5,
             'date2/count': 4,


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Only apply ReformatDateSubRule to datetime type. I tested this rule on a dateset with 26k rows and multiple text column. It originally took 100 seconds. This change reduced the time to 8 seconds.

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
