### PR TITLE
[sk] Fixed bugs with column type detector

### DIFF
--- a/mage_ai/data_cleaner/column_type_detector.py
+++ b/mage_ai/data_cleaner/column_type_detector.py
@@ -56,7 +56,7 @@ REGEX_ZIP_CODE_PATTERN = r'^\d{3,5}(?:[-\s]\d{4})?$'
 REGEX_ZIP_CODE = re.compile(REGEX_ZIP_CODE_PATTERN)
 
 RESERVED_PHONE_NUMBER_WORDS = frozenset(['phone', 'landline'])
-RESERVED_ZIP_CODE_WORDS = frozenset(['zip', 'postal'])
+RESERVED_ZIP_CODE_WORDS = frozenset(['zip', 'postal', 'zipcode', 'postcode'])
 
 
 def str_in_set(string, string_set):

--- a/mage_ai/data_cleaner/column_type_detector.py
+++ b/mage_ai/data_cleaner/column_type_detector.py
@@ -60,10 +60,7 @@ RESERVED_ZIP_CODE_WORDS = frozenset(['zip', 'postal', 'zipcode', 'postcode'])
 
 
 def str_in_set(string, string_set):
-    for entry in string_set:
-        if entry in string:
-            return True
-    return False
+    return any(entry in string for entry in string_set)
 
 
 def get_mismatched_row_count(series, column_type):
@@ -149,15 +146,15 @@ def infer_object_type(series, column_name, kwargs):
             if clean_series.str.contains(REGEX_FLOAT_NEW_SYM).sum():
                 mdtype = NUMBER_WITH_DECIMALS
             else:
-                lower = column_name.lower()
+                lowercase_column_name = column_name.lower()
                 correct_phone_nums = clean_series.str.match(REGEX_PHONE_NUMBER).sum()
                 correct_zip_codes = clean_series.str.match(REGEX_ZIP_CODE).sum()
                 if correct_phone_nums / length >= NUMBER_TYPE_MATCHES_THRESHOLD and str_in_set(
-                    lower, RESERVED_PHONE_NUMBER_WORDS
+                    lowercase_column_name, RESERVED_PHONE_NUMBER_WORDS
                 ):
                     mdtype = PHONE_NUMBER
                 elif correct_zip_codes / length >= NUMBER_TYPE_MATCHES_THRESHOLD and str_in_set(
-                    lower, RESERVED_ZIP_CODE_WORDS
+                    lowercase_column_name, RESERVED_ZIP_CODE_WORDS
                 ):
                     mdtype = ZIP_CODE
                 else:
@@ -170,15 +167,15 @@ def infer_object_type(series, column_name, kwargs):
                 correct_emails = clean_series.str.match(REGEX_EMAIL).sum()
                 correct_phone_nums = clean_series.str.match(REGEX_PHONE_NUMBER).sum()
                 correct_zip_codes = clean_series.str.match(REGEX_ZIP_CODE).sum()
-                lower = column_name.lower()
+                lowercase_column_name = column_name.lower()
                 if correct_emails / length >= STRING_TYPE_MATCHES_THRESHOLD:
                     mdtype = EMAIL
                 elif correct_phone_nums / length >= STRING_TYPE_MATCHES_THRESHOLD and str_in_set(
-                    lower, RESERVED_PHONE_NUMBER_WORDS
+                    lowercase_column_name, RESERVED_PHONE_NUMBER_WORDS
                 ):
                     mdtype = PHONE_NUMBER
                 elif correct_zip_codes / length >= STRING_TYPE_MATCHES_THRESHOLD and str_in_set(
-                    lower, RESERVED_ZIP_CODE_WORDS
+                    lowercase_column_name, RESERVED_ZIP_CODE_WORDS
                 ):
                     mdtype = ZIP_CODE
                 elif series_nunique == 2:

--- a/mage_ai/data_cleaner/shared/utils.py
+++ b/mage_ai/data_cleaner/shared/utils.py
@@ -3,6 +3,7 @@ from mage_ai.data_cleaner.column_type_detector import (
     NUMBER_WITH_DECIMALS,
     DATETIME,
     PHONE_NUMBER,
+    ZIP_CODE,
 )
 from mage_ai.data_cleaner.transformer_actions.constants import CURRENCY_SYMBOLS
 import pandas as pd
@@ -45,6 +46,8 @@ def clean_series(series, column_type, dropna=True):
     elif column_type == PHONE_NUMBER and dtype is not str:
         series_cleaned = series_cleaned.astype(str)
         series_cleaned = series_cleaned.str.replace(r'\.\d*', '')
+    elif column_type == ZIP_CODE and dtype is not str:
+        series_cleaned = series_cleaned.astype(str)
     return series_cleaned
 
 

--- a/mage_ai/tests/data_cleaner/test_column_type_detector.py
+++ b/mage_ai/tests/data_cleaner/test_column_type_detector.py
@@ -287,6 +287,15 @@ class ColumnTypeDetectorTests(TestCase):
                     8234592345,
                     np.nan,
                 ],
+                bad_column_name_one=[
+                    9999999999,
+                    np.nan,
+                    918328328322.0,
+                    33459830234,
+                    8234592345,
+                    np.nan,
+                ],
+                bad_column_name_two=[self.fake.phone_number() for _ in range(6)],
             )
         )
         ctypes = infer_column_types(df)
@@ -297,5 +306,68 @@ class ColumnTypeDetectorTests(TestCase):
             int_phone_nums='phone_number',
             float_phone_nums='phone_number',
             not_float_phone_nums='number_with_decimals',
+            bad_column_name_one='number_with_decimals',
+            bad_column_name_two='text',
+        )
+        self.assertEquals(ctypes, expected_ctypes)
+
+    def test_zip_code_recognition(self):
+        df = pd.DataFrame(
+            dict(
+                zip_code=[self.fake.postcode() for _ in range(6)],
+                postal_code=[self.fake.postcode() for _ in range(6)],
+                bad_column_name=[self.fake.postcode() for _ in range(6)],
+                string_zips=[
+                    '12345',
+                    '132',
+                    '234-3434',
+                    '765',
+                    '41324-2343',
+                    '12342',
+                ],
+                not_string_postal_zips=[
+                    '12',
+                    '13234523452',
+                    '23-3434',
+                    '765,23453',
+                    '41324-2343-23423',
+                    '12342',
+                ],
+                int_zips=[
+                    12345,
+                    53123,
+                    323,
+                    423,
+                    678,
+                    67896,
+                ],
+                not_int_zips=[
+                    12345,
+                    34553123,
+                    323343,
+                    423,
+                    67834534,
+                    67896,
+                ],
+                bad_column_name_two=[
+                    12345,
+                    53123,
+                    323,
+                    423,
+                    678,
+                    67896,
+                ],
+            )
+        )
+        ctypes = infer_column_types(df)
+        expected_ctypes = dict(
+            zip_code=ZIP_CODE,
+            postal_code=ZIP_CODE,
+            bad_column_name=NUMBER,
+            string_zips=ZIP_CODE,
+            not_string_postal_zips=TEXT,
+            int_zips=ZIP_CODE,
+            not_int_zips=NUMBER,
+            bad_column_name_two=NUMBER,
         )
         self.assertEquals(ctypes, expected_ctypes)


### PR DESCRIPTION
# Summary
Fixed two bugs with column type detection:
- Object types sometimes contained mixed types and so string functions failed to work on these objects. Fixed by casting object columns to string
- `infer_column_types` sometimes (incorrectly) identified a column as a phone number due being formatted as a phone number, despite column names suggesting otherwise. To resolve this problem, phone number and zip code detection now must match column names against a set of reserved keywords most often associated with phone number and zip code columns in order for the inference to report those columns as phone numbers or zip codes.

# Tests
Previous unit tests were reran to confirm correctness. New tests were written to test the new phone number and zip code detection system.

cc:
@wangxiaoyou1993 
