### PR TITLE
[sk] Added verbose pipeline argument

### DIFF
--- a/mage_ai/__init__.py
+++ b/mage_ai/__init__.py
@@ -136,19 +136,23 @@ def connect_data(df, name):
 
 def clean(
     df,
+    name=None,
     pipeline_uuid=None,
     pipeline_path=None,
     remote_pipeline_uuid=None,
     api_key=None,
+    verbose=False,
 ):
     if pipeline_uuid is not None:
-        df_clean = clean_df_with_pipeline(df, id=pipeline_uuid)
+        df_clean = clean_df_with_pipeline(df, id=pipeline_uuid, verbose=verbose)
     elif pipeline_path is not None:
-        df_clean = clean_df_with_pipeline(df, path=pipeline_path)
+        df_clean = clean_df_with_pipeline(df, path=pipeline_path, verbose=verbose)
     elif remote_pipeline_uuid is not None:
-        df_clean = clean_df_with_pipeline(df, remote_id=remote_pipeline_uuid, mage_api_key=api_key)
+        df_clean = clean_df_with_pipeline(
+            df, remote_id=remote_pipeline_uuid, mage_api_key=api_key, verbose=verbose
+        )
     else:
-        _, df_clean = clean_df(df)
+        _, df_clean = clean_df(df, name=name)
     return df_clean
 
 

--- a/mage_ai/__init__.py
+++ b/mage_ai/__init__.py
@@ -116,7 +116,7 @@ def display_inline_iframe(host=None, port=None, notebook_type=None, config={}):
         display(IFrame(path_to_server, width='95%', height=1000))
 
 
-def connect_data(df, name):
+def connect_data(df, name, verbose=False):
     if is_spark_dataframe(df):
         # Convert pyspark dataframe to pandas
         df_spark = df
@@ -128,9 +128,9 @@ def connect_data(df, name):
             df = df_spark.toPandas()
 
     if df.shape[0] > MAX_NUM_OF_ROWS:
-        feature_set, _ = connect_df(df.sample(MAX_NUM_OF_ROWS), name)
+        feature_set, _ = connect_df(df.sample(MAX_NUM_OF_ROWS), name, verbose=verbose)
     else:
-        feature_set, _ = connect_df(df, name)
+        feature_set, _ = connect_df(df, name, verbose=verbose)
     return feature_set
 
 

--- a/mage_ai/__init__.py
+++ b/mage_ai/__init__.py
@@ -152,7 +152,7 @@ def clean(
             df, remote_id=remote_pipeline_uuid, mage_api_key=api_key, verbose=verbose
         )
     else:
-        _, df_clean = clean_df(df, name=name)
+        _, df_clean = clean_df(df, name=name, verbose=verbose)
     return df_clean
 
 

--- a/mage_ai/__init__.py
+++ b/mage_ai/__init__.py
@@ -10,10 +10,13 @@ from mage_ai.server.app import (
     launch as launch_flask,
 )
 from mage_ai.server.constants import SERVER_PORT
+import logging
 import os
 
 IFRAME_HEIGHT = 1000
 MAX_NUM_OF_ROWS = 100_000
+
+logger = logging.getLogger(__name__)
 
 
 class NotebookType(str, Enum):
@@ -70,9 +73,12 @@ def display_inline_iframe(host=None, port=None, notebook_type=None, config={}):
 
     if notebook_type == NotebookType.GOOGLE_COLAB:
         from google.colab.output import eval_js
+
         path_to_server = eval_js(f'google.colab.kernel.proxyPort({SERVER_PORT})')
         __print_url()
-        display(Javascript("""
+        display(
+            Javascript(
+                """
             (async ()=>{
                 fm = document.createElement('iframe')
                 fm.src = await google.colab.kernel.proxyPort(%s)
@@ -81,7 +87,10 @@ def display_inline_iframe(host=None, port=None, notebook_type=None, config={}):
                 fm.frameBorder = 0
                 document.body.append(fm)
             })();
-            """ % (SERVER_PORT, IFRAME_HEIGHT)))
+            """
+                % (SERVER_PORT, IFRAME_HEIGHT)
+            )
+        )
     elif notebook_type == NotebookType.DATABRICKS:
         required_args = [
             'cluster_id',
@@ -91,14 +100,16 @@ def display_inline_iframe(host=None, port=None, notebook_type=None, config={}):
         ]
         for arg in required_args:
             if arg not in config:
-                print(f'Parameter "{arg}" is required to generate proxy url.')
+                logger.error(f'Parameter "{arg}" is required to generate proxy url.')
                 return
         databricks_host = config.get('databricks_host')
         cluster_id = config.get('cluster_id')
         workspace_id = config.get('workspace_id')
         token = config.get('token')
-        path_to_server = f'https://{databricks_host}/driver-proxy-api/o/'\
-                         f'{workspace_id}/{cluster_id}/{port}/?token={token}'
+        path_to_server = (
+            f'https://{databricks_host}/driver-proxy-api/o/'
+            f'{workspace_id}/{cluster_id}/{port}/?token={token}'
+        )
         __print_url()
     else:
         __print_url()

--- a/mage_ai/data_cleaner/analysis/calculator.py
+++ b/mage_ai/data_cleaner/analysis/calculator.py
@@ -8,7 +8,7 @@ from mage_ai.data_cleaner.shared.logger import timer
 from mage_ai.data_cleaner.shared.utils import clean_dataframe, is_numeric_dtype
 from mage_ai.data_cleaner.shared.hash import merge_dict
 from mage_ai.data_cleaner.column_types.constants import ColumnType
-import traceback
+import logging
 
 DD_KEY = 'lambda.analysis_calculator'
 TIMESERIES_COLUMN_TYPES = frozenset(
@@ -21,6 +21,8 @@ TIMESERIES_COLUMN_TYPES = frozenset(
     ]
 )
 VERBOSE = False
+
+logger = logging.getLogger(__name__)
 
 
 def increment(metric, tags={}):
@@ -121,8 +123,7 @@ class AnalysisCalculator:
             try:
                 return self.calculate_column_internal(df, feature)
             except Exception:
-                print(f'Failed to calculate stats for column {feature}')
-                traceback.print_exc()
+                logger.exception(f'Failed to calculate stats for column {feature}')
                 return {
                     'feature': feature,
                     DATA_KEY_CHARTS: [],

--- a/mage_ai/data_cleaner/data_cleaner.py
+++ b/mage_ai/data_cleaner/data_cleaner.py
@@ -2,7 +2,7 @@ from mage_ai.data_cleaner.analysis.calculator import AnalysisCalculator
 from mage_ai.data_cleaner.column_types import column_type_detector
 from mage_ai.data_cleaner.pipelines.base import DEFAULT_RULES, BasePipeline
 from mage_ai.data_cleaner.shared.hash import merge_dict
-from mage_ai.data_cleaner.shared.logger import timer
+from mage_ai.data_cleaner.shared.logger import timer, VerboseFunctionExec
 from mage_ai.data_cleaner.shared.utils import clean_dataframe
 from mage_ai.data_cleaner.statistics.calculator import StatisticsCalculator
 
@@ -12,12 +12,15 @@ def analyze(df):
     return cleaner.analyze(df)
 
 
-def clean(df, column_types={}, transform=True, rules=DEFAULT_RULES):
-    cleaner = DataCleaner()
+def clean(df, column_types={}, transform=True, rules=DEFAULT_RULES, verbose=True):
+    cleaner = DataCleaner(verbose=verbose)
     return cleaner.clean(df, column_types=column_types, rules=rules, transform=transform)
 
 
 class DataCleaner:
+    def __init__(self, verbose=False):
+        self.verbose = verbose
+
     def analyze(self, df, column_types={}):
         """Analyze a dataframe
         1. Detect column types
@@ -25,13 +28,21 @@ class DataCleaner:
         3. Calculate analysis
         """
         with timer('data_cleaner.infer_column_types'):
-            column_types = column_type_detector.infer_column_types(df, column_types=column_types)
+            with VerboseFunctionExec('Inferring variable type from dataset', self.verbose):
+                column_types = column_type_detector.infer_column_types(
+                    df, column_types=column_types
+                )
         with timer('data_cleaner.clean_series'):
-            df = clean_dataframe(df, column_types, dropna=False)
+            with VerboseFunctionExec('Converting entries to correct datatype', self.verbose):
+                df = clean_dataframe(df, column_types, dropna=False)
         with timer('data_cleaner.calculate_statistics'):
-            statistics = StatisticsCalculator(column_types).process(df, is_clean=True)
+            statistics = StatisticsCalculator(column_types, verbose=self.verbose).process(
+                df, is_clean=True
+            )
         with timer('data_cleaner.calculate_insights'):
-            analysis = AnalysisCalculator(df, column_types, statistics).process(df, is_clean=True)
+            analysis = AnalysisCalculator(
+                df, column_types, statistics, verbose=self.verbose
+            ).process(df, is_clean=True)
         return dict(
             insights=analysis,
             column_types=column_types,
@@ -41,7 +52,7 @@ class DataCleaner:
     def clean(self, df, column_types={}, transform=True, rules=DEFAULT_RULES):
         df_stats = self.analyze(df, column_types=column_types)
         df = clean_dataframe(df, df_stats['column_types'])
-        pipeline = BasePipeline(rules=rules)
+        pipeline = BasePipeline(rules=rules, verbose=self.verbose)
         if df_stats['statistics']['is_timeseries']:
             df = df.sort_values(by=df_stats['statistics']['timeseries_index'], axis=0)
         # TODO: Pass in both cleaned and uncleaned versions of dataset

--- a/mage_ai/data_cleaner/shared/logger.py
+++ b/mage_ai/data_cleaner/shared/logger.py
@@ -25,3 +25,19 @@ class timer(object):
         dt = int((time.time() - self.start) * 1000)
         if self.verbose:
             logger.debug(f'[time] metric: {self.metric}, value: {dt}ms, tags: {self.tags}')
+
+
+class VerboseFunctionExec:
+    def __init__(self, message, verbose=True):
+        self.message = message
+        self.verbose = verbose
+
+    def __enter__(self):
+        if self.verbose:
+            print(f'{self.message}...', end='')
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        if exc_type is not None:
+            print('FAILED')
+        elif self.verbose:
+            print('DONE')

--- a/mage_ai/data_cleaner/shared/logger.py
+++ b/mage_ai/data_cleaner/shared/logger.py
@@ -1,4 +1,7 @@
+import logging
 import time
+
+logger = logging.getLogger(__name__)
 
 
 class timer(object):
@@ -6,6 +9,7 @@ class timer(object):
     with timer('metric.metric', tags={ 'key': 'value' }):
         function()
     """
+
     def __init__(self, metric, tags={}, verbose=True):
         self.metric = metric
         self.start = None
@@ -20,4 +24,4 @@ class timer(object):
         # https://statsd.readthedocs.io/en/v3.1/timing.html
         dt = int((time.time() - self.start) * 1000)
         if self.verbose:
-            print(f'[time] metric: {self.metric}, value: {dt}ms, tags: {self.tags}')
+            logger.debug(f'[time] metric: {self.metric}, value: {dt}ms, tags: {self.tags}')

--- a/mage_ai/data_cleaner/shared/logger.py
+++ b/mage_ai/data_cleaner/shared/logger.py
@@ -37,7 +37,8 @@ class VerboseFunctionExec:
             print(f'{self.message}...', end='')
 
     def __exit__(self, exc_type, exc_value, exc_tb):
-        if exc_type is not None:
-            print('FAILED')
-        elif self.verbose:
-            print('DONE')
+        if self.verbose:
+            if exc_type is None:
+                print('DONE')
+            else:
+                print('FAILED')

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -7,7 +7,7 @@ from mage_ai.data_cleaner.shared.utils import clean_dataframe
 import math
 import numpy as np
 import pandas as pd
-import traceback
+import logging
 
 
 EMAIL_DOMAIN_REGEX = r'\@([^\s]*)'
@@ -17,6 +17,8 @@ OUTLIER_ZSCORE_THRESHOLD = 3
 PUNCTUATION = r'[:;\.,\/\\&`"\'\(\)\[\]\{\}]'
 STOP_WORD_LIST = frozenset(['is', 'and', 'yet', 'but', 'a', 'or', 'nor', 'not', 'to', 'the'])
 VALUE_COUNT_LIMIT = 20
+
+logger = logging.getLogger(__name__)
 
 
 def increment(metric, tags):
@@ -144,7 +146,7 @@ class StatisticsCalculator:
                     },
                 ),
             )
-            traceback.print_exc()
+            logger.exception(f'An error was caught while processing statistics: {err}')
             return {}
 
     def __evaluate_timeseries(self, data):
@@ -218,7 +220,6 @@ class StatisticsCalculator:
                 data[f'{col}/sum'] = series_non_null.sum()
                 data[f'{col}/skew'] = series_non_null.skew()
                 data[f'{col}/std'] = series_non_null.std()
-
                 # detect outliers
                 if data[f'{col}/std'] == 0:
                     data[f'{col}/outlier_count'] = 0

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -2,7 +2,7 @@ from mage_ai.data_cleaner.column_types.column_type_detector import find_syntax_e
 from mage_ai.data_cleaner.column_types.constants import NUMBER_TYPES, ColumnType
 from mage_ai.data_cleaner.shared.constants import SAMPLE_SIZE
 from mage_ai.data_cleaner.shared.hash import merge_dict
-from mage_ai.data_cleaner.shared.logger import timer
+from mage_ai.data_cleaner.shared.logger import timer, VerboseFunctionExec
 from mage_ai.data_cleaner.shared.utils import clean_dataframe
 import math
 import numpy as np
@@ -36,9 +36,11 @@ class StatisticsCalculator:
         # object_key_prefix,
         # feature_set_version,
         column_types,
+        verbose=False,
         **kwargs,
     ):
         self.column_types = column_types
+        self.verbose = verbose
 
     @property
     def data_tags(self):
@@ -54,67 +56,68 @@ class StatisticsCalculator:
         )
 
         with timer('statistics.calculate_statistics_overview.time', self.data_tags, verbose=False):
-            if not is_clean:
-                df = clean_dataframe(df, self.column_types, dropna=False)
-            data = dict(count=len(df.index))
+            with VerboseFunctionExec('Calculating statistics per variable', verbose=self.verbose):
+                if not is_clean:
+                    df = clean_dataframe(df, self.column_types, dropna=False)
+                data = dict(count=len(df.index))
 
-            arr_args_1 = ([df[col] for col in df.columns],)
-            arr_args_2 = ([col for col in df.columns],)
+                arr_args_1 = ([df[col] for col in df.columns],)
+                arr_args_2 = ([col for col in df.columns],)
 
-            dicts = map(self.statistics_overview, *arr_args_1, *arr_args_2)
+                dicts = map(self.statistics_overview, *arr_args_1, *arr_args_2)
 
-            for d in dicts:
-                data.update(d)
+                for d in dicts:
+                    data.update(d)
 
-            # Aggregated stats
-            column_count = len(df.columns)
-            row_count = df.shape[0]
+                # Aggregated stats
+                column_count = len(df.columns)
+                row_count = df.shape[0]
 
-            data['total_null_value_count'] = sum(
-                data[f'{col}/null_value_count'] for col in df.columns
-            )
-            data['total_null_value_rate'] = self.__protected_division(
-                data['total_null_value_count'], df.size
-            )
-            data['total_invalid_value_count'] = sum(
-                data[f'{col}/invalid_value_count'] for col in df.columns
-            )
-            data['total_invalid_value_rate'] = self.__protected_division(
-                data['total_invalid_value_count'], df.size
-            )
+                data['total_null_value_count'] = sum(
+                    data[f'{col}/null_value_count'] for col in df.columns
+                )
+                data['total_null_value_rate'] = self.__protected_division(
+                    data['total_null_value_count'], df.size
+                )
+                data['total_invalid_value_count'] = sum(
+                    data[f'{col}/invalid_value_count'] for col in df.columns
+                )
+                data['total_invalid_value_rate'] = self.__protected_division(
+                    data['total_invalid_value_count'], df.size
+                )
 
-            df_dedupe = df.drop_duplicates()
-            data['duplicate_row_count'] = row_count - df_dedupe.shape[0]
+                df_dedupe = df.drop_duplicates()
+                data['duplicate_row_count'] = row_count - df_dedupe.shape[0]
 
-            data['empty_column_count'] = len(
-                [col for col in df.columns if data[f'{col}/count'] == 0]
-            )
+                data['empty_column_count'] = len(
+                    [col for col in df.columns if data[f'{col}/count'] == 0]
+                )
 
-            data['avg_null_value_count'] = self.__protected_division(
-                data['total_null_value_count'], column_count
-            )
-            data['avg_invalid_value_count'] = self.__protected_division(
-                data['total_invalid_value_count'], column_count
-            )
-            data['empty_column_rate'] = self.__protected_division(
-                data['empty_column_count'], column_count
-            )
-            data['duplicate_row_rate'] = self.__protected_division(
-                data['duplicate_row_count'], row_count
-            )
+                data['avg_null_value_count'] = self.__protected_division(
+                    data['total_null_value_count'], column_count
+                )
+                data['avg_invalid_value_count'] = self.__protected_division(
+                    data['total_invalid_value_count'], column_count
+                )
+                data['empty_column_rate'] = self.__protected_division(
+                    data['empty_column_count'], column_count
+                )
+                data['duplicate_row_rate'] = self.__protected_division(
+                    data['duplicate_row_count'], row_count
+                )
 
-            data['completeness'] = 1 - self.__protected_division(
-                data['avg_null_value_count'], data['count']
-            )
-            data['validity'] = data['completeness'] - self.__protected_division(
-                data['avg_invalid_value_count'], data['count']
-            )
+                data['completeness'] = 1 - self.__protected_division(
+                    data['avg_null_value_count'], data['count']
+                )
+                data['validity'] = data['completeness'] - self.__protected_division(
+                    data['avg_invalid_value_count'], data['count']
+                )
 
-            timeseries_metadata = self.__evaluate_timeseries(data)
-            data.update(timeseries_metadata)
+                timeseries_metadata = self.__evaluate_timeseries(data)
+                data.update(timeseries_metadata)
 
-            # object_key = s3_paths.path_statistics_overview(self.object_key_prefix)
-            # s3_data.upload_json_sorted(self.s3_client, object_key, data)
+                # object_key = s3_paths.path_statistics_overview(self.object_key_prefix)
+                # s3_data.upload_json_sorted(self.s3_client, object_key, data)
 
         increment(
             'statistics.calculate_statistics_overview.success',

--- a/mage_ai/data_cleaner/transformer_actions/column.py
+++ b/mage_ai/data_cleaner/transformer_actions/column.py
@@ -16,8 +16,13 @@ from mage_ai.data_cleaner.transformer_actions.helpers import (
 )
 from mage_ai.data_cleaner.transformer_actions.udf.base import execute_udf
 from mage_ai.data_cleaner.transformer_actions.utils import clean_column_name, generate_string_cols
+from keyword import iskeyword
+import logging
 import pandas as pd
 import numpy as np
+
+
+logger = logging.getLogger(__name__)
 
 
 def add_column(df, action, **kwargs):
@@ -166,7 +171,7 @@ def reformat(df, action, **kwargs):
             try:
                 df.loc[:, column] = clean_col.astype(float)
             except ValueError:
-                print(
+                logger.warn(
                     f'Currency conversion applied on non-numerical column \'{column}\''
                     ': no action taken'
                 )

--- a/mage_ai/data_cleaner/transformer_actions/utils.py
+++ b/mage_ai/data_cleaner/transformer_actions/utils.py
@@ -5,6 +5,9 @@ from mage_ai.data_cleaner.transformer_actions.constants import (
     NameConventionPatterns,
 )
 from keyword import iskeyword
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def clean_column_name(name):
@@ -78,4 +81,6 @@ def generate_string_cols(df, columns):
         if exact_dtype is str:
             yield column
         else:
-            print(f'Attempted to perform string-only action on non-string column \'{column}\'')
+            logger.warn(
+                f'Attempted to perform string-only action on non-string column \'{column}\''
+            )

--- a/mage_ai/server/app.py
+++ b/mage_ai/server/app.py
@@ -50,8 +50,7 @@ def rescue_errors(endpoint, error_code=500):
                 status=200,
                 mimetype='application/json',
             )
-            log.error('An error was caught and reported to the client: ')
-            log.error(exception)
+            log.exception('An error was caught and reported to the client: ')
         return response
 
     return handler
@@ -355,7 +354,7 @@ def clean_df_with_pipeline(df, id=None, path=None, remote_id=None, mage_api_key=
         final_key = mage_api_key if mage_api_key is not None else api_key
         pipeline = BasePipeline(actions=Mage().get_pipeline_actions(remote_id, final_key))
     if pipeline is None:
-        print('Please provide a valid pipeline id or config path.')
+        log.error('Please provide a valid pipeline id or config path.')
         return df
     return pipeline.transform(df, auto=False)
 

--- a/mage_ai/server/app.py
+++ b/mage_ai/server/app.py
@@ -312,6 +312,7 @@ def update_pipeline(id):
             df_transformed,
             column_types=feature_set.metadata.get('column_types', {}),
             transform=False,
+            verbose=True,
         )
         prev_version = len(pipeline.pipeline.actions)
         pipeline.pipeline = clean_pipeline
@@ -368,10 +369,10 @@ def clean_df_with_pipeline(
     return pipeline.transform(df, auto=False)
 
 
-def connect_df(df, name):
+def connect_df(df, name, verbose=False):
     feature_set = FeatureSet(df=df, name=name)
 
-    result = clean_data(df, transform=False)
+    result = clean_data(df, transform=False, verbose=verbose)
 
     feature_set.write_files(result, write_orig_data=True)
     return (feature_set, df)

--- a/mage_ai/server/app.py
+++ b/mage_ai/server/app.py
@@ -336,10 +336,10 @@ def update_pipeline(id):
 #     return feature_set.column(column_name)
 
 
-def clean_df(df, name):
+def clean_df(df, name, verbose=False):
     feature_set = FeatureSet(df=df, name=name)
 
-    result = clean_data(df)
+    result = clean_data(df, verbose=verbose)
 
     feature_set.write_files(result)
     return (feature_set, result['df'])
@@ -350,13 +350,15 @@ def clean_df_with_pipeline(
 ):
     pipeline = None
     if id is not None:
-        with VerboseFunctionExec(f'Loading pipeline with uuid {id} from file...', verbose=verbose):
+        with VerboseFunctionExec(f'Loading pipeline with uuid \'{id}\' from file', verbose=verbose):
             pipeline = Pipeline(id=id).pipeline
     elif path is not None:
-        with VerboseFunctionExec(f'Loading pipeline from path {path}...', verbose=verbose):
+        with VerboseFunctionExec(f'Loading pipeline from path \'{path}\'', verbose=verbose):
             pipeline = Pipeline(path=path).pipeline
     elif remote_id is not None:
-        with VerboseFunctionExec(f'Loading pipeline from Mage servers..', verbose=verbose):
+        with VerboseFunctionExec(
+            f'Loading pipeline \'{remote_id}\' from Mage servers', verbose=verbose
+        ):
             final_key = mage_api_key if mage_api_key is not None else api_key
             pipeline = BasePipeline(actions=Mage().get_pipeline_actions(remote_id, final_key))
     if pipeline is None:

--- a/mage_ai/server/data/base.py
+++ b/mage_ai/server/data/base.py
@@ -1,11 +1,14 @@
 from numpyencoder import NumpyEncoder
 import json
+import logging
 import os
 import os.path
 import pandas as pd
 
 # This is equivalent to ./files
 DATA_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), 'files'))
+
+logger = logging.getLogger(__name__)
 
 
 class Model:
@@ -99,7 +102,7 @@ class Model:
             try:
                 arr.append(cls(id=id))
             except Exception:
-                print(f'Fail to load {cls.__name__} with id {id}')
+                logger.exception(f'Fail to load {cls.__name__} with id {id}')
         return arr
 
     @staticmethod

--- a/mage_ai/server/data/models.py
+++ b/mage_ai/server/data/models.py
@@ -3,9 +3,11 @@ from mage_ai.data_cleaner.shared.constants import SAMPLE_SIZE
 from mage_ai.data_cleaner.shared.hash import merge_dict
 from mage_ai.server.client.mage import Mage
 from mage_ai.server.data.base import Model
+import logging
 import os
 import os.path
 
+logger = logging.getLogger(__name__)
 
 # right now, we are writing the models to local files to reduce dependencies
 class FeatureSet(Model):
@@ -152,7 +154,7 @@ class FeatureSet(Model):
         try:
             self.write_json_file(f'{version}.json', version_snapshot, subdir='versions')
         except Exception:
-            print(f'Failed to write snapshot v{version} for feature set {self.id}')
+            logger.exception(f'Failed to write snapshot v{version} for feature set {self.id}')
         return version_snapshot
 
     def to_dict(self, column=None, detailed=True, version=None):
@@ -251,7 +253,7 @@ class Pipeline(Model):
     @pipeline.setter
     def pipeline(self, pipeline):
         return self.write_json_file('pipeline.json', pipeline.actions)
-    
+
     def get_feature_set(self):
         feature_set_id = self.metadata.get('feature_set_id')
         if feature_set_id is not None:

--- a/mage_ai/tests/data_cleaner/cleaning_rules/test_reformat_values.py
+++ b/mage_ai/tests/data_cleaner/cleaning_rules/test_reformat_values.py
@@ -239,7 +239,6 @@ class ReformatValuesCleaningRuleTests(TestCase):
         # date3 and date4 are detected as text type.
         # TODO: Update column_type_detector to detect date3 and date4 as datetime type.
         column_types = infer_column_types(df)
-        print(column_types)
         statistics = {
             'date1/count': 5,
             'date2/count': 4,

--- a/mage_ai/tests/data_cleaner/statistics/test_calculator.py
+++ b/mage_ai/tests/data_cleaner/statistics/test_calculator.py
@@ -214,7 +214,6 @@ class StatisticsCalculatorTest(TestCase):
         self.assertEqual(data['total_null_value_rate'], 0)
         self.assertEqual(data['total_invalid_value_rate'], 0)
         self.assertEqual(data['duplicate_row_rate'], 0)
-        print(data['date/value_counts'])
 
     def test_calculate_statistics_handle_nulls(self):
         calculator = StatisticsCalculator(

--- a/mage_ai/tests/data_cleaner/test_column_type_detector.py
+++ b/mage_ai/tests/data_cleaner/test_column_type_detector.py
@@ -88,7 +88,6 @@ class ColumnTypeDetectorTests(TestCase):
         ]
 
         for good in good_number_patterns:
-            print(good)
             match = REGEX_NUMBER.match(good)
             self.assertIsNotNone(match)
 
@@ -315,10 +314,8 @@ class ColumnTypeDetectorTests(TestCase):
                 ],
             )
         )
-        print(df)
         ctypes = infer_column_types(df)
         for col in ctypes:
-            print(col)
             self.assertEqual(ctypes[col], ColumnType.DATETIME)
 
     def __build_test_df(self):


### PR DESCRIPTION
# Summary
Two major changes are made to the `mage_ai` package:
- All debug, warning, and error message now use Python's `logging` package in order to have finer control over the amount of debugging output printed. By default, the logging level is `WARNING`, so debug messages (like timing functions) are no longer printed by default. Contributors can enable them by setting the logging level to `DEBUG`:
    ```python
    import logging
    logging.getLogger('mage_ai').setLevel(logging.DEBUG)
    ```
- The following functions now have a `verbose` keyword argument (set to False by default) that when enabled describes the current steps the pipeline is performing:
    - `connect_data`
    - `connect_df`
    - `clean` (supports cleaning with pipeline and without pipeline)
   
    An example output is displayed below when `clean(dataframe, verbose=True)` is called:
    ```text
    Inferring variable type from dataset...DONE
    Converting entries to correct datatype...DONE
    Calculating statistics per variable...DONE
    Generating visualizations...DONE
    Evaluating cleaning rule: CleanColumnNames...DONE
    Evaluating cleaning rule: RemoveColumnsWithHighEmptyRate...DONE
    Evaluating cleaning rule: RemoveColumnsWithSingleValue...DONE
    Evaluating cleaning rule: FixSyntaxErrors...DONE
    Evaluating cleaning rule: ReformatValues...DONE
    Evaluating cleaning rule: ImputeValues...DONE
    Evaluating cleaning rule: RemoveCollinearColumns...DONE
    Evaluating cleaning rule: RemoveDuplicateRows...DONE
    Evaluating cleaning rule: RemoveOutliers...DONE
    Executing cleaning action: Clean dirty column names...DONE
    Calculating statistics per variable...DONE
    Evaluating cleaning rule: CleanColumnNames...DONE
    ... (continues)
    ```


# Tests
Changes were tested locally with different dataset and different options of verbosity, including testing with pre-existing pipelines.

cc:
@wangxiaoyou1993 
