### PR TITLE
[nt]  datatable polish v3

### DIFF
--- a/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
@@ -1,16 +1,13 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useAbsoluteLayout, useBlockLayout, useFlexLayout, useTable } from 'react-table';
+import { useAbsoluteLayout, useTable } from 'react-table';
 import { TextStyle } from './index.style';
 import Text from '@oracle/elements/Text';
 
 import { DataTableColumn, DataTableRow } from './types';
-import { BORDER_RADIUS_LARGE } from '@oracle/styles/units/borders';
 import {
-  CellStyled,
-  RowCellStyle,
   TableBodyStyle,
   TableHeadStyle,
-  TaleRowStyle,
+  TableRowStyle,
   TableStyle,
 } from './Table.style';
 import { cutTextSize, getColumnWidth } from './helpers';
@@ -124,15 +121,12 @@ function BaseTable({
     ? widthProp
     : totalColumnsWidthInitial - (offsetWidth || 0);
 
-  // TODO: Base template, add styling later. Cell styling is only for selected. Skip for now.
   return (
     // Table: Relative, no overflow, outline in silver
     <TableStyle width={(widthProp || offsetWidth) ? totalColumnsWidth : null}>
       <table
           {...getTableProps()}
           style={{
-            // border: 'solid 1px #D8DCE3',
-            // borderRadius: `${BORDER_RADIUS_LARGE}px`,
             width: totalColumnsWidth,
           }}
         >
@@ -146,20 +140,15 @@ function BaseTable({
                 <th
                   {...column.getHeaderProps()}
                   style={{
-                    // background: '#F9FAFC',
                     maxWidth: `${getColumnWidth(rows, column.id)}px`,
                     minWidth: column.minWidth,
-                    // padding: '14px',
-                    // position: 'sticky',
                   }}
                 >
-                  {/* <RowCellStyle width={totalColumnsWidth}> */}
                   <TextStyle>
                     <Text bold leftAligned>
                       {column.render('Header')}
                     </Text>
                   </TextStyle>
-                  {/* </RowCellStyle> */}
                 </th>
                   ))}
             </tr>
@@ -173,7 +162,7 @@ function BaseTable({
 
             return (
               // @ts-ignore
-              <TaleRowStyle {...row.getRowProps()} showBackground={i % 2 === 1}>
+              <TableRowStyle {...row.getRowProps()} showBackground={i % 2 === 1}>
                 {row.cells.map(cell => {
                   const { value: cellValue } = cell;
                   console.log(cellValue)
@@ -187,7 +176,7 @@ function BaseTable({
                       }}
                     >
                       <TextStyle>
-                        <Text>
+                        <Text wordBreak>
                           {cellValue === true && 'true'}
                           {cellValue === false && 'false'}
                           {(cellValue === null || cellValue === 'null') && 'null'}
@@ -202,7 +191,7 @@ function BaseTable({
                     </td>
                   );
                 })}
-              </TaleRowStyle>
+              </TableRowStyle>
             );
           })}
         </TableBodyStyle>

--- a/mage_ai/frontend/oracle/components/Table/Table.style.tsx
+++ b/mage_ai/frontend/oracle/components/Table/Table.style.tsx
@@ -57,6 +57,12 @@ export const TableBodyStyle = styled.tbody`
   td {
     padding: ${UNIT * 0.5}px;
   }
+
+  td:not(:first-child) {
+    ${props => `
+    border-left: 1px solid  ${(props.theme.interactive || light.interactive).defaultBorder};
+  `}
+  }
 `;
 
 type TableRowProps = {

--- a/mage_ai/frontend/oracle/components/Table/Table.style.tsx
+++ b/mage_ai/frontend/oracle/components/Table/Table.style.tsx
@@ -7,11 +7,12 @@ import { UNIT, PADDING_UNITS } from '@oracle/styles/units/spacing';
 export const TableStyle = styled.div<any>`
   border-radius: ${BORDER_RADIUS_LARGE}px;
   max-width: 100vw;
+  max-height: 80vh;
   overflow: auto;
   position: relative;
 
   ${props => `
-    border: 1px solid ${(props.theme.monotone || light.monotone).grey200};
+    border: 1px solid ${(props.theme.interactive || light.interactive).defaultBorder};
   `}
 
   ${props => props.table &&`
@@ -40,14 +41,14 @@ export const TableHeadStyle = styled.thead`
     padding: ${UNIT * 0.5}px;
 
     ${props => `
-      border-bottom: 1px solid ${(props.theme.monotone || light.monotone).grey200};
-      background-color: ${(props.theme.monotone || light.monotone).grey100};
+      border-bottom: 1px solid ${(props.theme.interactive || light.interactive).defaultBorder};
+      background-color: ${(props.theme.background || light.background).header};
     `}
   }
 
   th:not(:first-child) {
     ${props => `
-      border-left: 1px solid ${(props.theme.monotone || light.monotone).grey200};
+      border-left: 1px solid ${(props.theme.interactive || light.interactive).defaultBorder};
     `}
   }
 `;
@@ -62,13 +63,12 @@ type TableRowProps = {
   showBackground?: boolean;
 };
 
-export const TaleRowStyle = styled.tr<TableRowProps>`
+export const TableRowStyle = styled.tr<TableRowProps>`
   ${props => props.showBackground && `
-    background-color: ${(props.theme.monotone || light.monotone).grey100};
+    background-color: ${(props.theme.background || light.background).row};
   `}
 `;
 
-// TODO: Update these hardcoded values
 export const RowCellStyle = styled.div<any>`
   flex-shrink: 0;
   max-height: 80px;


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
- Fix alignment issue using wordbreaks
- Style datatable with the colors and borders to match Figma design.
- Resize datatable to better fit screen height to enable vertical scrolling.

# Tests
<!-- How did you test your change? -->
Went on localhost and opened the long files.

### Datatable
<img width="1398" alt="image" src="https://user-images.githubusercontent.com/90282975/172266010-a780c11b-2b65-4eef-adba-6375b42aec48.png">

cc: @johnson-mage 
<!-- Optionally mention someone to let them know about this pull request -->
All that's left to do for the Datatable is the sticky header now.