### PR TITLE
[td] Fix host and protocol for cloud

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -1,0 +1,17 @@
+# Testing
+
+## Testing from branch
+
+Install `mage-ai` library from your branch:
+
+```bash
+$ pip3 install git+https://github.com/mage-ai/mage-ai.git@branch_name#egg=mage-ai
+```
+
+Build the front-end code:
+
+```bash
+$ cd mage_ai/frontend
+$ yarn install
+$ yarn export_prod
+```

--- a/mage_ai/frontend/api/utils/url.ts
+++ b/mage_ai/frontend/api/utils/url.ts
@@ -1,19 +1,31 @@
 import { queryString } from '@utils/url';
 
 export function getHost() {
+  const windowDefined = typeof window !== 'undefined';
   const LOCALHOST = 'localhost';
   const PORT = 5789;
 
   let host = LOCALHOST;
   let protocol = 'http://';
 
-  if (typeof window !== 'undefined') {
+  if (windowDefined) {
     host = window.location.hostname;
   }
+
   if (host === LOCALHOST) {
     host = `${host}:${PORT}`;
   } else {
     protocol = 'https://';
+
+    if (windowDefined) {
+      if (!window.location.protocol?.match(/https/)) {
+        protocol = 'http://';
+      }
+
+      if (!!window.location.port) {
+        host = `${host}:${window.location.port}`;
+      }
+    }
   }
 
   return `${protocol}${host}`;


### PR DESCRIPTION
# Summary
We need to use the current URL protocol and port when making API calls from the front-end to the backend server.

# Tests
Testing this branch on http://18.237.55.91:5789/datasets

```bash
$ pip3 install git+https://github.com/mage-ai/mage-ai.git@td--host_protocol_fix#egg=mage-ai
```

cc:
@wangxiaoyou1993 
