### PR TITLE
[nt] Temporary hotfix: Remove alternating borders

### DIFF
--- a/mage_ai/frontend/oracle/components/Table/index.style.tsx
+++ b/mage_ai/frontend/oracle/components/Table/index.style.tsx
@@ -74,13 +74,11 @@ export const RowStyle = styled.div<any>`
     border-top: none;
     border-bottom: none;
   `}
-
   ${props => !props.noBorder && `
     border-bottom: 1px solid ${(props.theme.interactive || light.interactive).defaultBorder};
     border-left: 1px solid ${(props.theme.interactive || light.interactive).defaultBorder};
     border-right: 1px solid ${(props.theme.interactive || light.interactive).defaultBorder};
   `}
-
   ${props => props.finalRow && `
     border-bottom-left-radius: ${BORDER_RADIUS}px;
     border-bottom-right-radius: ${BORDER_RADIUS}px;
@@ -96,6 +94,7 @@ export const TextStyle = styled.div`
 export const RowCellStyle = styled.div<any>`
   width: 100%;
   z-index: 0;
+
   ${props => !props.first && `
     border-left: 1px solid ${(props.theme.background || light.background).page};
   `}
@@ -105,10 +104,6 @@ export const RowCellStyle = styled.div<any>`
   ${props => props.small && `
     padding: ${UNIT * 1.5}px;
   `}
-  ${props => props.showBackground && `
-    background-color: ${(props.theme.background || light.background).row};
-  `}
-
   ${props => props.vanish && `
     border: none;
     padding: 0 !important;


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
### Temporary Hotfix
- Remove table background for now since it causes the borders to be overlapped and ugly.
# Tests
<!-- How did you test your change? -->
### Visit any chart
<img width="1336" alt="image" src="https://user-images.githubusercontent.com/90282975/172688325-31313eac-5af5-46e6-80df-a09101689769.png">

cc: @johnson-mage 
<!-- Optionally mention someone to let them know about this pull request -->
