### PR TITLE
[td] Sort bar chart horizontal so largest count at the top

### DIFF
--- a/mage_ai/frontend/components/datasets/overview/utils.tsx
+++ b/mage_ai/frontend/components/datasets/overview/utils.tsx
@@ -210,7 +210,9 @@ export function buildRenderColumnHeader({
         />
       );
     } else if (isCategoricalType) {
-      const data = sortByKey(statisticsByColumnArray, 'x').slice(0, 5);
+      const data = sortByKey(sortByKey(statisticsByColumnArray, 'x', {
+        ascending: false,
+      }).slice(0, 5), 'x');
 
       distributionChart = (
         <BarGraphHorizontal


### PR DESCRIPTION
# Summary
Before: the values were sorted in reverse order so the highest frequency value was not showing.

After: show the highest frequency values first.

# Tests
<img width="1337" alt="image" src="https://user-images.githubusercontent.com/1066980/172996856-f2a16422-0bda-48eb-862d-4c8801803dba.png">

cc:
@shrey-mage @nathaniel-mage 