### PR TITLE
[sk] Added File and PostgreSQL data loaders

### DIFF
--- a/mage_ai/data_loader/base.py
+++ b/mage_ai/data_loader/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
-from pandas import DataFrame
 from enum import Enum
+from pandas import DataFrame
 from typing import Any, Union
 import pandas as pd
 import os

--- a/mage_ai/data_loader/base.py
+++ b/mage_ai/data_loader/base.py
@@ -1,0 +1,122 @@
+from abc import ABC, abstractmethod
+from pandas import DataFrame
+from enum import Enum
+from typing import Any, Union
+import pandas as pd
+import os
+
+
+class FileFormat(str, Enum):
+    CSV = 'csv'
+    JSON = 'json'
+    PARQUET = 'parquet'
+    HDF5 = 'hdf5'
+
+
+FORMAT_TO_FUNCTION = {
+    FileFormat.CSV: pd.read_csv,
+    FileFormat.JSON: pd.read_json,
+    FileFormat.PARQUET: pd.read_parquet,
+    FileFormat.HDF5: pd.read_hdf,
+}
+
+
+class BaseLoader(ABC):
+    """
+    Data loader interface. All data loaders must inherit from this interface.
+    """
+
+    @abstractmethod
+    def load(self, *args, **kwargs) -> DataFrame:
+        """
+        Loads a data frame from source, returns it to memory. Subclasses must
+        override this method to specify how this data frame is to be returned.
+
+        Returns:
+            DataFrame: dataframe returned by the source.
+        """
+        pass
+
+
+class BaseFile(BaseLoader):
+    """
+    Data loader for file-like data sources (for example, loading from local
+    filesystem or external file storages such as AWS S3)
+    """
+
+    def __init__(self, filepath: os.PathLike, format: Union[FileFormat, str] = None) -> None:
+        """
+        Initializes the file data loader
+
+        Args:
+            filepath (os.PathLike): Path to the file
+            format (FileFormat, optional): File format for the data being loaded. Defaults to None.
+        """
+        if format is None:
+            format = os.path.splitext(filepath)[-1][1:]
+        self.reader = FORMAT_TO_FUNCTION[format]
+        self.filepath = filepath
+
+
+class BaseSQL(BaseLoader):
+    """
+    Data loader for connected SQL data sources. Can be used as a context manager or by manually opening or closing the connection
+    to the SQL data source after data loading is complete.
+
+    WARNING: queries may continue to run on data source unless connection manually closed. For this reason it is recommended to use a context
+    manager when connecting to external data sources.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        """
+        Initializes the connection with the settings given as keyword arguments. Specific data loaders will have access to different settings.
+        """
+        self.settings = kwargs
+
+    def close(self) -> None:
+        """
+        Close the underlying connection to the SQL data source if open. Else will do nothing.
+        """
+        if '_ctx' in self.__dict__:
+            self._ctx.close()
+            del self._ctx
+
+    @property
+    def conn(self) -> Any:
+        """
+        Returns the connection object to the SQL data source. The exact connection type depends
+        on the source and the definition of the data loader.
+        """
+        try:
+            return self._ctx
+        except AttributeError:
+            raise ConnectionError(
+                'No connection currently open. Open a new connection to access this property.'
+            )
+
+    @abstractmethod
+    def query(self, query_string: str, *args, **kwargs) -> None:
+        """
+        Executes the query on the SQL database connected to this data loader.
+
+        Args:
+            query_string (str): SQL query string to apply to the connected data source.
+        """
+        pass
+
+    @abstractmethod
+    def open(self) -> None:
+        """
+        Opens an underlying connection to the SQL data source.
+        """
+        pass
+
+    def __del__(self):
+        self.close()
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, *args):
+        self.close()

--- a/mage_ai/data_loader/file.py
+++ b/mage_ai/data_loader/file.py
@@ -1,0 +1,13 @@
+from mage_ai.data_loader.base import BaseFile
+from pandas import DataFrame
+
+
+class FileLoader(BaseFile):
+    def load(self, *args, **kwargs) -> DataFrame:
+        """
+        Loads the data frame from the file specified.
+
+        Returns:
+            DataFrame: Data frame object loaded from the specified data frame.
+        """
+        return self.reader(self.filepath, *args, **kwargs)

--- a/mage_ai/data_loader/postgres.py
+++ b/mage_ai/data_loader/postgres.py
@@ -1,6 +1,7 @@
 from mage_ai.data_loader.base import BaseSQL
 from pandas import DataFrame, read_sql
 from psycopg2 import connect
+from typing import Mapping, Sequence, Union
 
 
 class Postgres(BaseSQL):
@@ -15,9 +16,9 @@ class Postgres(BaseSQL):
         Args:
             dbname (str): The name of the database to connect to.
             user (str): The user with which to connect to the database with.
-            password (str): The login password for the above user. Defaults to None (as for users with no login password).
-            host (str): Path to host address for database. Defaults to None (as for in-memory datasets).
-            port (str): Port on which the database is running. Defaults to None (as for in-memory datasets).
+            password (str): The login password for the user.
+            host (str): Path to host address for database.
+            port (str): Port on which the database is running.
         """
         super().__init__(**kwargs)
 
@@ -27,16 +28,16 @@ class Postgres(BaseSQL):
         """
         self._ctx = connect(**self.settings)
 
-    def query(self, query_string: str, vars=None):
+    def query(self, query_string: str, query_vars: Union[Sequence, Mapping] = None) -> None:
         """
-        Queries the database to perform some query action.
+        Sends query to the connected database.
 
         Args:
             query_string (str): SQL query string to apply on the connected database.
-            *args, **kwargs: Additional query parameters.
+            query_vars (Union[Sequence, Mapping], optional): Variable values to fill in when using format strings in query. Defaults to None.
         """
         with self.conn.cursor() as cur:
-            return cur.execute(query_string, vars)
+            return cur.execute(query_string, query_vars)
 
     def load(self, query_string: str, **kwargs) -> DataFrame:
         """
@@ -48,6 +49,6 @@ class Postgres(BaseSQL):
             **kwargs: Additional query parameters.
 
         Returns:
-            DataFrame: The dataframe corresponding to the subtable returned by the given query.
+            DataFrame: The data frame corresponding to the data returned by the given query.
         """
         return read_sql(query_string, self.conn, **kwargs)

--- a/mage_ai/data_loader/postgres.py
+++ b/mage_ai/data_loader/postgres.py
@@ -1,0 +1,53 @@
+from mage_ai.data_loader.base import BaseSQL
+from pandas import DataFrame, read_sql
+from psycopg2 import connect
+
+
+class Postgres(BaseSQL):
+    """
+    Loads data from a PostgreSQL database.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        """
+        Initializes the data loader. Below are some sample arguments, for the full list see libpq parameter keywords.
+
+        Args:
+            dbname (str): The name of the database to connect to.
+            user (str): The user with which to connect to the database with.
+            password (str): The login password for the above user. Defaults to None (as for users with no login password).
+            host (str): Path to host address for database. Defaults to None (as for in-memory datasets).
+            port (str): Port on which the database is running. Defaults to None (as for in-memory datasets).
+        """
+        super().__init__(**kwargs)
+
+    def open(self) -> None:
+        """
+        Opens a connection to the PostgreSQL database specified by the parameters.
+        """
+        self._ctx = connect(**self.settings)
+
+    def query(self, query_string: str, vars=None):
+        """
+        Queries the database to perform some query action.
+
+        Args:
+            query_string (str): SQL query string to apply on the connected database.
+            *args, **kwargs: Additional query parameters.
+        """
+        with self.conn.cursor() as cur:
+            return cur.execute(query_string, vars)
+
+    def load(self, query_string: str, **kwargs) -> DataFrame:
+        """
+        Loads data from the connected database into a Pandas data frame based on the query given.
+        This will fail if the query returns no data from the database.
+
+        Args:
+            query_string (str): Query to execute on the database.
+            **kwargs: Additional query parameters.
+
+        Returns:
+            DataFrame: The dataframe corresponding to the subtable returned by the given query.
+        """
+        return read_sql(query_string, self.conn, **kwargs)

--- a/mage_ai/data_loader/postgres.py
+++ b/mage_ai/data_loader/postgres.py
@@ -11,7 +11,8 @@ class Postgres(BaseSQL):
 
     def __init__(self, **kwargs) -> None:
         """
-        Initializes the data loader. Below are some sample arguments, for the full list see libpq parameter keywords.
+        Initializes the data loader. Below are some sample arguments, for the full
+        list see libpq parameter keywords.
 
         Args:
             dbname (str): The name of the database to connect to.
@@ -34,7 +35,8 @@ class Postgres(BaseSQL):
 
         Args:
             query_string (str): SQL query string to apply on the connected database.
-            query_vars (Union[Sequence, Mapping], optional): Variable values to fill in when using format strings in query. Defaults to None.
+            query_vars (Union[Sequence, Mapping], optional): Variable values to fill
+            in when using format strings in query. Defaults to None.
         """
         with self.conn.cursor() as cur:
             return cur.execute(query_string, query_vars)

--- a/mage_ai/data_preparation/templates/data_loaders/file.py
+++ b/mage_ai/data_preparation/templates/data_loaders/file.py
@@ -1,0 +1,9 @@
+from mage_ai.data_loader.file import FileLoader
+
+
+def load_data_from_file():
+    """
+    Template code for loading data from local filesytem
+    """
+    filepath = 'path/to/your/file.ext'  # Specify the path to your file.
+    return FileLoader(filepath).load()

--- a/mage_ai/data_preparation/templates/data_loaders/postgres.py
+++ b/mage_ai/data_preparation/templates/data_loaders/postgres.py
@@ -1,14 +1,14 @@
 from mage_ai.data_loader.postgres import Postgres
 
 
-def load_data_from_databricks():
+def load_data_from_postgres():
     """
     Template code for loading data from PostgreSQL database
     """
     query = 'your PostgreSQL query'  # Specify your SQL query here
 
     config = {
-        # Specify all Databricks connection configuration settings here
+        # Specify all database connection configuration settings here
         'dbname': 'name of your database',
         'user': 'login username',
         'password': 'login password',

--- a/mage_ai/data_preparation/templates/data_loaders/postgres.py
+++ b/mage_ai/data_preparation/templates/data_loaders/postgres.py
@@ -12,6 +12,8 @@ def load_data_from_postgres():
         'dbname': 'name of your database',
         'user': 'login username',
         'password': 'login password',
+        'host': 'path to host address',
+        'port': 'database port on host address',
     }
 
     with Postgres(**config) as loader:

--- a/mage_ai/data_preparation/templates/data_loaders/postgres.py
+++ b/mage_ai/data_preparation/templates/data_loaders/postgres.py
@@ -1,0 +1,18 @@
+from mage_ai.data_loader.postgres import Postgres
+
+
+def load_data_from_databricks():
+    """
+    Template code for loading data from PostgreSQL database
+    """
+    query = 'your PostgreSQL query'  # Specify your SQL query here
+
+    config = {
+        # Specify all Databricks connection configuration settings here
+        'dbname': 'name of your database',
+        'user': 'login username',
+        'password': 'login password',
+    }
+
+    with Postgres(**config) as loader:
+        return loader.load(query)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ jupyter-server-proxy==3.2.1
 numpyencoder==0.3.0
 numpy~=1.21.0
 pandas~=1.3.0
-psycopg2-binary=2.9.3
+psycopg2-binary==2.9.3
 pyarrow==8.0.0
 python-dateutil==2.8.2
 pytz==2022.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,6 @@ requests==2.28.0
 scikit-learn>=1.0
 simplejson
 six>=1.15.0
+tables==3.7.0
 tornado==6.1
 zipp==3.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ jupyter-server-proxy==3.2.1
 numpyencoder==0.3.0
 numpy~=1.21.0
 pandas~=1.3.0
+psycopg2-binary=2.9.3
 pyarrow==8.0.0
 python-dateutil==2.8.2
 pytz==2022.1


### PR DESCRIPTION
# Summary
This PR adds the basic framework for the different types of data loaders, and implements two specific data loaders in 
- `File` - loads data frame from file using automatic format inference to select the correct pandas loading method. Currently the filetypes supported are: CSV, JSON, Parquet, and HDF5 (another high compression file format used in machine learning).
- `Postgres` - loads data frame from a select query applied to a PostgreSQL database, either local or external.

Templates were also written for users to load data with these methods and extend functionality from.

# Tests
Data loading was tested locally with loading local files of different formats. Postgres connections were tested by starting a database in memory, connecting to database, and loading data by making queries.

cc:
@wangxiaoyou1993
