### PR TITLE
[nt]  table tooltips polish

### DIFF
--- a/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
@@ -177,7 +177,7 @@ function BaseTable({
                         // minWidth: column.minWidth,
                       }}
                     >
-                      <Text maxWidth={UNIT * 25} title={data[i][j].toString()} wordBreak>
+                      <Text maxWidth={UNIT * 25} title={data[i][j]?.toString()} wordBreak>
                         {cellValue === true && 'true'}
                         {cellValue === false && 'false'}
                         {(cellValue === null || cellValue === 'null') && 'null'}

--- a/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
@@ -148,11 +148,9 @@ function BaseTable({
                   // maxWidth: `${getColumnWidth(rows, column.id)}px`,
                   // minWidth: column.minWidth,
                 }}>
-                  <TextStyle>
-                    <Text bold leftAligned maxWidth={UNIT * 25} title={titles[i]}>
-                      {column.render('Header')}
-                    </Text>
-                  </TextStyle>
+                  <Text bold leftAligned maxWidth={UNIT * 25} title={titles[i]}>
+                    {column.render('Header')}
+                  </Text>
                 </th>
                   ))}
             </tr>
@@ -179,19 +177,17 @@ function BaseTable({
                         // minWidth: column.minWidth,
                       }}
                     >
-                      <TextStyle>
-                        <Text maxWidth={UNIT * 25} title={data[i][j].toString()} wordBreak>
-                          {cellValue === true && 'true'}
-                          {cellValue === false && 'false'}
-                          {(cellValue === null || cellValue === 'null') && 'null'}
-                          {cellValue !== true
-                            && cellValue !== false
-                            && cellValue !== null
-                            && cellValue !== 'null'
-                            && cellValue
-                          }
-                        </Text>
-                      </TextStyle>
+                      <Text maxWidth={UNIT * 25} title={data[i][j]?.toString()} wordBreak>
+                        {cellValue === true && 'true'}
+                        {cellValue === false && 'false'}
+                        {(cellValue === null || cellValue === 'null') && 'null'}
+                        {cellValue !== true
+                          && cellValue !== false
+                          && cellValue !== null
+                          && cellValue !== 'null'
+                          && cellValue
+                        }
+                      </Text>
                     </td>
                   );
                 })}

--- a/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
@@ -177,7 +177,7 @@ function BaseTable({
                         // minWidth: column.minWidth,
                       }}
                     >
-                      <Text maxWidth={UNIT * 25} title={data[i][j]?.toString()} wordBreak>
+                      <Text maxWidth={UNIT * 25} title={data[i][j].toString()} wordBreak>
                         {cellValue === true && 'true'}
                         {cellValue === false && 'false'}
                         {(cellValue === null || cellValue === 'null') && 'null'}

--- a/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/BaseTable.tsx
@@ -10,7 +10,8 @@ import {
   TableRowStyle,
   TableStyle,
 } from './Table.style';
-import { cutTextSize, getColumnWidth } from './helpers';
+import { cutTextSize } from './helpers';
+import { UNIT } from '@oracle/styles/units/spacing';
 
 export type DataTableProps = {
   children?: any;
@@ -140,17 +141,15 @@ function BaseTable({
           { headerGroups.map(headerGroup => (
             // eslint-disable-next-line react/jsx-key
             <tr {...headerGroup.getHeaderGroupProps()}>
-              {headerGroup.headers.map(column => (
+              {headerGroup.headers.map((column, i) => (
                 // eslint-disable-next-line react/jsx-key
-                <th
-                  {...column.getHeaderProps()}
-                  style={{
-                    // maxWidth: `${getColumnWidth(rows, column.id)}px`,
-                    // minWidth: column.minWidth,
-                  }}
-                >
+                <th {...column.getHeaderProps()} 
+                style={{
+                  // maxWidth: `${getColumnWidth(rows, column.id)}px`,
+                  // minWidth: column.minWidth,
+                }}>
                   <TextStyle>
-                    <Text bold leftAligned>
+                    <Text bold leftAligned maxWidth={UNIT * 25} title={titles[i]}>
                       {column.render('Header')}
                     </Text>
                   </TextStyle>
@@ -166,21 +165,22 @@ function BaseTable({
             prepareRow(row);
 
             return (
-              // @ts-ignore
-              <TableRowStyle {...row.getRowProps()} showBackground={i % 2 === 1}>
-                {row.cells.map(cell => {
+              // eslint-disable-next-line react/jsx-key
+              <TableRowStyle {...row.getRowProps()} showBackground={i % 2 === 1} >
+                {row.cells.map((cell, j) => {
                   const { value: cellValue } = cell;
 
                   return (
+                    // eslint-disable-next-line react/jsx-key
                     <td
                       {...cell.getCellProps()}
                       style={{
-                        // maxWidth: `${getColumnWidth(rows, cell.column.id)}px`,
-                        // minWidth: cell.column.width,
+                        // maxWidth: `${getColumnWidth(rows, column.id)}px`,
+                        // minWidth: column.minWidth,
                       }}
                     >
                       <TextStyle>
-                        <Text wordBreak>
+                        <Text maxWidth={UNIT * 25} title={data[i][j].toString()} wordBreak>
                           {cellValue === true && 'true'}
                           {cellValue === false && 'false'}
                           {(cellValue === null || cellValue === 'null') && 'null'}

--- a/mage_ai/frontend/oracle/components/Table/Cell.tsx
+++ b/mage_ai/frontend/oracle/components/Table/Cell.tsx
@@ -86,7 +86,7 @@ function Cell({
     );
   } else if (showProgress) {
     cellEl = (
-      <FlexContainer alignItems={'center'}>
+      <FlexContainer alignItems={'center'} fullHeight fullWidth>
         <ProgressBar danger={value < 75} progress={value} />
       </FlexContainer>
     );


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
### Table tooltips
- Add table tooltips to BaseTable for the Dataset details page
- Show full value as tooltip instead of truncated text
- Fix bug with progress bar alignment.

# Tests
<!-- How did you test your change? -->
Localhost
### Hover over truncated text
<img width="461" alt="image" src="https://user-images.githubusercontent.com/90282975/172453000-c473c436-b0b0-407c-a6a8-9ec08fe62d88.png">

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@johnson-mage 
