### PR TITLE
[jk] Refetch fsv after applying action

### DIFF
--- a/mage_ai/frontend/components/datasets/Detail/index.tsx
+++ b/mage_ai/frontend/components/datasets/Detail/index.tsx
@@ -51,6 +51,7 @@ export type DatasetDetailSharedProps = {
 type DatasetDetailProps = {
   children: any;
   columnsVisible?: boolean;
+  fetchFeatureSetOriginal: (arg?: any) => void;
   hideColumnsHeader?: boolean;
   mainContentRef?: any;
   onTabClick?: (tab: string) => void;
@@ -66,6 +67,7 @@ function DatasetDetail({
   columnsVisible,
   featureSet,
   fetchFeatureSet,
+  fetchFeatureSetOriginal,
   hideColumnsHeader,
   mainContentRef,
   onTabClick,
@@ -149,6 +151,7 @@ function DatasetDetail({
               featureSetId: String(featureSetId),
               newValue: null,
             });
+            fetchFeatureSetOriginal();
 
             return fetchFeatureSet({
               ...featureSet,

--- a/mage_ai/frontend/components/datasets/overview/index.tsx
+++ b/mage_ai/frontend/components/datasets/overview/index.tsx
@@ -6,7 +6,6 @@ import React, {
   useState,
 } from 'react';
 import LoadingBar from 'react-top-loading-bar';
-import Router from 'next/router';
 
 import Button from '@oracle/elements/Button';
 import ColumnAnalysis from '@components/datasets/Insights/ColumnAnalysis';
@@ -71,7 +70,7 @@ function DatasetOverview({
   const refLoadingBar = useRef(null);
   const mainContentRef = useRef(null);
 
-  const { data: featureSetRawOriginal, mutateOriginal } = api.versions.feature_sets.detail(featureSet?.id, '0');
+  const { data: featureSetRawOriginal, mutate: mutateOriginal } = api.versions.feature_sets.detail(featureSet?.id, '0');
   const featureSetOriginal = featureSetRawOriginal ? deserializeFeatureSet(featureSetRawOriginal) : {};
 
   const { width: windowWidth } = useWindowSize();
@@ -239,6 +238,7 @@ function DatasetOverview({
       columnsVisible={columnsVisible}
       featureSet={featureSet}
       fetchFeatureSet={fetchFeatureSet}
+      fetchFeatureSetOriginal={mutateOriginal}
       hideColumnsHeader={windowWidth < LARGE_WINDOW_WIDTH}
       mainContentRef={mainContentRef}
       onTabClick={t => setTabs(t)}


### PR DESCRIPTION
# Summary
- Diffs would not initially show up for new datasets where no action was applied, so this PR will get the updated fsv data after applying an action.

# Tests
- Local

