### PR TITLE
[nt]  datatable datetime chart

### DIFF
--- a/mage_ai/frontend/components/datasets/overview/index.tsx
+++ b/mage_ai/frontend/components/datasets/overview/index.tsx
@@ -190,11 +190,13 @@ function DatasetOverview({
     columnTypes,
     columns,
     insightsByFeatureUUID,
+    insightsOverview,
     statistics,
   }), [
     columnTypes,
     columns,
     insightsByFeatureUUID,
+    insightsOverview,
     statistics,
   ]);
 

--- a/mage_ai/frontend/components/datasets/overview/utils.tsx
+++ b/mage_ai/frontend/components/datasets/overview/utils.tsx
@@ -157,6 +157,7 @@ export function buildRenderColumnHeader({
       }));
 
     const isBooleanType = ColumnTypeEnum.TRUE_OR_FALSE === columnType;
+    const isDatetimeType = ColumnTypeEnum.DATETIME === columnType;
     const isCategoricalType = [
       ColumnTypeEnum.CATEGORY,
       ColumnTypeEnum.CATEGORY_HIGH_CARDINALITY,
@@ -237,6 +238,52 @@ export function buildRenderColumnHeader({
           getY={([, value]) => value}
           height={COLUMN_HEADER_CHART_HEIGHT}
           textColor={light.monotone.black}
+        />
+      );
+    } else if (isDatetimeType) {
+      distributionChart = (
+        <Histogram
+          data={distribution?.data.map(({
+            hideRange,
+            isUnusual,
+            x,
+            xLabel,
+            y,
+          }) => [
+            xLabel,
+            y.value,
+            x.min,
+            x.max,
+            isUnusual,
+            hideRange,
+          ])}
+          height={COLUMN_HEADER_CHART_HEIGHT}
+          margin={{
+            bottom: 0,
+            left: 0,
+            right: 0,
+            top: 0,
+          }}
+          renderTooltipContent={([, value, xLabelMin, xLabelMax,, hideRange]) => (
+            <p>
+              {hideRange && (
+                <>
+                  Rows: {value}
+                  <br />
+                  Value: {xLabelMin}
+                </>
+              )}
+              {!hideRange && (
+                <>
+                  Rows: {value}
+                  <br />
+                  Range: {xLabelMin} - {xLabelMax}
+                </>
+              )}
+            </p>
+          )}
+          sortData={d => sortByKey(d, '[2]')}
+          width={columnWidth - (UNIT * 2)}
         />
       );
     }

--- a/mage_ai/frontend/components/datasets/overview/utils.tsx
+++ b/mage_ai/frontend/components/datasets/overview/utils.tsx
@@ -145,9 +145,14 @@ export function buildRenderColumnHeader({
         distribution,
       } = buildDistributionData(
         tsChart,
-        columnUUID,
+        {},
+        {
+          feature: {
+            'columnType': columnType,
+            'uuid': columnUUID,
+          },
+        },
       );
-
       timeSeriesData.push(distribution);
     });
 
@@ -184,7 +189,9 @@ export function buildRenderColumnHeader({
           <Text small>
             Rows: {count}
             <br />
-            Dates: {xLabelMin} - {xLabelMax}
+            Start: {xLabelMin}
+            <br />
+            End: {xLabelMax}
           </Text>
         )}
         showYAxisLabels

--- a/mage_ai/frontend/components/datasets/overview/utils.tsx
+++ b/mage_ai/frontend/components/datasets/overview/utils.tsx
@@ -164,7 +164,54 @@ export function buildRenderColumnHeader({
     ].includes(columnType);
 
     let distributionChart;
-    if (distribution && !isBooleanType) {
+    if (isDatetimeType) {
+      distributionChart = (
+        <Histogram
+          data={distribution?.data.map(({
+            hideRange,
+            isUnusual,
+            x,
+            xLabel,
+            y,
+          }) => [
+            xLabel,
+            y.value,
+            x.min,
+            x.max,
+            isUnusual,
+            hideRange,
+          ])}
+          height={COLUMN_HEADER_CHART_HEIGHT}
+          margin={{
+            bottom: 0,
+            left: 0,
+            right: 0,
+            top: 0,
+          }}
+          renderTooltipContent={([, value, xLabelMin, xLabelMax,, hideRange]) => (
+            <p>
+              {hideRange && (
+                <>
+                  Rows: {value}
+                  <br />
+                  Value: {xLabelMin}
+                </>
+              )}
+              {!hideRange && (
+                <>
+                  Rows: {value}
+                  <br />
+                  Range: {xLabelMin} - {xLabelMax}
+                </>
+              )}
+            </p>
+          )}
+          sortData={d => sortByKey(d, '[2]')}
+          width={columnWidth - (UNIT * 2)}
+        />
+      );
+    }
+    else if (distribution && !isBooleanType) {
       distributionChart = (
         <Histogram
           data={distribution.data.map(({
@@ -238,52 +285,6 @@ export function buildRenderColumnHeader({
           getY={([, value]) => value}
           height={COLUMN_HEADER_CHART_HEIGHT}
           textColor={light.monotone.black}
-        />
-      );
-    } else if (isDatetimeType) {
-      distributionChart = (
-        <Histogram
-          data={distribution?.data.map(({
-            hideRange,
-            isUnusual,
-            x,
-            xLabel,
-            y,
-          }) => [
-            xLabel,
-            y.value,
-            x.min,
-            x.max,
-            isUnusual,
-            hideRange,
-          ])}
-          height={COLUMN_HEADER_CHART_HEIGHT}
-          margin={{
-            bottom: 0,
-            left: 0,
-            right: 0,
-            top: 0,
-          }}
-          renderTooltipContent={([, value, xLabelMin, xLabelMax,, hideRange]) => (
-            <p>
-              {hideRange && (
-                <>
-                  Rows: {value}
-                  <br />
-                  Value: {xLabelMin}
-                </>
-              )}
-              {!hideRange && (
-                <>
-                  Rows: {value}
-                  <br />
-                  Range: {xLabelMin} - {xLabelMax}
-                </>
-              )}
-            </p>
-          )}
-          sortData={d => sortByKey(d, '[2]')}
-          width={columnWidth - (UNIT * 2)}
         />
       );
     }

--- a/mage_ai/frontend/components/datasets/overview/utils.tsx
+++ b/mage_ai/frontend/components/datasets/overview/utils.tsx
@@ -1,6 +1,7 @@
 import BarGraphHorizontal from '@components/charts/BarGraphHorizontal';
 import Histogram from '@components/charts/Histogram';
 import PieChart from '@components/charts/PieChart';
+import Text from '@oracle/elements/Text';
 import light from '@oracle/styles/themes/light';
 import {
   CATEGORICAL_TYPES,
@@ -154,11 +155,10 @@ export function buildRenderColumnHeader({
     const histogramChart = charts?.find(({ type }) => ChartTypeEnum.HISTOGRAM === type);
     const timeSeriesHistograms = timeSeriesData.map(({
       data,
-      featureUUID,
+      columnUUID,
     }) => (
       <Histogram
         data={data.map(({
-          isUnusual,
           x,
           xLabel,
           xLabelMax,
@@ -171,14 +171,14 @@ export function buildRenderColumnHeader({
           xLabelMax,
           x.min,
           x.max,
-          isUnusual,
         ])}
         getBarColor={([]) => light.brand.wind300}
-        height={UNIT * 50}
-        key={featureUUID}
+        height={COLUMN_HEADER_CHART_HEIGHT}
+        key={columnUUID}
         large
         margin={{
-          right: 4 * UNIT,
+          right: 5 * UNIT,
+          top: 10,
         }}
         renderTooltipContent={([, count, xLabelMin, xLabelMax]) => (
           <Text small>
@@ -187,9 +187,7 @@ export function buildRenderColumnHeader({
             Dates: {xLabelMin} - {xLabelMax}
           </Text>
         )}
-        showAxisLabels
         showYAxisLabels
-        showZeroes
         sortData={d => sortByKey(d, '[4]')}
       />
     ));


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
### Add Datetime chart to DataTable
- Displays Timeseries chart for Datetime types as a Histogram
- Excludes zeroes to free up space
- Display ranges when hovering over the chart.

# Tests
<!-- How did you test your change? -->
Visit Localhost and hover over a chart
### Datetime column
<img width="134" alt="image" src="https://user-images.githubusercontent.com/90282975/173472764-8fba6e93-3079-410f-b50f-2b94df6a6cab.png">

cc: @johnson-mage @dy46 
<!-- Optionally mention someone to let them know about this pull request -->
