### PR TITLE
[xy] Fix wrong histogram bucket.

### DIFF
--- a/mage_ai/data_cleaner/analysis/charts.py
+++ b/mage_ai/data_cleaner/analysis/charts.py
@@ -82,7 +82,7 @@ def build_histogram_data(col1, series, column_type):
 
     for value in series.values:
         index = math.floor((value - min_value) / bucket_interval)
-        if value == max_value:
+        if index >= len(buckets):
             index = len(buckets) - 1
         buckets[index]['values'].append(value)
 

--- a/mage_ai/data_cleaner/data_cleaner.py
+++ b/mage_ai/data_cleaner/data_cleaner.py
@@ -3,7 +3,7 @@ from mage_ai.data_cleaner.analysis.calculator import AnalysisCalculator
 from mage_ai.data_cleaner.pipelines.base import BasePipeline
 from mage_ai.data_cleaner.shared.hash import merge_dict
 from mage_ai.data_cleaner.shared.logger import timer
-from mage_ai.data_cleaner.shared.utils import clean_series, clean_dataframe
+from mage_ai.data_cleaner.shared.utils import clean_dataframe
 from mage_ai.data_cleaner.statistics.calculator import StatisticsCalculator
 
 


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Fix wrong histogram bucket. Distribution chart showed values higher than maximum value.

<img width="930" alt="image" src="https://user-images.githubusercontent.com/80284865/172495273-bcc9d58b-d1a3-4e4d-bb3a-bcbe2a993782.png">
<img width="152" alt="image" src="https://user-images.githubusercontent.com/80284865/172495391-296f3e01-0c0c-4b9d-a79e-fd9f843d8992.png">



# Tests
<!-- How did you test your change? -->
tested locally
<img width="663" alt="image" src="https://user-images.githubusercontent.com/80284865/172495237-68c76a65-187a-44b1-ae6f-5fa1939df30f.png">


cc:
<!-- Optionally mention someone to let them know about this pull request -->
