### PR TITLE
[sk] Added data loaders + templates for S3 and Redshift

### DIFF
--- a/mage_ai/data_loader/base.py
+++ b/mage_ai/data_loader/base.py
@@ -56,6 +56,7 @@ class BaseFile(BaseLoader):
             format = os.path.splitext(filepath)[-1][1:]
         self.reader = FORMAT_TO_FUNCTION[format]
         self.filepath = filepath
+        self.format = format
 
 
 class BaseSQL(BaseLoader):

--- a/mage_ai/data_loader/redshift.py
+++ b/mage_ai/data_loader/redshift.py
@@ -1,0 +1,98 @@
+from mage_ai.data_loader.base import BaseSQL
+from pandas import DataFrame
+from redshift_connector import connect
+
+
+class Redshift(BaseSQL):
+    """
+    Loads data from a Redshift data warehouse.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        """
+        Initializes settings for connecting to a Redshift warehouse.
+        """
+        super().__init__(**kwargs)
+
+    def open(self) -> None:
+        """
+        Opens a connection to the Redshift warehouse.
+        """
+        self._ctx = connect(**self.settings)
+
+    def query(self, query_string: str, **kwargs) -> None:
+        """
+        Executes any query on the Redshift warehouse.
+
+        Args:
+            query_string (str): The query to execute on the Redshift warehouse.
+            **kwargs: Additional parameters to pass to the query.
+        """
+        with self.conn.cursor() as cur:
+            return cur.execute(query_string, **kwargs)
+
+    def load(self, query_string: str, *args, **kwargs) -> DataFrame:
+        """
+        Loads data from Redshift into a Pandas data frame based on the query given.
+        This will fail if the query returns no data from the database.
+
+        Args:
+            query_string (str): Query to fetch a table or subset of a table.
+            *args, **kwargs: Additional parameters to send to query, including format strings.
+
+        Returns:
+            DataFrame: Data frame associated with the given query.
+        """
+        with self.conn.cursor() as cur:
+            return cur.execute(query_string, *args, **kwargs).fetch_dataframe()
+
+    @classmethod
+    def with_credentials(
+        cls, database: str, host: str, user: str, password: str, port: int = 5439, **kwargs
+    ):
+        """
+        Creates a Redshift data loader from temporary database credentials
+
+        Args:
+            database (str): Name of the database to connect to
+            host (str): The hostname of the Redshift cluster which the database belongs to
+            user (str): Username for authentication
+            password (str): Password for authentication
+            port (int, optional): Port number of the Redshift cluster. Defaults to 5439.
+
+        Returns:
+            Redshift: the constructed dataloader using this method
+        """
+        return cls(database=database, host=host, user=user, password=password, port=port, **kwargs)
+
+    @classmethod
+    def with_iam(
+        cls,
+        cluster_identifier: str,
+        database: str,
+        db_user: str,
+        profile: str = 'default',
+        **kwargs
+    ):
+        """
+        Creates a Redshift data loader using a profile from `~/.aws/credentials`. If credentials
+        not stored on system or not found by the connector, use `with_credentials` to construct
+        the data loader.
+
+        Args:
+            cluster_identifier (str): Identifier of the cluster to connect to.
+            database (str): The database to connect to within the specified cluster.
+            db_user (str): Database username
+            profile (str, optional): The profile to use from stored credentials file. Defaults to 'default'.
+
+        Returns:
+            Redshift: the constructed dataloader using this method
+        """
+        return cls(
+            cluster_identifier=cluster_identifier,
+            database=database,
+            profile=profile,
+            db_user=db_user,
+            iam=True,
+            **kwargs
+        )

--- a/mage_ai/data_loader/redshift.py
+++ b/mage_ai/data_loader/redshift.py
@@ -10,35 +10,36 @@ class Redshift(BaseSQL):
 
     def __init__(self, **kwargs) -> None:
         """
-        Initializes settings for connecting to a Redshift warehouse.
+        Initializes settings for connecting to a cluster.
         """
         super().__init__(**kwargs)
 
     def open(self) -> None:
         """
-        Opens a connection to the Redshift warehouse.
+        Opens a connection to the Redshift cluster.
         """
         self._ctx = connect(**self.settings)
 
     def query(self, query_string: str, **kwargs) -> None:
         """
-        Executes any query on the Redshift warehouse.
+        Sends query to the connected Redshift cluster.
 
         Args:
-            query_string (str): The query to execute on the Redshift warehouse.
+            query_string (str): The query to execute on the Redshift cluster.
             **kwargs: Additional parameters to pass to the query.
         """
         with self.conn.cursor() as cur:
-            return cur.execute(query_string, **kwargs)
+            cur.execute(query_string, **kwargs)
 
     def load(self, query_string: str, *args, **kwargs) -> DataFrame:
         """
-        Loads data from Redshift into a Pandas data frame based on the query given.
+        Uses query to load data from Redshift cluster into a Pandas data frame.
         This will fail if the query returns no data from the database.
 
         Args:
             query_string (str): Query to fetch a table or subset of a table.
-            *args, **kwargs: Additional parameters to send to query, including format strings.
+            *args, **kwargs: Additional parameters to send to query, including parameters
+            for use with format strings. See `redshift-connector` docs for more options.
 
         Returns:
             DataFrame: Data frame associated with the given query.
@@ -47,7 +48,7 @@ class Redshift(BaseSQL):
             return cur.execute(query_string, *args, **kwargs).fetch_dataframe()
 
     @classmethod
-    def with_credentials(
+    def with_temporary_credentials(
         cls, database: str, host: str, user: str, password: str, port: int = 5439, **kwargs
     ):
         """
@@ -59,6 +60,7 @@ class Redshift(BaseSQL):
             user (str): Username for authentication
             password (str): Password for authentication
             port (int, optional): Port number of the Redshift cluster. Defaults to 5439.
+            **kwargs: Additional parameters passed to the loader constructor
 
         Returns:
             Redshift: the constructed dataloader using this method
@@ -75,15 +77,19 @@ class Redshift(BaseSQL):
         **kwargs
     ):
         """
-        Creates a Redshift data loader using a profile from `~/.aws/credentials`. If credentials
-        not stored on system or not found by the connector, use `with_credentials` to construct
-        the data loader.
+        Creates a Redshift data loader using an IAM profile from `~/.aws`.
+
+        The IAM Profile configuration can also be manually specified as keyword
+        arguments to this constructor, but is not recommended. If credentials are manually
+        specified, the region of the Redshift cluster must also be specified.
 
         Args:
             cluster_identifier (str): Identifier of the cluster to connect to.
             database (str): The database to connect to within the specified cluster.
             db_user (str): Database username
-            profile (str, optional): The profile to use from stored credentials file. Defaults to 'default'.
+            profile (str, optional): The profile to use from stored credentials file.
+            Defaults to 'default'.
+            **kwargs: Additional parameters passed to the loader constructor
 
         Returns:
             Redshift: the constructed dataloader using this method

--- a/mage_ai/data_loader/s3.py
+++ b/mage_ai/data_loader/s3.py
@@ -2,12 +2,12 @@ from mage_ai.data_loader.base import BaseFile, FileFormat
 from pandas import DataFrame
 from io import BytesIO
 import boto3
-import os
 
 
 class S3(BaseFile):
     """
-    Loads data from a S3 bucket. Supports loading files of any of the following types:
+    Loads data from a S3 bucket into a Pandas data frame. Supports loading files
+    of any of the following types:
     - ".csv"
     - ".json"
     - ".parquet"
@@ -22,8 +22,9 @@ class S3(BaseFile):
         **kwargs,
     ) -> None:
         """
-        Initializes data loader from an S3 bucket. If credentials are stored on
-        file, no further arguments are needed. Otherwise, use the factory method to construct
+        Initializes data loader from an S3 bucket. If profile is stored on
+        file (in `~/.aws`), no further arguments are needed other than those
+        specified below. Otherwise, use the factory method `with_credentials` to construct
         the data loader using manually specified credentials.
 
         Args:
@@ -61,8 +62,8 @@ class S3(BaseFile):
     ) -> 'S3':
         """
         Initializes data loader from an S3 bucket using manually specified credentials.
-        If credentials are stored on file under `~/.aws`, do not use this factory method;
-        the default constructor will automatically recognize the credentials.
+        If credentials are stored on file under `~/.aws/`, do not use this
+        factory method, the default constructor will automatically load the credentials.
 
         Args:
             bucket_name (str): Bucket to load resource from

--- a/mage_ai/data_loader/s3.py
+++ b/mage_ai/data_loader/s3.py
@@ -1,0 +1,86 @@
+from mage_ai.data_loader.base import BaseFile, FileFormat
+from pandas import DataFrame
+from io import BytesIO
+import boto3
+import os
+
+
+class S3(BaseFile):
+    """
+    Loads data from a S3 bucket. Supports loading files of any of the following types:
+    - ".csv"
+    - ".json"
+    - ".parquet"
+    - ".hdf5"
+    """
+
+    @classmethod
+    def with_credentials(
+        cls,
+        bucket_name: str,
+        object_name: str,
+        access_key_id: str,
+        secret_access_key: str,
+        region: str,
+        format: FileFormat = None,
+    ) -> 'S3':
+        """
+        Initializes data loader from an S3 bucket using manually specified credentials.
+        If credentials are stored on file under `~/.aws`, do not use this factory method;
+        the default constructor will automatically recognize the credentials.
+
+        Args:
+            bucket_name (str): Bucket to load resource from
+            object_name (str): Object key name within bucket given
+            format (FileFormat, optional): File format of object. Defaults to None,
+            in which case the format is inferred.
+            access_key_id (str, optional): AWS Access Key ID credential. Specify if IAM
+            credentials are not configured. Defaults to None.
+            secret_access_key (str, optional): AWS Secret Access Key credential. Specify
+            if IAM credentials are not configured. Defaults to None.
+            region (str, optional): AWS Region. Specify if IAM credentials are not configured.
+            Defaults to None.
+        """
+        return cls(
+            bucket_name=bucket_name,
+            object_name=object_name,
+            format=format,
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+            region_name=region,
+        )
+
+    def __init__(
+        self,
+        bucket_name: str,
+        object_name: str,
+        format: FileFormat = None,
+        **kwargs,
+    ) -> None:
+        """
+        Initializes data loader from an S3 bucket. If credentials are stored on
+        file, no further arguments are needed. Otherwise, use the factory method to construct
+        the data loader using manually specified credentials.
+
+        Args:
+            bucket_name (str): Bucket to load resource from
+            object_name (str): Object key name within bucket given
+            format (FileFormat, optional): File format of object. Defaults to None, in which
+            case the format is inferred.
+            **kwargs: all other keyword arguments to pass to the client
+        """
+        super().__init__(object_name, format)
+        self.bucket_name = bucket_name
+        self.client = boto3.client('s3', **kwargs)
+
+    def load(self, **kwargs) -> DataFrame:
+        """
+        Loads data from S3 into a Pandas data frame.
+
+        Returns:
+            DataFrame: The data frame specified by the bucket name and object name
+        """
+        buffer = BytesIO()
+        self.client.download_fileobj(self.bucket_name, self.filepath, buffer)
+        buffer.seek(0)
+        return self.reader(buffer, **kwargs)

--- a/mage_ai/data_preparation/templates/data_loaders/file.py
+++ b/mage_ai/data_preparation/templates/data_loaders/file.py
@@ -1,7 +1,8 @@
 from mage_ai.data_loader.file import FileLoader
+from pandas import DataFrame
 
 
-def load_data_from_file():
+def load_data_from_file() -> DataFrame:
     """
     Template code for loading data from local filesytem
     """

--- a/mage_ai/data_preparation/templates/data_loaders/postgres.py
+++ b/mage_ai/data_preparation/templates/data_loaders/postgres.py
@@ -1,7 +1,8 @@
 from mage_ai.data_loader.postgres import Postgres
+from pandas import DataFrame
 
 
-def load_data_from_postgres():
+def load_data_from_postgres() -> DataFrame:
     """
     Template code for loading data from PostgreSQL database
     """

--- a/mage_ai/data_preparation/templates/data_loaders/redshift.py
+++ b/mage_ai/data_preparation/templates/data_loaders/redshift.py
@@ -4,20 +4,17 @@ from pandas import DataFrame
 
 def load_data_from_redshift() -> DataFrame:
     """
-    Template code for loading data from Redshift cluster.
-
-    This template assumes that IAM profiles are specified in `~/.aws`.
-    - If IAM profiles are not setup, manually specify them as keyword arguments in `config`
-    - If using temporary database credentials, use `Redshift.with_temporary_credentials()`
-    to create loader.
+    Template code for loading data from Redshift cluster. Additional
+    configuration parameters can be added to the `config` dictionary.
     """
     config = {
-        'cluster_identifier': 'your_redshift_cluster_name',
         'database': 'your_redshift_database_name',
-        'db_user': 'your_redshift_database_username',
-        'profile': 'default',
+        'user': 'database_login_username',
+        'password': 'database_login_password',
+        'host': 'database_host',
+        'port': 'database_port',
     }
     query = 'your_redshift_selection_query'
 
-    with Redshift.with_iam(**config) as loader:
+    with Redshift.with_temporary_credentials(**config) as loader:
         return loader.load(query)

--- a/mage_ai/data_preparation/templates/data_loaders/redshift.py
+++ b/mage_ai/data_preparation/templates/data_loaders/redshift.py
@@ -1,0 +1,15 @@
+from mage_ai.data_loader.redshift import Redshift
+from pandas import DataFrame
+
+
+def load_data_from_redshift() -> DataFrame:
+    config = {
+        'cluster_identifier': 'your_redshift_cluster_name',
+        'database': 'your_redshift_database_name',
+        'db_user': 'your_redshift_database_username',
+        'profile': 'default',
+    }
+    query = 'your_redshift_selection_query'
+
+    with Redshift.with_iam(**config) as loader:
+        return loader.load(query)

--- a/mage_ai/data_preparation/templates/data_loaders/redshift.py
+++ b/mage_ai/data_preparation/templates/data_loaders/redshift.py
@@ -3,6 +3,14 @@ from pandas import DataFrame
 
 
 def load_data_from_redshift() -> DataFrame:
+    """
+    Template code for loading data from Redshift cluster.
+
+    This template assumes that IAM profiles are specified in `~/.aws`.
+    - If IAM profiles are not setup, manually specify them as keyword arguments in `config`
+    - If using temporary database credentials, use `Redshift.with_temporary_credentials()`
+    to create loader.
+    """
     config = {
         'cluster_identifier': 'your_redshift_cluster_name',
         'database': 'your_redshift_database_name',

--- a/mage_ai/data_preparation/templates/data_loaders/s3.py
+++ b/mage_ai/data_preparation/templates/data_loaders/s3.py
@@ -11,6 +11,6 @@ def load_from_s3_bucket() -> DataFrame:
     AWS CLI to configure credentials on system.
     """
     bucket_name = 'your_s3_bucket_name'  # Specify S3 bucket name to pull data from
-    object_name = 'your_object_name'  # Specify object to download from S3 bucket
+    object_key = 'your_object_key'  # Specify object to download from S3 bucket
 
-    return S3(bucket_name, object_name).load()
+    return S3(bucket_name, object_key).load()

--- a/mage_ai/data_preparation/templates/data_loaders/s3.py
+++ b/mage_ai/data_preparation/templates/data_loaders/s3.py
@@ -1,0 +1,8 @@
+from mage_ai.data_loader.s3 import S3
+
+
+def load_from_s3_bucket():
+    bucket_name = 'your s3 bucket name'
+    object_name = 'your object name'
+
+    return S3(bucket_name, object_name).load()

--- a/mage_ai/data_preparation/templates/data_loaders/s3.py
+++ b/mage_ai/data_preparation/templates/data_loaders/s3.py
@@ -1,7 +1,8 @@
 from mage_ai.data_loader.s3 import S3
+from pandas import DataFrame
 
 
-def load_from_s3_bucket():
+def load_from_s3_bucket() -> DataFrame:
     bucket_name = 'your s3 bucket name'
     object_name = 'your object name'
 

--- a/mage_ai/data_preparation/templates/data_loaders/s3.py
+++ b/mage_ai/data_preparation/templates/data_loaders/s3.py
@@ -3,7 +3,14 @@ from pandas import DataFrame
 
 
 def load_from_s3_bucket() -> DataFrame:
-    bucket_name = 'your s3 bucket name'
-    object_name = 'your object name'
+    """
+    Template code for loading data from S3 bucket.
+
+    This template assumes that user credentials are specified in `~/.aws`.
+    If not, use `S3.with_credentials()` to manually specify AWS credentials or use
+    AWS CLI to configure credentials on system.
+    """
+    bucket_name = 'your_s3_bucket_name'  # Specify S3 bucket name to pull data from
+    object_name = 'your_object_name'  # Specify object to download from S3 bucket
 
     return S3(bucket_name, object_name).load()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ MarkupSafe==2.1.1
 Werkzeug==2.1.2
 asyncio==3.4.3
 beautifulsoup4
+boto3==1.24.19
 click==8.1.3
 flask-cors==3.0.10
 importlib-metadata==4.11.3
@@ -22,6 +23,7 @@ pyarrow==8.0.0
 python-dateutil==2.8.2
 pytz==2022.1
 pyyaml~=6.0
+redshift-connector==2.0.907
 requests==2.28.0
 scikit-learn>=1.0
 simplejson

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ python-dateutil==2.8.2
 pytz==2022.1
 pyyaml~=6.0
 redshift-connector==2.0.907
-requests==2.28.0
+requests==2.27.0
 scikit-learn>=1.0
 simplejson
 six>=1.15.0


### PR DESCRIPTION
# Summary
Added data loaders and templates for loading data from either an S3 bucket or a Redshift cluster. These data loaders are more complex since AWS offers multiple different authentication and authorization methods. I've designed support for the more common methods.

To perform these connections, two new libraries were added:
- `boto3` is used to access S3 buckets
- `redshift-connector` is used to access Redshift clusters

Note: The `redshift-connector` library (used to connect to a Redshift cluster) requires an older version of the `requests` library, so I downgraded it from version 2.28 to version 2.27. No other conflicts have emerged so far, but I can revert this change if need be.

# Tests
Tests were performed by testing loading and querying data from S3 buckets and Redshift clusters.

cc:
@wangxiaoyou1993 
