### PR TITLE
[sk] Added box plot statistics calculation

### DIFF
--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -251,7 +251,7 @@ class StatisticsCalculator:
                 )
                 outliers = series_non_null[outlier_mask].tolist()
                 data[f'{col}/box_plot_data'] = {
-                    'outliers': outliers,
+                    'outliers': outliers[:OUTLIER_SAMPLE_COUNT],
                     'min': data[f'{col}/min'],
                     'first_quartile': first_quartile,
                     'median': data[f'{col}/median'],

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -249,7 +249,7 @@ class StatisticsCalculator:
                 outlier_mask = (series_non_null <= first_quartile - 1.5 * iqr) | (
                     series_non_null >= third_quartile + 1.5 * iqr
                 )
-                outliers = series_non_null[outlier_mask].tolist()
+                outliers = series_non_null[outlier_mask].unique().tolist()
                 data[f'{col}/box_plot_data'] = {
                     'outliers': outliers[:OUTLIER_SAMPLE_COUNT],
                     'min': data[f'{col}/min'],

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -242,6 +242,26 @@ class StatisticsCalculator:
                         .iloc[:OUTLIER_SAMPLE_COUNT]
                         .tolist()
                     )
+                # generate five number summary
+                first_quartile = series_non_null.quantile(0.25, interpolation='nearest')
+                third_quartile = series_non_null.quantile(0.75, interpolation='nearest')
+                iqr = third_quartile - first_quartile
+                outlier_mask = (series_non_null <= first_quartile - 1.5 * iqr) | (
+                    series_non_null >= third_quartile + 1.5 * iqr
+                )
+                outliers = series_non_null[outlier_mask].tolist()
+                data[f'{col}/box_plot_data'] = {
+                    'outliers': outliers,
+                    'min': data[f'{col}/min'],
+                    'first_quartile': first_quartile,
+                    'median': data[f'{col}/median'],
+                    'third_quartile': third_quartile,
+                    'max': data[f'{col}/max'],
+                }
+                if len(outliers) != 0:
+                    not_outliers = series_non_null[~outlier_mask]
+                    data[f'{col}/box_plot_data']['min'] = not_outliers.min()
+                    data[f'{col}/box_plot_data']['max'] = not_outliers.max()
             elif column_type == ColumnType.DATETIME:
                 dates = pd.to_datetime(series_non_null, utc=True, errors='coerce').dropna()
                 data[f'{col}/max'] = dates.max().isoformat()

--- a/mage_ai/tests/data_cleaner/statistics/test_calculator.py
+++ b/mage_ai/tests/data_cleaner/statistics/test_calculator.py
@@ -396,3 +396,68 @@ class StatisticsCalculatorTest(TestCase):
             '3': 1,
         }
         self.assertEquals(expected_element_distribution, data['lists/element_distribution'])
+
+    def test_calculate_statistics_box_plot(self):
+        df = pd.DataFrame(
+            [
+                [1000, 'US', 30000, 10, 'cute animal #1', 100, 30],
+                [500, 'CA', 10000000, 20, 'intro to regression', 3000, 20],
+                [200, '', np.nan, 50, 'daily news #1', None, 75],
+                [250, 'CA', 7500, 25, 'machine learning seminar', 8000, 20],
+                [1000, 'MX', 45003, 20, 'cute animal #4', 90, 40],
+                [1500, 'MX', 75000, 30, '', 70, 25],
+                [1500, 'US', 75000, np.nan, 'daily news #3', 70, 25],
+                [None, 'US', 75000, 30, 'tutorial: how to start a startup', 70, np.nan],
+                [1250, 'US', 60000, 50, 'cute animal #3', 80, 20],
+                [200, 'CA', 5000, 30, '', 10000, 30],
+                [800, 'US', 50, 40, 'meme compilation', 2000, 45],
+                [600, 'CA', 11000, 50, 'daily news #2', 3000, 50],
+                [600, 'CA', '', 50, '', 3000, None],
+                [700, 'MX', 11750, 20, 'cute animal #2', 2750, 55],
+                [700, '', None, 20, '', None, 55],
+                [700, 'MX', 11750, '', '', 2750, 55],
+                [1200, 'MX', 52000, 10, 'vc funding strats', 75, 60],
+            ],
+            columns=[
+                'number_of_users',
+                'location',
+                'views',
+                'number_of_creators',
+                'name',
+                'losses',
+                'number_of_advertisers',
+            ],
+        )
+
+        column_types = {
+            'number_of_users': 'number',
+            'location': 'category',
+            'views': 'number',
+            'number_of_creators': 'number',
+            'name': 'text',
+            'losses': 'number',
+            'number_of_advertisers': 'number',
+        }
+        calculator = StatisticsCalculator(column_types=column_types)
+        data = calculator.calculate_statistics_overview(df, is_clean=False)
+
+        expected_box_plot_no_users = {
+            'outliers': [],
+            'min': 200.0,
+            'first_quartile': 600.0,
+            'median': 700.0,
+            'third_quartile': 1000.0,
+            'max': 1500.0,
+        }
+
+        expected_box_plot_views = {
+            'outliers': [10000000.0],
+            'min': 50.0,
+            'first_quartile': 11000.0,
+            'median': 37501.5,
+            'third_quartile': 75000.0,
+            'max': 75000.0,
+        }
+
+        self.assertEqual(expected_box_plot_no_users, data['number_of_users/box_plot_data'])
+        self.assertEqual(expected_box_plot_views, data['views/box_plot_data'])


### PR DESCRIPTION
# Summary
Generates five number summary + outliers found through the 1.5 IQR method, as used to generate a box plot visualization. This can be accessed using `column/box_plot_data`

There are three reasons for creating these statistics as their own object within the statistics dictionary instead of using already existing statistics
- Min/Max for a box plot may not equal the overall min/max as the overall min/max might be an outlier, requiring two different statistics for both the minimum and maximum. To avoid confusion, keep the box plot specific pair local to the box plot data.
- Outliers for a box plot (calculated using the 1.5 IQR method) differ from the outlier calculation method from the rest of the statistics object (calculated using the 3 standard deviations rule). Makes sense to separate them (unless we consider considering a very specific method)
- It is easier for the frontend to have all the box plot specific data in one statistics entry instead of pulling from various places in the statistics object

# Tests
Unit tests were written to make sure that outliers were correctly identified and that the summary statistics were found correctly.

cc:
@wangxiaoyou1993 @shrey-mage 
