### PR TITLE
[sp] improve feature profiles layout

### DIFF
--- a/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
+++ b/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
@@ -2,14 +2,9 @@ import React from 'react';
 import NextLink from 'next/link';
 import styled from 'styled-components';
 
-import FeatureType, {
-  ColumnTypeEnum,
-  COLUMN_TYPE_HUMAN_READABLE_MAPPING,
-  COLUMN_TYPE_NUMBERICAL_WITH_DATETIME_LIKE,
-} from '@interfaces/FeatureType';
+import FeatureType from '@interfaces/FeatureType';
 import FeatureSetType from '@interfaces/FeatureSetType';
 import Flex from '@oracle/components/Flex';
-import FlexContainer from '@oracle/components/FlexContainer';
 import Link from '@oracle/elements/Link';
 import Text from '@oracle/elements/Text';
 import { BORDER_RADIUS_LARGE } from '@oracle/styles/units/borders';
@@ -23,11 +18,18 @@ import {
 } from '@oracle/styles/colors/main';
 import { PADDING, UNIT } from '@oracle/styles/units/spacing';
 import { getFeatureIdMapping } from '@utils/models/featureSet';
+import Spacing from '@oracle/elements/Spacing';
 import { roundNumber } from '@utils/string';
 
 export const ContainerStyle = styled.div`
   border: 1px solid ${GRAY_LINES};
   border-radius: ${BORDER_RADIUS_LARGE}px;
+`;
+
+export const ColumnProfileStyle = styled.div`
+  background: ${SILVER};
+  border-bottom: 1px solid ${GRAY_LINES};
+  border-right: 1px solid ${GRAY_LINES};
 `;
 
 export const HeaderStyle = styled.div`
@@ -43,7 +45,6 @@ export const FeatureProfileStyle = styled.div`
 `;
 
 export const BodyStyle = styled.div`
-  height: 500px;
   border-bottom-left-radius: ${BORDER_RADIUS_LARGE}px;
   border-bottom-right-radius: ${BORDER_RADIUS_LARGE}px;
   overflow-y: scroll;
@@ -68,6 +69,18 @@ type FeatureProfilesProps = {
   statistics: any,
 };
 
+const entryTypes = [
+  'Type',
+  'Unique',
+  'Mean',
+  'Median',
+  'Mode',
+  'Min',
+  'Max',
+  'Null',
+  'Invalid',
+];
+
 function FeatureProfile({
   feature,
   featureSet,
@@ -89,68 +102,26 @@ function FeatureProfile({
   const modeValue = statistics?.[`${uuid}/mode`];
   const numberOfInvalidValues = statistics?.[`${uuid}/invalid_value_count`];
 
-  let entries = [];
-  
-  if (COLUMN_TYPE_NUMBERICAL_WITH_DATETIME_LIKE.includes(columnType)) {
-    entries = [
-      [
-        'Type',
-        'Count',
-        'Unique',
-        'Missing',
-      ],
-      [
-        COLUMN_TYPE_HUMAN_READABLE_MAPPING[columnType] || columnType,
-        numberOfValues,
-        numberOfUniqueValues,
-        numberOfNullValues,
-      ],
-      [
-        columnType === ColumnTypeEnum.DATETIME ? 'Median' : 'Mean',
-        'Minimum',
-        'Maximum',
-        'Invalid',
-      ],
-      [
-        columnType === ColumnTypeEnum.DATETIME ? medianValue : roundNumber(meanValue, 3),
-        typeof minValue === 'string' ? minValue: roundNumber(minValue, 3),
-        typeof maxValue === 'string' ? maxValue: roundNumber(maxValue, 3),
-        numberOfInvalidValues,
-      ],
-    ];
-  } else {
-    entries = [
-      [
-        'Type',
-        'Count',
-        'Unique',
-      ],
-      [
-        COLUMN_TYPE_HUMAN_READABLE_MAPPING[columnType] || columnType,
-        numberOfValues,
-        numberOfUniqueValues,
-      ],
-      [
-        'Missing',
-        'Mode',
-        'Invalid',
-      ],
-      [
-        numberOfNullValues,
-        modeValue,
-        numberOfInvalidValues,
-      ],
-    ];
-  }
+  const entries = [
+    columnType,
+    numberOfUniqueValues,
+    meanValue,
+    medianValue,
+    modeValue,
+    minValue,
+    maxValue,
+    numberOfNullValues,
+    numberOfInvalidValues,
+  ];
 
   const featureSetId = featureSet.id;
   const featureUuid = feature?.uuid;
-  const featureId = getFeatureIdMapping(featureSet)[featureUuid]
+  const featureId = getFeatureIdMapping(featureSet)[featureUuid];
 
   return (
-    <FlexContainer>
-      <Flex flex={1}>
-        <CellStyle>
+    <Flex flex={1} flexDirection="column">
+      <FeatureProfileStyle>
+        <Spacing p={2}>
           <NextLink
             as={`/datasets/${featureSetId}/features/${featureId}`}
             href="/datasets/[...slug]"
@@ -163,20 +134,16 @@ function FeatureProfile({
               </Text>
             </Link>
           </NextLink>
+        </Spacing>
+      </FeatureProfileStyle>
+      {Object.values(entries).map((label = '-', idx) => (
+        <CellStyle backgroundColor={idx % 2 === 0 ? WHITE : LIGHT} key={idx}>
+          <Text>
+            {!isNaN(label) ? roundNumber(label) : label}
+          </Text>
         </CellStyle>
-      </Flex>
-      {entries.map((values, idx) => (
-        <Flex flex={1} flexDirection="column" key={`column-${idx}`}>
-          {values.map((label, idx) => (
-            <CellStyle backgroundColor={idx % 2 === 0 ? WHITE : LIGHT} key={idx}>
-              <Text>
-                {label}
-              </Text>
-            </CellStyle>
-          ))}
-        </Flex>
       ))}
-    </FlexContainer>
+    </Flex>
   );
 }
 
@@ -193,15 +160,27 @@ function FeatureProfiles({
         </Text>
       </HeaderStyle>
       <BodyStyle>
-        {features.map((feature, idx) => (
-          <FeatureProfileStyle key={idx}>
-            <FeatureProfile
-              feature={feature}
-              featureSet={featureSet}
-              statistics={statistics}
-            />
-          </FeatureProfileStyle>
-        ))}
+        <Flex>
+          <ColumnProfileStyle>
+            <Flex flex={1} flexDirection="column" style={{ background: '#F9FAFC' }} >
+              <Spacing mr={1.25 * UNIT} mt={'52px'} />
+              {entryTypes.map((entry, idx) => (
+                <CellStyle key={`${entry}-${idx}`}>
+                  <Text secondary>{entry}</Text>
+                </CellStyle>
+              ))}
+            </Flex>
+          </ColumnProfileStyle>
+          {features.map((feature, idx) => (
+            <FeatureProfileStyle key={`${feature}-${idx}`}>
+              <FeatureProfile
+                feature={feature}
+                featureSet={featureSet}
+                statistics={statistics}
+              />
+            </FeatureProfileStyle>
+          ))}
+        </Flex>
       </BodyStyle>
     </ContainerStyle>
   );

--- a/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
+++ b/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
@@ -129,7 +129,7 @@ function FeatureProfile({
             passHref
           >
             <Link inline>
-              <Text backgroundColor={PURPLE_HIGHLIGHT} bold color={PURPLE} monospace textOverflow>
+              <Text backgroundColor={PURPLE_HIGHLIGHT} bold color={PURPLE} monospace textOverflow maxWidth={25*UNIT}>
                 {uuid}
               </Text>
             </Link>

--- a/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
+++ b/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
@@ -149,7 +149,14 @@ function FeatureProfile({
             passHref
           >
             <Link inline>
-              <Text backgroundColor={PURPLE_HIGHLIGHT} bold color={PURPLE} monospace textOverflow maxWidth={25*UNIT}>
+              <Text
+                backgroundColor={PURPLE_HIGHLIGHT}
+                bold
+                color={PURPLE}
+                maxWidth={25 * UNIT}
+                monospace
+                textOverflow
+              >
                 {uuid}
               </Text>
             </Link>

--- a/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
+++ b/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
@@ -19,7 +19,7 @@ import {
 import { PADDING, UNIT } from '@oracle/styles/units/spacing';
 import { getFeatureIdMapping } from '@utils/models/featureSet';
 import Spacing from '@oracle/elements/Spacing';
-import { roundNumber } from '@utils/string';
+import { formatPercent, roundNumber } from '@utils/string';
 
 export const ContainerStyle = styled.div`
   border: 1px solid ${GRAY_LINES};
@@ -81,6 +81,8 @@ const entryTypes = [
   'Invalid',
 ];
 
+const percentages = ['Null', 'Invalid', 'Unique'];
+
 function FeatureProfile({
   feature,
   featureSet,
@@ -136,10 +138,11 @@ function FeatureProfile({
           </NextLink>
         </Spacing>
       </FeatureProfileStyle>
-      {Object.values(entries).map((label = '-', idx) => (
+      {entries.map((label = '-', idx) => (
         <CellStyle backgroundColor={idx % 2 === 0 ? WHITE : LIGHT} key={idx}>
-          <Text>
+          <Text textOverflow>
             {!isNaN(label) ? roundNumber(label) : label}
+            {percentages.includes(entryTypes[idx]) && ` (${formatPercent(label/numberOfValues)})`}
           </Text>
         </CellStyle>
       ))}

--- a/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
+++ b/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
@@ -156,6 +156,7 @@ function FeatureProfile({
                 maxWidth={25 * UNIT}
                 monospace
                 textOverflow
+                title={uuid}
               >
                 {uuid}
               </Text>

--- a/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
+++ b/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
@@ -77,14 +77,22 @@ const entryTypes = [
   'Mode',
   'Min',
   'Max',
-  'Null',
+  'Missing',
   'Invalid',
   'Outliers',
   'Skewness',
   'Std dev',
 ];
 
-const percentages = ['Null', 'Invalid', 'Unique'];
+const percentages = ['Missing', 'Invalid', 'Unique'];
+
+// % thresholds, above which we warn the user
+const warnings = {
+  'Missing': 0,
+  'Invalid': 0,
+  'Outliers': 0,
+  'Unique': 0.9,
+};
 
 function FeatureProfile({
   feature,
@@ -147,14 +155,23 @@ function FeatureProfile({
           </NextLink>
         </Spacing>
       </FeatureProfileStyle>
-      {entries.map((label = '-', idx) => (
-        <CellStyle backgroundColor={idx % 2 === 0 ? WHITE : LIGHT} key={idx}>
-          <Text textOverflow>
-            {!isNaN(label) ? roundNumber(label) : label}
-            {percentages.includes(entryTypes[idx]) && ` (${formatPercent(label/numberOfValues)})`}
-          </Text>
-        </CellStyle>
-      ))}
+      {entries.map((label = '-', idx) => {
+        const entry = entryTypes[idx];
+        const val = !isNaN(label) ? roundNumber(label) : label;
+        const shouldWarn = entry in warnings && (val/numberOfValues) > warnings[entry];
+
+        return (
+          <CellStyle backgroundColor={idx % 2 === 0 ? WHITE : LIGHT} key={idx}>
+            <Text
+              color={shouldWarn && 'red'}
+              textOverflow
+            >
+              {val}
+              {percentages.includes(entry) && ` (${formatPercent(label/numberOfValues)})`}
+            </Text>
+          </CellStyle>
+        );
+      })}
     </Flex>
   );
 }

--- a/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
+++ b/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
@@ -79,6 +79,9 @@ const entryTypes = [
   'Max',
   'Null',
   'Invalid',
+  'Outliers',
+  'Skewness',
+  'Std dev',
 ];
 
 const percentages = ['Null', 'Invalid', 'Unique'];
@@ -103,6 +106,9 @@ function FeatureProfile({
   const medianValue = statistics?.[`${uuid}/median`];
   const modeValue = statistics?.[`${uuid}/mode`];
   const numberOfInvalidValues = statistics?.[`${uuid}/invalid_value_count`];
+  const numberOfOutliers = statistics?.[`${uuid}/outlier_count`];
+  const skewness = statistics?.[`${uuid}/skew`];
+  const stddev = statistics?.[`${uuid}/std`];
 
   const entries = [
     columnType,
@@ -114,6 +120,9 @@ function FeatureProfile({
     maxValue,
     numberOfNullValues,
     numberOfInvalidValues,
+    numberOfOutliers,
+    skewness,
+    stddev,
   ];
 
   const featureSetId = featureSet.id;

--- a/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
+++ b/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
@@ -20,6 +20,7 @@ import { PADDING, UNIT } from '@oracle/styles/units/spacing';
 import { getFeatureIdMapping } from '@utils/models/featureSet';
 import Spacing from '@oracle/elements/Spacing';
 import { formatPercent, roundNumber } from '@utils/string';
+import FlexContainer from '@oracle/components/FlexContainer';
 
 export const ContainerStyle = styled.div`
   border: 1px solid ${GRAY_LINES};
@@ -138,7 +139,7 @@ function FeatureProfile({
   const featureId = getFeatureIdMapping(featureSet)[featureUuid];
 
   return (
-    <Flex flex={1} flexDirection="column">
+    <Flex flexDirection="column">
       <FeatureProfileStyle>
         <Spacing p={2}>
           <NextLink
@@ -189,7 +190,7 @@ function FeatureProfiles({
         </Text>
       </HeaderStyle>
       <BodyStyle>
-        <Flex>
+        <FlexContainer>
           <ColumnProfileStyle>
             <Flex flex={1} flexDirection="column" style={{ background: '#F9FAFC' }} >
               <Spacing mr={1.25 * UNIT} mt={'52px'} />
@@ -209,7 +210,7 @@ function FeatureProfiles({
               />
             </FeatureProfileStyle>
           ))}
-        </Flex>
+        </FlexContainer>
       </BodyStyle>
     </ContainerStyle>
   );

--- a/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
+++ b/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
@@ -21,6 +21,7 @@ import { getFeatureIdMapping } from '@utils/models/featureSet';
 import Spacing from '@oracle/elements/Spacing';
 import { formatPercent, roundNumber } from '@utils/string';
 import FlexContainer from '@oracle/components/FlexContainer';
+import light from '@oracle/styles/themes/light';
 
 export const ContainerStyle = styled.div`
   border: 1px solid ${GRAY_LINES};
@@ -150,9 +151,9 @@ function FeatureProfile({
           >
             <Link inline>
               <Text
-                backgroundColor={PURPLE_HIGHLIGHT}
+                backgroundColor={light.feature.active}
                 bold
-                color={PURPLE}
+                color={light.interactive.linkSecondary}
                 maxWidth={25 * UNIT}
                 monospace
                 textOverflow
@@ -172,7 +173,8 @@ function FeatureProfile({
         return (
           <CellStyle backgroundColor={idx % 2 === 0 ? WHITE : LIGHT} key={idx}>
             <Text
-              color={shouldWarn && 'red'}
+              bold={shouldWarn}
+              color={shouldWarn && light.progress.negative}
               textOverflow
             >
               {val}

--- a/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
+++ b/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
@@ -153,9 +153,9 @@ function FeatureProfile({
               <Text
                 backgroundColor={light.feature.active}
                 bold
-                color={light.interactive.linkSecondary}
                 maxWidth={25 * UNIT}
                 monospace
+                secondary
                 textOverflow
                 title={uuid}
               >
@@ -174,7 +174,7 @@ function FeatureProfile({
           <CellStyle backgroundColor={idx % 2 === 0 ? WHITE : LIGHT} key={idx}>
             <Text
               bold={shouldWarn}
-              color={shouldWarn && light.progress.negative}
+              danger={shouldWarn}
               textOverflow
             >
               {val}

--- a/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
+++ b/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
@@ -129,7 +129,7 @@ function FeatureProfile({
             passHref
           >
             <Link inline>
-              <Text backgroundColor={PURPLE_HIGHLIGHT} bold color={PURPLE} monospace>
+              <Text backgroundColor={PURPLE_HIGHLIGHT} bold color={PURPLE} monospace textOverflow>
                 {uuid}
               </Text>
             </Link>


### PR DESCRIPTION
# Summary
- reworked feature profiles table to follow the chosen Figma design

# Tests
<img width="1375" alt="image" src="https://user-images.githubusercontent.com/105667442/172289520-c7d2a420-d082-4927-bab7-4793417194e8.png">

Long column names are truncated as shown below:

<img width="1373" alt="image" src="https://user-images.githubusercontent.com/105667442/172289760-7fd4edb7-56ef-4f3d-8013-a165729ea6d3.png">


cc: @wangxiaoyou1993 @johnson-mage 
