### PR TITLE
[sk] Add calculation of more text statistics

### DIFF
--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -4,7 +4,6 @@ from mage_ai.data_cleaner.shared.constants import SAMPLE_SIZE
 from mage_ai.data_cleaner.shared.hash import merge_dict
 from mage_ai.data_cleaner.shared.logger import timer
 from mage_ai.data_cleaner.shared.utils import clean_dataframe
-from string import punctuation
 import math
 import numpy as np
 import pandas as pd
@@ -230,7 +229,6 @@ class StatisticsCalculator:
             elif column_type == ColumnType.EMAIL:
                 valid_emails = series[~find_syntax_errors(series, ColumnType.EMAIL)]
                 domains = valid_emails.str.extract(EMAIL_DOMAIN_REGEX, expand=False)
-                print(domains)
                 data[f'{col}/domain_distribution'] = (
                     domains.value_counts().head(VALUE_COUNT_LIMIT).to_dict()
                 )

--- a/mage_ai/tests/data_cleaner/statistics/test_calculator.py
+++ b/mage_ai/tests/data_cleaner/statistics/test_calculator.py
@@ -276,10 +276,10 @@ class StatisticsCalculatorTest(TestCase):
     def test_calculate_statistics_text_data(self):
         # this data was generated using Faker
         texts = [
-            'Know fine seat prevent 92383ee3. \nCreate Mr. real',  # 49
-            'Avoid seat place.\nTrial exist against create.',  # 45
-            'Exactly question mention floor time. Tree theory central seat important beyond hour.',  # 84
-            'Physical father different ago away place. Health enough product even goal seat team.',  # 84
+            'Know fine seat prevent 92383ee3. \nCreate Mr. real',
+            'Avoid seat place.\nTrial exist against create.',
+            'Exactly question mention floor time. Tree theory central seat important beyond hour.',
+            'Physical father different ago away place. Health enough product even goal seat team.',
             None,
             None,
         ]
@@ -294,8 +294,29 @@ class StatisticsCalculatorTest(TestCase):
         self.assertEquals(data['text/word_distribution']['seat'], 4)
         self.assertEquals(data['text/word_distribution']['create'], 2)
         self.assertEquals(data['text/word_distribution']['place'], 2)
+        self.assertEquals(data['text/avg_stop_word_rate'], 0.0)
         self.assertEquals(data['text/avg_word_count'], 10)
         self.assertEquals(data['text/avg_string_length'], 65.5)
+
+    def test_calculate_statistics_stop_word_rate(self):
+        texts = [
+            'I know that bees make honey, but do they bake cake?',
+            'It is not a problem with the quantum flux capacitor, but the light conduits',
+            'Breaking News: scientists finally figure out if water is wet, leading to widespread controversy',
+            'The Mage data cleaning tool is overpowered, try it out now!',
+            None,
+            None,
+        ]
+        shuffle(texts)
+        df = pd.DataFrame({'text': texts})
+        calculator = StatisticsCalculator(
+            column_types=dict(
+                text='text',
+            ),
+        )
+        data = calculator.calculate_statistics_overview(df, is_clean=True)
+        self.assertEquals(data['text/avg_stop_word_count'], 2.75)
+        self.assertEquals(data['text/avg_stop_word_rate'], 0.22)
 
     def test_calculate_statistics_email_data(self):
         # This data was generated using Faker

--- a/mage_ai/tests/data_cleaner/statistics/test_calculator.py
+++ b/mage_ai/tests/data_cleaner/statistics/test_calculator.py
@@ -294,9 +294,10 @@ class StatisticsCalculatorTest(TestCase):
         self.assertEquals(data['text/word_distribution']['seat'], 4)
         self.assertEquals(data['text/word_distribution']['create'], 2)
         self.assertEquals(data['text/word_distribution']['place'], 2)
-        self.assertEquals(data['text/avg_stop_word_rate'], 0.0)
+        self.assertEquals(data['text/total_word_count'], 40)
         self.assertEquals(data['text/avg_word_count'], 10)
         self.assertEquals(data['text/avg_string_length'], 65.5)
+        self.assertEquals(data['text/total_character_count'], 262)
 
     def test_calculate_statistics_stop_word_rate(self):
         texts = [
@@ -315,8 +316,9 @@ class StatisticsCalculatorTest(TestCase):
             ),
         )
         data = calculator.calculate_statistics_overview(df, is_clean=True)
-        self.assertEquals(data['text/avg_stop_word_count'], 2.75)
-        self.assertEquals(data['text/avg_stop_word_rate'], 0.22)
+        self.assertAlmostEquals(data['text/total_stop_word_count'], 11, places=3)
+        self.assertAlmostEquals(data['text/stop_word_rate'], 0.22, places=3)
+        self.assertAlmostEquals(data['text/avg_stop_word_count'], 2.75, places=3)
 
     def test_calculate_statistics_email_data(self):
         # This data was generated using Faker

--- a/mage_ai/tests/data_cleaner/statistics/test_calculator.py
+++ b/mage_ai/tests/data_cleaner/statistics/test_calculator.py
@@ -1,10 +1,16 @@
+from faker import Faker
 from mage_ai.data_cleaner.statistics.calculator import StatisticsCalculator
 from mage_ai.tests.base_test import TestCase
+from random import shuffle
 import pandas as pd
 import numpy as np
 
 
 class StatisticsCalculatorTest(TestCase):
+    def setUp(self):
+        self.faker = Faker(locale='en_US')
+        return super().setUp()
+
     def test_calculate_statistics_overview(self):
         calculator = StatisticsCalculator(
             column_types=dict(
@@ -266,3 +272,68 @@ class StatisticsCalculatorTest(TestCase):
         self.assertEqual(data['cancelled/null_value_rate'], 0)
         self.assertEqual(data['cancelled/completeness'], 1)
         self.assertEqual(data['cancelled/quality'], 'Good')
+
+    def test_calculate_statistics_text_data(self):
+        # this data was generated using Faker
+        texts = [
+            'Know fine seat prevent 92383ee3. \nCreate Mr. real',  # 49
+            'Avoid seat place.\nTrial exist against create.',  # 45
+            'Exactly question mention floor time. Tree theory central seat important beyond hour.',  # 84
+            'Physical father different ago away place. Health enough product even goal seat team.',  # 84
+            None,
+            None,
+        ]
+        shuffle(texts)
+        df = pd.DataFrame({'text': texts})
+        calculator = StatisticsCalculator(
+            column_types=dict(
+                text='text',
+            ),
+        )
+        data = calculator.calculate_statistics_overview(df, is_clean=True)
+        self.assertEquals(data['text/word_distribution']['seat'], 4)
+        self.assertEquals(data['text/word_distribution']['create'], 2)
+        self.assertEquals(data['text/word_distribution']['place'], 2)
+        self.assertEquals(data['text/avg_word_count'], 10)
+        self.assertEquals(data['text/avg_string_length'], 65.5)
+
+    def test_calculate_statistics_email_data(self):
+        # This data was generated using Faker
+        emails = [
+            'xclarke@yahoo.com',
+            'daniel40@gmail.com',
+            'not an email',
+            'phammary@yahoo.com',
+            'welchjeffrey@gmail.com',
+            None,
+            'an improperly formatted email@net.co',
+            'wardcindy@gmail.com',
+            'bdavis@yahoo.com',
+            'qcarpenter@gmail.com',
+            'email@net@net.com',
+            'larsonkatherine@hotmail.com',
+            None,
+            'edwardswilliam@jones.org',
+            'ojensen@hotmail.com',
+            'karenmcbride@gmail.com',
+            'danielharris@kim.com',
+            'not an email',
+        ]
+        shuffle(emails)
+        df = pd.DataFrame({'emails': emails})
+        calculator = StatisticsCalculator(
+            column_types=dict(
+                emails='email',
+            ),
+        )
+        data = calculator.calculate_statistics_overview(df, is_clean=True)
+
+        expected_domain_distribution = {
+            'gmail.com': 5,
+            'yahoo.com': 3,
+            'hotmail.com': 2,
+            'jones.org': 1,
+            'kim.com': 1,
+        }
+
+        self.assertEquals(expected_domain_distribution, data['emails/domain_distribution'])


### PR DESCRIPTION
# Summary
Added the computation of the following statistics for text columns:
- Total word count - `total_word_count`
- Average word count per entry - `avg_word_count`
- Total character count - `total_character_count`
- Average string length per entry - `avg_string_length`
- Distribution of most common words - `word_distribution`
- Average stop word count - `avg_stop_word_count`
- Total stop word count - `total_stop_word_count`
- Stop word rate - `stop_word_rate`

Also added the following statistics for email columns
- Distribution of the most common domains - `domain_distribution`

# Tests
Unit tests were added to confirm these statistics are properly calculated, alongside testing on user data.

cc:
@wangxiaoyou1993 
