### PR TITLE
[sk] Support for custom cleaning actions

### DIFF
--- a/mage_ai/data_cleaner/transformer_actions/base.py
+++ b/mage_ai/data_cleaner/transformer_actions/base.py
@@ -22,6 +22,7 @@ FUNCTION_MAPPING = {
         ActionType.CLEAN_COLUMN_NAME: column.clean_column_names,
         ActionType.COUNT: column.count,
         ActionType.COUNT_DISTINCT: column.count_distinct,
+        ActionType.CUSTOM: column.custom,
         ActionType.DIFF: column.diff,
         # ActionType.EXPAND_COLUMN: column.expand_column,
         ActionType.FIRST: column.first,
@@ -38,6 +39,7 @@ FUNCTION_MAPPING = {
         ActionType.SUM: column.sum,
     },
     Axis.ROW: {
+        ActionType.CUSTOM: row.custom,
         ActionType.DROP_DUPLICATE: row.drop_duplicates,
         # ActionType.EXPLODE: row.explode,
         ActionType.FILTER: row.filter_rows,

--- a/mage_ai/data_cleaner/transformer_actions/column.py
+++ b/mage_ai/data_cleaner/transformer_actions/column.py
@@ -11,6 +11,7 @@ from mage_ai.data_cleaner.transformer_actions.helpers import (
     get_column_type,
     get_time_window_str,
 )
+from mage_ai.data_cleaner.transformer_actions.custom_action import execute_custom_action
 from mage_ai.data_cleaner.transformer_actions.udf.base import execute_udf
 from keyword import iskeyword
 import pandas as pd
@@ -52,6 +53,10 @@ def clean_column_names(df, action, **kwargs):
     columns = action['action_arguments']
     mapping = {col: __clean_column_name(col) for col in columns}
     return df.rename(columns=mapping)
+
+
+def custom(df, action, **kwargs):
+    return execute_custom_action(df, action, **kwargs)
 
 
 def diff(df, action, **kwargs):

--- a/mage_ai/data_cleaner/transformer_actions/constants.py
+++ b/mage_ai/data_cleaner/transformer_actions/constants.py
@@ -5,12 +5,13 @@ CONSTANT_IMPUTATION_DEFAULTS = dict(object='missing', datetime=pd.Timestamp.min,
 CURRENCY_SYMBOLS = re.compile(r'(?:[\$\€\¥\₹\元\£]|(?:Rs)|(?:CAD))')
 
 
-class ActionType():
+class ActionType:
     ADD = 'add'
     AVERAGE = 'average'
     CLEAN_COLUMN_NAME = 'clean_column_name'
     COUNT = 'count'
     COUNT_DISTINCT = 'count_distinct'
+    CUSTOM = 'custom'
     DIFF = 'diff'
     DROP_DUPLICATE = 'drop_duplicate'
     EXPAND_COLUMN = 'expand_column'
@@ -39,18 +40,18 @@ class ActionType():
     UPDATE_VALUE = 'update_value'
 
 
-class Axis():
+class Axis:
     COLUMN = 'column'
     ROW = 'row'
 
 
-class VariableType():
+class VariableType:
     FEATURE = 'feature'
     FEATURE_SET = 'feature_set'
     FEATURE_SET_VERSION = 'feature_set_version'
 
 
-class Operator():
+class Operator:
     CONTAINS = 'contains'
     NOT_CONTAINS = 'not contains'
     EQUALS = '=='
@@ -61,7 +62,7 @@ class Operator():
     LESS_THAN_OR_EQUALS = '<='
 
 
-class ImputationStrategy():
+class ImputationStrategy:
     AVERAGE = 'average'
     COLUMN = 'column'
     CONSTANT = 'constant'
@@ -73,7 +74,7 @@ class ImputationStrategy():
     SEQ = 'sequential'
 
 
-class NameConventionPatterns():
+class NameConventionPatterns:
     SNAKE = re.compile(r'^[a-z]+(?:\_[a-z0-9]+)*$')
     CAMEL = re.compile(r'^[a-z]+(?:[A-Z][a-z]*)*$')
     CAMEL_COMPONENT = re.compile(r'^[a-z]+')

--- a/mage_ai/data_cleaner/transformer_actions/custom_action.py
+++ b/mage_ai/data_cleaner/transformer_actions/custom_action.py
@@ -12,16 +12,26 @@ def build_custom_action_decorator(action_list):
 def execute_custom_action(df, action, **kwargs):
     """
     Handles custom action generation and execution. Custom actions are currently supported in two different ways:
-    - **`custom_action` decorator**: any function decorated with `@custom_action` will be executed afterwards as a custom action.
-    All functions must accept a Pandas dataframe and return a Pandas dataframe. The example below shows an expected function signature:
+    - `custom_action` decorator: any function decorated with `@custom_action` will be executed afterwards as a custom action.
+    All functions must accept a Pandas dataframe and return a Pandas dataframe. Functions decorated with `@custom_action` are
+    executed in the order of their definition.
 
-    - **Script style**: entering a script into the action code menu will execute the script. The script will have access to the dataframe through the
+    - Script style: entering a script into the action code menu will execute the script. The script will have access to the dataframe through the
     `df` variable and must mutate it before completion in order to apply the correct action.
 
-    Below is an example of a transformation function that could be given
-    ```
+    If both custom actions and scripts are provided, the scripts will be executed before the custom actions.
+
+    Below is an example of a user defined custom transformer action
+    ```python
     @custom_action
     def transform(df: pandas.DataFrame) -> pandas.DataFrame:
+        df['total'] = df.sum(axis=0)
+        return df
+    ```
+
+    Below is a python script performing the same function that can be run by this function:
+    ```python
+    df['total'] = df.sum(axis=0)
     ```
     """
     custom_actions = deque()

--- a/mage_ai/data_cleaner/transformer_actions/custom_action.py
+++ b/mage_ai/data_cleaner/transformer_actions/custom_action.py
@@ -1,0 +1,32 @@
+from collections import deque
+
+
+def build_custom_action_decorator(action_list):
+    def custom_action(function):
+        action_list.append(function)
+        return function
+
+    return custom_action
+
+
+def execute_custom_action(df, action, **kwargs):
+    """
+    Handles custom action generation and execution. Custom actions are currently supported in two different ways:
+    - **`custom_action` decorator**: any function decorated with `@custom_action` will be executed afterwards as a custom action.
+    All functions must accept a Pandas dataframe and return a Pandas dataframe. The example below shows an expected function signature:
+
+    - **Script style**: entering a script into the action code menu will execute the script. The script will have access to the dataframe through the
+    `df` variable and must mutate it before completion in order to apply the correct action.
+
+    Below is an example of a transformation function that could be given
+    ```
+    @custom_action
+    def transform(df: pandas.DataFrame) -> pandas.DataFrame:
+    ```
+    """
+    custom_actions = deque()
+    custom_action = build_custom_action_decorator(custom_actions)
+    exec(action['action_code'], {'df': df, 'custom_action': custom_action})
+    while len(custom_actions) != 0:
+        df = custom_actions.popleft()(df)
+    return df

--- a/mage_ai/data_cleaner/transformer_actions/row.py
+++ b/mage_ai/data_cleaner/transformer_actions/row.py
@@ -1,7 +1,12 @@
+from mage_ai.data_cleaner.transformer_actions.action_code import query_with_action_code
 from mage_ai.data_cleaner.column_type_detector import NUMBER_TYPES
 from mage_ai.data_cleaner.transformer_actions.constants import VariableType
-from mage_ai.data_cleaner.transformer_actions.action_code import query_with_action_code
+from mage_ai.data_cleaner.transformer_actions.custom_action import execute_custom_action
 import pandas as pd
+
+
+def custom(df, action, **kwargs):
+    return execute_custom_action(df, action, **kwargs)
 
 
 def drop_duplicates(df, action, **kwargs):
@@ -52,22 +57,31 @@ def sort_rows(df, action, **kwargs):
     if na_indexes is not None:
         bad_df = df.index.isin(na_indexes)
 
-    index = (df[~bad_df] if bad_df is not None else df).astype(as_types).sort_values(
-        by=action['action_arguments'],
-        ascending=ascendings if len(ascendings) > 0 else ascending,
-    ).index
+    index = (
+        (df[~bad_df] if bad_df is not None else df)
+        .astype(as_types)
+        .sort_values(
+            by=action['action_arguments'],
+            ascending=ascendings if len(ascendings) > 0 else ascending,
+        )
+        .index
+    )
 
     df_final = df.loc[index]
     if bad_df is not None:
         if ascending:
-            return pd.concat([
-                df.iloc[bad_df],
-                df_final,
-            ])
+            return pd.concat(
+                [
+                    df.iloc[bad_df],
+                    df_final,
+                ]
+            )
 
-        return pd.concat([
+        return pd.concat(
+            [
                 df_final,
                 df.iloc[bad_df],
-        ])
+            ]
+        )
 
     return df_final

--- a/mage_ai/tests/data_cleaner/transformer_actions/test_custom_actions.py
+++ b/mage_ai/tests/data_cleaner/transformer_actions/test_custom_actions.py
@@ -1,0 +1,189 @@
+from mage_ai.data_cleaner.transformer_actions.custom_action import execute_custom_action
+from mage_ai.tests.base_test import TestCase
+from pandas.testing import assert_frame_equal
+import pandas as pd
+import numpy as np
+
+
+class CustomActionTests(TestCase):
+    def test_decorated_custom_action(self):
+        df = pd.DataFrame(
+            [
+                ['1', 1.000, '2021-10-01', 'Store 1', 23023],
+                ['1', None, '2021-10-01', 'Store 2', np.nan],
+                [np.nan, 1100, '', '', 90233],
+                ['2', None, None, 'Store 1', 23920],
+                ['2', 12.00, '2021-09-01', None, np.nan],
+                ['2', 125.0, '2021-09-01', 'Store 3', 49833],
+            ],
+            columns=[
+                'group_id',
+                'price',
+                'group_churned_at',
+                'store',
+                'zip_code',
+            ],
+        )
+        expected_df = pd.DataFrame(
+            [
+                [1.0, 1.000, '2021-10-01', 'Store 1', 23023, 1],
+                [1.0, None, '2021-10-01', 'Store 2', np.nan, 1],
+                [np.nan, 1100, np.nan, np.nan, 90233, None],
+                [2.0, None, None, 'Store 1', 23920, 2],
+                [2.0, 12.00, '2021-09-01', None, np.nan, 2],
+                [2.0, 125.0, '2021-09-01', 'Store 3', 49833, 2],
+            ],
+            columns=['group_id', 'price', 'group_churned_at', 'store', 'zip_code', 'new_col'],
+        )
+        action = {
+            'action_type': 'custom',
+            'axis': 'row',
+            'action_code': 'from mage_ai.data_cleaner.column_type_detector import NUMBER,'
+            ' NUMBER_WITH_DECIMALS, DATETIME, infer_column_types\n'
+            'from mage_ai.data_cleaner.transformer_actions.constants import CURRENCY_SYMBOLS\n'
+            'import pandas as pd\n'
+            'import numpy as np\n\n\n'
+            'def clean_series(series, column_type, dropna=True):\n'
+            '    series_cleaned = series.apply(lambda x: x.strip(" \\\'\\\"") '
+            'if type(x) is str else x)\n'
+            '    series_cleaned = series_cleaned.map(\n'
+            '        lambda x: x if (not isinstance(x, str) or (len(x) > 0 and'
+            ' not x.isspace())) else np.nan\n '
+            '   )\n'
+            '    if dropna:\n'
+            '        series_cleaned = series_cleaned.dropna()\n\n'
+            '    if series_cleaned.count() == 0:\n'
+            '        return series_cleaned\n\n'
+            '    first_item = series_cleaned.dropna().iloc[0]\n'
+            '    if column_type == NUMBER or column_type == NUMBER_WITH_DECIMALS:\n'
+            '        is_percent = False\n        if type(first_item) is str:\n'
+            '            series_cleaned = series_cleaned.str.replace(",", "")\n'
+            '            if series_cleaned.str.count(CURRENCY_SYMBOLS).sum() != 0:\n'
+            '                series_cleaned = series_cleaned.str.replace(CURRENCY_SYMBOLS, "")\n'
+            '            elif series_cleaned.str.contains("%").sum() != 0:\n'
+            '                is_percent = True\n'
+            '                series_cleaned = series_cleaned.str.replace("%", "")\n'
+            '            series_cleaned = series_cleaned.str.replace(" ", "")\n'
+            '        if column_type == NUMBER:\n'
+            '           try:\n'
+            '                series_cleaned = series_cleaned.astype(int)\n'
+            '           except ValueError:\n'
+            '                series_cleaned = series_cleaned.astype(float)\n'
+            '        else:\n            series_cleaned = series_cleaned.astype(float)\n'
+            '        if is_percent:\n'
+            '            series_cleaned /= 100\n'
+            '    elif column_type == DATETIME:\n'
+            '        series_cleaned = pd.to_datetime(series_cleaned, errors="coerce",'
+            ' infer_datetime_format=True)\n'
+            '    return series_cleaned\n'
+            '   \n\n@custom_action\ndef clean_df(df):\n'
+            '    ctypes = infer_column_types(df)\n'
+            '    for col in df.columns:\n'
+            '        df[col] = clean_series(df[col], ctypes, dropna=False)\n'
+            '    return df\n\n'
+            '@custom_action  \n'
+            'def print_df(df):\n'
+            '    print(df)\n'
+            '    return df\n'
+            '    \n'
+            '@custom_action\n'
+            'def print_df_dtypes(df):\n'
+            '    print(df.dtypes)\n'
+            '    return df\n'
+            '    \n'
+            '@custom_action\n'
+            'def add_column(df):\n'
+            '    columns = list(df.columns)\n'
+            '    df["new_col"] = df[columns[0]]\n'
+            '    return df',
+            'action_variables': {},
+        }
+        new_df = execute_custom_action(df, action)
+        new_df['group_id'] = new_df['group_id'].astype(float)
+        new_df['new_col'] = new_df['new_col'].astype(float)
+        assert_frame_equal(new_df, expected_df)
+
+    def test_scripted_custom_action(self):
+        df = pd.DataFrame(
+            [
+                ['1', 1.000, '2021-10-01', 'Store 1', 23023],
+                ['1', None, '2021-10-01', 'Store 2', np.nan],
+                [np.nan, 1100, '', '', 90233],
+                ['2', None, None, 'Store 1', 23920],
+                ['2', 12.00, '2021-09-01', None, np.nan],
+                ['2', 125.0, '2021-09-01', 'Store 3', 49833],
+            ],
+            columns=[
+                'group_id',
+                'price',
+                'group_churned_at',
+                'store',
+                'zip_code',
+            ],
+        )
+        expected_df = pd.DataFrame(
+            [
+                [1.0, 1.000, '2021-10-01', 'Store 1', 23023, 1],
+                [1.0, None, '2021-10-01', 'Store 2', np.nan, 1],
+                [np.nan, 1100, np.nan, np.nan, 90233, None],
+                [2.0, None, None, 'Store 1', 23920, 2],
+                [2.0, 12.00, '2021-09-01', None, np.nan, 2],
+                [2.0, 125.0, '2021-09-01', 'Store 3', 49833, 2],
+            ],
+            columns=['group_id', 'price', 'group_churned_at', 'store', 'zip_code', 'new_col'],
+        )
+        action = {
+            'action_type': 'custom',
+            'axis': 'row',
+            'action_code': 'from mage_ai.data_cleaner.column_type_detector import NUMBER,'
+            ' NUMBER_WITH_DECIMALS, DATETIME, infer_column_types\n'
+            'from mage_ai.data_cleaner.transformer_actions.constants import CURRENCY_SYMBOLS\n'
+            'import pandas as pd\n'
+            'import numpy as np\n\n\n'
+            'def clean_series(series, column_type, dropna=True):\n'
+            '    series_cleaned = series.apply(lambda x: x.strip(" \\\'\\\"") '
+            'if type(x) is str else x)\n'
+            '    series_cleaned = series_cleaned.map(\n'
+            '        lambda x: x if (not isinstance(x, str) or (len(x) > 0 and'
+            ' not x.isspace())) else np.nan\n '
+            '   )\n'
+            '    if dropna:\n'
+            '        series_cleaned = series_cleaned.dropna()\n\n'
+            '    if series_cleaned.count() == 0:\n'
+            '        return series_cleaned\n\n'
+            '    first_item = series_cleaned.dropna().iloc[0]\n'
+            '    if column_type == NUMBER or column_type == NUMBER_WITH_DECIMALS:\n'
+            '        is_percent = False\n        if type(first_item) is str:\n'
+            '            series_cleaned = series_cleaned.str.replace(",", "")\n'
+            '            if series_cleaned.str.count(CURRENCY_SYMBOLS).sum() != 0:\n'
+            '                series_cleaned = series_cleaned.str.replace(CURRENCY_SYMBOLS, "")\n'
+            '            elif series_cleaned.str.contains("%").sum() != 0:\n'
+            '                is_percent = True\n'
+            '                series_cleaned = series_cleaned.str.replace("%", "")\n'
+            '            series_cleaned = series_cleaned.str.replace(" ", "")\n'
+            '        if column_type == NUMBER:\n'
+            '           try:\n'
+            '                series_cleaned = series_cleaned.astype(int)\n'
+            '           except ValueError:\n'
+            '                series_cleaned = series_cleaned.astype(float)\n'
+            '        else:\n            series_cleaned = series_cleaned.astype(float)\n'
+            '        if is_percent:\n'
+            '            series_cleaned /= 100\n'
+            '    elif column_type == DATETIME:\n'
+            '        series_cleaned = pd.to_datetime(series_cleaned, errors="coerce",'
+            ' infer_datetime_format=True)\n'
+            '    return series_cleaned\n'
+            '   \n\n'
+            'ctypes = infer_column_types(df)\n'
+            'for col in df.columns:\n'
+            '    df[col] = clean_series(df[col], ctypes, dropna=False)\n'
+            'print(df)\n'
+            'print(df.dtypes)\n'
+            'columns = list(df.columns)\n'
+            'df["new_col"] = df[columns[0]]\n',
+            'action_variables': {},
+        }
+        new_df = execute_custom_action(df, action)
+        new_df['group_id'] = new_df['group_id'].astype(float)
+        new_df['new_col'] = new_df['new_col'].astype(float)
+        assert_frame_equal(new_df, expected_df)


### PR DESCRIPTION
# Summary
Backend transformer action library now supports custom cleaning actions. The cleaning action accepts primarily two forms of python code input:
- `custom_action` decorator: any function decorated with `@custom_action` will be executed after the action invocation. All 
   such functions must accept a Pandas data frame and return a Pandas data frame. Functions decorated with 
    `@custom_action` are executed in the order of their definition.
- Script style: entering a script into the action code menu will execute the script. The script will have access to the 
   dataframe through the `df` variable and must mutate it before completion in order to apply the correct action.

If both are provided, the scripted logic is ran before any `@custom_action` decorated functions.

An example of a decorator style cleaning action:
```python
@custom_action
def transform(df: pandas.DataFrame) -> pandas.DataFrame:
    df['total'] = df.sum(axis=0)
    return df
```

An example of a script style cleaning action:
 ```python
 df['total'] = df.sum(axis=0)
```

# Tests
Unit tests were written and ran, alongside testing on real datasets using the client.

cc:
@wangxiaoyou1993 
