### PR TITLE
[jk] Don't capitalize links in Menu

### DIFF
--- a/mage_ai/frontend/oracle/components/Layout/MultiColumn.tsx
+++ b/mage_ai/frontend/oracle/components/Layout/MultiColumn.tsx
@@ -64,25 +64,24 @@ function MultiColumn({
         {tabs && (
           <Spacing px={PADDING_UNITS}>
             <FlexContainer>
-
-            {tabs.map((key: string, idx: number) => (
-              <Link
-                block
-                bold={selectedTab === key}
-                key={key}
-                noHoverUnderline
-                noOutline
-                onClick={() => onTabClick(key)}
-                preventDefault
-              >
-                <TabStyle
-                  first={idx === 0}
-                  selected={selectedTab === key}
+              {tabs.map((key: string, idx: number) => (
+                <Link
+                  block
+                  bold={selectedTab === key}
+                  key={key}
+                  noHoverUnderline
+                  noOutline
+                  onClick={() => onTabClick(key)}
+                  preventDefault
                 >
-                  {key}
-                </TabStyle>
-              </Link>
-            ))}
+                  <TabStyle
+                    first={idx === 0}
+                    selected={selectedTab === key}
+                  >
+                    {key}
+                  </TabStyle>
+                </Link>
+              ))}
             </FlexContainer>
           </Spacing>
         )}

--- a/mage_ai/frontend/oracle/components/Menu/index.tsx
+++ b/mage_ai/frontend/oracle/components/Menu/index.tsx
@@ -71,8 +71,7 @@ function Menu({
             onClick: onClickLink,
             uuid,
           }: LinkType) => {
-            const text = label;
-            const key = uuid || text;
+            const key = uuid || label;
 
             let linkEl = (
               <Link
@@ -91,7 +90,7 @@ function Menu({
                   px="4px"
                   py={1}
                 >
-                  {text}
+                  {label}
                 </Spacing>
               </Link>
             );

--- a/mage_ai/frontend/oracle/components/Menu/index.tsx
+++ b/mage_ai/frontend/oracle/components/Menu/index.tsx
@@ -7,7 +7,6 @@ import FlexContainer from '@oracle/components/FlexContainer';
 import Link from '@oracle/elements/Link';
 import Spacing from '@oracle/elements/Spacing';
 import MenuContainer from './MenuContainer';
-import { capitalize } from '@utils/string';
 
 export type LinkType = {
   afterElement?: any;
@@ -72,7 +71,7 @@ function Menu({
             onClick: onClickLink,
             uuid,
           }: LinkType) => {
-            const text = capitalize(label);
+            const text = label;
             const key = uuid || text;
 
             let linkEl = (


### PR DESCRIPTION
# Summary
- After cleaning column names, it appeared like the dropdown wasn't updating the names, but they were just getting capitalized.

# Tests
![col_dropdown](https://user-images.githubusercontent.com/78053898/173937964-c75660d0-573f-4b26-9380-0fdfab43458b.gif)


cc:
@tommydangerous 
