### PR TITLE
[sk] Fixed json serialization bug

### DIFF
--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -209,9 +209,9 @@ class StatisticsCalculator:
             if column_type not in NUMBER_TYPES:
                 if dates is not None:
                     df_value_counts = dates.value_counts()
-                    data[f'{col}/value_counts'] = (
-                        df_value_counts.head(VALUE_COUNT_LIMIT).astype(str).to_dict()
-                    )
+                    string_df_value_counts = df_value_counts.head(VALUE_COUNT_LIMIT)
+                    string_df_value_counts.index = string_df_value_counts.index.astype(str)
+                    data[f'{col}/value_counts'] = string_df_value_counts.to_dict()
 
                 mode, mode_idx = None, 0
                 while mode_idx < count_unique and pd.isna(df_value_counts.index[mode_idx]):
@@ -223,7 +223,7 @@ class StatisticsCalculator:
                     mode = mode.isoformat()
 
                 data[f'{col}/mode'] = mode
-                data[f'{col}/mode_ratio'] = df_value_counts[mode] / df_value_counts.sum()
+                data[f'{col}/mode_ratio'] = df_value_counts[mode].item() / df_value_counts.sum()
 
         # Detect mismatched formats for some column types
         data[f'{col}/invalid_value_count'] = get_mismatched_row_count(series_non_null, column_type)


### PR DESCRIPTION
# Summary
Fixed bug where the statistics calculator was accidentally writing Pandas series and Timestamp to the statistics metadata, throwing an error when the metadata was attempted to be serialized. This was a previous bug that re-arose due to updating the value counts after dates have been parsed (and the string conversion was improperly handled).

# Tests
Tested locally on user data.

cc:
@wangxiaoyou1993 