### PR TITLE
[sp] empty action code hotfix

### DIFF
--- a/mage_ai/frontend/components/ActionForm/index.tsx
+++ b/mage_ai/frontend/components/ActionForm/index.tsx
@@ -89,7 +89,7 @@ function ActionForm({
   shadow,
 }: ActionFormProps) {
   const themeContext = useContext(ThemeContext);
-  const [actionCodeState, setActionCodeState] = useState(payload?.action_code || CODE_EXAMPLE);
+  const [actionCodeState, setActionCodeState] = useState(payload?.action_code);
 
   const {
     action_arguments: actionArguments,


### PR DESCRIPTION
# Summary
Frontend no longer sends default transformer function as action code payload.

This fixes a code editor being displayed on every custom action.
However, this will cause an error when the user does not type any new code into the code editor, and should ideally be handled on the backend.

# Tests
Apply any custom action that doesn't require code. Code editor should no longer be displayed.

cc: @johnson-mage @wangxiaoyou1993 
