### PR TITLE
[nt] Change example placeholder to editable text

### DIFF
--- a/mage_ai/frontend/components/ActionForm/actions.ts
+++ b/mage_ai/frontend/components/ActionForm/actions.ts
@@ -25,7 +25,7 @@ const columns: {
       Add @transformer_action, then begin typing Python code inside a function. \
       You may refer to the current dataset as df.',
     code: {
-      custom: CODE_EXAMPLE,
+      default: CODE_EXAMPLE,
       multiline: true,
       values: USER_INPUT,
     },
@@ -144,7 +144,7 @@ const rows: {
       Add @transformer_action, then begin typing Python code inside a function. \
       You may refer to the current dataset as df.',
     code: {
-      custom: CODE_EXAMPLE,
+      default: CODE_EXAMPLE,
       multiline: true,
       values: USER_INPUT,
     },

--- a/mage_ai/frontend/components/ActionForm/actions.ts
+++ b/mage_ai/frontend/components/ActionForm/actions.ts
@@ -25,6 +25,7 @@ const columns: {
       Add @transformer_action, then begin typing Python code inside a function. \
       You may refer to the current dataset as df.',
     code: {
+      custom: CODE_EXAMPLE,
       multiline: true,
       values: USER_INPUT,
     },
@@ -143,6 +144,7 @@ const rows: {
       Add @transformer_action, then begin typing Python code inside a function. \
       You may refer to the current dataset as df.',
     code: {
+      custom: CODE_EXAMPLE,
       multiline: true,
       values: USER_INPUT,
     },

--- a/mage_ai/frontend/components/ActionForm/constants.ts
+++ b/mage_ai/frontend/components/ActionForm/constants.ts
@@ -13,7 +13,7 @@ export const OPERATOR_NOT_EQUAL = '!=';
 
 export const CODE_EXAMPLE = '@transformer_action\n\
 def transform(df):\n\
-\tdf.dropna()\n\
+\t# Your code here ... \n\
 \treturn df';
 
 export interface ConditionType {

--- a/mage_ai/frontend/components/ActionForm/constants.ts
+++ b/mage_ai/frontend/components/ActionForm/constants.ts
@@ -45,7 +45,7 @@ interface OptionType {
 }
 
 interface CodeType {
-  custom: string;
+  default: string;
   multiline?: boolean;
   value?: string;
   values?: typeof VALUES_TYPE_USER_INPUT

--- a/mage_ai/frontend/components/ActionForm/constants.ts
+++ b/mage_ai/frontend/components/ActionForm/constants.ts
@@ -45,7 +45,7 @@ interface OptionType {
 }
 
 interface CodeType {
-  default: string;
+  default?: string;
   multiline?: boolean;
   value?: string;
   values?: typeof VALUES_TYPE_USER_INPUT

--- a/mage_ai/frontend/components/ActionForm/constants.ts
+++ b/mage_ai/frontend/components/ActionForm/constants.ts
@@ -45,6 +45,7 @@ interface OptionType {
 }
 
 interface CodeType {
+  custom: string;
   multiline?: boolean;
   value?: string;
   values?: typeof VALUES_TYPE_USER_INPUT

--- a/mage_ai/frontend/components/ActionForm/index.tsx
+++ b/mage_ai/frontend/components/ActionForm/index.tsx
@@ -188,7 +188,7 @@ function ActionForm({
                   fontSize: REGULAR_FONT_SIZE,
                   tabSize: 4,
                 }}
-                value={actionCode || CODE_EXAMPLE}
+                value={actionCode || code.custom}
               />
             )}
           </Spacing>

--- a/mage_ai/frontend/components/ActionForm/index.tsx
+++ b/mage_ai/frontend/components/ActionForm/index.tsx
@@ -23,7 +23,6 @@ import {
   OptionStyle,
 } from './index.style';
 import {
-  CODE_EXAMPLE,
   FormConfigType,
   VALUES_TYPE_COLUMNS,
   VALUES_TYPE_USER_INPUT,

--- a/mage_ai/frontend/components/ActionForm/index.tsx
+++ b/mage_ai/frontend/components/ActionForm/index.tsx
@@ -182,14 +182,13 @@ function ActionForm({
                 minHeight={code.multiline ? UNIT * 12 : null}
                 onChange={e => setActionCodeState(e.target.value)}
                 padding={UNIT * 2}
-                placeholder={CODE_EXAMPLE}
                 style={{
                   backgroundColor: themeContext.monotone.grey100,
                   fontFamily: MONO_FONT_FAMILY_REGULAR,
                   fontSize: REGULAR_FONT_SIZE,
                   tabSize: 4,
                 }}
-                value={actionCode}
+                value={actionCode || CODE_EXAMPLE}
               />
             )}
           </Spacing>

--- a/mage_ai/frontend/components/ActionForm/index.tsx
+++ b/mage_ai/frontend/components/ActionForm/index.tsx
@@ -188,7 +188,7 @@ function ActionForm({
                   fontSize: REGULAR_FONT_SIZE,
                   tabSize: 4,
                 }}
-                value={actionCode || code.custom}
+                value={actionCode || code.default}
               />
             )}
           </Spacing>


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
### Change the custom code placeholder to be default value
- Removed placeholder
- Update `CODE_EXAMPLE` to be more instructional

# Tests
<!-- How did you test your change? -->
Localhost and ran some queries.
### Queries
<img width="382" alt="image" src="https://user-images.githubusercontent.com/90282975/172705909-074f304a-baa1-42b8-8414-1469651aa0fe.png">

### Default values (editable)
<img width="524" alt="Screen Shot 2022-06-08 at 12 58 38 PM" src="https://user-images.githubusercontent.com/90282975/172706011-457b854b-1e7f-462c-a6b9-400e37e295e1.png">

_You can tell it's a value because it's colored_

cc: @johnson-mage 
<!-- Optionally mention someone to let them know about this pull request -->
Is this what you were thinking of @tommydangerous? Or did you want to display it somewhere else?
