### PR TITLE
[nt] Add surrounding background and cut off inner bar when not 100%

### DIFF
--- a/mage_ai/frontend/oracle/components/ProgressBar/index.tsx
+++ b/mage_ai/frontend/oracle/components/ProgressBar/index.tsx
@@ -18,15 +18,18 @@ export type ProgressBarProps = {
 };
 
 const ProgressBarContainerStyle = styled.div<ProgressBarProps>`
-  border-radius: ${BORDER_RADIUS_SMALL};
+  border-radius: ${BORDER_RADIUS_SMALL}px;
   height: ${UNIT * 0.75}px;
   overflow: hidden;
   position: relative;
   width: 100%;
+
+  ${props => `
+    background-color: ${(props.theme.monotone || light.monotone).grey200};
+  `}
 `;
 
 const ProgressBarStyle = styled.div<ProgressBarProps>`
-  border-radius: ${BORDER_RADIUS_SMALL}px;
   height: inherit;
   position: absolute;
 


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
### Update progress bar
- Add surrounding background to know when bar is max

# Tests
<!-- How did you test your change? -->
Pulled up the charts on localhost
### Bar when not full
<img width="898" alt="image" src="https://user-images.githubusercontent.com/90282975/172701252-9e70db02-5bbd-431f-ab27-d266ef2a57f8.png">

### Bar when full
<img width="488" alt="image" src="https://user-images.githubusercontent.com/90282975/172701324-681548bb-d525-415c-a95f-07b0ad48c7aa.png">

### Bar when empty
<img width="488" alt="image" src="https://user-images.githubusercontent.com/90282975/172701568-d27b189f-fe18-43b0-93ca-1f5c777a411c.png">

cc: @johnson-mage 
<!-- Optionally mention someone to let them know about this pull request -->
