### PR TITLE
[sk] Added IO config handler

### DIFF
--- a/mage_ai/data_preparation/templates/data_exporters/bigquery.py
+++ b/mage_ai/data_preparation/templates/data_exporters/bigquery.py
@@ -33,7 +33,7 @@ def export_data_to_big_query(df: DataFrame) -> None:
     Alternatively, all parameters can be specified in the configuration file.
     """
     table_id = 'your-project.your_dataset.your_table_name'
-    config_path = 'path/to/your/io/config/file.yaml'
+    config_path = './default_repo/io_config.yaml'
     config_profile = 'default'
 
     BigQuery.with_config(IOConfig(config_path).use(config_profile)).export(

--- a/mage_ai/data_preparation/templates/data_exporters/bigquery.py
+++ b/mage_ai/data_preparation/templates/data_exporters/bigquery.py
@@ -1,4 +1,5 @@
 from mage_ai.io.bigquery import BigQuery
+from mage_ai.io.io_config import IOConfig
 from pandas import DataFrame
 
 if 'data_exporter' not in globals():
@@ -28,13 +29,14 @@ def export_data_to_big_query(df: DataFrame) -> None:
     ```
     BigQuery.with_credentials_object({'service_key': ...}, **kwargs)
     ```
+
+    Alternatively, all parameters can be specified in the configuration file.
     """
     table_id = 'your-project.your_dataset.your_table_name'
-    config = {
-        # Specify any other configuration settings here to pass to BigQuery client
-        'project': 'your_project_name',
-    }
-    return BigQuery(**config).export(
+    config_path = 'path/to/your/io/config/file.yaml'
+    config_profile = 'default'
+
+    BigQuery.with_config(IOConfig(config_path).use(config_profile)).export(
         df,
         table_id,
         if_exists='replace',  # Specify resolution policy if table name already exists

--- a/mage_ai/data_preparation/templates/data_exporters/bigquery.py
+++ b/mage_ai/data_preparation/templates/data_exporters/bigquery.py
@@ -1,6 +1,8 @@
+from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.io.bigquery import BigQuery
 from mage_ai.io.io_config import IOConfig
 from pandas import DataFrame
+from os import path
 
 if 'data_exporter' not in globals():
     from mage_ai.data_preparation.decorators import data_exporter
@@ -33,7 +35,7 @@ def export_data_to_big_query(df: DataFrame) -> None:
     Alternatively, all parameters can be specified in the configuration file.
     """
     table_id = 'your-project.your_dataset.your_table_name'
-    config_path = './default_repo/io_config.yaml'
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
 
     BigQuery.with_config(IOConfig(config_path).use(config_profile)).export(

--- a/mage_ai/data_preparation/templates/data_exporters/file.py
+++ b/mage_ai/data_preparation/templates/data_exporters/file.py
@@ -1,6 +1,8 @@
+from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.io.file import FileIO
 from mage_ai.io.io_config import IOConfig
 from pandas import DataFrame
+from os import path
 
 if 'data_exporter' not in globals():
     from mage_ai.data_preparation.decorators import data_exporter
@@ -11,7 +13,7 @@ def export_data_to_file(df: DataFrame) -> None:
     """
     Template code for exporting data to local filesytem
     """
-    config_path = './default_repo/io_config.yaml'
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
 
     FileIO.with_config(IOConfig(config_path).use(config_profile)).export(df)

--- a/mage_ai/data_preparation/templates/data_exporters/file.py
+++ b/mage_ai/data_preparation/templates/data_exporters/file.py
@@ -11,7 +11,7 @@ def export_data_to_file(df: DataFrame) -> None:
     """
     Template code for exporting data to local filesytem
     """
-    config_path = 'path/to/your/io/config/file.yaml'
+    config_path = './default_repo/io_config.yaml'
     config_profile = 'default'
 
     FileIO.with_config(IOConfig(config_path).use(config_profile)).export(df)

--- a/mage_ai/data_preparation/templates/data_exporters/file.py
+++ b/mage_ai/data_preparation/templates/data_exporters/file.py
@@ -1,4 +1,5 @@
 from mage_ai.io.file import FileIO
+from mage_ai.io.io_config import IOConfig
 from pandas import DataFrame
 
 if 'data_exporter' not in globals():
@@ -10,5 +11,7 @@ def export_data_to_file(df: DataFrame) -> None:
     """
     Template code for exporting data to local filesytem
     """
-    filepath = 'path/to/your/file.ext'  # Specify the path to your file.
-    return FileIO(filepath).export(df)
+    config_path = 'path/to/your/io/config/file.yaml'
+    config_profile = 'default'
+
+    FileIO.with_config(IOConfig(config_path).use(config_profile)).export(df)

--- a/mage_ai/data_preparation/templates/data_exporters/postgres.py
+++ b/mage_ai/data_preparation/templates/data_exporters/postgres.py
@@ -1,3 +1,4 @@
+from mage_ai.io.io_config import IOConfig
 from mage_ai.io.postgres import Postgres
 from pandas import DataFrame
 
@@ -11,17 +12,11 @@ def export_data_to_postgres(df: DataFrame) -> None:
     Template code for exporting data to a table in a PostgreSQL database
     """
     table_name = 'your_table_name'  # Specify the name of the table to export data to
-    config = {
-        # Specify all database connection configuration settings here
-        'dbname': 'name of your database',
-        'user': 'login username',
-        'password': 'login password',
-        'host': 'path to host address',
-        'port': 'database port on host address',
-    }
+    config_path = 'path/to/your/io/config/file.yaml'
+    config_profile = 'default'
 
-    with Postgres(**config) as loader:
-        return loader.export(
+    with Postgres.with_config(IOConfig(config_path).use(config_profile)) as loader:
+        loader.export(
             df,
             table_name,
             index=False,  # Specifies whether to include index in exported table

--- a/mage_ai/data_preparation/templates/data_exporters/postgres.py
+++ b/mage_ai/data_preparation/templates/data_exporters/postgres.py
@@ -1,6 +1,8 @@
+from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.io.io_config import IOConfig
 from mage_ai.io.postgres import Postgres
 from pandas import DataFrame
+from os import path
 
 if 'data_exporter' not in globals():
     from mage_ai.data_preparation.decorators import data_exporter
@@ -12,7 +14,7 @@ def export_data_to_postgres(df: DataFrame) -> None:
     Template code for exporting data to a table in a PostgreSQL database
     """
     table_name = 'your_table_name'  # Specify the name of the table to export data to
-    config_path = './default_repo/io_config.yaml'
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
 
     with Postgres.with_config(IOConfig(config_path).use(config_profile)) as loader:

--- a/mage_ai/data_preparation/templates/data_exporters/postgres.py
+++ b/mage_ai/data_preparation/templates/data_exporters/postgres.py
@@ -12,7 +12,7 @@ def export_data_to_postgres(df: DataFrame) -> None:
     Template code for exporting data to a table in a PostgreSQL database
     """
     table_name = 'your_table_name'  # Specify the name of the table to export data to
-    config_path = 'path/to/your/io/config/file.yaml'
+    config_path = './default_repo/io_config.yaml'
     config_profile = 'default'
 
     with Postgres.with_config(IOConfig(config_path).use(config_profile)) as loader:

--- a/mage_ai/data_preparation/templates/data_exporters/redshift.py
+++ b/mage_ai/data_preparation/templates/data_exporters/redshift.py
@@ -1,3 +1,4 @@
+from mage_ai.io.io_config import IOConfig
 from mage_ai.io.redshift import Redshift
 from pandas import DataFrame
 
@@ -8,17 +9,12 @@ if 'data_exporter' not in globals():
 @data_exporter
 def export_data_to_redshift(df: DataFrame) -> None:
     """
-    Template code for exporting data to a table in a Redshift cluster. Additional
-    configuration parameters can be added to the `config` dictionary.
+    Template code for exporting data to a table in a Redshift cluster.  Additional
+    configuration parameters can be defined in your configuration file.
     """
     table_name = 'your_table_name'
-    config = {
-        'database': 'your_redshift_database_name',
-        'user': 'database_login_username',
-        'password': 'database_login_password',
-        'host': 'database_host',
-        'port': 'database_port',
-    }
+    config_path = 'path/to/your/io/config/file.yaml'
+    config_profile = 'default'
 
-    with Redshift.with_temporary_credentials(**config) as loader:
-        return loader.export(df, table_name)
+    with Redshift.with_config(IOConfig(config_path).use(config_profile)) as loader:
+        loader.export(df, table_name)

--- a/mage_ai/data_preparation/templates/data_exporters/redshift.py
+++ b/mage_ai/data_preparation/templates/data_exporters/redshift.py
@@ -1,6 +1,8 @@
+from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.io.io_config import IOConfig
 from mage_ai.io.redshift import Redshift
 from pandas import DataFrame
+from os import path
 
 if 'data_exporter' not in globals():
     from mage_ai.data_preparation.decorators import data_exporter
@@ -13,7 +15,7 @@ def export_data_to_redshift(df: DataFrame) -> None:
     configuration parameters can be defined in your configuration file.
     """
     table_name = 'your_table_name'
-    config_path = './default_repo/io_config.yaml'
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
 
     with Redshift.with_config(IOConfig(config_path).use(config_profile)) as loader:

--- a/mage_ai/data_preparation/templates/data_exporters/redshift.py
+++ b/mage_ai/data_preparation/templates/data_exporters/redshift.py
@@ -13,7 +13,7 @@ def export_data_to_redshift(df: DataFrame) -> None:
     configuration parameters can be defined in your configuration file.
     """
     table_name = 'your_table_name'
-    config_path = 'path/to/your/io/config/file.yaml'
+    config_path = './default_repo/io_config.yaml'
     config_profile = 'default'
 
     with Redshift.with_config(IOConfig(config_path).use(config_profile)) as loader:

--- a/mage_ai/data_preparation/templates/data_exporters/s3.py
+++ b/mage_ai/data_preparation/templates/data_exporters/s3.py
@@ -14,7 +14,7 @@ def export_data_to_s3(df: DataFrame) -> None:
     If user credentials are not specified in `~/.aws`, you must specify your
     user credentials manually in your configuration file.
     """
-    config_path = 'path/to/your/io/config/file.yaml'
+    config_path = './default_repo/io_config.yaml'
     config_profile = 'default'
 
     S3.with_config(IOConfig(config_path).use(config_profile)).export(df)

--- a/mage_ai/data_preparation/templates/data_exporters/s3.py
+++ b/mage_ai/data_preparation/templates/data_exporters/s3.py
@@ -1,6 +1,8 @@
+from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.io.io_config import IOConfig
 from mage_ai.io.s3 import S3
 from pandas import DataFrame
+from os import path
 
 if 'data_exporter' not in globals():
     from mage_ai.data_preparation.decorators import data_exporter
@@ -14,7 +16,7 @@ def export_data_to_s3(df: DataFrame) -> None:
     If user credentials are not specified in `~/.aws`, you must specify your
     user credentials manually in your configuration file.
     """
-    config_path = './default_repo/io_config.yaml'
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
 
     S3.with_config(IOConfig(config_path).use(config_profile)).export(df)

--- a/mage_ai/data_preparation/templates/data_exporters/s3.py
+++ b/mage_ai/data_preparation/templates/data_exporters/s3.py
@@ -1,3 +1,4 @@
+from mage_ai.io.io_config import IOConfig
 from mage_ai.io.s3 import S3
 from pandas import DataFrame
 
@@ -10,11 +11,10 @@ def export_data_to_s3(df: DataFrame) -> None:
     """
     Template code for exporting data to a S3 bucket.
 
-    This template assumes that user credentials are specified in `~/.aws`.
-    If not, use `S3.with_credentials()` to manually specify AWS credentials or use
-    AWS CLI to configure credentials on system.
+    If user credentials are not specified in `~/.aws`, you must specify your
+    user credentials manually in your configuration file.
     """
-    bucket_name = 'your_s3_bucket_name'  # Specify S3 bucket name to pull data from
-    object_key = 'your_object_key'  # Specify object to download from S3 bucket
+    config_path = 'path/to/your/io/config/file.yaml'
+    config_profile = 'default'
 
-    return S3(bucket_name, object_key).export(df)
+    S3.with_config(IOConfig(config_path).use(config_profile)).export(df)

--- a/mage_ai/data_preparation/templates/data_exporters/snowflake.py
+++ b/mage_ai/data_preparation/templates/data_exporters/snowflake.py
@@ -1,3 +1,4 @@
+from mage_ai.io.io_config import IOConfig
 from mage_ai.io.snowflake import Snowflake
 from pandas import DataFrame
 
@@ -13,13 +14,10 @@ def export_data_to_snowflake(df: DataFrame) -> None:
     table_name = 'your_table_name'
     database = 'your_database_name'
     schema = 'your_schema_name'
-    config = {
-        'user': 'your_snowflake_username',
-        'password': 'your_snowflake_password',
-        'account': 'your_snowflake_account_identifier',
-    }
+    config_path = 'path/to/your/io/config/file.yaml'
+    config_profile = 'default'
 
-    with Snowflake(**config) as loader:
+    with Snowflake.with_config(IOConfig(config_path).use(config_profile)) as loader:
         return loader.export(
             df,
             table_name,

--- a/mage_ai/data_preparation/templates/data_exporters/snowflake.py
+++ b/mage_ai/data_preparation/templates/data_exporters/snowflake.py
@@ -14,7 +14,7 @@ def export_data_to_snowflake(df: DataFrame) -> None:
     table_name = 'your_table_name'
     database = 'your_database_name'
     schema = 'your_schema_name'
-    config_path = 'path/to/your/io/config/file.yaml'
+    config_path = './default_repo/io_config.yaml'
     config_profile = 'default'
 
     with Snowflake.with_config(IOConfig(config_path).use(config_profile)) as loader:

--- a/mage_ai/data_preparation/templates/data_exporters/snowflake.py
+++ b/mage_ai/data_preparation/templates/data_exporters/snowflake.py
@@ -1,6 +1,8 @@
+from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.io.io_config import IOConfig
 from mage_ai.io.snowflake import Snowflake
 from pandas import DataFrame
+from os import path
 
 if 'data_exporter' not in globals():
     from mage_ai.data_preparation.decorators import data_exporter
@@ -14,7 +16,7 @@ def export_data_to_snowflake(df: DataFrame) -> None:
     table_name = 'your_table_name'
     database = 'your_database_name'
     schema = 'your_schema_name'
-    config_path = './default_repo/io_config.yaml'
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
 
     with Snowflake.with_config(IOConfig(config_path).use(config_profile)) as loader:

--- a/mage_ai/data_preparation/templates/data_loaders/bigquery.py
+++ b/mage_ai/data_preparation/templates/data_loaders/bigquery.py
@@ -1,6 +1,8 @@
+from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.io.bigquery import BigQuery
 from mage_ai.io.io_config import IOConfig
 from pandas import DataFrame
+from os import path
 
 if 'data_loader' not in globals():
     from mage_ai.data_preparation.decorators import data_loader
@@ -34,7 +36,7 @@ def load_data_from_big_query() -> DataFrame:
     """
 
     query = 'your_gbq_query'
-    config_path = './default_repo/io_config.yaml'
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
 
     return BigQuery.with_config(IOConfig(config_path).use(config_profile)).load(query)

--- a/mage_ai/data_preparation/templates/data_loaders/bigquery.py
+++ b/mage_ai/data_preparation/templates/data_loaders/bigquery.py
@@ -34,7 +34,7 @@ def load_data_from_big_query() -> DataFrame:
     """
 
     query = 'your_gbq_query'
-    config_path = 'path/to/your/io/config/file.yaml'
+    config_path = './default_repo/io_config.yaml'
     config_profile = 'default'
 
     return BigQuery.with_config(IOConfig(config_path).use(config_profile)).load(query)

--- a/mage_ai/data_preparation/templates/data_loaders/bigquery.py
+++ b/mage_ai/data_preparation/templates/data_loaders/bigquery.py
@@ -1,4 +1,5 @@
 from mage_ai.io.bigquery import BigQuery
+from mage_ai.io.io_config import IOConfig
 from pandas import DataFrame
 
 if 'data_loader' not in globals():
@@ -28,11 +29,12 @@ def load_data_from_big_query() -> DataFrame:
     ```
     BigQuery.with_credentials_object({'service_key': ...}, **kwargs)
     ```
+
+    Alternatively, all parameters can be specified in the configuration file.
     """
 
     query = 'your_gbq_query'
-    config = {
-        # Specify any other configuration settings here to pass to BigQuery client
-        'project': 'your_project_name',
-    }
-    return BigQuery(**config).load(query)
+    config_path = 'path/to/your/io/config/file.yaml'
+    config_profile = 'default'
+
+    return BigQuery.with_config(IOConfig(config_path).use(config_profile)).load(query)

--- a/mage_ai/data_preparation/templates/data_loaders/file.py
+++ b/mage_ai/data_preparation/templates/data_loaders/file.py
@@ -11,7 +11,7 @@ def load_data_from_file() -> DataFrame:
     """
     Template code for loading data from local filesytem
     """
-    config_path = 'path/to/your/io/config/file.yaml'
+    config_path = './default_repo/io_config.yaml'
     config_profile = 'default'
 
     return FileIO.with_config(IOConfig(config_path).use(config_profile)).load()

--- a/mage_ai/data_preparation/templates/data_loaders/file.py
+++ b/mage_ai/data_preparation/templates/data_loaders/file.py
@@ -1,4 +1,5 @@
 from mage_ai.io.file import FileIO
+from mage_ai.io.io_config import IOConfig
 from pandas import DataFrame
 
 if 'data_loader' not in globals():
@@ -10,5 +11,7 @@ def load_data_from_file() -> DataFrame:
     """
     Template code for loading data from local filesytem
     """
-    filepath = 'path/to/your/file.ext'  # Specify the path to your file.
-    return FileIO(filepath).load()
+    config_path = 'path/to/your/io/config/file.yaml'
+    config_profile = 'default'
+
+    return FileIO.with_config(IOConfig(config_path).use(config_profile)).load()

--- a/mage_ai/data_preparation/templates/data_loaders/file.py
+++ b/mage_ai/data_preparation/templates/data_loaders/file.py
@@ -1,6 +1,8 @@
+from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.io.file import FileIO
 from mage_ai.io.io_config import IOConfig
 from pandas import DataFrame
+from os import path
 
 if 'data_loader' not in globals():
     from mage_ai.data_preparation.decorators import data_loader
@@ -11,7 +13,7 @@ def load_data_from_file() -> DataFrame:
     """
     Template code for loading data from local filesytem
     """
-    config_path = './default_repo/io_config.yaml'
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
 
     return FileIO.with_config(IOConfig(config_path).use(config_profile)).load()

--- a/mage_ai/data_preparation/templates/data_loaders/postgres.py
+++ b/mage_ai/data_preparation/templates/data_loaders/postgres.py
@@ -12,7 +12,7 @@ def load_data_from_postgres() -> DataFrame:
     Template code for loading data from PostgreSQL database
     """
     query = 'your PostgreSQL query'  # Specify your SQL query here
-    config_path = 'path/to/your/io/config/file.yaml'
+    config_path = './default_repo/io_config.yaml'
     config_profile = 'default'
 
     with Postgres.with_config(IOConfig(config_path).use(config_profile)) as loader:

--- a/mage_ai/data_preparation/templates/data_loaders/postgres.py
+++ b/mage_ai/data_preparation/templates/data_loaders/postgres.py
@@ -1,6 +1,8 @@
+from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.io.io_config import IOConfig
 from mage_ai.io.postgres import Postgres
 from pandas import DataFrame
+from os import path
 
 if 'data_loader' not in globals():
     from mage_ai.data_preparation.decorators import data_loader
@@ -12,7 +14,7 @@ def load_data_from_postgres() -> DataFrame:
     Template code for loading data from PostgreSQL database
     """
     query = 'your PostgreSQL query'  # Specify your SQL query here
-    config_path = './default_repo/io_config.yaml'
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
 
     with Postgres.with_config(IOConfig(config_path).use(config_profile)) as loader:

--- a/mage_ai/data_preparation/templates/data_loaders/postgres.py
+++ b/mage_ai/data_preparation/templates/data_loaders/postgres.py
@@ -1,3 +1,4 @@
+from mage_ai.io.io_config import IOConfig
 from mage_ai.io.postgres import Postgres
 from pandas import DataFrame
 
@@ -11,15 +12,8 @@ def load_data_from_postgres() -> DataFrame:
     Template code for loading data from PostgreSQL database
     """
     query = 'your PostgreSQL query'  # Specify your SQL query here
+    config_path = 'path/to/your/io/config/file.yaml'
+    config_profile = 'default'
 
-    config = {
-        # Specify all database connection configuration settings here
-        'dbname': 'name of your database',
-        'user': 'login username',
-        'password': 'login password',
-        'host': 'path to host address',
-        'port': 'database port on host address',
-    }
-
-    with Postgres(**config) as loader:
+    with Postgres.with_config(IOConfig(config_path).use(config_profile)) as loader:
         return loader.load(query)

--- a/mage_ai/data_preparation/templates/data_loaders/redshift.py
+++ b/mage_ai/data_preparation/templates/data_loaders/redshift.py
@@ -1,3 +1,4 @@
+from mage_ai.io.io_config import IOConfig
 from mage_ai.io.redshift import Redshift
 from pandas import DataFrame
 
@@ -9,16 +10,11 @@ if 'data_loader' not in globals():
 def load_data_from_redshift() -> DataFrame:
     """
     Template code for loading data from Redshift cluster. Additional
-    configuration parameters can be added to the `config` dictionary.
+    configuration parameters can be defined in your configuration file.
     """
     query = 'your_redshift_selection_query'
-    config = {
-        'database': 'your_redshift_database_name',
-        'user': 'database_login_username',
-        'password': 'database_login_password',
-        'host': 'database_host',
-        'port': 'database_port',
-    }
+    config_path = 'path/to/your/io/config/file.yaml'
+    config_profile = 'default'
 
-    with Redshift.with_temporary_credentials(**config) as loader:
+    with Redshift.with_config(IOConfig(config_path).use(config_profile)) as loader:
         return loader.load(query)

--- a/mage_ai/data_preparation/templates/data_loaders/redshift.py
+++ b/mage_ai/data_preparation/templates/data_loaders/redshift.py
@@ -1,6 +1,8 @@
+from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.io.io_config import IOConfig
 from mage_ai.io.redshift import Redshift
 from pandas import DataFrame
+from os import path
 
 if 'data_loader' not in globals():
     from mage_ai.data_preparation.decorators import data_loader
@@ -13,7 +15,7 @@ def load_data_from_redshift() -> DataFrame:
     configuration parameters can be defined in your configuration file.
     """
     query = 'your_redshift_selection_query'
-    config_path = './default_repo/io_config.yaml'
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
 
     with Redshift.with_config(IOConfig(config_path).use(config_profile)) as loader:

--- a/mage_ai/data_preparation/templates/data_loaders/redshift.py
+++ b/mage_ai/data_preparation/templates/data_loaders/redshift.py
@@ -13,7 +13,7 @@ def load_data_from_redshift() -> DataFrame:
     configuration parameters can be defined in your configuration file.
     """
     query = 'your_redshift_selection_query'
-    config_path = 'path/to/your/io/config/file.yaml'
+    config_path = './default_repo/io_config.yaml'
     config_profile = 'default'
 
     with Redshift.with_config(IOConfig(config_path).use(config_profile)) as loader:

--- a/mage_ai/data_preparation/templates/data_loaders/s3.py
+++ b/mage_ai/data_preparation/templates/data_loaders/s3.py
@@ -1,3 +1,4 @@
+from mage_ai.io.io_config import IOConfig
 from mage_ai.io.s3 import S3
 from pandas import DataFrame
 
@@ -10,11 +11,10 @@ def load_from_s3_bucket() -> DataFrame:
     """
     Template code for loading data from S3 bucket.
 
-    This template assumes that user credentials are specified in `~/.aws`.
-    If not, use `S3.with_credentials()` to manually specify AWS credentials or use
-    AWS CLI to configure credentials on system.
+    If user credentials are not specified in `~/.aws`, you must specify your
+    user credentials manually in your configuration file.
     """
-    bucket_name = 'your_s3_bucket_name'  # Specify S3 bucket name to pull data from
-    object_key = 'your_object_key'  # Specify object to download from S3 bucket
+    config_path = 'path/to/your/io/config/file.yaml'
+    config_profile = 'default'
 
-    return S3(bucket_name, object_key).load()
+    return S3.with_config(IOConfig(config_path).use(config_profile)).load()

--- a/mage_ai/data_preparation/templates/data_loaders/s3.py
+++ b/mage_ai/data_preparation/templates/data_loaders/s3.py
@@ -1,6 +1,8 @@
+from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.io.io_config import IOConfig
 from mage_ai.io.s3 import S3
 from pandas import DataFrame
+from os import path
 
 if 'data_loader' not in globals():
     from mage_ai.data_preparation.decorators import data_loader
@@ -14,7 +16,7 @@ def load_from_s3_bucket() -> DataFrame:
     If user credentials are not specified in `~/.aws`, you must specify your
     user credentials manually in your configuration file.
     """
-    config_path = './default_repo/io_config.yaml'
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
 
     return S3.with_config(IOConfig(config_path).use(config_profile)).load()

--- a/mage_ai/data_preparation/templates/data_loaders/s3.py
+++ b/mage_ai/data_preparation/templates/data_loaders/s3.py
@@ -14,7 +14,7 @@ def load_from_s3_bucket() -> DataFrame:
     If user credentials are not specified in `~/.aws`, you must specify your
     user credentials manually in your configuration file.
     """
-    config_path = 'path/to/your/io/config/file.yaml'
+    config_path = './default_repo/io_config.yaml'
     config_profile = 'default'
 
     return S3.with_config(IOConfig(config_path).use(config_profile)).load()

--- a/mage_ai/data_preparation/templates/data_loaders/snowflake.py
+++ b/mage_ai/data_preparation/templates/data_loaders/snowflake.py
@@ -1,3 +1,4 @@
+from mage_ai.io.io_config import IOConfig
 from mage_ai.io.snowflake import Snowflake
 from pandas import DataFrame
 
@@ -10,12 +11,9 @@ def load_data_from_snowflake() -> DataFrame:
     """
     Template code for loading data from a Snowflake warehouse
     """
-    config = {
-        'user': 'your_snowflake_username',
-        'password': 'your_snowflake_password',
-        'account': 'your_snowflake_account_identifier',
-    }
     query = 'your_snowflake_query'
+    config_path = 'path/to/your/io/config/file.yaml'
+    config_profile = 'default'
 
-    with Snowflake(**config) as loader:
+    with Snowflake.with_config(IOConfig(config_path).use(config_profile)) as loader:
         return loader.load(query)

--- a/mage_ai/data_preparation/templates/data_loaders/snowflake.py
+++ b/mage_ai/data_preparation/templates/data_loaders/snowflake.py
@@ -1,6 +1,8 @@
+from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.io.io_config import IOConfig
 from mage_ai.io.snowflake import Snowflake
 from pandas import DataFrame
+from os import path
 
 if 'data_loader' not in globals():
     from mage_ai.data_preparation.decorators import data_loader
@@ -12,7 +14,7 @@ def load_data_from_snowflake() -> DataFrame:
     Template code for loading data from a Snowflake warehouse
     """
     query = 'your_snowflake_query'
-    config_path = './default_repo/io_config.yaml'
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
 
     with Snowflake.with_config(IOConfig(config_path).use(config_profile)) as loader:

--- a/mage_ai/data_preparation/templates/data_loaders/snowflake.py
+++ b/mage_ai/data_preparation/templates/data_loaders/snowflake.py
@@ -12,7 +12,7 @@ def load_data_from_snowflake() -> DataFrame:
     Template code for loading data from a Snowflake warehouse
     """
     query = 'your_snowflake_query'
-    config_path = 'path/to/your/io/config/file.yaml'
+    config_path = './default_repo/io_config.yaml'
     config_profile = 'default'
 
     with Snowflake.with_config(IOConfig(config_path).use(config_profile)) as loader:

--- a/mage_ai/data_preparation/templates/repo/io_config.yaml
+++ b/mage_ai/data_preparation/templates/repo/io_config.yaml
@@ -1,36 +1,37 @@
-default
-  #  Default profile created for data IO access. Added credentials for the sources you use, and remove the rest
-  BigQuery
-    path_to_credentials: 'path/to/service/account/credentials'
-  File
-    filepath: 'filepath'
-    format: 'format'
-  AWS
-    Redshift
+default:
+  #  Default profile created for data IO access. Add credentials for the sources you use and remove the rest.
+  BigQuery:
+    path_to_credentials: path/to/service/account/credentials
+  File:
+    filepath: filepath
+    format: format
+  AWS:
+    Redshift:
+      database: your_redshift_database_name
       # Use the settings below if you are using temporary credentials
-      database: 'your_redshift_database_name'
-      user: 'your_redshift_temporary_credentials_user_name'
-      password: 'your_redshift_temporary_credentials_password'
-      host: 'your_redshift_cluster_hostname'
-      port: 'your_redshift_cluster_port'
+      user: your_authentication_user_name
+      password: your_authentication_password
+      host: your_redshift_cluster_hostname
+      port: your_redshift_cluster_port
       # Use the settings below if you are using IAM credentials
-      cluster_identifier: 'your_redshift_identifier'
-      db_user: 'your_redshift_cluster_database_username'
-      profile: 'your_aws_iam_config'
-    S3
-      bucket_name: 'your_bucket_name'
-      object_key: 'your_object_key'
+      cluster_identifier: your_redshift_identifier
+      db_user: your_redshift_username
+      profile: your_aws_credentials_profile
+      iam: True
+    S3:
+      bucket_name: your_bucket_name
+      object_key: your_object_key
     # Omit these settings if aws credentials are already configured on file
-    aws_access_key_id: 'your_aws_access_key_id'
-    aws_secret_access_key: 'your_secret_access_key_id'
-    region_name: 'your_aws_region'
-  PostgreSQL
-    database: 'your_postgres_database_name'
-    user: 'your_postgres_database_username'
-    password: 'your_postgres_database_password'
-    host: 'your_postgres_database_host'
-    port: 'your_postgres'
-  Snowflake
-    user: 'your_snowflake_username'
-    password: 'your_snowflake_password'
-    account: 'your_snowflake_account_identifier(with region)'
+    aws_access_key_id: your_aws_access_key_id
+    aws_secret_access_key: your_secret_access_key_id
+    region_name: your_aws_region
+  PostgreSQL:
+    database: your_postgres_database_name
+    user: your_postgres_database_username
+    password: your_postgres_database_password
+    host: your_postgres_database_host
+    port: your_postgres
+  Snowflake:
+    user: your_snowflake_username
+    password: your_snowflake_password
+    account: your_snowflake_account_identifier(with region)

--- a/mage_ai/data_preparation/templates/repo/io_config.yaml
+++ b/mage_ai/data_preparation/templates/repo/io_config.yaml
@@ -22,9 +22,9 @@ default:
       bucket_name: your_bucket_name
       object_key: your_object_key
     # Omit these settings if aws credentials are already configured on file
-    aws_access_key_id: your_aws_access_key_id
-    aws_secret_access_key: your_secret_access_key_id
-    region_name: your_aws_region
+    access_key_id: your_aws_access_key_id
+    secret_access_key: your_secret_access_key_id
+    region: your_aws_region
   PostgreSQL:
     database: your_postgres_database_name
     user: your_postgres_database_username

--- a/mage_ai/data_preparation/templates/repo/io_config.yaml
+++ b/mage_ai/data_preparation/templates/repo/io_config.yaml
@@ -21,10 +21,10 @@ default
       bucket_name: 'your_bucket_name'
       object_key: 'your_object_key'
     # Omit these settings if aws credentials are already configured on file
-    access_key_id: 'your_aws_access_key_id'
-    secret_access_key: 'your_secret_access_key_id'
-    region: 'your_aws_region'
-  Postgres
+    aws_access_key_id: 'your_aws_access_key_id'
+    aws_secret_access_key: 'your_secret_access_key_id'
+    region_name: 'your_aws_region'
+  PostgreSQL
     database: 'your_postgres_database_name'
     user: 'your_postgres_database_username'
     password: 'your_postgres_database_password'

--- a/mage_ai/data_preparation/templates/repo/io_config.yaml
+++ b/mage_ai/data_preparation/templates/repo/io_config.yaml
@@ -1,0 +1,36 @@
+default
+  #  Default profile created for data IO access. Added credentials for the sources you use, and remove the rest
+  BigQuery
+    path_to_credentials: 'path/to/service/account/credentials'
+  File
+    filepath: 'filepath'
+    format: 'format'
+  AWS
+    Redshift
+      # Use the settings below if you are using temporary credentials
+      database: 'your_redshift_database_name'
+      user: 'your_redshift_temporary_credentials_user_name'
+      password: 'your_redshift_temporary_credentials_password'
+      host: 'your_redshift_cluster_hostname'
+      port: 'your_redshift_cluster_port'
+      # Use the settings below if you are using IAM credentials
+      cluster_identifier: 'your_redshift_identifier'
+      db_user: 'your_redshift_cluster_database_username'
+      profile: 'your_aws_iam_config'
+    S3
+      bucket_name: 'your_bucket_name'
+      object_key: 'your_object_key'
+    # Omit these settings if aws credentials are already configured on file
+    access_key_id: 'your_aws_access_key_id'
+    secret_access_key: 'your_secret_access_key_id'
+    region: 'your_aws_region'
+  Postgres
+    database: 'your_postgres_database_name'
+    user: 'your_postgres_database_username'
+    password: 'your_postgres_database_password'
+    host: 'your_postgres_database_host'
+    port: 'your_postgres'
+  Snowflake
+    user: 'your_snowflake_username'
+    password: 'your_snowflake_password'
+    account: 'your_snowflake_account_identifier(with region)'

--- a/mage_ai/io/base.py
+++ b/mage_ai/io/base.py
@@ -42,7 +42,7 @@ class BaseIO(ABC):
 
     @classmethod
     @abstractmethod
-    def from_config(cls, config: Mapping[str, Any]) -> None:
+    def with_config(cls, config: Mapping[str, Any]) -> None:
         pass
 
     @abstractmethod

--- a/mage_ai/io/base.py
+++ b/mage_ai/io/base.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from mage_ai.shared.logger import VerbosePrintHandler
 from pandas import DataFrame
-from typing import IO, Any, Callable, Union
+from typing import IO, Any, Callable, Mapping, Union
 import pandas as pd
 import os
 
@@ -39,6 +39,11 @@ class BaseIO(ABC):
     def __init__(self, verbose=False) -> None:
         self.verbose = verbose
         self.printer = VerbosePrintHandler(f'{type(self).__name__} initialized', verbose=verbose)
+
+    @classmethod
+    @abstractmethod
+    def from_config(cls, config: Mapping[str, Any]) -> None:
+        pass
 
     @abstractmethod
     def load(self, *args, **kwargs) -> DataFrame:

--- a/mage_ai/io/bigquery.py
+++ b/mage_ai/io/bigquery.py
@@ -2,7 +2,7 @@ from google.cloud.bigquery import Client, LoadJobConfig, WriteDisposition
 from google.oauth2 import service_account
 from mage_ai.io.base import BaseIO
 from pandas import DataFrame
-from typing import Mapping
+from typing import Any, Mapping
 
 
 class BigQuery(BaseIO):
@@ -99,6 +99,10 @@ class BigQuery(BaseIO):
                         f'Invalid policy specified for handling existence of table: \'{if_exists}\''
                     )
             self.client.load_table_from_dataframe(df, table_id, job_config=config).result()
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any]) -> 'BigQuery':
+        return cls(**config['BigQuery'])
 
     @classmethod
     def with_credentials_file(cls, path_to_credentials: str, **kwargs):

--- a/mage_ai/io/bigquery.py
+++ b/mage_ai/io/bigquery.py
@@ -101,7 +101,7 @@ class BigQuery(BaseIO):
             self.client.load_table_from_dataframe(df, table_id, job_config=config).result()
 
     @classmethod
-    def from_config(cls, config: Mapping[str, Any]) -> 'BigQuery':
+    def with_config(cls, config: Mapping[str, Any]) -> 'BigQuery':
         return cls(**config['BigQuery'])
 
     @classmethod

--- a/mage_ai/io/bigquery.py
+++ b/mage_ai/io/bigquery.py
@@ -105,7 +105,7 @@ class BigQuery(BaseIO):
         return cls(**config['BigQuery'])
 
     @classmethod
-    def with_credentials_file(cls, path_to_credentials: str, **kwargs):
+    def with_credentials_file(cls, path_to_credentials: str, **kwargs) -> 'BigQuery':
         """
         Constructs BigQuery data loader using the file containing the service account key.
 
@@ -118,7 +118,7 @@ class BigQuery(BaseIO):
         return cls(path_to_credentials=path_to_credentials, **kwargs)
 
     @classmethod
-    def with_credentials_object(cls, credentials: Mapping[str, str], **kwargs):
+    def with_credentials_object(cls, credentials: Mapping[str, str], **kwargs) -> 'BigQuery':
         """
         Constructs BigQuery data loader using manually specified authentication credentials object.
 

--- a/mage_ai/io/bigquery.py
+++ b/mage_ai/io/bigquery.py
@@ -1,6 +1,7 @@
 from google.cloud.bigquery import Client, LoadJobConfig, WriteDisposition
 from google.oauth2 import service_account
 from mage_ai.io.base import BaseIO
+from mage_ai.io.io_config import IOConfigKeys
 from pandas import DataFrame
 from typing import Any, Mapping
 
@@ -102,7 +103,12 @@ class BigQuery(BaseIO):
 
     @classmethod
     def with_config(cls, config: Mapping[str, Any]) -> 'BigQuery':
-        return cls(**config['BigQuery'])
+        try:
+            return cls(**config[IOConfigKeys.BIGQUERY])
+        except KeyError:
+            raise KeyError(
+                f'No configuration settings found for \'{IOConfigKeys.BIGQUERY}\' under profile'
+            )
 
     @classmethod
     def with_credentials_file(cls, path_to_credentials: str, **kwargs) -> 'BigQuery':

--- a/mage_ai/io/file.py
+++ b/mage_ai/io/file.py
@@ -1,5 +1,6 @@
 from mage_ai.io.base import BaseFile
 from pandas import DataFrame
+from typing import Any, Mapping
 
 
 class FileIO(BaseFile):
@@ -27,3 +28,8 @@ class FileIO(BaseFile):
         """
         with self.printer.print_msg(f'Exporting data frame to \'{self.filepath}\''):
             self._write(df, self.filepath, **kwargs)
+        return self._write(df, self.filepath, **kwargs)
+
+    @classmethod
+    def with_config(cls, config: Mapping[str, Any]) -> 'FileIO':
+        return cls(**config['File'])

--- a/mage_ai/io/file.py
+++ b/mage_ai/io/file.py
@@ -1,4 +1,5 @@
 from mage_ai.io.base import BaseFile
+from mage_ai.io.io_config import IOConfigKeys
 from pandas import DataFrame
 from typing import Any, Mapping
 
@@ -32,4 +33,9 @@ class FileIO(BaseFile):
 
     @classmethod
     def with_config(cls, config: Mapping[str, Any]) -> 'FileIO':
-        return cls(**config['File'])
+        try:
+            return cls(**config[IOConfigKeys.FILE])
+        except KeyError:
+            raise KeyError(
+                f'No configuration settings found for \'{IOConfigKeys.FILE}\' under profile'
+            )

--- a/mage_ai/io/io_config.py
+++ b/mage_ai/io/io_config.py
@@ -1,0 +1,36 @@
+from typing import Any, Mapping
+import pathlib
+import os
+import yaml
+
+
+class IOConfig:
+    """
+    Wrapper around IO configuration file.
+    """
+
+    def __init__(self, filepath: os.PathLike) -> None:
+        """
+        Initializes IO Configuration loader
+
+        Args:
+            filepath (os.PathLike): Path to IO configuration file.
+        """
+        self.filepath = pathlib.Path(filepath)
+
+    def use(self, profile: str = 'default') -> Mapping[str, Any]:
+        """
+        Specifies the profile to use. Profiles are sets of configuration settings.
+
+        Args:
+            profile (str, optional): Name of the profile to use. Defaults to 'default'.
+
+        Returns:
+            Mapping[str, Any]: Configuration settings for this profile
+        """
+        with self.filepath.open('r') as fin:
+            config = yaml.full_load(fin)
+        profile_settings = config.get(profile)
+        if profile_settings is None:
+            raise ValueError(f'Invalid config profile specified: \'{profile}\'')
+        return profile_settings

--- a/mage_ai/io/io_config.py
+++ b/mage_ai/io/io_config.py
@@ -1,7 +1,18 @@
+from enum import Enum
 from typing import Any, Mapping
 import pathlib
 import os
 import yaml
+
+
+class IOConfigKeys(str, Enum):
+    AWS = 'AWS'
+    BIGQUERY = 'BigQuery'
+    FILE = 'File'
+    POSTGRES = 'PostgreSQL'
+    REDSHIFT = 'Redshift'
+    S3 = 'S3'
+    SNOWFLAKE = 'Snowflake'
 
 
 class IOConfig:

--- a/mage_ai/io/io_config.py
+++ b/mage_ai/io/io_config.py
@@ -18,19 +18,19 @@ class IOConfig:
         """
         self.filepath = pathlib.Path(filepath)
 
-    def use(self, profile: str = 'default') -> Mapping[str, Any]:
+    def use(self, profile: str) -> Mapping[str, Any]:
         """
         Specifies the profile to use. Profiles are sets of configuration settings.
 
         Args:
-            profile (str, optional): Name of the profile to use. Defaults to 'default'.
+            profile (str): Name of the profile to use.
 
         Returns:
             Mapping[str, Any]: Configuration settings for this profile
         """
         with self.filepath.open('r') as fin:
-            config = yaml.full_load(fin)
+            config = yaml.full_load(fin.read())
         profile_settings = config.get(profile)
         if profile_settings is None:
-            raise ValueError(f'Invalid config profile specified: \'{profile}\'')
+            raise ValueError(f'Invalid configuration profile specified: \'{profile}\'')
         return profile_settings

--- a/mage_ai/io/io_config.py
+++ b/mage_ai/io/io_config.py
@@ -9,7 +9,7 @@ class IOConfig:
     Wrapper around IO configuration file.
     """
 
-    def __init__(self, filepath: os.PathLike) -> None:
+    def __init__(self, filepath: os.PathLike = './default_repo/io_config.yaml') -> None:
         """
         Initializes IO Configuration loader
 

--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -1,6 +1,7 @@
 from mage_ai.io.base import BaseSQL
 from pandas import DataFrame, read_sql
 from sqlalchemy import create_engine
+from typing import Any, Mapping
 
 
 class Postgres(BaseSQL):
@@ -86,3 +87,8 @@ class Postgres(BaseSQL):
         """
         with self.printer.print_msg(f'Exporting data frame to table \'{name}\''):
             df.to_sql(name, self.conn, index=index, if_exists=if_exists, **kwargs)
+        df.to_sql(name, self.conn, index=index, if_exists=if_exists, **kwargs)
+
+    @classmethod
+    def with_config(cls, config: Mapping[str, Any]) -> 'Postgres':
+        return cls(**config['PostgreSQL'])

--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -1,4 +1,5 @@
 from mage_ai.io.base import BaseSQL
+from mage_ai.io.io_config import IOConfigKeys
 from pandas import DataFrame, read_sql
 from sqlalchemy import create_engine
 from typing import Any, Mapping
@@ -91,4 +92,9 @@ class Postgres(BaseSQL):
 
     @classmethod
     def with_config(cls, config: Mapping[str, Any]) -> 'Postgres':
-        return cls(**config['PostgreSQL'])
+        try:
+            return cls(**config[IOConfigKeys.POSTGRES])
+        except KeyError:
+            raise KeyError(
+                f'No configuration settings found for \'{IOConfigKeys.POSTGRES}\' under profile'
+            )

--- a/mage_ai/io/redshift.py
+++ b/mage_ai/io/redshift.py
@@ -1,6 +1,7 @@
 from mage_ai.io.base import BaseSQL
 from pandas import DataFrame
 from redshift_connector import connect
+from typing import Any, Mapping
 
 
 class Redshift(BaseSQL):
@@ -13,6 +14,16 @@ class Redshift(BaseSQL):
         Initializes settings for connecting to a cluster.
         """
         super().__init__(**kwargs)
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any]) -> 'Redshift':
+        aws_config = config['AWS']
+        redshift_config = aws_config['Redshift']
+        credentials = ['aws_access_key_id', 'aws_secret_access_key', 'region_name']
+        for credential in credentials:
+            if credential in aws_config:
+                redshift_config[credential] = aws_config[credential]
+        return cls(**redshift_config)
 
     def open(self) -> None:
         """

--- a/mage_ai/io/redshift.py
+++ b/mage_ai/io/redshift.py
@@ -76,6 +76,16 @@ class Redshift(BaseSQL):
                 cur.write_dataframe(df, table_name)
 
     @classmethod
+    def with_config(cls, config: Mapping[str, Any]) -> 'Redshift':
+        aws_config = config['AWS']
+        redshift_config = aws_config['Redshift']
+        credentials = ['aws_access_key_id', 'aws_secret_access_key', 'region_name']
+        for credential in credentials:
+            if credential in aws_config:
+                redshift_config[credential] = aws_config[credential]
+        return cls(**redshift_config)
+
+    @classmethod
     def with_temporary_credentials(
         cls, database: str, host: str, user: str, password: str, port: int = 5439, **kwargs
     ):

--- a/mage_ai/io/redshift.py
+++ b/mage_ai/io/redshift.py
@@ -15,16 +15,6 @@ class Redshift(BaseSQL):
         """
         super().__init__(**kwargs)
 
-    @classmethod
-    def with_config(cls, config: Mapping[str, Any]) -> 'Redshift':
-        aws_config = config['AWS']
-        redshift_config = aws_config['Redshift']
-        credentials = ['aws_access_key_id', 'aws_secret_access_key', 'region_name']
-        for credential in credentials:
-            if credential in aws_config:
-                redshift_config[credential] = aws_config[credential]
-        return cls(**redshift_config)
-
     def open(self) -> None:
         """
         Opens a connection to the Redshift cluster.
@@ -88,7 +78,7 @@ class Redshift(BaseSQL):
     @classmethod
     def with_temporary_credentials(
         cls, database: str, host: str, user: str, password: str, port: int = 5439, **kwargs
-    ):
+    ) -> 'Redshift':
         """
         Creates a Redshift data loader from temporary database credentials
 
@@ -113,7 +103,7 @@ class Redshift(BaseSQL):
         db_user: str,
         profile: str = 'default',
         **kwargs,
-    ):
+    ) -> 'Redshift':
         """
         Creates a Redshift data loader using an IAM profile from `~/.aws`.
 

--- a/mage_ai/io/redshift.py
+++ b/mage_ai/io/redshift.py
@@ -1,4 +1,5 @@
 from mage_ai.io.base import BaseSQL
+from mage_ai.io.io_config import IOConfigKeys
 from pandas import DataFrame
 from redshift_connector import connect
 from typing import Any, Mapping
@@ -67,8 +68,14 @@ class Redshift(BaseSQL):
 
     @classmethod
     def with_config(cls, config: Mapping[str, Any]) -> 'Redshift':
-        aws_config = config['AWS']
-        redshift_config = aws_config['Redshift']
+        try:
+            aws_config = config[IOConfigKeys.AWS]
+            redshift_config = aws_config[IOConfigKeys.REDSHIFT]
+        except KeyError:
+            raise KeyError(
+                f'No configuration settings found for '
+                '\'{IOConfigKeys.AWS}.{IOConfigKeys.REDSHIFT}\' under profile'
+            )
         credentials = ['access_key_id', 'secret_access_key', 'region']
         for credential in credentials:
             if credential in aws_config:

--- a/mage_ai/io/redshift.py
+++ b/mage_ai/io/redshift.py
@@ -74,7 +74,7 @@ class Redshift(BaseSQL):
         except KeyError:
             raise KeyError(
                 f'No configuration settings found for '
-                '\'{IOConfigKeys.AWS}.{IOConfigKeys.REDSHIFT}\' under profile'
+                f'\'{IOConfigKeys.AWS}.{IOConfigKeys.REDSHIFT}\' under profile'
             )
         credentials = ['access_key_id', 'secret_access_key', 'region']
         for credential in credentials:

--- a/mage_ai/io/redshift.py
+++ b/mage_ai/io/redshift.py
@@ -16,7 +16,7 @@ class Redshift(BaseSQL):
         super().__init__(**kwargs)
 
     @classmethod
-    def from_config(cls, config: Mapping[str, Any]) -> 'Redshift':
+    def with_config(cls, config: Mapping[str, Any]) -> 'Redshift':
         aws_config = config['AWS']
         redshift_config = aws_config['Redshift']
         credentials = ['aws_access_key_id', 'aws_secret_access_key', 'region_name']

--- a/mage_ai/io/redshift.py
+++ b/mage_ai/io/redshift.py
@@ -69,7 +69,7 @@ class Redshift(BaseSQL):
     def with_config(cls, config: Mapping[str, Any]) -> 'Redshift':
         aws_config = config['AWS']
         redshift_config = aws_config['Redshift']
-        credentials = ['aws_access_key_id', 'aws_secret_access_key', 'region_name']
+        credentials = ['access_key_id', 'secret_access_key', 'region']
         for credential in credentials:
             if credential in aws_config:
                 redshift_config[credential] = aws_config[credential]

--- a/mage_ai/io/s3.py
+++ b/mage_ai/io/s3.py
@@ -111,7 +111,7 @@ class S3(BaseFile):
                 )
 
     @classmethod
-    def from_config(cls, config: Mapping[str, Any]) -> 'S3':
+    def with_config(cls, config: Mapping[str, Any]) -> 'S3':
         aws_config = config['AWS']
         s3_config = aws_config['S3']
         credentials = ['aws_access_key_id', 'aws_secret_access_key', 'region_name']

--- a/mage_ai/io/s3.py
+++ b/mage_ai/io/s3.py
@@ -3,6 +3,7 @@ from typing import Mapping
 from mage_ai.io.base import BaseFile, FileFormat
 from pandas import DataFrame
 from pathlib import Path
+from typing import Any, Mapping
 import boto3
 
 
@@ -108,6 +109,16 @@ class S3(BaseFile):
                 self.client.put_object(
                     Body=buffer, Bucket=self.bucket_name, Key=self.filepath, **export_config
                 )
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any]) -> 'S3':
+        aws_config = config['AWS']
+        s3_config = aws_config['S3']
+        credentials = ['aws_access_key_id', 'aws_secret_access_key', 'region_name']
+        for credential in credentials:
+            if credential in aws_config:
+                s3_config[credential] = aws_config[credential]
+        return cls(**s3_config)
 
     @classmethod
     def with_credentials(

--- a/mage_ai/io/s3.py
+++ b/mage_ai/io/s3.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 from typing import Mapping
 from mage_ai.io.base import BaseFile, FileFormat
+from mage_ai.io.io_config import IOConfigKeys
 from pandas import DataFrame
 from pathlib import Path
 from typing import Any, Mapping
@@ -112,8 +113,14 @@ class S3(BaseFile):
 
     @classmethod
     def with_config(cls, config: Mapping[str, Any]) -> 'S3':
-        aws_config = config['AWS']
-        s3_config = aws_config['S3']
+        try:
+            aws_config = config[IOConfigKeys.AWS]
+            s3_config = aws_config[IOConfigKeys.S3]
+        except KeyError:
+            raise KeyError(
+                f'No configuration settings found for '
+                '\'{IOConfigKeys.AWS}.{IOConfigKeys.S3}\' under profile'
+            )
         credentials = ['access_key_id', 'secret_access_key', 'region']
         parameters = ['aws_access_key_id', 'aws_secret_access_key', 'region_name']
         for credential, parameter in zip(credentials, parameters):

--- a/mage_ai/io/s3.py
+++ b/mage_ai/io/s3.py
@@ -114,10 +114,11 @@ class S3(BaseFile):
     def with_config(cls, config: Mapping[str, Any]) -> 'S3':
         aws_config = config['AWS']
         s3_config = aws_config['S3']
-        credentials = ['aws_access_key_id', 'aws_secret_access_key', 'region_name']
-        for credential in credentials:
+        credentials = ['access_key_id', 'secret_access_key', 'region']
+        parameters = ['aws_access_key_id', 'aws_secret_access_key', 'region_name']
+        for credential, parameter in zip(credentials, parameters):
             if credential in aws_config:
-                s3_config[credential] = aws_config[credential]
+                s3_config[parameter] = aws_config[credential]
         return cls(**s3_config)
 
     @classmethod

--- a/mage_ai/io/s3.py
+++ b/mage_ai/io/s3.py
@@ -119,7 +119,7 @@ class S3(BaseFile):
         except KeyError:
             raise KeyError(
                 f'No configuration settings found for '
-                '\'{IOConfigKeys.AWS}.{IOConfigKeys.S3}\' under profile'
+                f'\'{IOConfigKeys.AWS}.{IOConfigKeys.S3}\' under profile'
             )
         credentials = ['access_key_id', 'secret_access_key', 'region']
         parameters = ['aws_access_key_id', 'aws_secret_access_key', 'region_name']

--- a/mage_ai/io/snowflake.py
+++ b/mage_ai/io/snowflake.py
@@ -2,6 +2,7 @@ from mage_ai.io.base import BaseSQL
 from pandas import DataFrame
 from snowflake.connector import connect
 from snowflake.connector.pandas_tools import write_pandas
+from typing import Any, Mapping
 
 
 class Snowflake(BaseSQL):
@@ -117,3 +118,7 @@ class Snowflake(BaseSQL):
                 auto_create_table=auto_create_table,
                 **kwargs,
             )
+
+    @classmethod
+    def with_config(cls, config: Mapping[str, Any]) -> 'Snowflake':
+        return cls(**config['Snowflake'])

--- a/mage_ai/io/snowflake.py
+++ b/mage_ai/io/snowflake.py
@@ -1,4 +1,5 @@
 from mage_ai.io.base import BaseSQL
+from mage_ai.io.io_config import IOConfigKeys
 from pandas import DataFrame
 from snowflake.connector import connect
 from snowflake.connector.pandas_tools import write_pandas
@@ -121,4 +122,9 @@ class Snowflake(BaseSQL):
 
     @classmethod
     def with_config(cls, config: Mapping[str, Any]) -> 'Snowflake':
-        return cls(**config['Snowflake'])
+        try:
+            return cls(**config[IOConfigKeys.SNOWFLAKE])
+        except KeyError:
+            raise KeyError(
+                f'No configuration settings found for \'{IOConfigKeys.SNOWFLAKE}\' under profile'
+            )

--- a/mage_ai/tests/data_preparation/test_templates.py
+++ b/mage_ai/tests/data_preparation/test_templates.py
@@ -102,9 +102,11 @@ def load_data() -> DataFrame:
         self.assertEqual(expected_template, new_template2)
 
     def test_template_generation_data_loader_specific(self):
-        redshift_template = """from mage_ai.io.io_config import IOConfig
+        redshift_template = """from mage_ai.data_preparation.repo_manager import get_repo_path
+from mage_ai.io.io_config import IOConfig
 from mage_ai.io.redshift import Redshift
 from pandas import DataFrame
+from os import path
 
 if 'data_loader' not in globals():
     from mage_ai.data_preparation.decorators import data_loader
@@ -117,15 +119,17 @@ def load_data_from_redshift() -> DataFrame:
     configuration parameters can be defined in your configuration file.
     \"\"\"
     query = 'your_redshift_selection_query'
-    config_path = './default_repo/io_config.yaml'
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
 
     with Redshift.with_config(IOConfig(config_path).use(config_profile)) as loader:
         return loader.load(query)
 """
-        s3_template = """from mage_ai.io.io_config import IOConfig
+        s3_template = """from mage_ai.data_preparation.repo_manager import get_repo_path
+from mage_ai.io.io_config import IOConfig
 from mage_ai.io.s3 import S3
 from pandas import DataFrame
+from os import path
 
 if 'data_loader' not in globals():
     from mage_ai.data_preparation.decorators import data_loader
@@ -139,7 +143,7 @@ def load_from_s3_bucket() -> DataFrame:
     If user credentials are not specified in `~/.aws`, you must specify your
     user credentials manually in your configuration file.
     \"\"\"
-    config_path = './default_repo/io_config.yaml'
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
 
     return S3.with_config(IOConfig(config_path).use(config_profile)).load()
@@ -365,9 +369,11 @@ def export_data(df: DataFrame) -> None:
         self.assertEqual(expected_template, new_template2)
 
     def test_template_generation_data_exporter_specific(self):
-        bigquery_template = """from mage_ai.io.bigquery import BigQuery
+        bigquery_template = """from mage_ai.data_preparation.repo_manager import get_repo_path
+from mage_ai.io.bigquery import BigQuery
 from mage_ai.io.io_config import IOConfig
 from pandas import DataFrame
+from os import path
 
 if 'data_exporter' not in globals():
     from mage_ai.data_preparation.decorators import data_exporter
@@ -400,7 +406,7 @@ def export_data_to_big_query(df: DataFrame) -> None:
     Alternatively, all parameters can be specified in the configuration file.
     \"\"\"
     table_id = 'your-project.your_dataset.your_table_name'
-    config_path = './default_repo/io_config.yaml'
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
 
     BigQuery.with_config(IOConfig(config_path).use(config_profile)).export(
@@ -409,9 +415,11 @@ def export_data_to_big_query(df: DataFrame) -> None:
         if_exists='replace',  # Specify resolution policy if table name already exists
     )
 """
-        snowflake_template = """from mage_ai.io.io_config import IOConfig
+        snowflake_template = """from mage_ai.data_preparation.repo_manager import get_repo_path
+from mage_ai.io.io_config import IOConfig
 from mage_ai.io.snowflake import Snowflake
 from pandas import DataFrame
+from os import path
 
 if 'data_exporter' not in globals():
     from mage_ai.data_preparation.decorators import data_exporter
@@ -425,7 +433,7 @@ def export_data_to_snowflake(df: DataFrame) -> None:
     table_name = 'your_table_name'
     database = 'your_database_name'
     schema = 'your_schema_name'
-    config_path = './default_repo/io_config.yaml'
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
 
     with Snowflake.with_config(IOConfig(config_path).use(config_profile)) as loader:

--- a/mage_ai/tests/data_preparation/test_templates.py
+++ b/mage_ai/tests/data_preparation/test_templates.py
@@ -102,7 +102,8 @@ def load_data() -> DataFrame:
         self.assertEqual(expected_template, new_template2)
 
     def test_template_generation_data_loader_specific(self):
-        redshift_template = """from mage_ai.io.redshift import Redshift
+        redshift_template = """from mage_ai.io.io_config import IOConfig
+from mage_ai.io.redshift import Redshift
 from pandas import DataFrame
 
 if 'data_loader' not in globals():
@@ -113,21 +114,17 @@ if 'data_loader' not in globals():
 def load_data_from_redshift() -> DataFrame:
     \"\"\"
     Template code for loading data from Redshift cluster. Additional
-    configuration parameters can be added to the `config` dictionary.
+    configuration parameters can be defined in your configuration file.
     \"\"\"
     query = 'your_redshift_selection_query'
-    config = {
-        'database': 'your_redshift_database_name',
-        'user': 'database_login_username',
-        'password': 'database_login_password',
-        'host': 'database_host',
-        'port': 'database_port',
-    }
+    config_path = 'path/to/your/io/config/file.yaml'
+    config_profile = 'default'
 
-    with Redshift.with_temporary_credentials(**config) as loader:
+    with Redshift.with_config(IOConfig(config_path).use(config_profile)) as loader:
         return loader.load(query)
 """
-        s3_template = """from mage_ai.io.s3 import S3
+        s3_template = """from mage_ai.io.io_config import IOConfig
+from mage_ai.io.s3 import S3
 from pandas import DataFrame
 
 if 'data_loader' not in globals():
@@ -139,14 +136,13 @@ def load_from_s3_bucket() -> DataFrame:
     \"\"\"
     Template code for loading data from S3 bucket.
 
-    This template assumes that user credentials are specified in `~/.aws`.
-    If not, use `S3.with_credentials()` to manually specify AWS credentials or use
-    AWS CLI to configure credentials on system.
+    If user credentials are not specified in `~/.aws`, you must specify your
+    user credentials manually in your configuration file.
     \"\"\"
-    bucket_name = 'your_s3_bucket_name'  # Specify S3 bucket name to pull data from
-    object_key = 'your_object_key'  # Specify object to download from S3 bucket
+    config_path = 'path/to/your/io/config/file.yaml'
+    config_profile = 'default'
 
-    return S3(bucket_name, object_key).load()
+    return S3.with_config(IOConfig(config_path).use(config_profile)).load()
 """
 
         config1 = {'data_source': DataSource.REDSHIFT}
@@ -370,6 +366,7 @@ def export_data(df: DataFrame) -> None:
 
     def test_template_generation_data_exporter_specific(self):
         bigquery_template = """from mage_ai.io.bigquery import BigQuery
+from mage_ai.io.io_config import IOConfig
 from pandas import DataFrame
 
 if 'data_exporter' not in globals():
@@ -399,19 +396,21 @@ def export_data_to_big_query(df: DataFrame) -> None:
     ```
     BigQuery.with_credentials_object({'service_key': ...}, **kwargs)
     ```
+
+    Alternatively, all parameters can be specified in the configuration file.
     \"\"\"
     table_id = 'your-project.your_dataset.your_table_name'
-    config = {
-        # Specify any other configuration settings here to pass to BigQuery client
-        'project': 'your_project_name',
-    }
-    return BigQuery(**config).export(
+    config_path = 'path/to/your/io/config/file.yaml'
+    config_profile = 'default'
+
+    BigQuery.with_config(IOConfig(config_path).use(config_profile)).export(
         df,
         table_id,
         if_exists='replace',  # Specify resolution policy if table name already exists
     )
 """
-        snowflake_template = """from mage_ai.io.snowflake import Snowflake
+        snowflake_template = """from mage_ai.io.io_config import IOConfig
+from mage_ai.io.snowflake import Snowflake
 from pandas import DataFrame
 
 if 'data_exporter' not in globals():
@@ -426,13 +425,10 @@ def export_data_to_snowflake(df: DataFrame) -> None:
     table_name = 'your_table_name'
     database = 'your_database_name'
     schema = 'your_schema_name'
-    config = {
-        'user': 'your_snowflake_username',
-        'password': 'your_snowflake_password',
-        'account': 'your_snowflake_account_identifier',
-    }
+    config_path = 'path/to/your/io/config/file.yaml'
+    config_profile = 'default'
 
-    with Snowflake(**config) as loader:
+    with Snowflake.with_config(IOConfig(config_path).use(config_profile)) as loader:
         return loader.export(
             df,
             table_name,

--- a/mage_ai/tests/data_preparation/test_templates.py
+++ b/mage_ai/tests/data_preparation/test_templates.py
@@ -117,7 +117,7 @@ def load_data_from_redshift() -> DataFrame:
     configuration parameters can be defined in your configuration file.
     \"\"\"
     query = 'your_redshift_selection_query'
-    config_path = 'path/to/your/io/config/file.yaml'
+    config_path = './default_repo/io_config.yaml'
     config_profile = 'default'
 
     with Redshift.with_config(IOConfig(config_path).use(config_profile)) as loader:
@@ -139,7 +139,7 @@ def load_from_s3_bucket() -> DataFrame:
     If user credentials are not specified in `~/.aws`, you must specify your
     user credentials manually in your configuration file.
     \"\"\"
-    config_path = 'path/to/your/io/config/file.yaml'
+    config_path = './default_repo/io_config.yaml'
     config_profile = 'default'
 
     return S3.with_config(IOConfig(config_path).use(config_profile)).load()
@@ -400,7 +400,7 @@ def export_data_to_big_query(df: DataFrame) -> None:
     Alternatively, all parameters can be specified in the configuration file.
     \"\"\"
     table_id = 'your-project.your_dataset.your_table_name'
-    config_path = 'path/to/your/io/config/file.yaml'
+    config_path = './default_repo/io_config.yaml'
     config_profile = 'default'
 
     BigQuery.with_config(IOConfig(config_path).use(config_profile)).export(
@@ -425,7 +425,7 @@ def export_data_to_snowflake(df: DataFrame) -> None:
     table_name = 'your_table_name'
     database = 'your_database_name'
     schema = 'your_schema_name'
-    config_path = 'path/to/your/io/config/file.yaml'
+    config_path = './default_repo/io_config.yaml'
     config_profile = 'default'
 
     with Snowflake.with_config(IOConfig(config_path).use(config_profile)) as loader:


### PR DESCRIPTION
# Summary
This code enables the user to define data IO configuration settings via a configuration file. In every repo created with `mage 
init`, a new file named `io_config.yaml` will be created, in which all IO configurations can be stored (alternatively from manually specifying the arguments in code). This is more useful, for example, when storing secret keys and access tokens where the secrets can be handled separately from code execution.

Here is a sample config file (contains only the default profile with credentials only for AWS data sources):
```yaml
default:
  AWS:
    Redshift:
      database: your_redshift_database_name
      # Use the settings below if you are using temporary credentials
      user: your_authentication_user_name
      password: your_authentication_password
      host: your_redshift_cluster_hostname
      port: your_redshift_cluster_port
      # Use the settings below if you are using IAM credentials
      cluster_identifier: your_redshift_identifier
      db_user: your_redshift_username
      profile: your_aws_credentials_profile
      iam: True
    S3:
      bucket_name: your_bucket_name
      object_key: your_object_key
    # Omit these settings if aws credentials are already configured on file
    aws_access_key_id: your_aws_access_key_id
    aws_secret_access_key: your_secret_access_key_id
    region_name: your_aws_region
```

To use this configuration file, use the following example code below:
```python
with BaseLoader.with_config(IOConfig(CONFIG_PATH).use('default')) as loader:
     pass
```
which initializes the data loader with the credentials stored in the `default` profile in `io_config.yaml`. The path to the config file should be specified as input to the constructor of the `IOConfig` object. The `.use()` function allows the user to specify the profile they wish to use.

In the example above, the 'AWS' and 'Redshift' objects are read to initialize the `Redshift` data loader. Specifically, the shared credentials from 'AWS' object and the specific 'Redshift' credentials are combined as inputs to the `Redshift` data loader. The implementation for how parameters are read from the configuration file are data loader dependent.

# Tests
Testing was performed to make sure that all data loaders still worked while loading this configuration file.

cc:
@wangxiaoyou1993 
