### PR TITLE
[xy] Use pandas version ~1.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ itsdangerous==2.1.2
 joblib>=1.1.0
 numpy~=1.21.0
 numpyencoder==0.3.0
-pandas~=1.4.0
+pandas~=1.3.0
 pyarrow==8.0.0
 python-dateutil==2.8.2
 pytz==2022.1


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Use pandas version ~1.3.0. Pandas ~1.4.0 is only supported for python version 3.8 and higher. https://pandas.pydata.org/docs/whatsnew/v1.4.0.html#increased-minimum-version-for-python


# Tests
<!-- How did you test your change? -->
tested locally. unit tests.

cc:
<!-- Optionally mention someone to let them know about this pull request -->
