### PR TITLE
[sp] fix warning for column stats

### DIFF
--- a/mage_ai/frontend/components/datasets/StatsTable/index.tsx
+++ b/mage_ai/frontend/components/datasets/StatsTable/index.tsx
@@ -10,10 +10,10 @@ export type StatRow = {
   value?: any,
   rate?: number,
   progress?: boolean,
-  warning?: Warning;
+  warning?: WarningType;
 };
 
-export type Warning = {
+export type WarningType = {
   compare: (a: number, b: number) => boolean;
   val: number;
 };
@@ -23,7 +23,7 @@ export type StatsTableProps = {
   title: string,
 };
 
-const shouldWarn = (w: Warning, n: number) => w && w.compare(n, w.val);
+const shouldWarn = (w: WarningType, n: number) => w && w.compare(n, w.val);
 
 function StatsTable({ stats, title }: StatsTableProps) {
   return (

--- a/mage_ai/frontend/components/datasets/columns/ColumnReports.tsx
+++ b/mage_ai/frontend/components/datasets/columns/ColumnReports.tsx
@@ -87,7 +87,7 @@ function ColumnReports({
       rate: uniqueValueRate,
       warning: {
         compare: greaterThan,
-        val: 0,
+        val: 0.8,
       },
     },
     {


### PR DESCRIPTION
# Summary
- fix unique values warning from `n > 0` to `n > 80%`
- refactor `Warning` in `StatsTable` to `WarningType` for clarity

# Tests
<img width="537" alt="image" src="https://user-images.githubusercontent.com/105667442/173711220-4d5d8a46-ef8c-4e01-8d03-7684b0a72c5a.png">
<img width="540" alt="image" src="https://user-images.githubusercontent.com/105667442/173711235-2990ef71-c26e-4999-b554-07fdc3ef348b.png">


cc: @johnson-mage @dy46 @wangxiaoyou1993 
