### PR TITLE
[sp] metrics warnings hotfix

### DIFF
--- a/mage_ai/frontend/oracle/components/Table/SimpleDataTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/SimpleDataTable.tsx
@@ -153,7 +153,7 @@ function SimpleDataTable({
           const cells = [];
 
           const warning = warnings.find(warn => warn.name === columnValues[0]);
-          const val = isString(columnValues[1]) ? removePercent(columnValues[1]) : columnValues[1];
+          const val = warning && isString(columnValues[1]) ? removePercent(columnValues[1]) : columnValues[1];
           const shouldWarn = warning && warning.compare(val, warning.val);
 
           columnValues?.forEach((value: any, cellIndex: number) => {

--- a/mage_ai/frontend/utils/string.ts
+++ b/mage_ai/frontend/utils/string.ts
@@ -233,7 +233,7 @@ export function extractNumber(text) {
 
 export function removePercent(text) {
   const matches = text.match(/\d+(\.?\d*)%/) || [];
-  return Number(matches[0].slice(0,-1));
+  return Number(matches[0]?.slice(0,-1));
 }
 
 export function changeDecimalToWholeNumber(number, floatingPoints = 2) {


### PR DESCRIPTION
# Summary
- fixed case where `removePercent()` logic was being performed on strings not containing percentages

# Tests

Using the following dataset and clicking on the "Visualizations" tab used to crash the frontend. This is now fixed.

[dirty_dataset.csv](https://github.com/mage-ai/mage-ai/files/8857768/dirty_dataset.csv)

<img width="976" alt="image" src="https://user-images.githubusercontent.com/105667442/172517058-14015c7c-1c47-474c-8df4-41a638e32437.png">


cc: @johnson-mage 
