### PR TITLE
[jk] Update home page redirect

### DIFF
--- a/mage_ai/frontend/api/utils/url.ts
+++ b/mage_ai/frontend/api/utils/url.ts
@@ -4,9 +4,11 @@ export function getHost() {
   const windowDefined = typeof window !== 'undefined';
   const LOCALHOST = 'localhost';
   const PORT = 5789;
+  const CLOUD_BASE_PATH = '/CLOUD_NOTEBOOK_BASE_PATH_PLACEHOLDER_';
 
   let host = LOCALHOST;
   let protocol = 'http://';
+  let basePath = '';
 
   if (windowDefined) {
     host = window.location.hostname;
@@ -26,9 +28,13 @@ export function getHost() {
         host = `${host}:${window.location.port}`;
       }
     }
+
+  }
+  if (!CLOUD_BASE_PATH.includes('CLOUD_NOTEBOOK_BASE_PATH_PLACEHOLDER')) {
+    basePath = CLOUD_BASE_PATH;
   }
 
-  return `${protocol}${host}`;
+  return `${protocol}${host}${basePath}`;
 }
 
 export function buildUrl(

--- a/mage_ai/frontend/next.config.js
+++ b/mage_ai/frontend/next.config.js
@@ -1,6 +1,18 @@
 const removeImports = require('next-remove-imports')();
 
 module.exports = removeImports({
+  async rewrites() {
+    return [
+      {
+        source: '/CLOUD_NOTEBOOK_BASE_PATH_PLACEHOLDER_/datasets',
+        destination: '/datasets',
+      },
+      {
+        source: '/CLOUD_NOTEBOOK_BASE_PATH_PLACEHOLDER_',
+        destination: '/datasets',
+      },
+    ];
+  },
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/mage_ai/frontend/pages/index.tsx
+++ b/mage_ai/frontend/pages/index.tsx
@@ -7,7 +7,7 @@ const Home = () => {
   const completePath = router.asPath;
   const basePath = completePath.split('?')[0];
   let pathname = '/datasets';
-  if (basePath !== '/') {
+  if (basePath && basePath !== '/') {
     pathname = `${basePath}/datasets`;
   }
 

--- a/mage_ai/frontend/pages/index.tsx
+++ b/mage_ai/frontend/pages/index.tsx
@@ -1,10 +1,21 @@
-import Router from 'next/router';
+import Router, { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
 const Home = () => {
-    useEffect(() => {
-        Router.push('/datasets');
+  const router = useRouter();
+  const queryParams = router.query;
+  const basePath = router.pathname;
+  let pathname = '/datasets';
+  if (basePath !== '/') {
+    pathname = `${basePath}/datasets`;
+  }
+
+  useEffect(() => {
+    Router.push({
+      pathname,
+      query: queryParams,
     });
+  });
 };
 
 export default Home;

--- a/mage_ai/frontend/pages/index.tsx
+++ b/mage_ai/frontend/pages/index.tsx
@@ -4,7 +4,8 @@ import { useEffect } from 'react';
 const Home = () => {
   const router = useRouter();
   const queryParams = router.query;
-  const basePath = router.pathname;
+  const completePath = router.asPath;
+  const basePath = completePath.split('?')[0];
   let pathname = '/datasets';
   if (basePath !== '/') {
     pathname = `${basePath}/datasets`;

--- a/mage_ai/frontend/pages/index.tsx
+++ b/mage_ai/frontend/pages/index.tsx
@@ -8,7 +8,9 @@ const Home = () => {
   const basePath = completePath.split('?')[0];
   let pathname = '/datasets';
   if (basePath && basePath !== '/') {
-    pathname = `${basePath}/datasets`;
+    pathname = !basePath.includes('/datasets')
+      ? `${basePath}/datasets`
+      : basePath;
   }
 
   useEffect(() => {
@@ -16,7 +18,7 @@ const Home = () => {
       pathname,
       query: queryParams,
     });
-  });
+  }, []);
 };
 
 export default Home;

--- a/mage_ai/server/utils/frontend_renderer.py
+++ b/mage_ai/server/utils/frontend_renderer.py
@@ -94,7 +94,7 @@ def update_frontend_urls(host=None, port=None, notebook_type=None, config={}):
         server_config.server_url_params = url_params
         __update_frontend_urls_in_files(base_path, url_params)
     elif notebook_type == NotebookType.SAGEMAKER:
-        base_path = f'/proxy/{port}/'
+        base_path = f'/proxy/{port}'
         __update_frontend_urls_in_files(base_path, None)
 
 


### PR DESCRIPTION
# Summary
- If there are additional query parameters or paths outside of the domain name, we need to redirect to pages while retaining all parts of the URL.

# Tests
- Local

## Additional backend steps to manually update base path in FE build
1. Add assetPrefix in html files.
- Replace all instances of `"nextExport":true` in the frontend_dist folder with `"assetPrefix":"/base/path","nextExport":true`.
- For example, the string replacement could be `"assetPrefix":"/proxy/5789","nextExport":true`.
2. Replace cloud base path placeholder with the relevant base path in order to make the correct API requests.
- Find the following exact string to replace in the frontend_dist folder: `CLOUD_NOTEBOOK_BASE_PATH_PLACEHOLDER_`
- It is important to include the `_` at the end of the placeholder string. Excluding it may cause issues.
- Do not prefix the base path with a forward slash. For example, the replaced base path could be `proxy/5789`.
3. Replace cloud base path placeholder with the relevant base path in the “_buildManifest.js” file.
- Placeholder value (same as above) in a file in the frontend_dist folder tree: `CLOUD_NOTEBOOK_BASE_PATH_PLACEHOLDER_`
- Do not prefix the base path with a forward slash. For example, the replaced base path could be `proxy/5789`.
- This step could probably be combined with Step 2.
4. Replace font face urls in the globals.css file.
- Replace all instances of `src:url(/fonts` with `src:url(/base/path/fonts` in the frontend_dist folder.
- For example, the replaced path could be `src:url(/proxy/5789/fonts`.


cc:
@dy46 @wangxiaoyou1993 
