### PR TITLE
[nt] Reset margins to match other histogram charts.

### DIFF
--- a/mage_ai/frontend/components/datasets/overview/utils.tsx
+++ b/mage_ai/frontend/components/datasets/overview/utils.tsx
@@ -182,8 +182,10 @@ export function buildRenderColumnHeader({
         key={columnUUID}
         large
         margin={{
-          right: 5 * UNIT,
-          top: 10,
+          bottom: 0,
+          left: 0,
+          right: 0,
+          top: 0,
         }}
         renderTooltipContent={([, count, xLabelMin, xLabelMax]) => (
           <Text small>
@@ -194,7 +196,6 @@ export function buildRenderColumnHeader({
             End: {xLabelMax}
           </Text>
         )}
-        showYAxisLabels
         sortData={d => sortByKey(d, '[4]')}
       />
     ));


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
- Fix bug where chart wasn't rendering at full width. The margin was being offset which made it look weird. I changed it to match what other histogram charts did.

# Tests
<!-- How did you test your change? -->
Localhost, pull up a chart for datetime columns
### Lots of values
<img width="175" alt="image" src="https://user-images.githubusercontent.com/90282975/173666957-ba979700-39c3-4cf3-865d-e0861fc9f9df.png">

### Small number of values
<img width="153" alt="image" src="https://user-images.githubusercontent.com/90282975/173667199-95169496-40d2-421d-8153-8052d3dcf268.png">

cc: @johnson-mage @dy46 
<!-- Optionally mention someone to let them know about this pull request -->
