### PR TITLE
[sk] Adding syntax error cleaning action

### DIFF
--- a/mage_ai/data_cleaner/column_type_detector.py
+++ b/mage_ai/data_cleaner/column_type_detector.py
@@ -41,7 +41,7 @@ COLUMN_TYPES = frozenset(
 
 REGEX_DATETIME_PATTERN = r'^\d{2,4}-\d{1,2}-\d{1,2}$|^\d{2,4}-\d{1,2}-\d{1,2}[Tt ]{1}\d{1,2}:\d{1,2}[:]{0,1}\d{1,2}[\.]{0,1}\d*|^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$|^\d{1,4}[-\/]{1}\d{1,2}[-\/]{1}\d{1,2}$|^\d{1,2}[-\/]{1}\d{1,2}[-\/]{1}\d{1,4}$|^\d{1,2}[-\/]\d{1,2}[-\/]\d{2,4}[Tt ]{1}\d{1,2}:\d{1,2}[:]{0,1}\d{1,2}[\.]{0,1}\d*|(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+(\d{1,2})[\s,]+(\d{2,4})'
 REGEX_DATETIME = re.compile(REGEX_DATETIME_PATTERN)
-REGEX_EMAIL_PATTERN = r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'
+REGEX_EMAIL_PATTERN = r'^[a-zA-Z0-9_.+#-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'
 REGEX_EMAIL = re.compile(REGEX_EMAIL_PATTERN)
 REGEX_INTEGER_PATTERN = r'^\-{0,1}\s*(?:(?:[$€¥₹£]|Rs|CAD){0,1}\s*(?:[0-9]+(?:,[0-9]+)*|[0-9]+){0,1}|(?:[0-9]+(?:,[0-9]+)*|[0-9]+){0,1}\s*(?:[元€$]|CAD){0,1})$'
 REGEX_INTEGER = re.compile(REGEX_INTEGER_PATTERN)
@@ -66,22 +66,35 @@ def str_in_set(string, string_set):
 def find_syntax_errors(series, column_type):
     if len(series) == 0:
         return pd.Series([])
-    str_series = series.astype(str)
+    dtype = series.dtype
+    str_series = series
     if column_type == EMAIL:
         pattern = REGEX_EMAIL
     elif column_type == PHONE_NUMBER:
+        str_series = str_series.astype(str)
         pattern = REGEX_PHONE_NUMBER
     elif column_type == ZIP_CODE:
+        str_series = str_series.astype(str)
         pattern = REGEX_ZIP_CODE
-    elif column_type in NUMBER_TYPES:
+    elif (
+        column_type in NUMBER_TYPES
+        and not np.issubdtype(dtype, np.integer)
+        and not np.issubdtype(dtype, np.floating)
+    ):
+        str_series = str_series.astype(str)
         pattern = REGEX_NUMBER
-    elif column_type == DATETIME:
+    elif (
+        column_type == DATETIME
+        and not np.issubdtype(dtype, np.datetime64)
+        and not dtype is pd.Timestamp
+    ):
+        str_series = str_series.astype(str)
         pattern = REGEX_DATETIME
     else:
         mask = pd.Series([False] * len(series))
         mask.index = series.index
         return mask
-    return ~str_series.str.match(pattern) & series.notna()
+    return ~str_series.str.match(pattern, na=True) & series.notna()
 
 
 def infer_number_type(series, column_name, dtype):

--- a/mage_ai/data_cleaner/column_type_detector.py
+++ b/mage_ai/data_cleaner/column_type_detector.py
@@ -73,7 +73,7 @@ def find_syntax_errors(series, column_type):
         pattern = REGEX_PHONE_NUMBER
     elif column_type == ZIP_CODE:
         pattern = REGEX_ZIP_CODE
-    elif column_type == NUMBER or column_type == NUMBER_WITH_DECIMALS:
+    elif column_type in NUMBER_TYPES:
         pattern = REGEX_NUMBER
     elif column_type == DATETIME:
         pattern = REGEX_DATETIME

--- a/mage_ai/data_cleaner/column_type_detector.py
+++ b/mage_ai/data_cleaner/column_type_detector.py
@@ -66,17 +66,22 @@ def str_in_set(string, string_set):
 def find_syntax_errors(series, column_type):
     if len(series) == 0:
         return pd.Series([])
+    str_series = series.astype(str)
     if column_type == EMAIL:
-        return ~series.str.match(REGEX_EMAIL)
+        pattern = REGEX_EMAIL
     elif column_type == PHONE_NUMBER:
-        return ~series.str.match(REGEX_PHONE_NUMBER)
+        pattern = REGEX_PHONE_NUMBER
     elif column_type == ZIP_CODE:
-        str_series = series.astype(str)
-        return ~str_series.str.match(REGEX_ZIP_CODE)
+        pattern = REGEX_ZIP_CODE
+    elif column_type == NUMBER or column_type == NUMBER_WITH_DECIMALS:
+        pattern = REGEX_NUMBER
+    elif column_type == DATETIME:
+        pattern = REGEX_DATETIME
     else:
         mask = pd.Series([False] * len(series))
         mask.index = series.index
         return mask
+    return ~str_series.str.match(pattern) & series.notna()
 
 
 def infer_number_type(series, column_name, dtype):

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -244,7 +244,9 @@ class StatisticsCalculator:
         data[f'{col}/invalid_indices'] = invalid_indices[
             np.where(invalid_indices <= SAMPLE_SIZE)
         ].tolist()
-        data[f'{col}/invalid_value_distribution'] = invalid_values.value_counts().to_dict()
+        data[f'{col}/invalid_value_distribution'] = (
+            invalid_values.value_counts().head(VALUE_COUNT_LIMIT).to_dict()
+        )
         data[f'{col}/invalid_value_rate'] = (
             0 if series.size == 0 else data[f'{col}/invalid_value_count'] / series.size
         )

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -244,6 +244,7 @@ class StatisticsCalculator:
         data[f'{col}/invalid_indices'] = invalid_indices[
             np.where(invalid_indices <= SAMPLE_SIZE)
         ].tolist()
+        data[f'{col}/invalid_value_distribution'] = invalid_values.value_counts().to_dict()
         data[f'{col}/invalid_value_rate'] = (
             0 if series.size == 0 else data[f'{col}/invalid_value_count'] / series.size
         )

--- a/mage_ai/data_cleaner/transformer_actions/base.py
+++ b/mage_ai/data_cleaner/transformer_actions/base.py
@@ -26,7 +26,7 @@ FUNCTION_MAPPING = {
         ActionType.DIFF: column.diff,
         # ActionType.EXPAND_COLUMN: column.expand_column,
         ActionType.FIRST: column.first,
-        ActionType.FIX_SYNTAX_ERRORS: column.find_syntax_errors,
+        ActionType.FIX_SYNTAX_ERRORS: column.fix_syntax_errors,
         ActionType.IMPUTE: column.impute,
         ActionType.LAST: column.last,
         ActionType.MAX: column.max,

--- a/mage_ai/data_cleaner/transformer_actions/base.py
+++ b/mage_ai/data_cleaner/transformer_actions/base.py
@@ -26,6 +26,7 @@ FUNCTION_MAPPING = {
         ActionType.DIFF: column.diff,
         # ActionType.EXPAND_COLUMN: column.expand_column,
         ActionType.FIRST: column.first,
+        ActionType.FIX_SYNTAX_ERRORS: column.find_syntax_errors,
         ActionType.IMPUTE: column.impute,
         ActionType.LAST: column.last,
         ActionType.MAX: column.max,

--- a/mage_ai/data_cleaner/transformer_actions/column.py
+++ b/mage_ai/data_cleaner/transformer_actions/column.py
@@ -1,13 +1,14 @@
 from mage_ai.data_cleaner.column_type_detector import (
     DATETIME,
-    find_syntax_errors,
     NUMBER_TYPES,
     REGEX_NUMBER,
+    find_syntax_errors,
 )
 from mage_ai.data_cleaner.transformer_actions.action_code import query_with_action_code
 from mage_ai.data_cleaner.transformer_actions.constants import (
     CONSTANT_IMPUTATION_DEFAULTS,
     CURRENCY_SYMBOLS,
+    INVALID_VALUE_PLACEHOLDERS,
     ImputationStrategy,
     NameConventionPatterns,
 )
@@ -81,7 +82,7 @@ def fix_syntax_errors(df, action, **kwargs):
     for column in generate_string_cols(df, columns):
         dtype = action_variables[column]['feature']['column_type']
         mask = find_syntax_errors(df[column], dtype)
-        df.loc[mask, column] = 'invalid'
+        df.loc[mask, column] = INVALID_VALUE_PLACEHOLDERS[dtype]
     return df
 
 
@@ -99,17 +100,9 @@ def impute(df, action, **kwargs):
         df[columns] = df[columns].fillna(df[columns].astype(float).mean(axis=0))
     elif strategy == ImputationStrategy.CONSTANT:
         if value is None:
-            col_by_type = {}
             for column in columns:
                 dtype = action_variables[column]['feature']['column_type']
-                key = 'object'
-                if dtype == DATETIME:
-                    key = 'datetime'
-                elif dtype in NUMBER_TYPES:
-                    key = 'number'
-                col_by_type.setdefault(key, []).append(column)
-            for key, column_set in col_by_type.items():
-                df[column_set] = df[column_set].fillna(CONSTANT_IMPUTATION_DEFAULTS[key])
+                df[column] = df[column].fillna(CONSTANT_IMPUTATION_DEFAULTS[dtype])
         else:
             df[columns] = df[columns].fillna(value)
     elif strategy == ImputationStrategy.MEDIAN:

--- a/mage_ai/data_cleaner/transformer_actions/column.py
+++ b/mage_ai/data_cleaner/transformer_actions/column.py
@@ -1,5 +1,6 @@
 from mage_ai.data_cleaner.column_type_detector import (
     DATETIME,
+    find_syntax_errors,
     NUMBER_TYPES,
     REGEX_NUMBER,
 )
@@ -72,6 +73,16 @@ def diff(df, action, **kwargs):
 
 def first(df, action, **kwargs):
     return __agg(df, action, 'first')
+
+
+def fix_syntax_errors(df, action, **kwargs):
+    action_variables = action['action_variables']
+    columns = action['action_arguments']
+    for column in generate_string_cols(df, columns):
+        dtype = action_variables[column]['feature']['column_type']
+        mask = find_syntax_errors(df[column], dtype)
+        df.loc[mask, column] = 'invalid'
+    return df
 
 
 def impute(df, action, **kwargs):

--- a/mage_ai/data_cleaner/transformer_actions/constants.py
+++ b/mage_ai/data_cleaner/transformer_actions/constants.py
@@ -1,8 +1,41 @@
+from mage_ai.data_cleaner.column_type_detector import (
+    CATEGORY,
+    CATEGORY_HIGH_CARDINALITY,
+    DATETIME,
+    EMAIL,
+    NUMBER,
+    NUMBER_WITH_DECIMALS,
+    TEXT,
+    PHONE_NUMBER,
+    ZIP_CODE,
+)
 import pandas as pd
+import numpy as np
 import re
 
-CONSTANT_IMPUTATION_DEFAULTS = dict(object='missing', datetime=pd.Timestamp.min, number=0)
+CONSTANT_IMPUTATION_DEFAULTS = {
+    CATEGORY: 'missing',
+    CATEGORY_HIGH_CARDINALITY: 'missing',
+    DATETIME: pd.Timestamp.min,
+    EMAIL: 'missing',
+    NUMBER: 0,
+    NUMBER_WITH_DECIMALS: 0,
+    TEXT: 'missing',
+    PHONE_NUMBER: 'missing',
+    ZIP_CODE: 'missing',
+}
 CURRENCY_SYMBOLS = re.compile(r'(?:[\$\€\¥\₹\元\£]|(?:Rs)|(?:CAD))')
+INVALID_VALUE_PLACEHOLDERS = {
+    CATEGORY: 'invalid',
+    CATEGORY_HIGH_CARDINALITY: 'invalid',
+    DATETIME: 'invalid',
+    EMAIL: 'invalid',
+    NUMBER: np.nan,
+    NUMBER_WITH_DECIMALS: np.nan,
+    TEXT: 'invalid',
+    PHONE_NUMBER: 'invalid',
+    ZIP_CODE: 'invalid',
+}
 
 
 class ActionType:

--- a/mage_ai/data_cleaner/transformer_actions/constants.py
+++ b/mage_ai/data_cleaner/transformer_actions/constants.py
@@ -18,6 +18,7 @@ class ActionType:
     EXPLODE = 'explode'
     FILTER = 'filter'
     FIRST = 'first'
+    FIX_SYNTAX_ERRORS = 'fix_syntax_errors'
     GROUP = 'group'
     IMPUTE = 'impute'
     JOIN = 'join'

--- a/mage_ai/tests/data_cleaner/statistics/test_calculator.py
+++ b/mage_ai/tests/data_cleaner/statistics/test_calculator.py
@@ -76,12 +76,12 @@ class StatisticsCalculatorTest(TestCase):
     def test_calculate_statistics_overview_invalid_indices(self):
         df = pd.DataFrame(
             [
-                [1, 'abc@xyz.com', '32132'],
-                [2, 'abc2@xyz.com', '12345'],
-                [3, 'test', '1234'],
+                [1, 'abc@xyz.com', 32132],
+                [2, None, 12345],
+                [3, 'test', 1234],
                 [4, 'abc@test.net', 'abcde'],
-                [5, 'abc12345@', '54321'],
-                [6, 'abcdef@123.com', '56789'],
+                [5, 'abc12345@', 54321],
+                [6, 'abcdef@123.com', 56789],
             ],
             columns=['id', 'email', 'zip_code'],
         )

--- a/mage_ai/tests/data_cleaner/transformer_actions/test_column.py
+++ b/mage_ai/tests/data_cleaner/transformer_actions/test_column.py
@@ -1494,7 +1494,7 @@ class ColumnTests(TestCase):
                     dt(2022, 6, 27),
                 ],
                 [
-                    'invalid',
+                    np.nan,
                     np.nan,
                     '09876',
                     None,
@@ -1504,7 +1504,7 @@ class ColumnTests(TestCase):
                 ],
                 ['-4', 1150, None, 'invalid', 'invalid', None, dt(2022, 6, 27)],
                 [
-                    'invalid',
+                    np.nan,
                     1150,
                     'invalid',
                     'invalid',

--- a/mage_ai/tests/data_cleaner/transformer_actions/test_column.py
+++ b/mage_ai/tests/data_cleaner/transformer_actions/test_column.py
@@ -7,6 +7,7 @@ from mage_ai.data_cleaner.transformer_actions.column import (
     diff,
     # expand_column,
     first,
+    fix_syntax_errors,
     last,
     remove_column,
     select,
@@ -1379,6 +1380,159 @@ class ColumnTests(TestCase):
                 ),
             ],
         )
+
+    def test_fix_syntax_errors(self):
+        from mage_ai.data_cleaner.transformer_actions.column import find_syntax_errors
+
+        df = pd.DataFrame(
+            [
+                [
+                    '-12.3%',
+                    1000,
+                    '11111',
+                    'email@maile.com',
+                    '12223334444',
+                    '12/13/2014',
+                    dt(2022, 6, 27),
+                ],
+                [
+                    '$2.234',
+                    1050,
+                    '2222-2222',
+                    'er34ee@int.co',
+                    ' 1(000)-111-2222',
+                    'not a time',
+                    dt(2022, 6, 27),
+                ],
+                [
+                    'eieio',
+                    np.nan,
+                    '09876',
+                    None,
+                    '12345678901234',
+                    '4/27/2019 12:34:45',
+                    dt(2022, 6, 27),
+                ],
+                ['-4', 1150, None, 'email@email@email.com', 'qqqqqqqqqqq', None, dt(2022, 6, 27)],
+                [
+                    'not a number',
+                    1150,
+                    '23423932423',
+                    'eeeeeeeee',
+                    '1234',
+                    '12-24-2022',
+                    dt(2022, 6, 27),
+                ],
+                [
+                    None,
+                    1150,
+                    '234.3324',
+                    'agoodemail@network.net',
+                    '43213240089',
+                    'is not time',
+                    dt(2022, 6, 27),
+                ],
+            ],
+            columns=[
+                'number',
+                'number_but_correct_type',
+                'zipcode',
+                'email',
+                'phone_number',
+                'date',
+                'date_but_correct_type',
+            ],
+        )
+        action = dict(
+            action_arguments=[
+                'number',
+                'number_but_correct_type',
+                'zipcode',
+                'email',
+                'phone_number',
+                'date',
+                'date_but_correct_type',
+            ],
+            action_variables=dict(
+                number=dict(feature=dict(column_type='number', uuid='number'), type='feature'),
+                number_but_correct_type=dict(
+                    feature=dict(column_type='number', uuid='number_but_correct_type'),
+                    type='feature',
+                ),
+                zipcode=dict(feature=dict(column_type='zip_code', uuid='zipcode'), type='feature'),
+                email=dict(feature=dict(column_type='email', uuid='email'), type='feature'),
+                phone_number=dict(
+                    feature=dict(column_type='phone_number', uuid='phone_number'),
+                    type='feature',
+                ),
+                date=dict(feature=dict(column_type='datetime', uuid='date'), type='feature'),
+                date_but_correct_type=dict(
+                    feature=dict(column_type='datetime', uuid='date_but_correct_type'),
+                    type='feature',
+                ),
+            ),
+        )
+        new_df = fix_syntax_errors(df, action)
+        expected_df = pd.DataFrame(
+            [
+                [
+                    '-12.3%',
+                    1000,
+                    '11111',
+                    'email@maile.com',
+                    '12223334444',
+                    '12/13/2014',
+                    dt(2022, 6, 27),
+                ],
+                [
+                    '$2.234',
+                    1050,
+                    '2222-2222',
+                    'er34ee@int.co',
+                    ' 1(000)-111-2222',
+                    'invalid',
+                    dt(2022, 6, 27),
+                ],
+                [
+                    'invalid',
+                    np.nan,
+                    '09876',
+                    None,
+                    'invalid',
+                    '4/27/2019 12:34:45',
+                    dt(2022, 6, 27),
+                ],
+                ['-4', 1150, None, 'invalid', 'invalid', None, dt(2022, 6, 27)],
+                [
+                    'invalid',
+                    1150,
+                    'invalid',
+                    'invalid',
+                    'invalid',
+                    '12-24-2022',
+                    dt(2022, 6, 27),
+                ],
+                [
+                    None,
+                    1150,
+                    'invalid',
+                    'agoodemail@network.net',
+                    '43213240089',
+                    'invalid',
+                    dt(2022, 6, 27),
+                ],
+            ],
+            columns=[
+                'number',
+                'number_but_correct_type',
+                'zipcode',
+                'email',
+                'phone_number',
+                'date',
+                'date_but_correct_type',
+            ],
+        )
+        assert_frame_equal(new_df, expected_df)
 
     def test_impute(self):
         from mage_ai.data_cleaner.transformer_actions.column import impute


### PR DESCRIPTION
# Summary
Added transformer action to clean syntax errors by replacing invalid values with an 'invalid' marker. Some notable changes:
- `find_syntax_errors` now supports cleaning integers and datetimes (however as of now they still can't be used with the cleaning suggestion since the dataset gets automatically cleaned).
- `find_syntax_errors` filters out null values (null values are null, not invalid)
- Added `invalid_value_distribution` entry in statistics which can be used to generate a visualization on the distribution of the invalid values in a column


# Tests
Unit tests were written to test that invalid values are recognized and replaced properly, and also the backend was tested with API calls to the pipeline to remove syntax errors.

cc:
@wangxiaoyou1993 @nathaniel-mage 
