### PR TITLE
[sp] add bottom padding to file tree

### DIFF
--- a/mage_ai/frontend/components/FileTree/index.tsx
+++ b/mage_ai/frontend/components/FileTree/index.tsx
@@ -170,7 +170,9 @@ function FileTree({
 
   return (
     <FlexContainer flexDirection="column">
-      {buildTreeEl(tree)}
+      <Spacing pb={4}>
+        {buildTreeEl(tree)}
+      </Spacing>
     </FlexContainer>
   );
 }


### PR DESCRIPTION
# Summary
- add bottom padding to stop browser link preview from obscuring last file node

# Tests
![image](https://user-images.githubusercontent.com/105667442/177435325-7750661c-e02c-4959-ba09-0799fd0f9616.png)
![image](https://user-images.githubusercontent.com/105667442/177435333-88821f26-5647-448b-9897-7864d10eb3ff.png)

cc: @johnson-mage 
