### PR TITLE
[xy] Save outputs for scratchpad

### DIFF
--- a/mage_ai/data_preparation/models/block.py
+++ b/mage_ai/data_preparation/models/block.py
@@ -232,6 +232,13 @@ class Block:
             outputs.append(data)
         return outputs
 
+    def save_outputs(self, outputs):
+        variable_mapping = dict()
+        for o in outputs:
+            if all(k in o for k in ['variable_uuid', 'text_data']):
+                variable_mapping[o['variable_uuid']] = o['text_data']
+        self.__store_variables(variable_mapping)
+
     def to_dict(self, include_content=False, include_outputs=False, sample_count=None):
         data = dict(
             name=self.name,

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -1,6 +1,10 @@
 from mage_ai.data_cleaner.shared.utils import clean_name
 from mage_ai.data_preparation.models.block import Block
-from mage_ai.data_preparation.models.constants import PIPELINE_CONFIG_FILE, PIPELINES_FOLDER
+from mage_ai.data_preparation.models.constants import (
+    BlockType,
+    PIPELINE_CONFIG_FILE,
+    PIPELINES_FOLDER,
+)
 from mage_ai.data_preparation.models.variable import Variable
 from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.data_preparation.templates.template import copy_template_directory
@@ -157,10 +161,14 @@ class Pipeline:
             os.rename(old_pipeline_path, new_pipeline_path)
         if update_content and 'blocks' in data:
             for block_data in data['blocks']:
-                if 'uuid' in block_data and 'content' in block_data:
+                if 'uuid' in block_data:
                     block = self.blocks_by_uuid.get(block_data['uuid'])
-                    if block is not None:
+                    if block is None:
+                        continue
+                    if 'content' in block_data:
                         block.update_content(block_data['content'])
+                    if 'outputs' in block_data and block.type == BlockType.SCRATCHPAD:
+                        block.save_outputs(block_data['outputs'])
 
     def add_block(self, block, upstream_block_uuids=[]):
         upstream_blocks = self.get_blocks(upstream_block_uuids)

--- a/mage_ai/data_preparation/variable_manager.py
+++ b/mage_ai/data_preparation/variable_manager.py
@@ -60,6 +60,17 @@ class VariableManager:
                 variables_by_block[d] = sorted([v.split('.')[0] for v in variables])
         return variables_by_block
 
+    def get_variables_by_block(self, pipeline_uuid: str, block_uuid: str) -> Dict[str, List[str]]:
+        variable_dir_path = os.path.join(
+            self.__pipeline_path(pipeline_uuid),
+            VARIABLE_DIR,
+            block_uuid,
+        )
+        if not os.path.exists(variable_dir_path):
+            return []
+        variables = os.listdir(variable_dir_path)
+        return sorted([v.split('.')[0] for v in variables])
+
     def __pipeline_path(self, pipeline_uuid: str) -> str:
         return os.path.join(self.repo_path, 'pipelines', pipeline_uuid)
 

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -113,7 +113,11 @@ class ApiPipelineHandler(BaseHandler):
         update_content = self.get_bool_argument('update_content', False)
         data = json.loads(self.request.body).get('pipeline', {})
         pipeline.update(data, update_content=update_content)
-        self.write(dict(pipeline=pipeline.to_dict(include_content=update_content)))
+        self.write(dict(pipeline=pipeline.to_dict(
+            include_content=update_content,
+            include_outputs=update_content,
+            sample_count=DATAFRAME_SAMPLE_COUNT_PREVIEW,
+        )))
 
 
 class ApiPipelineExecuteHandler(BaseHandler):


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
This PR supports saving outputs for scratchpad
If 'outputs' is specified in scratchpad block of Pipeline PUT request, we'll save the outputs to disk and return them when fetching block outputs.

# Tests
<!-- How did you test your change? -->
<img width="1140" alt="image" src="https://user-images.githubusercontent.com/80284865/177429107-0fadc73f-68fd-4c29-8aac-4224b6f194d3.png">

cc:
<!-- Optionally mention someone to let them know about this pull request -->
