### PR TITLE
[xy] Bump up pandas version to improve perf.

### DIFF
--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -155,13 +155,12 @@ class StatisticsCalculator:
         # Fix json serialization issue
         df_top_value_counts.index = df_top_value_counts.index.astype(str)
 
-        count_unique = len(df_value_counts.index)
+        df_value_counts_non_null = df_value_counts[df_value_counts.index.notnull()]
+        count_unique = len(df_value_counts_non_null)
 
         data = {
             f'{col}/count': series_non_null.size,
-            f'{col}/count_distinct': count_unique - 1
-            if np.nan in df_value_counts
-            else count_unique,
+            f'{col}/count_distinct': count_unique,
             f'{col}/null_value_rate': 0
             if series.size == 0
             else series.isnull().sum() / series.size,

--- a/mage_ai/tests/data_cleaner/transformer_actions/test_column.py
+++ b/mage_ai/tests/data_cleaner/transformer_actions/test_column.py
@@ -931,6 +931,7 @@ class ColumnTests(TestCase):
             ],
             columns=['group_id', 'amount', 'average_amount'],
         )
+        df_new['average_amount'] = df_new['average_amount'].astype(int)
         assert_frame_equal(df_new, df_expected)
 
     def test_count(self):
@@ -2082,6 +2083,7 @@ class ColumnTests(TestCase):
             ],
         )
         df_new = median(df, action)
+        df_new['median_amount'] = df_new['median_amount'].astype(int)
         df_expected = pd.DataFrame(
             [
                 [1, 1000, 1050],

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ itsdangerous==2.1.2
 joblib>=1.1.0
 numpy~=1.21.0
 numpyencoder==0.3.0
-pandas==1.1.3
+pandas~=1.4.0
 pyarrow==8.0.0
 python-dateutil==2.8.2
 pytz==2022.1


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Bump up pandas version to improve perf. pandas [1.4.0](https://github.com/pandas-dev/pandas/releases/tag/v1.4.0), [1.3.0](https://github.com/pandas-dev/pandas/releases/tag/v1.3.0) and [1.2.0](https://github.com/pandas-dev/pandas/releases/tag/v1.2.0) all have perf improvements.

The old pandas version was slow on computing nunique (it took 5 seconds to calculate nunique for 100k unique rows). It's instant using the new pandas version.

Performance comparison (a dataset with 100k rows and 32 columns.
Old pandas version
* infer_column_types took 10s.
* calculate_statistics took 15s

New pandas version
* infer_column_types took 5s.
* calculate_statistics took 1.1s

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
