### PR TITLE
[xy] Fix iframe on google colab.

### DIFF
--- a/mage_ai/__init__.py
+++ b/mage_ai/__init__.py
@@ -48,13 +48,13 @@ def display_inline_iframe(host=None, port=None):
         display(Javascript("""
             (async ()=>{
                 fm = document.createElement('iframe')
-                fm.src = %s
+                fm.src = await google.colab.kernel.proxyPort(%s)
                 fm.width = '95%%'
                 fm.height = '%d'
                 fm.frameBorder = 0
                 document.body.append(fm)
             })();
-            """ % (path_to_server, IFRAME_HEIGHT)))
+            """ % (SERVER_PORT, IFRAME_HEIGHT)))
     else:
         __print_url()
         display(IFrame(path_to_server, width='95%', height=1000))


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Fix iframe on google colab. When we directly specifying the src of iframe, the iframe was not shown in colab.

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/80284865/173693682-fc006932-941f-49c6-93ce-65d70b4e3d12.png">


# Tests
<!-- How did you test your change? -->
tested on google colab
<img width="1441" alt="image" src="https://user-images.githubusercontent.com/80284865/173693587-a88def77-f273-4ba2-8c42-9c7888047398.png">


cc:
<!-- Optionally mention someone to let them know about this pull request -->
