### PR TITLE
[sp] fix suggestions overflow

### DIFF
--- a/mage_ai/frontend/components/suggestions/SuggestionRow.tsx
+++ b/mage_ai/frontend/components/suggestions/SuggestionRow.tsx
@@ -91,6 +91,7 @@ const SuggestionRow = ({
           })}
           preventDefault
           underline
+          wordWrap
         >
           {col}
         </Link>

--- a/mage_ai/frontend/oracle/elements/Link/index.tsx
+++ b/mage_ai/frontend/oracle/elements/Link/index.tsx
@@ -30,6 +30,8 @@ export type LinkProps = {
   href?: string;
   inline?: boolean;
   large?: boolean;
+  minWidth?: string | number;
+  maxWidth?: string | number;
   muted?: boolean;
   noColor?: boolean;
   noHoverUnderline?: boolean;
@@ -51,7 +53,6 @@ export type LinkProps = {
   transparentBorder?: boolean;
   underline?: boolean;
   weightStyle?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
-  width?: number;
   wordWrap?: boolean;
 };
 
@@ -202,14 +203,15 @@ export const SHARED_LINK_STYLES = css<any>`
     text-overflow: ${props.textOverflow};
   `}
 
-  ${props => props.width && `
+  ${props => (props.minWidth || props.maxWidth) && `
+    display: block;
     overflow: hidden;
-    max-width: ${props.width}px;
+    ${props.minWidth ? `min-width: ${props.minWidth}px;` : ''}
+    ${props.maxWidth ? `max-width: ${props.maxWidth}px;` : ''}
     text-overflow: ellipsis;
     width: 100%;
     white-space: nowrap;
   `}
-
 
   ${props => props.fullHeight && `
     height: 100%;

--- a/mage_ai/frontend/oracle/elements/Link/index.tsx
+++ b/mage_ai/frontend/oracle/elements/Link/index.tsx
@@ -30,8 +30,6 @@ export type LinkProps = {
   href?: string;
   inline?: boolean;
   large?: boolean;
-  minWidth?: string | number;
-  maxWidth?: string | number;
   muted?: boolean;
   noColor?: boolean;
   noHoverUnderline?: boolean;
@@ -201,16 +199,6 @@ export const SHARED_LINK_STYLES = css<any>`
   ${props => props.textOverflow && `
     overflow: hidden;
     text-overflow: ${props.textOverflow};
-  `}
-
-  ${props => (props.minWidth || props.maxWidth) && `
-    display: block;
-    overflow: hidden;
-    ${props.minWidth ? `min-width: ${props.minWidth}px;` : ''}
-    ${props.maxWidth ? `max-width: ${props.maxWidth}px;` : ''}
-    text-overflow: ellipsis;
-    width: 100%;
-    white-space: nowrap;
   `}
 
   ${props => props.fullHeight && `


### PR DESCRIPTION
# Summary
- extremely long column name links now wrap instead of overflowing `SuggestionRow`

# Tests

There's still an issue with "Remove outliers" because it needs to display the super long column name variable, which I'm not sure if we can do much about. It should be a very rare edge case.

<img width="382" alt="image" src="https://user-images.githubusercontent.com/105667442/172531773-bf649ac8-c005-4685-bffe-aa05437361b3.png">

cc: @tommydangerous @johnson-mage 
