### PR TITLE
[xy] Fallback to thread.is_alive().

### DIFF
--- a/mage_ai/server/app.py
+++ b/mage_ai/server/app.py
@@ -373,5 +373,10 @@ def kill():
     if thread is not None:
         thread.kill()
         thread.join()
-        if not thread.isAlive():
+        try:
+            alive = thread.isAlive()
+        except AttributeError:
+            # thread's method isAlive() was renamed to is_alive() in python version 3.9
+            alive = thread.is_alive()
+        if not alive:
             print('Flask server is terminated')


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Fix bug: ![unnamed](https://user-images.githubusercontent.com/80284865/173280269-5c3b25e5-76ae-43d5-975d-6ac82c32af57.png)
Thread's method isAlive() was renamed to is_alive() in python version 3.9.
This PR catches AttributeError and fall back to call is_alive() method.

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
