### PR TITLE
[sp] fix out-of-sync action code editor

### DIFF
--- a/mage_ai/frontend/components/ActionForm/index.tsx
+++ b/mage_ai/frontend/components/ActionForm/index.tsx
@@ -6,7 +6,6 @@ import '@uiw/react-textarea-code-editor/dist.css';
 import ActionPayloadType, {
   ActionPayloadOverrideType,
   ActionVariableTypeEnum,
-  ActionVariablesType,
   AxisEnum,
 } from '@interfaces/ActionPayloadType';
 import Button from '@oracle/elements/Button';

--- a/mage_ai/frontend/components/suggestions/SuggestionRow.tsx
+++ b/mage_ai/frontend/components/suggestions/SuggestionRow.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import '@uiw/react-textarea-code-editor/dist.css';
 import dynamic from 'next/dynamic';
 import { ThemeContext } from 'styled-components';
@@ -71,6 +71,8 @@ const SuggestionRow = ({
     action_code: actionCode,
     action_options: actionOptions,
   } = action_payload;
+
+  useEffect(() => setActionPayload(action_payload), [action_payload]);
 
   const numFeatures = actionArguments?.length || 0;
   const numOptions = actionOptions ? Object.keys(actionOptions).length : 0;

--- a/mage_ai/frontend/components/suggestions/index.tsx
+++ b/mage_ai/frontend/components/suggestions/index.tsx
@@ -22,7 +22,6 @@ function Suggestions({
   featureSet,
   isLoading,
   removeAction,
-  removeSuggestion,
   suggestions,
 }: SuggestionsProps) {
   const {
@@ -43,11 +42,11 @@ function Suggestions({
       {hasActions && (
         <Spacing mb={2}>
           {actions?.map((action, idx) => {
-            const { title } = action;
+            const { title, message } = action;
 
             return (
               <Spacing
-                key={`${idx}-${title}`}
+                key={`${idx}-${message}-${title}`}
                 mt={idx >= 1 ? 1 : 0}
               >
                 <SuggestionRow


### PR DESCRIPTION
# Summary
- add `useEffect()` hook to `SuggestionRow` to update custom action payload state in sync with backend changes

# Tests
1. Apply a "Remove outliers" suggestion.
2. Edit the next available "remove outliers" suggestion.
3. The action code editor still displays the action code for the "remove outliers" suggestion that was just applied.

This PR fixes this behavior, and should fix future issues as we expand custom actions.

cc: @johnson-mage 
