### PR TITLE
[xy] Speed up analysis calculator

### DIFF
--- a/mage_ai/data_cleaner/analysis/calculator.py
+++ b/mage_ai/data_cleaner/analysis/calculator.py
@@ -134,10 +134,6 @@ class AnalysisCalculator:
         col = feature['uuid']
         column_type = feature['column_type']
 
-        # series = df[col]
-        # series_cleaned = clean_series(series, column_type)
-        series_cleaned = df[col].dropna()
-
         chart_data = []
         correlation = []
 
@@ -148,6 +144,7 @@ class AnalysisCalculator:
                 dict(feature=feature),
                 verbose=VERBOSE,
             ):
+                series_cleaned = df[col].dropna()
                 histogram_data = charts.build_histogram_data(col, series_cleaned, column_type)
                 if histogram_data:
                     chart_data.append(histogram_data)

--- a/mage_ai/data_cleaner/analysis/charts.py
+++ b/mage_ai/data_cleaner/analysis/charts.py
@@ -166,6 +166,7 @@ def build_time_series_data(df, features, datetime_column):
             )
         )
 
+        series_count = df_filtered.shape[0]
         for f in features:
             col = f['uuid']
             column_type = f['column_type']
@@ -176,13 +177,14 @@ def build_time_series_data(df, features, datetime_column):
             # series_cleaned = clean_series(series, column_type, dropna=False)
             series_cleaned = series
             series_non_null = series_cleaned.dropna()
+            non_null_count = series_non_null.size
 
             y_data = dict(
-                count=series_non_null.size,
+                count=non_null_count,
                 count_distinct=series_non_null.nunique(),
                 null_value_rate=0
-                if series_cleaned.size == 0
-                else series_cleaned.isnull().sum() / series_cleaned.size,
+                if series_count == 0
+                else (series_count - non_null_count) / series_count,
             )
 
             if column_type in [ColumnType.NUMBER, ColumnType.NUMBER_WITH_DECIMALS]:
@@ -194,7 +196,7 @@ def build_time_series_data(df, features, datetime_column):
                     dict(
                         average=average,
                         max=series_non_null.max(),
-                        median=series_non_null.quantile(0.5),
+                        median=series_non_null.median(),
                         min=series_non_null.min(),
                         sum=series_non_null.sum(),
                     )
@@ -206,7 +208,7 @@ def build_time_series_data(df, features, datetime_column):
             ]:
                 value_counts = series_non_null.value_counts()
                 if len(value_counts.index):
-                    value_counts_top = value_counts.sort_values(ascending=False).iloc[:12]
+                    value_counts_top = value_counts.iloc[:12]
                     mode = value_counts_top.index[0]
                     y_data.update(
                         dict(

--- a/mage_ai/data_cleaner/analysis/charts.py
+++ b/mage_ai/data_cleaner/analysis/charts.py
@@ -75,23 +75,20 @@ def build_histogram_data(col1, series, column_type):
     if bucket_interval == 0:
         return
 
-    for value in series.values:
-        index = math.floor((value - min_value) / bucket_interval)
-        if index >= len(buckets):
-            index = len(buckets) - 1
-        buckets[index]['values'].append(value)
+    bins = [b['min_value'] for b in buckets] + [buckets[-1]['max_value']]
+    count, _ = np.histogram(series, bins=bins)
 
     x = []
     y = []
 
-    for bucket in buckets:
+    for idx, bucket in enumerate(buckets):
         x.append(
             dict(
                 max=bucket['max_value'],
                 min=bucket['min_value'],
             )
         )
-        y.append(dict(value=len(bucket['values'])))
+        y.append(dict(value=count[idx]))
 
     increment(f'{DD_KEY}.build_histogram_data.succeeded', dict(feature_uuid=col1))
 

--- a/mage_ai/data_cleaner/analysis/charts.py
+++ b/mage_ai/data_cleaner/analysis/charts.py
@@ -133,7 +133,7 @@ def build_time_series_data(df, features, datetime_column):
     if datetimes.size <= 1:
         return
 
-    datetimes = pd.to_datetime(datetimes, infer_datetime_format=True, errors='coerce')
+    # datetimes = pd.to_datetime(datetimes, infer_datetime_format=True, errors='coerce')
 
     min_value_datetime = datetimes.min().timestamp()
     max_value_datetime = datetimes.max().timestamp()
@@ -149,7 +149,7 @@ def build_time_series_data(df, features, datetime_column):
     y_dict = dict()
 
     df_copy = df.copy()
-    df_copy[datetime_column] = datetimes.apply(lambda x: x if pd.isnull(x) else x.timestamp())
+    df_copy[datetime_column] = datetimes.view(int) / 10**9
 
     for bucket in buckets:
         max_value = bucket['max_value']
@@ -252,9 +252,7 @@ def build_overview_data(
         df_copy[datetime_column] = pd.to_datetime(
             df[datetime_column], infer_datetime_format=True, errors='coerce'
         )
-        df_copy[datetime_column] = df_copy[datetime_column].apply(
-            lambda x: x if pd.isnull(x) else x.timestamp()
-        )
+        df_copy[datetime_column] = df_copy[datetime_column].view(int) / 10**9
 
         min_value1 = df_copy[datetime_column].min()
         max_value1 = df_copy[datetime_column].max()


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Speed up analysis calculator. Tested on a dataset with 100k rows and 32 columns (with datetime column). Original time was 2.1s. This PR reduced the analysis calculation time by 66% to 0.7s.
* Speed up timestamp calculation: 2.1s -> 1.5s
  *  https://stackoverflow.com/questions/54313463/pandas-datetime-to-unix-timestamp-seconds
* Optimize stats calculation in timeseries chart: 1.5s -> 1.15s 
* Update histogram calculation to use np.histogram method: 1.15s -> 0.78s
* Only dropna when necessary for histogram calculation: 0.78s -> 0.7s

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
