### PR TITLE
[xy] Add iframe_host and iframe_port back.

### DIFF
--- a/mage_ai/__init__.py
+++ b/mage_ai/__init__.py
@@ -34,6 +34,8 @@ def launch(
     inline=True,
     api_key=None,
     notebook_type=None,
+    iframe_host=None,
+    iframe_port=None,
     config={},
 ):
     if notebook_type is None:
@@ -43,8 +45,8 @@ def launch(
     thread = launch_flask(mage_api_key=api_key, host=host, port=port)
     if inline:
         display_inline_iframe(
-            host=host,
-            port=port,
+            host=iframe_host or host,
+            port=iframe_port or port,
             notebook_type=notebook_type,
             config=config,
         )


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Add iframe_host and iframe_port back.
The host that the server is running on could be different the host we use in iframe. When running the app on a ec2 host, we use 0.0.0.0 as the host and use the EC2 instance IP as the iframe host.

# Tests
<!-- How did you test your change? -->
tested locally
<img width="612" alt="image" src="https://user-images.githubusercontent.com/80284865/174144792-50db5c69-47ee-42a5-a820-d4d6c47c16fb.png">

cc:
<!-- Optionally mention someone to let them know about this pull request -->
