### PR TITLE
[nt] Add divide by zero edge cases

### DIFF
--- a/mage_ai/frontend/components/datasets/overview/utils.ts
+++ b/mage_ai/frontend/components/datasets/overview/utils.ts
@@ -69,7 +69,11 @@ export function createStatisticsSample(statistics, colTypes) {
       const name = HUMAN_READABLE_MAPPING[key];
       let value = statistics[key];
       if (WARN_KEYS.includes(key)) {
-        value = `${value} (${getPercentage(value / total)})`;
+        if (total !== 0) {
+          value = `${value} (${getPercentage(value / total)})`;
+        } else {
+          value = '0 (0%)';
+        }
       }
       rowData.push({
         columnValues: [name, value],
@@ -77,13 +81,22 @@ export function createStatisticsSample(statistics, colTypes) {
     }
   });
 
-  rowData.push({
-    columnValues: ['Categorical Features', `${countCategory} (${getPercentage(countCategory / total)})`],
-  },{
-    columnValues: ['Numerical Features', `${countNumerical} (${getPercentage(countNumerical / total)})`],
-  },{
-    columnValues: ['Time series Features', `${countTimeseries} (${getPercentage(countTimeseries / total)})`],
-  });
-
+  if (total !== 0) {
+    rowData.push({
+      columnValues: ['Categorical Features', `${countCategory} (${getPercentage(countCategory / total)})`],
+    },{
+      columnValues: ['Numerical Features', `${countNumerical} (${getPercentage(countNumerical / total)})`],
+    },{
+      columnValues: ['Time series Features', `${countTimeseries} (${getPercentage(countTimeseries / total)})`],
+    });
+  } else {
+    rowData.push({
+      columnValues: ['Categorical Features', '0 (0%)'],
+    },{
+      columnValues: ['Numerical Features', '0 (0%)'],
+    },{
+      columnValues: ['Time series Features', '0 (0%)'],
+    });
+  }
   return { rowData };
 }

--- a/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
@@ -4,7 +4,7 @@ import { TextStyle } from './index.style';
 import Text from '@oracle/elements/Text';
 
 import { DataTableColumn, DataTableRow } from './types';
-import { TableStyle} from './Table.style';
+import { TableStyle } from './Table.style';
 import { cutTextSize } from './helpers';
 
   export type DataTableProps = {


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
### Adds edge case for when the count of datatypes are zero when getting the ratio to display

# Tests
<!-- How did you test your change? -->
Localhost, pull up the statistics table.

### Before
<img width="452" alt="image" src="https://user-images.githubusercontent.com/90282975/172220796-a4a7d046-41e9-4a3d-a5e1-1f6d6c532c48.png">

### After
<img width="378" alt="image" src="https://user-images.githubusercontent.com/90282975/172220516-e880eaaf-bdb7-461c-a248-93d076484662.png">

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@johnson-mage 