### PR TITLE
[sp] add column icons to feature profiles

### DIFF
--- a/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
+++ b/mage_ai/frontend/components/datasets/FeatureProfiles.tsx
@@ -10,6 +10,7 @@ import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
 import light from '@oracle/styles/themes/light';
 import { BORDER_RADIUS_LARGE } from '@oracle/styles/units/borders';
+import { COLUMN_TYPE_ICON_MAPPING } from '@components/constants';
 import {
   GRAY_LINES,
   LIGHT,
@@ -164,32 +165,37 @@ function FeatureProfile({
     'Unique': formatPercent(uniqueValueRate),
   };
 
+  const ColumnTypeIcon = COLUMN_TYPE_ICON_MAPPING[columnType];
+
   return (
     <Flex flexDirection="column">
       <FeatureProfileStyle>
         <Spacing p={2}>
-          <Link
-            inline
-            onClick={() => goToWithQuery({
-              column: columns.indexOf(uuid),
-            }, {
-              pushHistory: true,
-            })}
-            preventDefault
-            secondary
-          >
-            <Text
-              backgroundColor={light.feature.active}
-              bold
-              maxWidth={25 * UNIT}
-              monospace
+          <FlexContainer alignItems="center">
+            {ColumnTypeIcon && <ColumnTypeIcon size={UNIT * 2} />}
+            <Link
+              inline
+              onClick={() => goToWithQuery({
+                column: columns.indexOf(uuid),
+              }, {
+                pushHistory: true,
+              })}
+              preventDefault
               secondary
-              textOverflow
-              title={uuid}
             >
-              {uuid}
-            </Text>
-          </Link>
+              <Text
+                backgroundColor={light.feature.active}
+                bold
+                maxWidth={25 * UNIT}
+                monospace
+                secondary
+                textOverflow
+                title={uuid}
+              >
+                {uuid}
+              </Text>
+            </Link>
+          </FlexContainer>
         </Spacing>
       </FeatureProfileStyle>
       {entries.map((label = '-', idx) => {


### PR DESCRIPTION
# Summary
- see above

# Tests

Doesn't break max width text styling, so long column names still display correctly.

<img width="889" alt="image" src="https://user-images.githubusercontent.com/105667442/174904826-38c3101f-056e-4ab8-89b5-81e340e2d10f.png">

cc: @johnson-mage @dy46 
