### PR TITLE
[sp] fix link styling throughout app

### DIFF
--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -354,7 +354,7 @@ function Table({
                     className="th"
                     key={column.id}
                     style={columnStyle}
-                    title={firstColumn ? 'Row number' : `${column.Header}`}
+                    title={firstColumn && 'Row number'}
                   >
                     {el}
                   </div>

--- a/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
+++ b/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
@@ -169,6 +169,7 @@ function FeatureProfile({
               pushHistory: true,
             })}
             preventDefault
+            secondary
           >
             <Text
               backgroundColor={light.feature.active}

--- a/mage_ai/frontend/components/datasets/overview/utils.tsx
+++ b/mage_ai/frontend/components/datasets/overview/utils.tsx
@@ -346,17 +346,13 @@ export function buildRenderColumnHeader({
               href="/datasets/[...slug]"
               passHref
             >
-              <Link>
-                <Text
-                  backgroundColor={light.feature.active}
-                  bold
-                  monospace
-                  secondary
-                  textOverflow
-                  title={columns[columnIndex]}
-                >
-                  {columns[columnIndex]}
-                </Text>
+              <Link
+                bold
+                monospace
+                secondary
+                title={columns[columnIndex]}
+              >
+                {columns[columnIndex]}
               </Link>
             </NextLink>
           </div>

--- a/mage_ai/frontend/components/datasets/overview/utils.tsx
+++ b/mage_ai/frontend/components/datasets/overview/utils.tsx
@@ -350,6 +350,7 @@ export function buildRenderColumnHeader({
                 bold
                 monospace
                 secondary
+                small
                 title={columns[columnIndex]}
               >
                 {columns[columnIndex]}

--- a/mage_ai/frontend/components/suggestions/SuggestionRow.tsx
+++ b/mage_ai/frontend/components/suggestions/SuggestionRow.tsx
@@ -18,8 +18,8 @@ import { FeatureResponseType } from '@interfaces/FeatureType';
 import { MAX_LINES_ACTIONS, READ_ONLY } from '@oracle/styles/editor/rules';
 import { MONO_FONT_FAMILY_REGULAR } from '@oracle/styles/fonts/primary';
 import { REGULAR_FONT_SIZE } from '@oracle/styles/fonts/sizes';
-import { goToWithQuery } from '@utils/routing';
 import { UNIT } from '@oracle/styles/units/spacing';
+import { goToWithQuery } from '@utils/routing';
 
 export type SuggestionRowProps = {
   action: TransformerActionType;
@@ -100,7 +100,7 @@ const SuggestionRow = ({
             pushHistory: true,
           })}
           preventDefault
-          wordWrap
+          secondary
         >
           <Text
             maxWidth={30 * UNIT}
@@ -113,7 +113,7 @@ const SuggestionRow = ({
         </Link>
         :
         <Text
-          color={themeContext.interactive.linkSecondaryDisabled}
+          color={themeContext.monotone.grey400}
           maxWidth={30 * UNIT}
           monospace
           title={col}
@@ -163,7 +163,11 @@ const SuggestionRow = ({
 
         {featureLinks}
         {numFeatures > DISPLAY_COLS_NUM &&
-          <Link noOutline onClick={() => setDisplayAllCols(!displayAllCols)}>
+          <Link
+            noOutline
+            onClick={() => setDisplayAllCols(!displayAllCols)}
+            secondary
+          >
             <Text bold secondary>
               {displayAllCols
                 ?

--- a/mage_ai/frontend/oracle/elements/Link/index.tsx
+++ b/mage_ai/frontend/oracle/elements/Link/index.tsx
@@ -31,6 +31,7 @@ export type LinkProps = {
   inline?: boolean;
   large?: boolean;
   minWidth?: number;
+  monospace?: boolean;
   muted?: boolean;
   noColor?: boolean;
   noHoverUnderline?: boolean;


### PR DESCRIPTION
# Summary
- standardize underline colors (eg. purple column links now have purple underlines as expected)
- remove unnecessary nested `Text` components inside of links
- adjust disabled column link color to dark gray

# Tests
<img width="399" alt="image" src="https://user-images.githubusercontent.com/105667442/174411784-32608346-a46b-4704-9842-984d94c96885.png">
<img width="358" alt="image" src="https://user-images.githubusercontent.com/105667442/174411800-d31896e9-e60a-43b9-ad1e-39d67969167a.png">
<img width="353" alt="image" src="https://user-images.githubusercontent.com/105667442/174411812-8274cf7e-ef41-445f-a6dd-9d63c2bdca15.png">
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/105667442/174411933-2c4e4fbd-f18f-457b-bfea-b046bc3e030b.png">
<img width="378" alt="image" src="https://user-images.githubusercontent.com/105667442/174413657-47ee476b-d025-437e-8d0d-45ecdb1757ac.png">


cc: @johnson-mage 
