### PR TITLE
[sp] action code editor fixes

### DIFF
--- a/mage_ai/data_cleaner/transformer_actions/custom_action.py
+++ b/mage_ai/data_cleaner/transformer_actions/custom_action.py
@@ -36,7 +36,9 @@ def execute_custom_action(df, action, **kwargs):
     """
     custom_actions = deque()
     transformer_action = build_custom_action_decorator(custom_actions)
-    exec(action['action_code'], {'df': df, 'transformer_action': transformer_action})
+    action_code = action['action_code']
+    action_code = action_code.replace('\t', ' ' * 4)
+    exec(action_code, {'df': df, 'transformer_action': transformer_action})
     while len(custom_actions) != 0:
         df = custom_actions.popleft()(df)
     return df

--- a/mage_ai/frontend/components/ActionForm/index.tsx
+++ b/mage_ai/frontend/components/ActionForm/index.tsx
@@ -200,7 +200,7 @@ function ActionForm({
                 minLines={MIN_LINES_ACTIONS}
                 mode="python"
                 onChange={e => {
-                  payload['action_code'] = e;
+                  payload['action_code'] = e.replace('\t', ' '.repeat(4));
                   setActionCodeState(payload.action_code ?? actionCode);
                   setCustomCodeState({
                     actionType,

--- a/mage_ai/frontend/components/ActionForm/index.tsx
+++ b/mage_ai/frontend/components/ActionForm/index.tsx
@@ -35,6 +35,7 @@ import {
   OptionStyle,
 } from './index.style';
 import {
+  CODE_EXAMPLE,
   FormConfigType,
   VALUES_TYPE_COLUMNS,
   VALUES_TYPE_USER_INPUT,
@@ -89,7 +90,7 @@ function ActionForm({
   shadow,
 }: ActionFormProps) {
   const themeContext = useContext(ThemeContext);
-  const [actionCodeState, setActionCodeState] = useState(payload?.action_code);
+  const [actionCodeState, setActionCodeState] = useState(payload?.action_code || CODE_EXAMPLE);
 
   const {
     action_arguments: actionArguments,

--- a/mage_ai/frontend/components/ActionForm/index.tsx
+++ b/mage_ai/frontend/components/ActionForm/index.tsx
@@ -200,7 +200,7 @@ function ActionForm({
                 minLines={MIN_LINES_ACTIONS}
                 mode="python"
                 onChange={e => {
-                  payload['action_code'] = e.replace('\t', ' '.repeat(4));
+                  payload['action_code'] = e;
                   setActionCodeState(payload.action_code ?? actionCode);
                   setCustomCodeState({
                     actionType,

--- a/mage_ai/frontend/components/suggestions/SuggestionRow.tsx
+++ b/mage_ai/frontend/components/suggestions/SuggestionRow.tsx
@@ -89,7 +89,7 @@ const SuggestionRow = ({
   const DISPLAY_COLS_NUM = 5;
 
   const displayArguments = displayAllCols ? actionArguments : actionArguments?.slice(0, DISPLAY_COLS_NUM);
-  const featureLinks = displayArguments.map((col: string) => (
+  const featureLinks = displayArguments?.map((col: string) => (
     <span key={col}>
       {col in featureIdMapping ?
         <Link


### PR DESCRIPTION
# Summary
- fix backend error when user applies code example
- replace tabs with spaces
- add optional chaining to displayed action arguments

# Tests
- Click "New Action" > make no changes, click "Apply". Backend no longer returns an error, and code is applied.
- Write a line with four manual spaces. Write a line with a tab. Backend no longer returns an error, and code is applied.

cc: @johnson-mage @dy46 @tommydangerous @wangxiaoyou1993 
