### PR TITLE
[dy] Add subprocess

### DIFF
--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -4,6 +4,7 @@ from mage_ai.data_preparation.templates.utils import copy_templates
 from queue import Queue
 import asyncio
 import os
+import subprocess
 import yaml
 
 PIPELINES_FOLDER = 'pipelines'
@@ -61,6 +62,8 @@ class Pipeline:
         This function will schedule the block execution in topological
         order based on a block's upstream dependencies.
         """
+        subprocess.run(['pip', 'install', '-r', f'{self.dir_path}/requirements.txt'])
+
         tasks = dict()
         blocks = Queue()
         for b in self.blocks_by_uuid.values():


### PR DESCRIPTION
# Summary

Add subprocess to install dependencies before running pipeline. This could be a little annoying because it will run every time the pipeline runs, but I'm not sure how else to do it.

Also, I noticed that we will have a repo level `requirements.txt` file as well, but I don't see it being run anywhere. I'm not sure when we should install those dependencies either.
<!-- Brief summary of what your code does -->

# Tests

local / unit tests
<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
