### PR TITLE
[jk] Responsive tab content

### DIFF
--- a/mage_ai/frontend/components/datasets/Insights/ColumnAnalysis.tsx
+++ b/mage_ai/frontend/components/datasets/Insights/ColumnAnalysis.tsx
@@ -625,6 +625,7 @@ function ColumnAnalysis({
               />
             </ChartContainer>
           }
+          responsive
           right={
             <ChartContainer
               noPadding={!!correlationsRowData}

--- a/mage_ai/frontend/components/datasets/Insights/ColumnAnalysis.tsx
+++ b/mage_ai/frontend/components/datasets/Insights/ColumnAnalysis.tsx
@@ -381,9 +381,6 @@ function ColumnAnalysis({
       };
     });
 
-    console.log("legend names:", legendNames);
-    console.log("data:", data);
-
     return (
       <LineSeries
         data={data}

--- a/mage_ai/frontend/components/datasets/Insights/Overview.tsx
+++ b/mage_ai/frontend/components/datasets/Insights/Overview.tsx
@@ -33,6 +33,7 @@ export const ChartStyle = styled.div`
   border: 1px solid ${GRAY_LINES};
   border-radius: ${BORDER_RADIUS_LARGE}px;
   overflow: auto;
+  margin-bottom: ${UNIT * PADDING_UNITS}px;
 `;
 
 export const ChartHeaderStyle = styled.div`
@@ -92,32 +93,32 @@ export function ChartContainer({
 
 export function ChartRow({
   left,
+  responsive,
   right,
 }: {
-  left: any,
-  right?: any,
+  left: any;
+  responsive?: boolean;
+  right?: any;
 }) {
   return (
-    <Spacing mb={PADDING_UNITS}>
-      <FlexContainer>
-        <FlexContainer flex={1}>
-          <div style={{ width: '100%', height: '100%' }}>
-            {left}
-          </div>
-        </FlexContainer>
-        {right && (
-          <>
-            <Spacing mr={PADDING_UNITS} />
-
-            <FlexContainer flex={1}>
-              <div style={{ width: '100%', height: '100%' }}>
-                {right}
-              </div>
-            </FlexContainer>
-          </>
-        )}
+    <FlexContainer responsive={responsive}>
+      <FlexContainer flex={1}>
+        <div style={{ width: '100%', height: '100%' }}>
+          {left}
+        </div>
       </FlexContainer>
-    </Spacing>
+      {right && (
+        <>
+          <Spacing mr={PADDING_UNITS} />
+
+          <FlexContainer flex={1}>
+            <div style={{ width: '100%', height: '100%' }}>
+              {right}
+            </div>
+          </FlexContainer>
+        </>
+      )}
+    </FlexContainer>
   );
 }
 
@@ -318,6 +319,7 @@ function Overview({
             />
           </ChartContainer>
         }
+        responsive
         right={
           <ChartContainer
             noPadding={columnsWithHighNullValues.length >= 1}
@@ -371,6 +373,7 @@ function Overview({
                   {chart}
                 </ChartContainer>
               }
+              responsive
               right={
                 <ChartContainer
                   noPadding={unusualDates.length >= 1}
@@ -435,6 +438,7 @@ function Overview({
             />
           </ChartContainer>
         }
+        responsive
         right={
           <ChartContainer
             noPadding={columnsWithHighUniqueValues.length >= 1}
@@ -508,6 +512,7 @@ function Overview({
               />
             </ChartContainer>
           }
+          responsive
           right={
             <ChartContainer
               noPadding={columnsWithHighDistribution.length >= 1}

--- a/mage_ai/frontend/components/datasets/columns/ColumnReports.tsx
+++ b/mage_ai/frontend/components/datasets/columns/ColumnReports.tsx
@@ -149,7 +149,7 @@ function ColumnReports({
   );
 
   return (
-    <FlexContainer justifyContent={'center'}>
+    <FlexContainer justifyContent="center" responsive>
       <Flex flex={1} flexDirection="column">
         <SimpleDataTable
           columnFlexNumbers={[2, 1, 2]}
@@ -159,7 +159,7 @@ function ColumnReports({
           }]}
         />
 
-        <Spacing mt={PADDING_UNITS}>
+        <Spacing my={PADDING_UNITS}>
           <SimpleDataTable
             columnFlexNumbers={[2, 3]}
             columnHeaders={[{ label: 'Statistics' }]}

--- a/mage_ai/frontend/components/datasets/overview/index.tsx
+++ b/mage_ai/frontend/components/datasets/overview/index.tsx
@@ -263,29 +263,34 @@ function DatasetOverview({
 
           {!selectedColumn && (
             <>
-              <FlexContainer justifyContent={'center'}>
+              <FlexContainer
+                justifyContent="center"
+                responsive
+              >
                 <Flex flex={1} flexDirection="column">
                   {qualityMetrics && (
-                    <SimpleDataTable
-                      columnFlexNumbers={[2, 1, 2 ]}
-                      columnHeaders={[{ label: 'Quality metrics' }]}
-                      rowGroupData={[qualityMetrics]}
-                      warnings={[{
-                        compare: lessThan,
-                        name: 'Validity',
-                        val: 80,
-                      },
-                      {
-                        compare: lessThan,
-                        name: 'Completeness',
-                        val: 80,
-                      },
-                      {
-                        compare: greaterThan,
-                        name: 'Duplicate rows',
-                        val: 0,
-                      }]}
-                    />
+                    <Spacing mb={PADDING_UNITS}>
+                      <SimpleDataTable
+                        columnFlexNumbers={[2, 1, 2]}
+                        columnHeaders={[{ label: 'Quality metrics' }]}
+                        rowGroupData={[qualityMetrics]}
+                        warnings={[{
+                          compare: lessThan,
+                          name: 'Validity',
+                          val: 80,
+                        },
+                        {
+                          compare: lessThan,
+                          name: 'Completeness',
+                          val: 80,
+                        },
+                        {
+                          compare: greaterThan,
+                          name: 'Duplicate rows',
+                          val: 0,
+                        }]}
+                      />
+                    </Spacing>
                   )}
                 </Flex>
 
@@ -294,7 +299,7 @@ function DatasetOverview({
                 <Flex flex={1}>
                   {statSample && (
                     <SimpleDataTable
-                      columnFlexNumbers={[1, 1, 1]}
+                      columnFlexNumbers={[1, 1]}
                       columnHeaders={[{ label: 'Statistics' }]}
                       rowGroupData={[statSample]}
                       warnings={[

--- a/mage_ai/frontend/oracle/components/FlexContainer.tsx
+++ b/mage_ai/frontend/oracle/components/FlexContainer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { flexbox, FlexboxProps } from 'styled-system';
+import { media } from 'styled-bootstrap-grid';
 
 type FlexContainerProps = {
   children: any | any[];
@@ -10,17 +11,49 @@ type FlexContainerProps = {
   justifyContent?: string;
   offsetHeight?: number;
   relative?: boolean;
+  responsive?: boolean;
   textOverflow?: boolean;
   verticalHeight?: number;
   verticalHeightOffset?: number;
   width?: number;
-  wrap?: boolean;
 } & FlexboxProps;
+
+const SHARED_FLEX_DIRECTION_STYLE = css`
+  flex-direction: column;
+`;
+
+const RESPONSIVE_FLEX_DIRECTION = css`
+  ${media.xs`
+    ${(props: any) => props.responsive && `
+      ${SHARED_FLEX_DIRECTION_STYLE}
+    `}
+  `}
+
+  ${media.sm`
+    ${(props: any) => props.responsive && `
+      ${SHARED_FLEX_DIRECTION_STYLE}
+    `}
+  `}
+
+  ${media.md`
+    ${(props: any) => props.responsive && `
+      ${SHARED_FLEX_DIRECTION_STYLE}
+    `}
+  `}
+  
+  ${media.lg`
+    ${(props: any) => props.responsive && `
+      flex-direction: row;
+    `}
+  `}
+`;
 
 const FlexContainerStyle = styled.div<FlexContainerProps>`
   ${flexbox}
 
   display: flex;
+
+  ${RESPONSIVE_FLEX_DIRECTION}
 
   ${props => props.verticalHeight && `
     height: calc(${props.verticalHeight}vh - ${props.verticalHeightOffset}px);
@@ -46,10 +79,6 @@ const FlexContainerStyle = styled.div<FlexContainerProps>`
     min-height: calc(100vh - ${props.offsetHeight}px);
   `}
 
-  ${props => props.justifyContent && `
-    justify-content: ${props.justifyContent};
-  `}
-
   ${props => props.width && `
     width: ${props.width}px;
   `}
@@ -66,13 +95,12 @@ const FlexContainerStyle = styled.div<FlexContainerProps>`
   `}
 `;
 
-const FlexContainer = React.forwardRef(({
+const FlexContainer = ({
   children,
   fullHeight,
   verticalHeightOffset = 0,
-  wrap,
   ...props
-}: FlexContainerProps, ref) => (
+}: FlexContainerProps) => (
   <FlexContainerStyle
     {...props}
     fullHeight={fullHeight}
@@ -80,6 +108,6 @@ const FlexContainer = React.forwardRef(({
   >
     {children}
   </FlexContainerStyle>
-));
+);
 
 export default FlexContainer;

--- a/mage_ai/frontend/oracle/components/Layout/MultiColumn.style.tsx
+++ b/mage_ai/frontend/oracle/components/Layout/MultiColumn.style.tsx
@@ -4,7 +4,7 @@ import light from '@oracle/styles/themes/light';
 import { BORDER_RADIUS } from '@oracle/styles/units/borders';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 
-export const BEFORE_WIDTH = UNIT * 40;
+export const BEFORE_WIDTH = UNIT * 35;
 const AFTER_WIDTH = UNIT * 50;
 
 export const HeaderStyle = styled.div<{


### PR DESCRIPTION
# Summary
- Use single blocks instead of two columns for tables/charts on smaller screens.

# Tests
![image](https://user-images.githubusercontent.com/78053898/173403997-ec52641e-5ea4-406d-9002-ad9b3aca3d7a.png)

![image](https://user-images.githubusercontent.com/78053898/173404042-c85dc7ce-2bab-4d18-aade-3690b5edd414.png)

![image](https://user-images.githubusercontent.com/78053898/173404122-bbe3d1f4-ce72-46fe-91a0-5fa543b5509d.png)

