### PR TITLE
[jk]  Fix diffs bug when empty fsv response

### DIFF
--- a/mage_ai/frontend/components/datasets/Detail/index.tsx
+++ b/mage_ai/frontend/components/datasets/Detail/index.tsx
@@ -45,7 +45,6 @@ import { setCustomCodeState } from '@storage/localStorage';
 
 export type DatasetDetailSharedProps = {
   featureSet: FeatureSetType;
-  featureSetOriginal: FeatureSetType;
   fetchFeatureSet: (arg: any) => void;
 };
 
@@ -206,7 +205,7 @@ function DatasetDetail({
                 uuid: selectedColumn,
               },
               type: ActionVariableTypeEnum.FEATURE,
-            }
+            },
           },
         },
       });

--- a/mage_ai/frontend/components/datasets/overview/index.tsx
+++ b/mage_ai/frontend/components/datasets/overview/index.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from 'react';
 import LoadingBar from 'react-top-loading-bar';
+import Router from 'next/router';
 
 import Button from '@oracle/elements/Button';
 import ColumnAnalysis from '@components/datasets/Insights/ColumnAnalysis';
@@ -20,6 +21,7 @@ import Overview from '@components/datasets/Insights/Overview';
 import Spacing from '@oracle/elements/Spacing';
 import StatsTable, { StatRow } from '../StatsTable';
 import Text from '@oracle/elements/Text';
+import api from '@api';
 import light from '@oracle/styles/themes/light';
 import usePrevious from '@utils/usePrevious';
 
@@ -35,6 +37,7 @@ import { LARGE_WINDOW_WIDTH } from '@components/datasets/constants';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { REGULAR_LINE_HEIGHT } from '@oracle/styles/fonts/sizes';
 import {
+  deserializeFeatureSet,
   getFeatureSetInvalidValuesAll,
   getFeatureSetStatistics,
 } from '@utils/models/featureSet';
@@ -62,12 +65,14 @@ type DatasetOverviewProps = {
 
 function DatasetOverview({
   featureSet,
-  featureSetOriginal,
   fetchFeatureSet,
   selectedColumnIndex,
 }: DatasetOverviewProps) {
   const refLoadingBar = useRef(null);
   const mainContentRef = useRef(null);
+
+  const { data: featureSetRawOriginal, mutateOriginal } = api.versions.feature_sets.detail(featureSet?.id, '0');
+  const featureSetOriginal = featureSetRawOriginal ? deserializeFeatureSet(featureSetRawOriginal) : {};
 
   const { width: windowWidth } = useWindowSize();
   const windowWidthPrevious = usePrevious(windowWidth);
@@ -233,7 +238,6 @@ function DatasetOverview({
     <DatasetDetail
       columnsVisible={columnsVisible}
       featureSet={featureSet}
-      featureSetOriginal={featureSetOriginal}
       fetchFeatureSet={fetchFeatureSet}
       hideColumnsHeader={windowWidth < LARGE_WINDOW_WIDTH}
       mainContentRef={mainContentRef}

--- a/mage_ai/frontend/components/datasets/overview/index.tsx
+++ b/mage_ai/frontend/components/datasets/overview/index.tsx
@@ -116,7 +116,7 @@ function DatasetOverview({
 
   const {
     metadata: originalMetadata,
-    statistics: originalStatistics = {},
+    statistics: originalStatistics,
   } = featureSetOriginal || {};
   const originalColumnTypes = originalMetadata?.column_types;
 

--- a/mage_ai/frontend/pages/datasets/[...slug].tsx
+++ b/mage_ai/frontend/pages/datasets/[...slug].tsx
@@ -24,9 +24,7 @@ function DatasetDetail() {
   // @ts-ignore
   const [featureSetId, subpath] = slug;
   const { data: featureSetRaw, mutate } = api.feature_sets.detail(featureSetId);
-  const { data: featureSetRawOriginal, mutateOriginal } = api.versions.feature_sets.detail(featureSetId, '0');
   const featureSet = featureSetRaw ? deserializeFeatureSet(featureSetRaw) : {};
-  const featureSetOriginal = featureSetRawOriginal ? deserializeFeatureSet(featureSetRawOriginal) : {};
 
   const {
     metadata,
@@ -34,9 +32,7 @@ function DatasetDetail() {
 
   const sharedProps = {
     featureSet,
-    featureSetOriginal,
     fetchFeatureSet: mutate,
-    fetchFeatureSetOriginal: mutateOriginal,
     selectedColumnIndex: columnIndex,
   };
 

--- a/mage_ai/frontend/utils/number.ts
+++ b/mage_ai/frontend/utils/number.ts
@@ -35,6 +35,10 @@ export function getPercentage(number) {
 }
 
 export function calculateChange(endValue, startValue) {
+  if (typeof startValue === 'undefined') {
+    return 0;
+  }
+
   const difference = endValue - startValue;
   return difference / startValue;
 }


### PR DESCRIPTION
# Summary
- Initial empty feature set version response was causing issues with the displaying of metrics percentage diffs when there shouldn't be any since no actions have been applied yet.

# Tests
Before:
<img width="766" alt="image" src="https://user-images.githubusercontent.com/78053898/174976831-5d4e3630-30ea-458d-af20-3924724d74d0.png">

After:
<img width="767" alt="image" src="https://user-images.githubusercontent.com/78053898/174976895-59ca4ae6-0bd2-44a3-b75c-95f98efbb204.png">
