### PR TITLE
[xy] Speed up clean_dataframe.

### DIFF
--- a/mage_ai/data_cleaner/shared/utils.py
+++ b/mage_ai/data_cleaner/shared/utils.py
@@ -16,10 +16,13 @@ PAREN_LIKE_CLOSE = frozenset([']', ')'])
 
 
 def clean_series(series, column_type, dropna=True):
-    series_cleaned = series.apply(lambda x: x.strip(' \'\"') if type(x) is str else x)
-    series_cleaned = series_cleaned.map(
-        lambda x: x if (not isinstance(x, str) or (len(x) > 0 and not x.isspace())) else np.nan
-    )
+    if series.dtype == 'object':
+        series_cleaned = series.apply(lambda x: x.strip(' \'\"') if type(x) is str else x)
+        series_cleaned = series_cleaned.map(
+            lambda x: x if (not isinstance(x, str) or x != '') else np.nan
+        )
+    else:
+        series_cleaned = series
     if dropna:
         series_cleaned = series_cleaned.dropna()
 


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Speed up clean_dataframe: only apply str cleaning on object dtype.
This reduces the time of clean_dataframe from 1.9s to 0.8s on a dataframe with 100k rows and 32 columns.

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
