### PR TITLE
[sk] Calculate the indices of invalid values

### DIFF
--- a/mage_ai/data_cleaner/column_type_detector.py
+++ b/mage_ai/data_cleaner/column_type_detector.py
@@ -63,18 +63,23 @@ def str_in_set(string, string_set):
     return any(entry in string for entry in string_set)
 
 
-def get_mismatched_rows(series, column_type):
+def find_syntax_errors(series, column_type):
     if len(series) == 0:
-        return []
-    mismatched_rows = []
+        return pd.Series([])
+    mask = pd.Series([False] * len(series))
+    mask.index = series.index
     if column_type == EMAIL:
-        mismatched_rows = series[~series.str.match(REGEX_EMAIL)].tolist()
+        mask |= ~series.str.match(REGEX_EMAIL)
     elif column_type == PHONE_NUMBER:
-        mismatched_rows = series[~series.str.match(REGEX_PHONE_NUMBER)].tolist()
+        mask |= ~series.str.match(REGEX_PHONE_NUMBER)
     elif column_type == ZIP_CODE:
         str_series = series.astype(str)
-        mismatched_rows = series[~str_series.str.match(REGEX_ZIP_CODE)].tolist()
-    return mismatched_rows
+        mask |= ~str_series.str.match(REGEX_ZIP_CODE)
+    # elif column_type == NUMBER:
+    #     mask |= ~series.astr.match(REGEX_NUMBER)
+    # elif column_type == DATETIME:
+    #     mask |= ~series.str.match(REGEX_DATETIME)
+    return mask
 
 
 def infer_number_type(series, column_name, dtype):

--- a/mage_ai/data_cleaner/column_type_detector.py
+++ b/mage_ai/data_cleaner/column_type_detector.py
@@ -66,20 +66,17 @@ def str_in_set(string, string_set):
 def find_syntax_errors(series, column_type):
     if len(series) == 0:
         return pd.Series([])
-    mask = pd.Series([False] * len(series))
-    mask.index = series.index
     if column_type == EMAIL:
-        mask |= ~series.str.match(REGEX_EMAIL)
+        return ~series.str.match(REGEX_EMAIL)
     elif column_type == PHONE_NUMBER:
-        mask |= ~series.str.match(REGEX_PHONE_NUMBER)
+        return ~series.str.match(REGEX_PHONE_NUMBER)
     elif column_type == ZIP_CODE:
         str_series = series.astype(str)
-        mask |= ~str_series.str.match(REGEX_ZIP_CODE)
-    # elif column_type == NUMBER:
-    #     mask |= ~series.astr.match(REGEX_NUMBER)
-    # elif column_type == DATETIME:
-    #     mask |= ~series.str.match(REGEX_DATETIME)
-    return mask
+        return ~str_series.str.match(REGEX_ZIP_CODE)
+    else:
+        mask = pd.Series([False] * len(series))
+        mask.index = series.index
+        return mask
 
 
 def infer_number_type(series, column_name, dtype):

--- a/mage_ai/data_cleaner/shared/constants.py
+++ b/mage_ai/data_cleaner/shared/constants.py
@@ -1,0 +1,1 @@
+SAMPLE_SIZE = 1000

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -1,4 +1,3 @@
-from importlib import invalidate_caches
 from mage_ai.data_cleaner.shared.hash import merge_dict
 from mage_ai.data_cleaner.shared.logger import timer
 from mage_ai.data_cleaner.shared.utils import clean_dataframe
@@ -239,10 +238,8 @@ class StatisticsCalculator:
         invalid_rows = find_syntax_errors(series_non_null, column_type)
         data[f'{col}/invalid_value_count'] = invalid_rows.sum()
         invalid_values = series_non_null[invalid_rows]
-        data[f'{col}/invalid_values'] = invalid_values.tolist()[:INVALID_VALUE_SAMPLE_COUNT]
-        data[f'{col}/invalid_indices'] = (
-            invalid_values.index.tolist() if data[f'{col}/invalid_value_count'] else []
-        )
+        data[f'{col}/invalid_values'] = invalid_values[:INVALID_VALUE_SAMPLE_COUNT].tolist()
+        data[f'{col}/invalid_indices'] = invalid_values.index.tolist()
         data[f'{col}/invalid_value_rate'] = (
             0 if series.size == 0 else data[f'{col}/invalid_value_count'] / series.size
         )

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -1,10 +1,11 @@
+from importlib import invalidate_caches
 from mage_ai.data_cleaner.shared.hash import merge_dict
 from mage_ai.data_cleaner.shared.logger import timer
 from mage_ai.data_cleaner.shared.utils import clean_dataframe
 from mage_ai.data_cleaner.column_type_detector import (
     DATETIME,
     NUMBER_TYPES,
-    get_mismatched_rows,
+    find_syntax_errors,
 )
 import math
 import numpy as np
@@ -22,6 +23,10 @@ def increment(metric, tags):
 
 
 class StatisticsCalculator:
+    """
+    Key Assumption: statistics are clean - all values of the correct exact type at this point
+    """
+
     def __init__(
         self,
         # s3_client,
@@ -231,9 +236,13 @@ class StatisticsCalculator:
             )
 
         # Detect mismatched formats for some column types
-        invalid_rows = get_mismatched_rows(series_non_null, column_type)
-        data[f'{col}/invalid_value_count'] = len(invalid_rows)
-        data[f'{col}/invalid_values'] = invalid_rows[:INVALID_VALUE_SAMPLE_COUNT]
+        invalid_rows = find_syntax_errors(series_non_null, column_type)
+        data[f'{col}/invalid_value_count'] = invalid_rows.sum()
+        invalid_values = series_non_null[invalid_rows]
+        data[f'{col}/invalid_values'] = invalid_values.tolist()[:INVALID_VALUE_SAMPLE_COUNT]
+        data[f'{col}/invalid_indices'] = (
+            invalid_values.index.tolist() if data[f'{col}/invalid_value_count'] else []
+        )
         data[f'{col}/invalid_value_rate'] = (
             0 if series.size == 0 else data[f'{col}/invalid_value_count'] / series.size
         )

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -242,7 +242,9 @@ class StatisticsCalculator:
         invalid_values = series_non_null[invalid_rows]
         data[f'{col}/invalid_values'] = invalid_values[:INVALID_VALUE_SAMPLE_COUNT].tolist()
         invalid_indices = series.index.get_indexer(invalid_values.index)
-        data[f'{col}/invalid_indices'] = invalid_indices[np.where(invalid_indices <= SAMPLE_SIZE)]
+        data[f'{col}/invalid_indices'] = invalid_indices[
+            np.where(invalid_indices <= SAMPLE_SIZE)
+        ].tolist()
         data[f'{col}/invalid_value_rate'] = (
             0 if series.size == 0 else data[f'{col}/invalid_value_count'] / series.size
         )

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -1,3 +1,4 @@
+from mage_ai.data_cleaner.shared.constants import SAMPLE_SIZE
 from mage_ai.data_cleaner.shared.hash import merge_dict
 from mage_ai.data_cleaner.shared.logger import timer
 from mage_ai.data_cleaner.shared.utils import clean_dataframe
@@ -10,6 +11,7 @@ import math
 import numpy as np
 import pandas as pd
 import traceback
+
 
 INVALID_VALUE_SAMPLE_COUNT = 100
 OUTLIER_SAMPLE_COUNT = 100
@@ -239,7 +241,8 @@ class StatisticsCalculator:
         data[f'{col}/invalid_value_count'] = invalid_rows.sum()
         invalid_values = series_non_null[invalid_rows]
         data[f'{col}/invalid_values'] = invalid_values[:INVALID_VALUE_SAMPLE_COUNT].tolist()
-        data[f'{col}/invalid_indices'] = invalid_values.index.tolist()
+        invalid_indices = series.index.get_indexer(invalid_values.index)
+        data[f'{col}/invalid_indices'] = invalid_indices[np.where(invalid_indices <= SAMPLE_SIZE)]
         data[f'{col}/invalid_value_rate'] = (
             0 if series.size == 0 else data[f'{col}/invalid_value_count'] / series.size
         )

--- a/mage_ai/data_cleaner/transformer_actions/column.py
+++ b/mage_ai/data_cleaner/transformer_actions/column.py
@@ -2,7 +2,6 @@ from mage_ai.data_cleaner.column_type_detector import (
     DATETIME,
     NUMBER_TYPES,
     REGEX_NUMBER,
-    find_syntax_errors,
 )
 from mage_ai.data_cleaner.transformer_actions.action_code import query_with_action_code
 from mage_ai.data_cleaner.transformer_actions.constants import (
@@ -73,11 +72,6 @@ def diff(df, action, **kwargs):
 
 def first(df, action, **kwargs):
     return __agg(df, action, 'first')
-
-
-def fix_syntax_errors(df, action, **kwargs):
-    columns = action['action_arguments']
-    action_variables = action['action_variables']
 
 
 def impute(df, action, **kwargs):

--- a/mage_ai/data_cleaner/transformer_actions/column.py
+++ b/mage_ai/data_cleaner/transformer_actions/column.py
@@ -1,4 +1,9 @@
-from mage_ai.data_cleaner.column_type_detector import DATETIME, NUMBER_TYPES, REGEX_NUMBER
+from mage_ai.data_cleaner.column_type_detector import (
+    DATETIME,
+    NUMBER_TYPES,
+    REGEX_NUMBER,
+    find_syntax_errors,
+)
 from mage_ai.data_cleaner.transformer_actions.action_code import query_with_action_code
 from mage_ai.data_cleaner.transformer_actions.constants import (
     CONSTANT_IMPUTATION_DEFAULTS,
@@ -68,6 +73,11 @@ def diff(df, action, **kwargs):
 
 def first(df, action, **kwargs):
     return __agg(df, action, 'first')
+
+
+def fix_syntax_errors(df, action, **kwargs):
+    columns = action['action_arguments']
+    action_variables = action['action_variables']
 
 
 def impute(df, action, **kwargs):

--- a/mage_ai/server/data/models.py
+++ b/mage_ai/server/data/models.py
@@ -1,10 +1,9 @@
 from mage_ai.data_cleaner.pipelines.base import BasePipeline
+from mage_ai.data_cleaner.shared.constants import SAMPLE_SIZE
 from mage_ai.data_cleaner.shared.hash import merge_dict
 from mage_ai.server.data.base import Model
 import os
 import os.path
-
-SAMPLE_SIZE = 1000
 
 
 # right now, we are writing the models to local files to reduce dependencies
@@ -154,8 +153,9 @@ class FeatureSet(Model):
         )
         if detailed:
             sample_data = self.sample_data
-            datetime_cols = [col for col in sample_data.columns
-                             if 'datetime64' in str(sample_data[col])]
+            datetime_cols = [
+                col for col in sample_data.columns if 'datetime64' in str(sample_data[col])
+            ]
             sample_data[datetime_cols] = sample_data[datetime_cols].astype(str)
             # Filter sample data
             if column is not None:
@@ -180,12 +180,11 @@ class FeatureSet(Model):
             # Deduplicate outlier removal suggestions
             pipeline_dict = self.pipeline.to_dict()
             statistics = self.statistics
-            suggestions_filtered, statistics_updated = \
-                BasePipeline.deduplicate_suggestions(
-                    pipeline_dict['actions'],
-                    suggestions,
-                    statistics,
-                )
+            suggestions_filtered, statistics_updated = BasePipeline.deduplicate_suggestions(
+                pipeline_dict['actions'],
+                suggestions,
+                statistics,
+            )
             obj = merge_dict(
                 obj,
                 dict(

--- a/mage_ai/tests/data_cleaner/statistics/test_calculator.py
+++ b/mage_ai/tests/data_cleaner/statistics/test_calculator.py
@@ -95,17 +95,17 @@ class StatisticsCalculatorTest(TestCase):
         data = calculator.calculate_statistics_overview(df, is_clean=True)
 
         self.assertEqual(data['email/invalid_values'], ['test', 'abc12345@'])
-        self.assertEqual(data['email/invalid_indices'], [2, 4])
+        self.assertTrue((data['email/invalid_indices'] == np.array([2, 4])).all())
         self.assertEqual(data['email/invalid_value_count'], 2)
         self.assertEqual(data['email/invalid_value_rate'], 2 / 6)
 
         self.assertEqual(data['zip_code/invalid_values'], ['abcde'])
-        self.assertEqual(data['zip_code/invalid_indices'], [3])
+        self.assertTrue((data['zip_code/invalid_indices'] == np.array([3])).all())
         self.assertEqual(data['zip_code/invalid_value_count'], 1)
         self.assertEqual(data['zip_code/invalid_value_rate'], 1 / 6)
 
         self.assertEqual(data['id/invalid_values'], [])
-        self.assertEqual(data['id/invalid_indices'], [])
+        self.assertTrue((data['id/invalid_indices'] == np.array([]).astype(int)).all())
         self.assertEqual(data['id/invalid_value_count'], 0)
         self.assertEqual(data['id/invalid_value_rate'], 0 / 6)
 

--- a/mage_ai/tests/data_cleaner/statistics/test_calculator.py
+++ b/mage_ai/tests/data_cleaner/statistics/test_calculator.py
@@ -73,6 +73,42 @@ class StatisticsCalculatorTest(TestCase):
         self.assertEqual(data['cancelled/completeness'], 1)
         self.assertEqual(data['cancelled/quality'], 'Good')
 
+    def test_calculate_statistics_overview_invalid_indices(self):
+        df = pd.DataFrame(
+            [
+                [1, 'abc@xyz.com', '32132'],
+                [2, 'abc2@xyz.com', '12345'],
+                [3, 'test', '1234'],
+                [4, 'abc@test.net', 'abcde'],
+                [5, 'abc12345@', '54321'],
+                [6, 'abcdef@123.com', '56789'],
+            ],
+            columns=['id', 'email', 'zip_code'],
+        )
+        calculator = StatisticsCalculator(
+            column_types=dict(
+                id='number',
+                email='email',
+                zip_code='zip_code',
+            ),
+        )
+        data = calculator.calculate_statistics_overview(df, is_clean=True)
+
+        self.assertEqual(data['email/invalid_values'], ['test', 'abc12345@'])
+        self.assertEqual(data['email/invalid_indices'], [2, 4])
+        self.assertEqual(data['email/invalid_value_count'], 2)
+        self.assertEqual(data['email/invalid_value_rate'], 2 / 6)
+
+        self.assertEqual(data['zip_code/invalid_values'], ['abcde'])
+        self.assertEqual(data['zip_code/invalid_indices'], [3])
+        self.assertEqual(data['zip_code/invalid_value_count'], 1)
+        self.assertEqual(data['zip_code/invalid_value_rate'], 1 / 6)
+
+        self.assertEqual(data['id/invalid_values'], [])
+        self.assertEqual(data['id/invalid_indices'], [])
+        self.assertEqual(data['id/invalid_value_count'], 0)
+        self.assertEqual(data['id/invalid_value_rate'], 0 / 6)
+
     def test_calculate_statistics_overview_no_cleaning(self):
         calculator = StatisticsCalculator(
             column_types=dict(

--- a/mage_ai/tests/data_cleaner/test_column_type_detector.py
+++ b/mage_ai/tests/data_cleaner/test_column_type_detector.py
@@ -10,7 +10,7 @@ from mage_ai.data_cleaner.column_type_detector import (
     TEXT,
     TRUE_OR_FALSE,
     ZIP_CODE,
-    get_mismatched_rows,
+    find_syntax_errors,
     infer_column_types,
     REGEX_NUMBER,
 )
@@ -25,7 +25,7 @@ class ColumnTypeDetectorTests(TestCase):
         self.fake = Faker()
         return super().setUp()
 
-    def test_get_mismatched_rows(self):
+    def test_get_syntax_errors(self):
         df = pd.DataFrame(
             [
                 [1, 'abc@xyz.com', '32132'],
@@ -37,9 +37,9 @@ class ColumnTypeDetectorTests(TestCase):
             ],
             columns=['id', 'email', 'zip_code'],
         )
-        rows1 = get_mismatched_rows(df['id'], 'number')
-        rows2 = get_mismatched_rows(df['email'], 'email')
-        rows3 = get_mismatched_rows(df['zip_code'], 'zip_code')
+        rows1 = df['id'][find_syntax_errors(df['id'], 'number')].tolist()
+        rows2 = df['email'][find_syntax_errors(df['email'], 'email')].tolist()
+        rows3 = df['zip_code'][find_syntax_errors(df['zip_code'], 'zip_code')].tolist()
         self.assertEqual(rows1, [])
         self.assertEqual(rows2, ['test', 'abc12345@'])
         self.assertEqual(rows3, ['abcde'])


### PR DESCRIPTION
# Summary
Backend now calculates indices of invalid values for phone numbers, zip codes, and emails. This can be used by the frontend to highlight these entries as invalid.

# Tests
Unit tests were developed locally to test that the invalid indices are calculated correctly, alongside testing on user datasets to confirm that the validity metric still reports outputs correctly.

cc:
@wangxiaoyou1993 
