### PR TITLE
[sp] adjust folder caret icon color

### DIFF
--- a/mage_ai/frontend/components/FileTree/index.tsx
+++ b/mage_ai/frontend/components/FileTree/index.tsx
@@ -140,7 +140,7 @@ function FileTree({
               <Spacing py={`${0.75 * UNIT}px`}>
                 <FlexContainer alignItems="center">
                   {children && (
-                    collapsed ? <ArrowRight /> : <ArrowDown />
+                    collapsed ? <ArrowRight muted /> : <ArrowDown muted />
                   )}
                   &nbsp;
                   <FileTreeIcon fill={iconColor} />

--- a/mage_ai/frontend/oracle/icons/BaseIcon.tsx
+++ b/mage_ai/frontend/oracle/icons/BaseIcon.tsx
@@ -67,7 +67,7 @@ export const SHARED_STYLES = css<any>`
   `}
 
   ${props => !props.useStroke && props.muted && !props.disabled && `
-    fill: ${(props.theme.monotone || light.monotone).gray};
+    fill: ${(props.theme.monotone || light.monotone).grey400};
   `}
 
   ${props => !props.useStroke && props.default && !props.disabled && `


### PR DESCRIPTION
# Summary
- adjust folder caret icon color to match Figma design

# Tests
<img width="272" alt="image" src="https://user-images.githubusercontent.com/105667442/177443914-58aeb1c4-eeef-449a-b6f9-7be07907bfe9.png">

cc: @tommydangerous @johnson-mage 
