### PR TITLE
[xy] Support databricks notebook type.

### DIFF
--- a/mage_ai/__init__.py
+++ b/mage_ai/__init__.py
@@ -1,5 +1,6 @@
 from IPython import get_ipython
 from IPython.display import IFrame, Javascript, display
+from enum import Enum
 from mage_ai.server.app import (
     clean_df,
     clean_df_with_pipeline,
@@ -8,22 +9,44 @@ from mage_ai.server.app import (
     launch as launch_flask,
 )
 from mage_ai.server.constants import SERVER_PORT
+import os
 
 IFRAME_HEIGHT = 1000
 MAX_NUM_OF_ROWS = 100_000
 
 
+class NotebookType(str, Enum):
+    DATABRICKS = 'databricks'
+    GOOGLE_COLAB = 'google_colab'
+
+
+def infer_notebook_type():
+    if os.environ.get('DATABRICKS_RUNTIME_VERSION'):
+        return NotebookType.DATABRICKS
+    elif type(get_ipython()).__module__.startswith('google.colab'):
+        return NotebookType.GOOGLE_COLAB
+    return None
+
+
 def launch(
-    iframe_host=None,
-    iframe_port=None,
+    host=None,
+    port=None,
     inline=True,
     api_key=None,
+    notebook_type=None,
+    config={},
 ):
-    thread = launch_flask(api_key)
+    if notebook_type is None:
+        notebook_type = infer_notebook_type()
+    if notebook_type == NotebookType.DATABRICKS:
+        host = '0.0.0.0'
+    thread = launch_flask(mage_api_key=api_key, host=host, port=port)
     if inline:
         display_inline_iframe(
-            host=iframe_host,
-            port=iframe_port,
+            host=host,
+            port=port,
+            notebook_type=notebook_type,
+            config=config,
         )
 
     return thread
@@ -33,7 +56,7 @@ def kill():
     kill_flask()
 
 
-def display_inline_iframe(host=None, port=None):
+def display_inline_iframe(host=None, port=None, notebook_type=None, config={}):
     host = host or 'localhost'
     port = port or SERVER_PORT
 
@@ -42,7 +65,7 @@ def display_inline_iframe(host=None, port=None):
     def __print_url():
         print(f'Open UI in another tab with url: {path_to_server}')
 
-    if type(get_ipython()).__module__.startswith('google.colab'):
+    if notebook_type == NotebookType.GOOGLE_COLAB:
         from google.colab.output import eval_js
         path_to_server = eval_js(f'google.colab.kernel.proxyPort({SERVER_PORT})')
         __print_url()
@@ -56,6 +79,24 @@ def display_inline_iframe(host=None, port=None):
                 document.body.append(fm)
             })();
             """ % (SERVER_PORT, IFRAME_HEIGHT)))
+    elif notebook_type == NotebookType.DATABRICKS:
+        required_args = [
+            'cluster_id',
+            'databricks_host',
+            'workspace_id',
+            'token',
+        ]
+        for arg in required_args:
+            if arg not in config:
+                print(f'Parameter "{arg}" is required to generate proxy url.')
+                return
+        databricks_host = config.get('databricks_host')
+        cluster_id = config.get('cluster_id')
+        workspace_id = config.get('workspace_id')
+        token = config.get('token')
+        path_to_server = f'https://{databricks_host}/driver-proxy-api/o/'\
+                         f'{workspace_id}/{cluster_id}/{port}/?token={token}'
+        __print_url()
     else:
         __print_url()
         display(IFrame(path_to_server, width='95%', height=1000))

--- a/mage_ai/server/app.py
+++ b/mage_ai/server/app.py
@@ -374,15 +374,17 @@ class ThreadWithTrace(threading.Thread):
         self.killed = True
 
 
-def launch(mage_api_key=None) -> None:
+def launch(mage_api_key=None, host=None, port=None) -> None:
     global thread
     global api_key
     if mage_api_key:
         api_key = mage_api_key
         sync_pipelines()
 
-    host = os.getenv('HOST', 'localhost')
-    port = os.getenv('PORT', SERVER_PORT)
+    if host is None:
+        host = os.getenv('HOST', 'localhost')
+    if port is None:
+        port = os.getenv('PORT', SERVER_PORT)
 
     app_kwargs = {
         'debug': False,


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Support databricks notebook type.

Web server url: `https://{databricks_host}/driver-proxy-api/o/{workspace_id}/{cluster_id}/{port}/?token={token}`

# Tests
<!-- How did you test your change? -->
to be tested in databricks notebook after merged.
tested printing out the url
<img width="1225" alt="image" src="https://user-images.githubusercontent.com/80284865/174020959-5dc42ad1-82ca-48b4-8d57-8505d82d39ec.png">

cc:
<!-- Optionally mention someone to let them know about this pull request -->
