### PR TITLE
[dy] Launch with API key

### DIFF
--- a/mage_ai/__init__.py
+++ b/mage_ai/__init__.py
@@ -60,11 +60,13 @@ def connect_data(df, name):
     return feature_set
 
 
-def clean(df, pipeline_uuid=None, pipeline_path=None):
+def clean(df, pipeline_uuid=None, pipeline_path=None, remote_pipeline_uuid=None):
     if pipeline_uuid is not None:
         df_clean = clean_df_with_pipeline(df, id=pipeline_uuid)
     elif pipeline_path is not None:
         df_clean = clean_df_with_pipeline(df, path=pipeline_path)
+    elif remote_pipeline_uuid is not None:
+        df_clean = clean_df_with_pipeline(df, remote_id=remote_pipeline_uuid)
     else:
         _, df_clean = clean_df(df)
     return df_clean

--- a/mage_ai/__init__.py
+++ b/mage_ai/__init__.py
@@ -25,6 +25,7 @@ def launch(
             host=iframe_host,
             port=iframe_port,
         )
+
     return thread
 
 

--- a/mage_ai/__init__.py
+++ b/mage_ai/__init__.py
@@ -61,13 +61,19 @@ def connect_data(df, name):
     return feature_set
 
 
-def clean(df, pipeline_uuid=None, pipeline_path=None, remote_pipeline_uuid=None):
+def clean(
+    df,
+    pipeline_uuid=None,
+    pipeline_path=None,
+    remote_pipeline_uuid=None,
+    api_key=None,
+):
     if pipeline_uuid is not None:
         df_clean = clean_df_with_pipeline(df, id=pipeline_uuid)
     elif pipeline_path is not None:
         df_clean = clean_df_with_pipeline(df, path=pipeline_path)
     elif remote_pipeline_uuid is not None:
-        df_clean = clean_df_with_pipeline(df, remote_id=remote_pipeline_uuid)
+        df_clean = clean_df_with_pipeline(df, remote_id=remote_pipeline_uuid, mage_api_key=api_key)
     else:
         _, df_clean = clean_df(df)
     return df_clean

--- a/mage_ai/__init__.py
+++ b/mage_ai/__init__.py
@@ -17,14 +17,14 @@ def launch(
     iframe_host=None,
     iframe_port=None,
     inline=True,
+    api_key=None,
 ):
-    thread = launch_flask()
+    thread = launch_flask(api_key)
     if inline:
         display_inline_iframe(
             host=iframe_host,
             port=iframe_port,
         )
-
     return thread
 
 

--- a/mage_ai/frontend/components/datasets/Export/index.tsx
+++ b/mage_ai/frontend/components/datasets/Export/index.tsx
@@ -257,7 +257,7 @@ function Export({
         fullWidth
       >
         <Headline level={3}>
-          [WIP] Method 2: API key
+          Method 3: API key
         </Headline>
 
         <Spacing my={3}>

--- a/mage_ai/server/app.py
+++ b/mage_ai/server/app.py
@@ -26,7 +26,7 @@ app = Flask(
 CORS(app, resources={r'/*': {'origins': '*'}})
 
 thread = None
-
+api_key = None
 
 def rescue_errors(endpoint, error_code=500):
     def handler(*args, **kwargs):
@@ -292,9 +292,8 @@ def update_pipeline(id):
     else:
         pipeline.pipeline = clean_pipeline
 
-    global api_key
-    if api_key:
-        pipeline.sync_pipeline()
+    if api_key is not None:
+        pipeline.sync_pipeline(api_key)
 
     response = app.response_class(
         response=json.dumps(pipeline.to_dict(), cls=NumpyEncoder),

--- a/mage_ai/server/app.py
+++ b/mage_ai/server/app.py
@@ -319,14 +319,15 @@ def clean_df(df, name):
     return (feature_set, result['df'])
 
 
-def clean_df_with_pipeline(df, id=None, path=None, remote_id=None):
+def clean_df_with_pipeline(df, id=None, path=None, remote_id=None, mage_api_key=None):
     pipeline = None
     if id is not None:
         pipeline = Pipeline(id=id).pipeline
     elif path is not None:
         pipeline = Pipeline(path=path).pipeline
     elif remote_id is not None:
-        pipeline = BasePipeline(actions=Mage().get_pipeline_actions(remote_id, api_key))
+        final_key = mage_api_key if mage_api_key is not None else api_key
+        pipeline = BasePipeline(actions=Mage().get_pipeline_actions(remote_id, final_key))
     if pipeline is None:
         print('Please provide a valid pipeline id or config path.')
         return df
@@ -388,7 +389,6 @@ def launch(mage_api_key=None) -> None:
         'host': host,
         'port': port,
     }
-    app_kwargs = {'port': SERVER_PORT, 'host': 'localhost', 'debug': False}
     thread = ThreadWithTrace(target=app.run, kwargs=app_kwargs, daemon=True)
     thread.start()
     print(f'Mage running on host and port {host}:{port}')

--- a/mage_ai/server/app.py
+++ b/mage_ai/server/app.py
@@ -94,7 +94,6 @@ def process():
     if not id:
         return
 
-    global api_key
     feature_set = FeatureSet(id=id, api_key=api_key)
     df = feature_set.data
     metadata = feature_set.metadata
@@ -327,7 +326,6 @@ def clean_df_with_pipeline(df, id=None, path=None, remote_id=None):
     elif path is not None:
         pipeline = Pipeline(path=path).pipeline
     elif remote_id is not None:
-        global api_key
         pipeline = BasePipeline(actions=Mage().get_pipeline_actions(remote_id, api_key))
     if pipeline is None:
         print('Please provide a valid pipeline id or config path.')
@@ -377,8 +375,8 @@ class ThreadWithTrace(threading.Thread):
 
 def launch(mage_api_key=None) -> None:
     global thread
+    global api_key
     if mage_api_key:
-        global api_key
         api_key = mage_api_key
         sync_pipelines()
 
@@ -402,7 +400,6 @@ def sync_pipelines():
     for pipeline in local_pipelines:
         print('.', end='')
         pipeline.sync_pipeline(api_key)
-
 
 def kill():
     if thread is not None:

--- a/mage_ai/server/client/mage.py
+++ b/mage_ai/server/client/mage.py
@@ -54,7 +54,7 @@ class Mage():
     def get_pipeline_actions(self, id, api_key):
         if api_key is None:
             print('Fetching pipeline actions failed, invalid API key')
-            return
+            return []
         try:
             response = requests.get(
                 headers={

--- a/mage_ai/server/client/mage.py
+++ b/mage_ai/server/client/mage.py
@@ -1,13 +1,21 @@
+from mage_ai.data_cleaner.shared.hash import merge_dict
+
 import json
 import requests
-from mage_ai.data_cleaner.shared.hash import merge_dict
 
 class Mage():
     def __init__(self, **kwargs):
         self.url_prefix = 'https://backend.mage.ai/api/v1'
     
     def sync_pipeline(self, pipeline, api_key):
+        error_message = f'Syncing pipeline {pipeline.id} failed'
+        if api_key is None:
+            print(f'{error_message}, invalid API key')
+            return
         feature_set = pipeline.get_feature_set()
+        if feature_set is None:
+            print(f'{error_message}, feature set does not exist')
+            return
         pipeline_name = f"{feature_set.metadata['name']}_pipeline"
         data = {
             'data_cleaning_pipeline': {
@@ -40,9 +48,13 @@ class Mage():
                     'remote_id': pipeline_response['id'],
                 })
         except:
+            print(error_message)
             pass
 
     def get_pipeline_actions(self, id, api_key):
+        if api_key is None:
+            print('Fetching pipeline actions failed, invalid API key')
+            return
         try:
             response = requests.get(
                 headers={
@@ -53,4 +65,5 @@ class Mage():
             ).json()
             return response['data_cleaning_pipeline'].get('pipeline_actions', [])
         except:
+            print('Fetching pipeline actions from database failed')
             return []

--- a/mage_ai/server/client/mage.py
+++ b/mage_ai/server/client/mage.py
@@ -44,12 +44,13 @@ class Mage():
 
     def get_pipeline_actions(self, id, api_key):
         try:
-            requests.get(
+            response = requests.get(
                 headers={
                     'Content-Type': 'application/json',
                     'X-API-KEY': api_key,
                 },
                 url=f'{self.url_prefix}/data_cleaning_pipelines/{id}',
-            ).json()['data_cleaning_pipeline']['pipeline_actions']
+            ).json()
+            return response['data_cleaning_pipeline'].get('pipeline_actions', [])
         except:
-            pass
+            return []

--- a/mage_ai/server/client/mage.py
+++ b/mage_ai/server/client/mage.py
@@ -1,0 +1,55 @@
+import json
+import requests
+from mage_ai.data_cleaner.shared.hash import merge_dict
+
+class Mage():
+    def __init__(self, **kwargs):
+        self.url_prefix = 'https://backend.mage.ai/api/v1'
+    
+    def sync_pipeline(self, pipeline, api_key):
+        feature_set = pipeline.get_feature_set()
+        pipeline_name = f"{feature_set.metadata['name']}_pipeline"
+        data = {
+            'data_cleaning_pipeline': {
+                'name': pipeline_name,
+                'pipeline_actions': pipeline.pipeline.actions
+            }
+        }
+        try:
+            remote_id = pipeline.metadata.get('remote_id')
+            if remote_id is not None:
+                requests.put(
+                    data=json.dumps(data),
+                    headers={
+                        'Content-Type': 'application/json',
+                        'X-API-KEY': api_key,
+                    },
+                    url=f'{self.url_prefix}/data_cleaning_pipelines/{remote_id}',
+                )
+            else:
+                response = requests.post(
+                    data=json.dumps(data),
+                    headers={
+                        'Content-Type': 'application/json',
+                        'X-API-KEY': api_key,
+                    },
+                    url=f'{self.url_prefix}/data_cleaning_pipelines',
+                ).json()
+                pipeline_response = response['data_cleaning_pipeline']
+                pipeline.metadata = merge_dict(pipeline.metadata, {
+                    'remote_id': pipeline_response['id'],
+                })
+        except:
+            pass
+
+    def get_pipeline_actions(self, id, api_key):
+        try:
+            requests.get(
+                headers={
+                    'Content-Type': 'application/json',
+                    'X-API-KEY': api_key,
+                },
+                url=f'{self.url_prefix}/data_cleaning_pipelines/{id}',
+            ).json()['data_cleaning_pipeline']['pipeline_actions']
+        except:
+            pass

--- a/mage_ai/server/data/models.py
+++ b/mage_ai/server/data/models.py
@@ -1,6 +1,7 @@
 from mage_ai.data_cleaner.pipelines.base import BasePipeline
 from mage_ai.data_cleaner.shared.constants import SAMPLE_SIZE
 from mage_ai.data_cleaner.shared.hash import merge_dict
+from mage_ai.server.client.mage import Mage
 from mage_ai.server.data.base import Model
 import os
 import os.path
@@ -8,7 +9,7 @@ import os.path
 
 # right now, we are writing the models to local files to reduce dependencies
 class FeatureSet(Model):
-    def __init__(self, id=None, df=None, name=None):
+    def __init__(self, id=None, df=None, name=None, api_key=None):
         super().__init__(id)
 
         # Update metadata
@@ -24,7 +25,7 @@ class FeatureSet(Model):
             metadata_updated = True
 
         if self.pipeline is None:
-            pipeline = Pipeline(feature_set_id=self.id)
+            pipeline = Pipeline(feature_set_id=self.id, api_key=api_key)
             metadata['pipeline_id'] = pipeline.id
             metadata_updated = True
 
@@ -209,7 +210,7 @@ class FeatureSet(Model):
 
 
 class Pipeline(Model):
-    def __init__(self, id=None, path=None, feature_set_id=None, pipeline=None):
+    def __init__(self, id=None, path=None, feature_set_id=None, pipeline=None, api_key=None):
         super().__init__(id=id, path=path)
 
         # Update metadata
@@ -225,6 +226,11 @@ class Pipeline(Model):
 
         if pipeline is not None:
             self.pipeline = pipeline
+
+        self.sync_pipeline(api_key)
+
+    def sync_pipeline(self, api_key):
+        Mage().sync_pipeline(self, api_key)
 
     @property
     def metadata(self):

--- a/mage_ai/server/data/models.py
+++ b/mage_ai/server/data/models.py
@@ -226,9 +226,8 @@ class Pipeline(Model):
 
         if pipeline is not None:
             self.pipeline = pipeline
-
-        if api_key is not None:
-            self.sync_pipeline(api_key)
+            if api_key is not None:
+                self.sync_pipeline(api_key)
 
     def sync_pipeline(self, api_key):
         Mage().sync_pipeline(self, api_key)

--- a/mage_ai/server/data/models.py
+++ b/mage_ai/server/data/models.py
@@ -227,7 +227,8 @@ class Pipeline(Model):
         if pipeline is not None:
             self.pipeline = pipeline
 
-        self.sync_pipeline(api_key)
+        if api_key is not None:
+            self.sync_pipeline(api_key)
 
     def sync_pipeline(self, api_key):
         Mage().sync_pipeline(self, api_key)
@@ -251,6 +252,11 @@ class Pipeline(Model):
     @pipeline.setter
     def pipeline(self, pipeline):
         return self.write_json_file('pipeline.json', pipeline.actions)
+    
+    def get_feature_set(self):
+        feature_set_id = self.metadata.get('feature_set_id')
+        if feature_set_id is not None:
+            return FeatureSet(id=feature_set_id)
 
     def to_dict(self, detailed=True):
         return dict(

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ pandas~=1.3.0
 pyarrow==8.0.0
 python-dateutil==2.8.2
 pytz==2022.1
+requests==2.28.0
 scikit-learn>=1.0
 simplejson
 six>=1.15.0


### PR DESCRIPTION
# Summary

Launch the data cleaning tool with a group API key to sync pipelines with the Mage database. Calling `mage_ai.launch` with an api_key will kick off the `sync_pipelines()` method which will sync the pipelines between the user's local storage and Mage's database. Right now, we will automatically upload all of the local pipelines to Mage associated to the api key's group.

Usage:
```
import mage_ai

df = pd.read_csv('./testfiles/life_expectancy.csv')

mage_ai.launch(api_key="ErLVkWVZMJVSVDHDpembT7sPpom6cl0Vl8jR1dlg")
mage_ai.clean(df, remote_pipeline_uuid=1)
```
<!-- Brief summary of what your code does -->

# Tests

tested locally
<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
