### PR TITLE
[sp] fix RowDataTable element cloning

### DIFF
--- a/mage_ai/frontend/oracle/components/RowDataTable/index.tsx
+++ b/mage_ai/frontend/oracle/components/RowDataTable/index.tsx
@@ -44,14 +44,12 @@ function RowDataTable({
         minHeight={minHeight}
         scrollable={scrollable}
       >
-        {children.length && children?.map((row, idx) => (
-          React.cloneElement(
-            row,
-            {
-              last: idx === children.length - 1,
-              secondary: alternating && idx % 2 === 1,
-            },
-          )
+        {React.Children.map(children, (row, idx) => row && React.cloneElement(
+          row,
+          {
+            last: idx === children.length - 1,
+            secondary: alternating && idx % 2 === 1,
+          },
         ))}
       </RowContainerStyle>
     </>


### PR DESCRIPTION
# Summary
- fixed RowDataTable to clone each child element correctly

# Tests
- Dataset Dashboard now correctly displays "No datasets available again"
- No unexpected errors when no datasets are added to the tool

cc: @johnson-mage 
