### PR TITLE
[sk] Added list statistics

### DIFF
--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -281,7 +281,7 @@ class StatisticsCalculator:
                     domains.value_counts().head(VALUE_COUNT_LIMIT).to_dict()
                 )
             elif column_type == ColumnType.LIST:
-                lengths = series_non_null.apply(len)
+                lengths = series_non_null.str.len()
                 data[f'{col}/avg_list_length'] = lengths.mean()
                 data[f'{col}/max_list_length'] = lengths.max()
                 data[f'{col}/min_list_length'] = lengths.min()

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -280,6 +280,22 @@ class StatisticsCalculator:
                 data[f'{col}/domain_distribution'] = (
                     domains.value_counts().head(VALUE_COUNT_LIMIT).to_dict()
                 )
+            elif column_type == ColumnType.LIST:
+                lengths = series_non_null.apply(len)
+                data[f'{col}/avg_list_length'] = lengths.mean()
+                data[f'{col}/max_list_length'] = lengths.max()
+                data[f'{col}/min_list_length'] = lengths.min()
+                data[f'{col}/length_distribution'] = (
+                    lengths.value_counts().head(VALUE_COUNT_LIMIT).to_dict()
+                )
+
+                elements = series_non_null.explode()
+                element_value_counts = elements.value_counts(dropna=False)
+                data[f'{col}/most_frequent_element'] = element_value_counts.index[0]
+                data[f'{col}/least_frequent_element'] = element_value_counts.index[-1]
+                data[f'{col}/element_distribution'] = element_value_counts.head(
+                    VALUE_COUNT_LIMIT
+                ).to_dict()
 
         if column_type not in NUMBER_TYPES:
             if dates is not None:


### PR DESCRIPTION
# Summary
Added list statistics for the new list datatype:
- Minimum list length per column
- Maximum list length per column
- Average list length per column
- Distribution of list lengths per column
- Most frequent element that appears in all lists in a column
- Least frequent element that appears in all lists in a column
- Distribution of the elements that appear in lists in a column

To motivate these statistics, consider a scenario where tags are assigned to a product. For each product, the tags assigned are stored as lists in the dataframe. Then:
- The list length corresponds to the number of tags that have been assigned to the product. Thus looking at the min, max, average, and distribution of list lengths, a data scientist can gain insight into how many tags are being assigned by users
- The most frequent, least frequent, and distribution of elements can give insight into which of these tags are used most commonly or least commonly

# Tests
Unit tests were written to test the new statistics calculations.

cc:
@wangxiaoyou1993 
