### PR TITLE
[xy] Support more spark transformers and make some fixes

### DIFF
--- a/mage_ai/data_cleaner/transformer_actions/spark/transformers.py
+++ b/mage_ai/data_cleaner/transformer_actions/spark/transformers.py
@@ -230,7 +230,7 @@ def transform_with_partitions(feature_set, transformer_action, sort_options={}):
 
     df_filtered = fs.groupby(GROUP_MOD_COLUMN).apply(execute_transform)
 
-    return df_filtered
+    return df_filtered.drop(GROUP_MOD_COLUMN, ROW_NUMBER_COLUMN, ROW_NUMBER_LIT_COLUMN)
 
 
 TRANSFORMER_FUNCTION_MAPPING = {

--- a/mage_ai/data_cleaner/transformer_actions/spark/transformers.py
+++ b/mage_ai/data_cleaner/transformer_actions/spark/transformers.py
@@ -4,6 +4,7 @@ from mage_ai.data_cleaner.transformer_actions.spark.constants import (
     ROW_NUMBER_COLUMN,
     ROW_NUMBER_LIT_COLUMN,
 )
+from mage_ai.data_cleaner.transformer_actions.utils import clean_column_name
 from pyspark.sql import functions as F
 from pyspark.sql.functions import PandasUDFType, expr, pandas_udf
 from pyspark.sql.types import (
@@ -72,6 +73,14 @@ def transform_agg(feature_set, transformer_action, agg_func, use_string_col_name
 
 def transform_average(feature_set, transformer_action, sort_options={}):
     return transform_agg(feature_set, transformer_action, F.avg)
+
+
+def transform_clean_column_name(feature_set, transformer_action, sort_options={}):
+    columns = transformer_action['action_arguments']
+    mapping = {col: clean_column_name(col) for col in columns}
+    for old_name, new_name in mapping.items():
+        feature_set = feature_set.withColumnRenamed(old_name, new_name)
+    return feature_set
 
 
 def transform_count(feature_set, transformer_action, sort_options={}):
@@ -229,6 +238,7 @@ TRANSFORMER_FUNCTION_MAPPING = {
         # 'distance_between': transform_add_distance_between,
     },
     'average': transform_average,
+    'clean_column_name': transform_clean_column_name,
     'count': transform_count,
     'count_distinct': transform_count_distinct,
     'drop_duplicate': transform_drop_duplicate,

--- a/mage_ai/data_cleaner/transformer_actions/spark/transformers.py
+++ b/mage_ai/data_cleaner/transformer_actions/spark/transformers.py
@@ -243,7 +243,7 @@ TRANSFORMER_FUNCTION_MAPPING = {
     'count_distinct': transform_count_distinct,
     'drop_duplicate': transform_drop_duplicate,
     'expand_column': transform_group,
-    'filter': transform_filter,
+    # 'filter': transform_filter,
     'first': transform_first,
     # 'group': transform_group,
     'last': transform_last,

--- a/mage_ai/data_cleaner/transformer_actions/utils.py
+++ b/mage_ai/data_cleaner/transformer_actions/utils.py
@@ -1,4 +1,34 @@
-from mage_ai.data_cleaner.transformer_actions.constants import ActionType, Axis
+from mage_ai.data_cleaner.column_types.column_type_detector import REGEX_NUMBER
+from mage_ai.data_cleaner.transformer_actions.constants import (
+    ActionType,
+    Axis,
+    NameConventionPatterns,
+)
+from keyword import iskeyword
+
+
+def clean_column_name(name):
+    if iskeyword(name):
+        name = f'{name}_'
+    name = name.strip(' \'\"_-')
+    name = NameConventionPatterns.CONNECTORS.sub('_', name)
+    name = NameConventionPatterns.NON_ALNUM.sub('', name)
+    name = REGEX_NUMBER.sub(lambda number: f'number_{number.group(0)}', name)
+    if iskeyword(name):
+        name = f'{name}_'
+    uppercase_group = NameConventionPatterns.UPPERCASE.match(name)
+    pascal_group = NameConventionPatterns.PASCAL.match(name)
+    camel_group = NameConventionPatterns.CAMEL.match(name)
+    if uppercase_group:
+        name = name.lower()
+    elif pascal_group:
+        components = NameConventionPatterns.PASCAL_COMPONENT.findall(name)
+        name = '_'.join(components)
+    elif camel_group:
+        components = NameConventionPatterns.CAMEL_COMPONENT.findall(name)
+        components += NameConventionPatterns.PASCAL_COMPONENT.findall(name)
+        name = '_'.join(components)
+    return name.lower()
 
 
 def columns_to_remove(transformer_actions):


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
* Support clean_column_name transformer in spark.
* Remove used __row_number_lit__, __row_number__, __group_mod__ columns
* Use udf for filter transformer

# Tests
<!-- How did you test your change? -->
tested on databricks notebook

<img width="930" alt="image" src="https://user-images.githubusercontent.com/80284865/174356137-378c5cad-1a88-48c4-8b33-c5b06d5fb017.png">


<img width="1279" alt="image" src="https://user-images.githubusercontent.com/80284865/174356034-78fedd99-6b74-4b91-8e51-ed7db151da65.png">


cc:
<!-- Optionally mention someone to let them know about this pull request -->
