### PR TITLE
[nt] Add correlation table for high correlations

### DIFF
--- a/mage_ai/frontend/components/datasets/Insights/ColumnAnalysis.tsx
+++ b/mage_ai/frontend/components/datasets/Insights/ColumnAnalysis.tsx
@@ -145,6 +145,19 @@ function ColumnAnalysis({
     });
   }
 
+  const highCorrelations = [];
+  correlationsRowData?.map((_, col, r) => {
+    if (r[col][2] > 0.5) {
+      highCorrelations.push({
+        'columnValues': [
+          r[col][0]?.toString(),
+          r[col][1]?.toString(),
+          roundNumber(r[col][2])?.toString(),
+        ],
+      });
+    }
+  });
+
   const histogramChart = charts?.find(({ type }) => ChartTypeEnum.HISTOGRAM === type);
 
   const {
@@ -601,7 +614,33 @@ function ColumnAnalysis({
               />
             </ChartContainer>
           }
-          right={<div />}
+          right={
+            <ChartContainer
+              noPadding={!!correlationsRowData}
+              title="Values with high correlation"
+            >
+              <SimpleDataTable
+                columnFlexNumbers={[1, 1, 1]}
+                columnHeaders={[
+                  {
+                  label: 'Column',
+                  },
+                  {
+                  label: 'Related column',
+                  },
+                  {
+                  label: 'Correlation',
+                },]}
+                noBorder
+                rowGroupData={[
+                  {
+                    rowData: highCorrelations,
+                  },
+                ]}
+                small
+              />
+            </ChartContainer>
+          }
         />
       )}
     </FlexContainer>

--- a/mage_ai/frontend/components/datasets/Insights/ColumnAnalysis.tsx
+++ b/mage_ai/frontend/components/datasets/Insights/ColumnAnalysis.tsx
@@ -138,25 +138,24 @@ function ColumnAnalysis({
     : null;
   const yLabels = [column];
   const heatmapData = [[1]];
+  const highCorrelations = [];
   if (correlationsRowData) {
     correlationsRowData?.map(([, col, r], idx: number) => {
       yLabels.push(col);
       heatmapData.push([roundNumber(r)]);
     });
+    correlationsRowData?.map((_, col, r) => {
+      if (Math.abs(r[col][2]) > 0.5) {
+        highCorrelations.push({
+          'columnValues': [
+            r[col][0]?.toString(),
+            r[col][1]?.toString(),
+            roundNumber(r[col][2])?.toString(),
+          ],
+        });
+      }
+    });
   }
-
-  const highCorrelations = [];
-  correlationsRowData?.map((_, col, r) => {
-    if (r[col][2] > 0.5) {
-      highCorrelations.push({
-        'columnValues': [
-          r[col][0]?.toString(),
-          r[col][1]?.toString(),
-          roundNumber(r[col][2])?.toString(),
-        ],
-      });
-    }
-  });
 
   const histogramChart = charts?.find(({ type }) => ChartTypeEnum.HISTOGRAM === type);
 
@@ -630,7 +629,7 @@ function ColumnAnalysis({
                   },
                   {
                   label: 'Correlation',
-                },]}
+                }]}
                 noBorder
                 rowGroupData={[
                   {

--- a/mage_ai/frontend/components/datasets/Insights/ColumnAnalysis.tsx
+++ b/mage_ai/frontend/components/datasets/Insights/ColumnAnalysis.tsx
@@ -618,26 +618,43 @@ function ColumnAnalysis({
               noPadding={!!correlationsRowData}
               title="Values with high correlation"
             >
-              <SimpleDataTable
-                columnFlexNumbers={[1, 1, 1]}
-                columnHeaders={[
-                  {
-                  label: 'Column',
-                  },
-                  {
-                  label: 'Related column',
-                  },
-                  {
-                  label: 'Correlation',
-                }]}
-                noBorder
-                rowGroupData={[
-                  {
-                    rowData: highCorrelations,
-                  },
-                ]}
-                small
-              />
+              { highCorrelations.length > 0 ? (
+                <SimpleDataTable
+                  columnFlexNumbers={[1, 1, 1]}
+                  columnHeaders={[
+                    {
+                      label: 'Column',
+                    },
+                    {
+                      label: 'Related column',
+                    },
+                    {
+                      label: 'Correlation',
+                    },
+                  ]}
+                  noBorder
+                  rowGroupData={[
+                    {
+                      rowData: highCorrelations,
+                    },
+                  ]}
+                  small
+                />
+              ) : (
+                <>
+                  <Text>
+                    There are no values with high correlation.
+                  </Text>
+
+                  <SimpleDataTable
+                    columnFlexNumbers={[1, 1, 1]}
+                    columnHeaders={[]}
+                    noBorder
+                    rowGroupData={[]}
+                    small
+                  />
+                </>
+              )}
             </ChartContainer>
           }
         />

--- a/mage_ai/frontend/components/datasets/Insights/ColumnAnalysis.tsx
+++ b/mage_ai/frontend/components/datasets/Insights/ColumnAnalysis.tsx
@@ -642,10 +642,11 @@ function ColumnAnalysis({
                 />
               ) : (
                 <>
-                  <Text>
-                    There are no values with high correlation.
-                  </Text>
-
+                  <Spacing mb={1} ml={1} mt={1}>
+                    <Text>
+                      There are no values with high correlation.
+                    </Text>
+                  </Spacing>
                   <SimpleDataTable
                     columnFlexNumbers={[1, 1, 1]}
                     columnHeaders={[]}

--- a/mage_ai/frontend/oracle/components/Table/Cell.tsx
+++ b/mage_ai/frontend/oracle/components/Table/Cell.tsx
@@ -17,6 +17,7 @@ type CellProps = {
   rowIndex: number;
   selected: boolean;
   small: boolean;
+  showBackground?: boolean;
   showProgress?: boolean;
   value: any;
 };
@@ -30,6 +31,7 @@ function Cell({
   rowIndex,
   selected,
   small,
+  showBackground,
   showProgress,
   value,
 }: CellProps) {
@@ -113,6 +115,7 @@ function Cell({
     >
       <RowCellStyle
         first={cellIndex === 0}
+        showBackground={showBackground}
         small={small}
       >
         {cellEl}

--- a/mage_ai/frontend/oracle/components/Table/SimpleDataTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/SimpleDataTable.tsx
@@ -155,6 +155,7 @@ function SimpleDataTable({
                   rowGroupIndex={rowGroupIndex}
                   rowIndex={rowIndex}
                   selected={isSelected}
+                  showBackground={rowIndex % 2 === 1}
                   showProgress={value[0]}
                   small={small}
                   value={value[1]}
@@ -171,6 +172,7 @@ function SimpleDataTable({
                   rowGroupIndex={rowGroupIndex}
                   rowIndex={rowIndex}
                   selected={isSelected}
+                  showBackground={rowIndex % 2 === 1}
                   small={small}
                   value={value}
                 />,

--- a/mage_ai/frontend/oracle/components/Table/index.style.tsx
+++ b/mage_ai/frontend/oracle/components/Table/index.style.tsx
@@ -8,7 +8,6 @@ import { transition } from '@oracle/styles/mixins';
 export const PADDING_SIZE_UNITS = 2;
 
 export const TableStyle = styled.div<any>`
-  border-radius: ${BORDER_RADIUS}px;
   overflow-y: auto;
   position: relative;
   width: 100%;
@@ -39,6 +38,10 @@ export const ColumnHeaderRowStyle = styled.div<any>`
 
   ${props => !props.noBorder && `
     border: 1px solid ${(props.theme.interative || light.interactive).defaultBorder};
+  `}
+
+  ${props => props.noBorder && `
+    border-radius: 0px 0px 0px 0px;
   `}
 `;
 

--- a/mage_ai/frontend/oracle/components/Table/index.style.tsx
+++ b/mage_ai/frontend/oracle/components/Table/index.style.tsx
@@ -111,4 +111,8 @@ export const RowCellStyle = styled.div<any>`
   ${props => props.small && `
     padding: ${UNIT * 1.5}px;
   `}
+
+  ${props => props.showBackground && `
+    background-color: ${(props.theme.background || light.background).row};
+  `}
 `;


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
### Display a table of high correlation values
- On the column detail visualization view, add table for "Columns with high correlation" next to the correlations heatmap, for all correlation values of abs(0.5) or more.

# Tests
<!-- How did you test your change? -->

### Table with a highly correlated column
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/90282975/172490334-85d5844a-89cc-425c-aa28-e367b3439cd4.png">

### Table with a low correlation
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/90282975/172490293-282ab40e-b1dc-4c88-b71e-c1922855ef1a.png">

### Table with no correlation
<img width="1002" alt="image" src="https://user-images.githubusercontent.com/90282975/172494537-dae7c20e-4fef-4e89-bef6-75e66feff1f0.png">


cc: @johnson-mage 
<!-- Optionally mention someone to let them know about this pull request -->
