### PR TITLE
[dy] Add pre wrap property

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
@@ -109,7 +109,7 @@ function CodeOutput({
             } else if (dataType === DataTypeEnum.TEXT || dataType === DataTypeEnum.TEXT_PLAIN) {
               displayElement = (
                 <OutputRowStyle {...outputRowSharedProps}>
-                  <Text monospace>
+                  <Text monospace preWrap>
                     <Ansi>
                       {data}
                     </Ansi>

--- a/mage_ai/frontend/oracle/elements/Text/index.tsx
+++ b/mage_ai/frontend/oracle/elements/Text/index.tsx
@@ -54,6 +54,7 @@ export type TextProps = {
   noWrapping?: boolean;
   overflow?: string;
   overflowWrap?: boolean;
+  preWrap?: boolean;
   primary?: boolean;
   raw?: boolean;
   rightAligned?: boolean;
@@ -307,6 +308,10 @@ export const SHARED_STYLES = css<TextProps>`
 
   ${props => props.whiteSpaceNormal && `
     white-space: normal;
+  `}
+
+  ${props => props.preWrap && `
+    white-space: pre-wrap;
   `}
 `;
 


### PR DESCRIPTION
# Summary

Add white-space: pre-wrap to the code output text for traceback formatting. Otherwise, it was just ignoring the white space in the string.
<!-- Brief summary of what your code does -->

# Tests

![Screen Shot 2022-07-06 at 9 34 55 AM](https://user-images.githubusercontent.com/14357209/177599974-d0e8daef-6c34-4c7a-a25e-fd53dd6d2739.png)


<!-- How did you test your change? -->

cc: @tommydangerous @johnson-mage @shrey-mage 
<!-- Optionally mention someone to let them know about this pull request -->
