### PR TITLE
[dy] Add links to correlation labels

### DIFF
--- a/mage_ai/frontend/components/charts/HeatMap.tsx
+++ b/mage_ai/frontend/components/charts/HeatMap.tsx
@@ -7,6 +7,7 @@ import { scaleLinear } from '@visx/scale';
 
 import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
+import Link from '@oracle/elements/Link';
 import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
 import light from '@oracle/styles/themes/light';
@@ -40,13 +41,20 @@ function min<Datum>(data: Datum[], value: (d: Datum) => number): number {
 const bins = (d: any) => d.bins;
 const count = (d: any) => d.count;
 
+export type LabelType = {
+  label: number | string;
+  linkProps?: {
+    onClick?: () => void,
+  };
+}
+
 type HeatMapSharedProps = {
   countMidpoint?: number;
   data: number[][] | string[][];
   height: number;
   margin?: { top?: number; right?: number; bottom?: number; left?: number };
   minCount?: number;
-  yLabels?: number[] | string[];
+  yLabels?: LabelType[];
 };
 
 export type HeatmapProps = {
@@ -56,7 +64,7 @@ export type HeatmapProps = {
 
 type HeatMapContainerProps = {
   xAxisLabel?: string;
-  xLabels?: number[] | string[];
+  xLabels?: LabelType[];
   yAxisLabel?: string;
 } & HeatMapSharedProps;
 
@@ -241,18 +249,29 @@ function HeatMapContainer({
 
             {xLabels && (
               <FlexContainer>
-                {/* @ts-ignore */}
-                {xLabels.map(label => (
+                {xLabels.map(({ label, linkProps }) => (
                   <Flex flex="1" key={label} justifyContent="center">
-                    <Text
-                      bold
-                      center
-                      minWidth={70}
-                      title={label}
-                      xsmall
-                    >
-                      {displayLabel(label)}
-                    </Text>
+                    {linkProps ? (
+                      <Link
+                        bold
+                        centerAlign
+                        minWidth={70}
+                        onClick={linkProps.onClick}
+                        xsmall
+                      >
+                        {label}
+                      </Link>
+                    ) : (
+                      <Text
+                        bold
+                        center
+                        minWidth={70}
+                        title={String(label)}
+                        xsmall
+                      >
+                        {displayLabel(String(label))}
+                      </Text>
+                    )}
                   </Flex>
                 ))}
               </FlexContainer>
@@ -281,16 +300,27 @@ function HeatMapContainer({
               width={yLabelsWidth}
             >
               {/* @ts-ignore */}
-              {yLabels.map(label => (
+              {yLabels.map(({ label, linkProps }) => (
                 <Flex alignItems="center" flex="1" key={label}>
-                  <Text
-                    bold
-                    center
-                    title={label}
-                    xsmall
-                  >
-                    {displayLabel(label)}
-                  </Text>
+                  {linkProps ? (
+                    <Link
+                      bold
+                      centerAlign
+                      onClick={linkProps.onClick}
+                      xsmall
+                    >
+                      {label}
+                    </Link>
+                  ) : (
+                    <Text
+                      bold
+                      center
+                      title={String(label)}
+                      xsmall
+                    >
+                      {displayLabel(String(label))}
+                    </Text>
+                  )}
                 </Flex>
               ))}
             </FlexContainer>

--- a/mage_ai/frontend/components/datasets/Insights/ColumnAnalysis.tsx
+++ b/mage_ai/frontend/components/datasets/Insights/ColumnAnalysis.tsx
@@ -7,7 +7,7 @@ import FeatureType, {
   COLUMN_TYPE_NUMBERS,
 } from '@interfaces/FeatureType';
 import FlexContainer from '@oracle/components/FlexContainer';
-import HeatMap from '@components/charts/HeatMap';
+import HeatMap, { LabelType } from '@components/charts/HeatMap';
 import Histogram from '@components/charts/Histogram';
 import LineSeries from '@components/charts/LineSeries';
 import PieChart from '@components/charts/PieChart';
@@ -26,6 +26,7 @@ import {
 } from '@components/datasets/Insights/utils/data';
 import { formatNumberLabel } from '@components/charts/utils/label';
 import { formatPercent, numberWithCommas, roundNumber } from '@utils/string';
+import { goToWithQuery } from '@utils/routing';
 import {
   groupBy,
   indexBy,
@@ -130,18 +131,29 @@ function ColumnAnalysis({
     time_series: timeSeries,
   } = insights || {};
 
+  const columnsAll = features.map(({ uuid }) => uuid);
+
   const correlationsRowData = correlations?.length >= 1
     ? buildCorrelationsRowData([{
       correlations,
       feature,
     }])
     : null;
-  const yLabels = [column];
+  const yLabels: LabelType[] = [{ label: column }];
   const heatmapData = [[1]];
   const highCorrelations = [];
   if (correlationsRowData) {
     correlationsRowData?.map(([, col, r], idx: number) => {
-      yLabels.push(col);
+      yLabels.push({
+        label: col,
+        linkProps: {
+          onClick: () => goToWithQuery({
+            column: col === null ? null : columnsAll.indexOf(col),
+          }, {
+            pushHistory: true,
+          }),
+        },
+      });
       heatmapData.push([roundNumber(r)]);
     });
     correlationsRowData?.map((_, col, r) => {
@@ -620,7 +632,7 @@ function ColumnAnalysis({
                 data={heatmapData}
                 height={UNIT * 8 * yLabels.length}
                 minCount={-1}
-                xLabels={[column]}
+                xLabels={[{ label: column }]}
                 yLabels={yLabels}
               />
             </ChartContainer>

--- a/mage_ai/frontend/components/datasets/Insights/Overview.tsx
+++ b/mage_ai/frontend/components/datasets/Insights/Overview.tsx
@@ -28,6 +28,7 @@ import {
 import { formatNumberLabel } from '@components/charts/utils/label';
 import { formatPercent, numberWithCommas, roundNumber } from '@utils/string';
 import { indexBy, maxInArray, sortByKey } from '@utils/array';
+import { goToWithQuery } from '@utils/routing';
 
 export const ChartStyle = styled.div`
   border: 1px solid ${GRAY_LINES};
@@ -133,7 +134,7 @@ function Overview({
     scatter_plot: scatterPlot,
     scatter_plot_labels: scatterPlotLabels,
   } = insightsOverview;
-
+  const columnsAll = features.map(({ uuid }) => uuid);
   const xyLabels = [];
   const heatmapData = correlations?.map(({
     correlations: c,
@@ -141,7 +142,16 @@ function Overview({
       uuid,
     },
   }, idx: number) => {
-    xyLabels.push(uuid);
+    xyLabels.push({
+      label: uuid,
+      linkProps: {
+        onClick: () => goToWithQuery({
+          column: uuid === null ? null : columnsAll.indexOf(uuid),
+        }, {
+          pushHistory: true,
+        }),
+      }
+    });
 
     const arr = c[0].y.map(({ value }) => roundNumber(value));
     arr.splice(idx, 0, 1);

--- a/mage_ai/frontend/components/datasets/overview/index.tsx
+++ b/mage_ai/frontend/components/datasets/overview/index.tsx
@@ -128,8 +128,10 @@ function DatasetOverview({
   const {
     column_types: columnTypes,
   } = metadata || {};
-  const features: FeatureType[] = Object.entries(featureSet?.metadata?.column_types || {})
-    .map(([k, v]: [string, ColumnTypeEnum]) => ({ columnType: v, uuid: k }));
+  const features: FeatureType[] = columnsAll.map(uuid => ({
+    columnType: columnTypes[uuid],
+    uuid,
+  }))
 
   const qualityMetrics = statistics ? createMetricsSample(statistics, columnTypes) : null;
   const statSample = (statistics && columnTypes)

--- a/mage_ai/frontend/oracle/elements/Link/index.tsx
+++ b/mage_ai/frontend/oracle/elements/Link/index.tsx
@@ -30,6 +30,7 @@ export type LinkProps = {
   href?: string;
   inline?: boolean;
   large?: boolean;
+  minWidth?: number;
   muted?: boolean;
   noColor?: boolean;
   noHoverUnderline?: boolean;
@@ -52,6 +53,7 @@ export type LinkProps = {
   underline?: boolean;
   weightStyle?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
   wordWrap?: boolean;
+  xsmall?: boolean;
 };
 
 export const SHARED_LINK_STYLES = css<any>`


### PR DESCRIPTION
# Summary
Add links to correlation heat map so that users can easily navigate to the column page.

<img width="1346" alt="Screen Shot 2022-06-16 at 11 14 45 AM" src="https://user-images.githubusercontent.com/14357209/174138873-eaa09d86-5c06-467a-a27a-851885afef3c.png">

<!-- Brief summary of what your code does -->

# Tests

local
<!-- How did you test your change? -->

cc: @johnson-mage @shrey-mage 
<!-- Optionally mention someone to let them know about this pull request -->
