### PR TITLE
[nt] table invalid redirect

### DIFF
--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -15,6 +15,7 @@ import {
 } from 'react-table';
 import { useSticky } from 'react-table-sticky';
 
+import FlexContainer from '@oracle/components/FlexContainer';
 import light from '@oracle/styles/themes/light';
 import Text from '@oracle/elements/Text';
 import {
@@ -25,8 +26,8 @@ import {
   REGULAR,
   REGULAR_LINE_HEIGHT,
 } from '@oracle/styles/fonts/sizes';
+import { TABS_QUERY_PARAM, SHOW_COLUMNS_QUERY_PARAM } from '@components/datasets/overview';
 import { UNIT } from '@oracle/styles/units/spacing';
-import FlexContainer from '@oracle/components/FlexContainer';
 
 const BASE_ROW_HEIGHT = (UNIT * 2) + REGULAR_LINE_HEIGHT;
 const DEFAULT_COLUMN_WIDTH = UNIT * 20;
@@ -239,7 +240,7 @@ function Table({
             cellStyle.width = maxWidthOfFirstColumn;
           }
 
-          let cellValue = original[idx - 1];
+          const cellValue = original[idx - 1];
           if (isInvalid) {
             cellStyle.color = light.interactive.dangerBorder;
           }
@@ -253,21 +254,21 @@ function Table({
             >
               {firstColumn && cell.render('Cell')}
               {!firstColumn && (
-                <FlexContainer justifyContent={'space-between'}>
+                <FlexContainer justifyContent="space-between">
                   <Text danger={isInvalid} wordBreak>
                     {cellValue === true && 'true'}
                     {cellValue === false && 'false'}
                     {(cellValue === null || cellValue === 'null') && 'null'}
                     {cellValue !== true
-                    && cellValue !== false
-                    && cellValue !== null
-                    && cellValue !== 'null'
-                    && cellValue
-                  }
+                      && cellValue !== false
+                      && cellValue !== null
+                      && cellValue !== 'null'
+                      && cellValue
+                    }
                   </Text>
                   {isInvalid && (
                     <NextLink
-                      as={`/datasets/${slug}/?tabs[]=Reports&show_columns=1&column=${index}`}
+                      as={`/datasets/${slug}/?${TABS_QUERY_PARAM}=Reports&${SHOW_COLUMNS_QUERY_PARAM}=1&column=${index}`}
                       href="/datasets/[...slug]"
                       passHref
                     >
@@ -283,11 +284,7 @@ function Table({
         })}
       </div>
     );
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    prepareRow,
-    rows,
-  ]);
+  }, [invalidValues, maxWidthOfFirstColumn, prepareRow, rows, slug]);
 
   const listHeight = useMemo(() => {
     let val = height;

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -1,3 +1,4 @@
+import NextLink from 'next/link';
 import React, {
   useCallback,
   useEffect,
@@ -198,6 +199,13 @@ function Table({
     useSticky,
   );
 
+  const viewInvalidCellValue = (cell, isInvalid) => {
+    if (isInvalid) {
+      console.log('clicked');
+    }
+
+  };
+
   // Index refers to rowIndex but you cannot change the name.
   const RenderRow = useCallback(({ index, style }) => {
     const row = rows[index];
@@ -233,18 +241,19 @@ function Table({
             cellStyle.width = maxWidthOfFirstColumn;
           }
 
+          let cellValue = original[idx - 1];
           if (isInvalid) {
             cellStyle.background = light.interactive.dangerBorder;
             cellStyle.color = light.monotone.white;
+            cellValue = cellValue + ' View all';
           }
-
-          const cellValue = original[idx - 1];
 
           return (
             <div
               {...cellProps}
               className="td"
               key={`${idx}-${cellValue}`}
+              onClick={()=> viewInvalidCellValue(cell, isInvalid)}
               style={cellStyle}
             >
               {firstColumn && cell.render('Cell')}

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -240,8 +240,7 @@ function Table({
 
           let cellValue = original[idx - 1];
           if (isInvalid) {
-            cellStyle.background = light.interactive.dangerBorder;
-            cellStyle.color = light.monotone.white;
+            cellStyle.color = light.interactive.dangerBorder;
           }
 
           return (
@@ -253,7 +252,7 @@ function Table({
             >
               {firstColumn && cell.render('Cell')}
               {!firstColumn && (
-                <FlexContainer alignItems="left">
+                <FlexContainer justifyContent={'space-between'}>
                   {cellValue === true && 'true'}
                   {cellValue === false && 'false'}
                   {(cellValue === null || cellValue === 'null') && 'null'}
@@ -263,19 +262,19 @@ function Table({
                     && cellValue !== 'null'
                     && cellValue
                   }
-                </FlexContainer>
-              )}
-              {isInvalid && (
-                <FlexContainer alignItems="right">
-                  <NextLink
-                    as={`/datasets/${slug}/?tabs[]=Reports&show_columns=1&column=${index}`}
-                    href="/datasets/[...slug]"
-                    passHref
-                  >
-                    <Link>
-                      View all
-                    </Link>
-                  </NextLink>
+                  {isInvalid && (
+                  <FlexContainer justifyContent={'space-between'}>
+                    <NextLink
+                      as={`/datasets/${slug}/?tabs[]=Reports&show_columns=1&column=${index}`}
+                      href="/datasets/[...slug]"
+                      passHref
+                    >
+                      <Link>
+                        View all
+                      </Link>
+                    </NextLink>
+                  </FlexContainer>
+                  )}
                 </FlexContainer>
               )}
             </div>

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -1,10 +1,10 @@
-import NextLink from 'next/link';
 import React, {
   useCallback,
   useEffect,
   useMemo,
   useRef,
 } from 'react';
+import router from 'next/router';
 import styled from 'styled-components';
 import { VariableSizeList } from 'react-window';
 import {
@@ -199,11 +199,11 @@ function Table({
     useSticky,
   );
 
-  const viewInvalidCellValue = (cell, isInvalid) => {
+  const viewInvalidCellValue = (index, isInvalid) => {
     if (isInvalid) {
-      console.log('clicked');
+      const { slug = [] } = router.query;
+      router.push(`/datasets/${slug}/?tabs[]=Reports&show_columns=1&column=${index}`);
     }
-
   };
 
   // Index refers to rowIndex but you cannot change the name.
@@ -253,7 +253,7 @@ function Table({
               {...cellProps}
               className="td"
               key={`${idx}-${cellValue}`}
-              onClick={()=> viewInvalidCellValue(cell, isInvalid)}
+              onClick={()=> viewInvalidCellValue(idx - 1, isInvalid)}
               style={cellStyle}
             >
               {firstColumn && cell.render('Cell')}

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -4,6 +4,8 @@ import React, {
   useMemo,
   useRef,
 } from 'react';
+import Link from '@oracle/elements/Link';
+import NextLink from 'next/link';
 import router from 'next/router';
 import styled from 'styled-components';
 import { VariableSizeList } from 'react-window';
@@ -23,6 +25,7 @@ import {
   REGULAR_LINE_HEIGHT,
 } from '@oracle/styles/fonts/sizes';
 import { UNIT } from '@oracle/styles/units/spacing';
+import FlexContainer from '@oracle/components/FlexContainer';
 
 const BASE_ROW_HEIGHT = (UNIT * 2) + REGULAR_LINE_HEIGHT;
 const DEFAULT_COLUMN_WIDTH = UNIT * 20;
@@ -198,13 +201,7 @@ function Table({
     useBlockLayout,
     useSticky,
   );
-
-  const viewInvalidCellValue = (index, isInvalid) => {
-    if (isInvalid) {
-      const { slug = [] } = router.query;
-      router.push(`/datasets/${slug}/?tabs[]=Reports&show_columns=1&column=${index}`);
-    }
-  };
+  const { slug = [] } = router.query;
 
   // Index refers to rowIndex but you cannot change the name.
   const RenderRow = useCallback(({ index, style }) => {
@@ -245,7 +242,6 @@ function Table({
           if (isInvalid) {
             cellStyle.background = light.interactive.dangerBorder;
             cellStyle.color = light.monotone.white;
-            cellValue = cellValue + ' View all';
           }
 
           return (
@@ -253,12 +249,11 @@ function Table({
               {...cellProps}
               className="td"
               key={`${idx}-${cellValue}`}
-              onClick={()=> viewInvalidCellValue(idx - 1, isInvalid)}
               style={cellStyle}
             >
               {firstColumn && cell.render('Cell')}
               {!firstColumn && (
-                <>
+                <FlexContainer alignItems="left">
                   {cellValue === true && 'true'}
                   {cellValue === false && 'false'}
                   {(cellValue === null || cellValue === 'null') && 'null'}
@@ -268,13 +263,27 @@ function Table({
                     && cellValue !== 'null'
                     && cellValue
                   }
-                </>
+                </FlexContainer>
+              )}
+              {isInvalid && (
+                <FlexContainer alignItems="right">
+                  <NextLink
+                    as={`/datasets/${slug}/?tabs[]=Reports&show_columns=1&column=${index}`}
+                    href="/datasets/[...slug]"
+                    passHref
+                  >
+                    <Link>
+                      View all
+                    </Link>
+                  </NextLink>
+                </FlexContainer>
               )}
             </div>
           );
         })}
       </div>
     );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     prepareRow,
     rows,

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -16,6 +16,7 @@ import {
 import { useSticky } from 'react-table-sticky';
 
 import light from '@oracle/styles/themes/light';
+import Text from '@oracle/elements/Text';
 import {
   FONT_FAMILY_REGULAR,
   MONO_FONT_FAMILY_REGULAR,
@@ -253,27 +254,27 @@ function Table({
               {firstColumn && cell.render('Cell')}
               {!firstColumn && (
                 <FlexContainer justifyContent={'space-between'}>
-                  {cellValue === true && 'true'}
-                  {cellValue === false && 'false'}
-                  {(cellValue === null || cellValue === 'null') && 'null'}
-                  {cellValue !== true
+                  <Text danger={isInvalid} wordBreak>
+                    {cellValue === true && 'true'}
+                    {cellValue === false && 'false'}
+                    {(cellValue === null || cellValue === 'null') && 'null'}
+                    {cellValue !== true
                     && cellValue !== false
                     && cellValue !== null
                     && cellValue !== 'null'
                     && cellValue
                   }
+                  </Text>
                   {isInvalid && (
-                  <FlexContainer justifyContent={'space-between'}>
                     <NextLink
                       as={`/datasets/${slug}/?tabs[]=Reports&show_columns=1&column=${index}`}
                       href="/datasets/[...slug]"
                       passHref
                     >
-                      <Link>
+                      <Link danger>
                         View all
                       </Link>
                     </NextLink>
-                  </FlexContainer>
                   )}
                 </FlexContainer>
               )}

--- a/mage_ai/frontend/oracle/elements/Link/index.tsx
+++ b/mage_ai/frontend/oracle/elements/Link/index.tsx
@@ -114,6 +114,10 @@ export const SHARED_LINK_STYLES = css<any>`
     border: ${BORDER_WIDTH}px ${BORDER_STYLE} ${(props.theme.monotone || light.monotone).focusBorder};
   `}
 
+  ${props => props.danger && `
+    color: ${(props.theme.interactive || light.interactive).dangerBorder} !important;
+  `}
+
   ${props => props.transparentBorder && `
     border: ${BORDER_WIDTH}px ${BORDER_STYLE} transparent;
   `}


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
### Clicking on the table cell of an invalid value will redirect to reports.
- The reports page has a table containing invalid values, accessed by the reports tab or clicking an invalid cell.
- In a future branch, we'll rework the reports page to be 'value': 'count' to increase readability/reduce duplicates.

# Tests
<!-- How did you test your change? -->
Tested on the Localhost app. I broke this off into two versions due to some UX decisions to get input.
### Version 1 (Remote branch)
View all is side by side with the cell, but the onClick is triggered when clicking on the cell
<img width="126" alt="image" src="https://user-images.githubusercontent.com/90282975/173640356-2d281dc0-2d46-47d1-90ed-1da9a2faeb0b.png">

### Version 2 (Local branch)
View all is not side by side but the onClick is triggered when clicking on the text
<img width="123" alt="image" src="https://user-images.githubusercontent.com/90282975/173640608-4802a001-509c-4527-b79f-8ff18e0b8dac.png">

Let me know which version is preferred and I can edit it accordingly.
cc: @dy46 @johnson-mage 
<!-- Optionally mention someone to let them know about this pull request -->
