### PR TITLE
[sk] Statistics performance updates

### DIFF
--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -53,7 +53,6 @@ class StatisticsCalculator:
             arr_args_1 = ([df[col] for col in df.columns],)
             arr_args_2 = ([col for col in df.columns],)
 
-            # dicts = run_parallel(self.statistics_overview, arr_args_1, arr_args_2)
             dicts = map(self.statistics_overview, *arr_args_1, *arr_args_2)
 
             for d in dicts:

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -48,17 +48,13 @@ class StatisticsCalculator:
         with timer('statistics.calculate_statistics_overview.time', self.data_tags):
             if not is_clean:
                 df = clean_dataframe(df, self.column_types, dropna=False)
-            timeseries_metadata = self.__evaluate_timeseries(df)
-            data = dict(
-                count=len(df.index),
-                is_timeseries=timeseries_metadata['is_timeseries'],
-                timeseries_index=timeseries_metadata['timeseries_index'],
-            )
+            data = dict(count=len(df.index))
 
             arr_args_1 = ([df[col] for col in df.columns],)
             arr_args_2 = ([col for col in df.columns],)
 
-            dicts = run_parallel(self.statistics_overview, arr_args_1, arr_args_2)
+            # dicts = run_parallel(self.statistics_overview, arr_args_1, arr_args_2)
+            dicts = map(self.statistics_overview, *arr_args_1, *arr_args_2)
 
             for d in dicts:
                 data.update(d)
@@ -87,6 +83,9 @@ class StatisticsCalculator:
                 [col for col in df.columns if data[f'{col}/count'] == 0]
             )
 
+            timeseries_metadata = self.__evaluate_timeseries(data)
+            data.update(timeseries_metadata)
+
             # object_key = s3_paths.path_statistics_overview(self.object_key_prefix)
             # s3_data.upload_json_sorted(self.s3_client, object_key, data)
 
@@ -97,17 +96,14 @@ class StatisticsCalculator:
 
         return data
 
-    def get_longest_null_seq(self, series):
-        longest_sequence = 0
-        curr_sequence = 0
-        for is_null in series.isna():
+    def null_seq_gen(self, arr):
+        prev = -1
+        for is_null in arr:
             if is_null:
-                curr_sequence += 1
+                prev += 1
             else:
-                longest_sequence = max(longest_sequence, curr_sequence)
-                curr_sequence = 0
-        longest_sequence = max(longest_sequence, curr_sequence)
-        return longest_sequence
+                prev = 0
+            yield prev
 
     def statistics_overview(self, series, col):
         try:
@@ -126,14 +122,11 @@ class StatisticsCalculator:
             traceback.print_exc()
             return {}
 
-    def __evaluate_timeseries(self, df):
+    def __evaluate_timeseries(self, data):
         indices = []
-        for column in df.columns:
-            dtype = self.column_types[column]
-            if dtype == DATETIME:
-                null_value_rate = df[column].isnull().sum() / df[column].size
-                if null_value_rate <= 0.1 and dtype == DATETIME:
-                    indices.append(column)
+        for column, dtype in self.column_types.items():
+            if data[f'{column}/null_value_rate'] <= 0.1 and dtype == DATETIME:
+                indices.append(column)
         return {'is_timeseries': len(indices) != 0, 'timeseries_index': indices}
 
     def __statistics_overview(self, series, col):
@@ -176,16 +169,19 @@ class StatisticsCalculator:
             if series.size == 0
             else series.isnull().sum() / series.size,
             f'{col}/null_value_count': series.isnull().sum(),
-            f'{col}/max_null_seq': self.get_longest_null_seq(series),
             f'{col}/value_counts': df_top_value_counts.to_dict(),
         }
+
+        data[f'{col}/max_null_seq'] = (
+            max(self.null_seq_gen(series.isna().to_numpy())) if series.size else 0
+        )
 
         if len(series_non_null) > 0:
             dates = None
             if column_type in NUMBER_TYPES:
-                data[f'{col}/average'] = series_non_null.sum() / len(series_non_null)
+                data[f'{col}/average'] = series_non_null.mean()
                 data[f'{col}/max'] = series_non_null.max()
-                data[f'{col}/median'] = series_non_null.quantile(0.5)
+                data[f'{col}/median'] = series_non_null.median()
                 data[f'{col}/min'] = series_non_null.min()
                 data[f'{col}/sum'] = series_non_null.sum()
                 data[f'{col}/skew'] = series_non_null.skew()
@@ -221,8 +217,6 @@ class StatisticsCalculator:
 
                 data[f'{col}/mode'] = mode
                 data[f'{col}/mode_ratio'] = value_counts.max() / value_counts.sum()
-
-            data[f'{col}/max_null_seq'] = self.get_longest_null_seq(series)
 
         # Detect mismatched formats for some column types
         data[f'{col}/invalid_value_count'] = get_mismatched_row_count(series_non_null, column_type)

--- a/mage_ai/tests/data_cleaner/statistics/test_calculator.py
+++ b/mage_ai/tests/data_cleaner/statistics/test_calculator.py
@@ -143,14 +143,90 @@ class StatisticsCalculatorTest(TestCase):
 
     def test_calculate_statistics_overview_divide_by_zero(self):
         calculator = StatisticsCalculator(
-            column_types=dict(
-                age='number',
-            ),
+            column_types=dict(age='number', date='datetime', category='category', string='string'),
         )
 
-        df = pd.DataFrame([], columns=['age'])
+        df = pd.DataFrame([], columns=['age', 'date', 'category', 'string'])
         data = calculator.calculate_statistics_overview(df, is_clean=False)
 
         self.assertEqual(data['age/count'], 0)
         self.assertEqual(data['age/count_distinct'], 0)
         self.assertEqual(data['age/null_value_rate'], 0)
+        self.assertEqual(data['date/count'], 0)
+        self.assertEqual(data['date/count_distinct'], 0)
+        self.assertEqual(data['date/null_value_rate'], 0)
+        self.assertEqual(data['category/count'], 0)
+        self.assertEqual(data['category/count_distinct'], 0)
+        self.assertEqual(data['category/null_value_rate'], 0)
+        self.assertEqual(data['string/count'], 0)
+        self.assertEqual(data['string/count_distinct'], 0)
+        self.assertEqual(data['string/null_value_rate'], 0)
+        print(data['date/value_counts'])
+
+    def test_calculate_statistics_handle_nulls(self):
+        calculator = StatisticsCalculator(
+            column_types=dict(
+                age='number',
+                country='category',
+                date_joined='datetime',
+                id='number',
+                cancelled='true_or_false',
+            ),
+        )
+
+        df = pd.DataFrame(
+            [
+                [1, None, None, 1, False],
+                [np.nan, None, '2000-12-01', 2, False],
+                [np.nan, 'US', '2000-07-01 00:00:00+00:00', 3, False],
+                [np.nan, 'US', '2000-07-01 00:00:00+00:00', 4, False],
+                [1, None, None, 5, False],
+                [np.nan, None, '899-07-01 00:00:00+00:00', 6, False],
+                [3, 'JP', None, 7, True],
+            ],
+            columns=['age', 'country', 'date_joined', 'id', 'cancelled'],
+        )
+
+        data = calculator.calculate_statistics_overview(df, is_clean=True)
+
+        self.assertEqual(data['count'], 7)
+        self.assertEqual(data['total_null_value_count'], 11)
+
+        self.assertEqual(data['age/average'], 5 / 3)
+        self.assertEqual(data['age/count'], 3)
+        self.assertEqual(data['age/count_distinct'], 2)
+        self.assertEqual(data['age/max'], 3)
+        self.assertEqual(data['age/median'], 1)
+        self.assertEqual(data['age/min'], 1)
+        self.assertEqual(data['age/sum'], 5)
+        self.assertEqual(data['age/null_value_rate'], 4 / 7)
+        self.assertEqual(data['age/completeness'], 1 - data['age/null_value_rate'])
+        self.assertEqual(data['age/quality'], 'Bad')
+
+        self.assertEqual(data['country/count'], 3)
+        self.assertEqual(data['country/count_distinct'], 2)
+        self.assertEqual(data['country/mode'], 'US')
+        self.assertEqual(data['country/null_value_rate'], 4 / 7)
+        self.assertEqual(data['country/completeness'], 1 - data['country/null_value_rate'])
+        self.assertEqual(data['country/quality'], 'Bad')
+
+        self.assertEqual(data['date_joined/count'], 4)
+        self.assertEqual(data['date_joined/count_distinct'], 3)
+        self.assertEqual(data['date_joined/max'], '2000-12-01T00:00:00+00:00')
+        self.assertEqual(data['date_joined/median'], '2000-07-01T00:00:00+00:00')
+        self.assertEqual(data['date_joined/min'], '2000-07-01T00:00:00+00:00')
+        self.assertEqual(data['date_joined/mode'], '2000-07-01T00:00:00+00:00')
+        self.assertEqual(data['date_joined/null_value_rate'], 3 / 7)
+        self.assertEqual(data['date_joined/completeness'], 1 - data['date_joined/null_value_rate'])
+        self.assertEqual(data['date_joined/quality'], 'Bad')
+
+        self.assertEqual(data['id/count'], 7)
+        self.assertEqual(data['id/count_distinct'], 7)
+        self.assertEqual(data['id/null_value_rate'], 0)
+        self.assertEqual(data['id/completeness'], 1)
+        self.assertEqual(data['id/quality'], 'Good')
+
+        self.assertEqual(data['cancelled/mode'], False)
+        self.assertEqual(data['cancelled/null_value_rate'], 0)
+        self.assertEqual(data['cancelled/completeness'], 1)
+        self.assertEqual(data['cancelled/quality'], 'Good')


### PR DESCRIPTION
# Summary
Updates to speed up statistics calculation. 

# Performance Metrics
Performance was evaluated on dataset with 100000 rows and 28 columns (total of 2.8 million entries) with numbers, categories, boolean, and text columns. All times are averaged over 100 trials. 
**Baseline**: 1.463 seconds
- No multithreading - 1.408 seconds (likely because statistics calculation is CPU bound rather than IO bound)
- Deduplicated null value calculation between null_value_rate and null_value_count - 1.362 seconds      
- Switched to inbuilt mean calculation - 1.344 seconds
- Switched from quantile to inbuilt median calculation - 1.323 seconds
- Refactored timeseries check to avoid manually calculating the null value rate - 1.285 seconds
- Optimizing longest null sequence:
    - Switched from pandas series to Numpy ndarray - 1.211 seconds
    - Switched to generator of null values (implicit running mean) - 1.04 seconds
- Removed duplicate max_null_sequence calculation - 0.91 seconds

**Final Time:** 0.91 seconds (~38% decrease)

# Tests
Correctness was confirmed by running the code on unit tests, and also through local testing.

cc:
@wangxiaoyou1993 
