### PR TITLE
[sk] Fixed check for collinear columns

### DIFF
--- a/mage_ai/data_cleaner/cleaning_rules/remove_collinear_columns.py
+++ b/mage_ai/data_cleaner/cleaning_rules/remove_collinear_columns.py
@@ -1,4 +1,3 @@
-from urllib import response
 from mage_ai.data_cleaner.cleaning_rules.base import BaseRule
 from mage_ai.data_cleaner.column_type_detector import NUMBER_TYPES
 from mage_ai.data_cleaner.transformer_actions.constants import ActionType, Axis
@@ -76,10 +75,9 @@ class RemoveCollinearColumns(BaseRule):
         params, _, _, _ = np.linalg.lstsq(predictors, responses, rcond=None)
 
         mean = responses.mean()
-        residuals = predictors @ params - responses
-        sum_sq_resid = np.sum(residuals * residuals)
+        centered_predictions = predictors @ params - mean
+        sum_sq_model = np.sum(centered_predictions * centered_predictions)
         centered_responses = responses - mean
         sum_sq_to = np.sum(centered_responses * centered_responses)
-
-        r_sq = 1 - sum_sq_resid / sum_sq_to if sum_sq_to else 0
+        r_sq = sum_sq_model / sum_sq_to if sum_sq_to else 0
         return 1 / (1 - r_sq + self.EPSILON)


### PR DESCRIPTION
# Summary
Previous VIF calculation checked for linear independence of the variables in the dataset. However collinearity as defined in statistics actually means affine independence, which is a stronger measure of redundancy. 

Intuitively, linear independence says that no one variable can be predicted using multiples and combinations the other variables, while affine independence says that no one variable can be predicted using multiples and combinations variables along with additional information.

A good example: suppose we have two columns
- '`price'` -  price of some good
- `'price+1'` - price of the same good plus $1

As 'price+1' is not a multiple of 'price', these columns are linearly independent. However there is a very clear relationship that is redundant here: `'price+1' = 1+'price'`. This relationship is called affine dependence. 

To fix this, it suffices to:
- Add an intercept term to the regression problem (representing the constant bias in affine dependence relationships)
- Center the calculations of the coefficient of determination by subtracting the mean - null hypothesis is that any column (barring noise) has some constant, (possibly) nonzero relationship with all other columns, so $r^2$ must be adjusted to only consider deviations from this constant value.

# Tests
Tests were updated locally to check for affine independence alongside testing on sample datasets to confirm that collinear columns with affine relationships are identified by the cleaning suggestion.

cc:
<!-- Optionally mention someone to let them know about this pull request -->
