### PR TITLE
[jk] Fix rendering of Correlations chart

### DIFF
--- a/mage_ai/frontend/components/BlockCharts/index.tsx
+++ b/mage_ai/frontend/components/BlockCharts/index.tsx
@@ -4,7 +4,7 @@ import FlexContainer from '@oracle/components/FlexContainer';
 import HeatMap from '@components/charts/HeatMap';
 import RowDataTable from '@oracle/components/RowDataTable';
 import Spacing from '@oracle/elements/Spacing';
-import { UNIT } from '@oracle/styles/units/spacing';
+import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import {
   buildHeatmapData,
   buildNullValueData,
@@ -14,20 +14,22 @@ import {
 import { formatPercent } from '@utils/string';
 
 export type BlockOverviewProps = {
+  afterWidth: number;
   features: FeatureType[];
   insightsOverview: any;
   statistics: any;
 };
 
 function BlockCharts({
+  afterWidth,
   features,
   insightsOverview,
   statistics,
 }: BlockOverviewProps) {
-
   const {
     correlations = [],
   } = insightsOverview;
+  const finalAfterWidth = afterWidth - (2 * (PADDING_UNITS * UNIT));
 
   const { heatmapData, xyLabels } = buildHeatmapData(correlations);
   const nullValueData = buildNullValueData(features, statistics);
@@ -40,6 +42,7 @@ function BlockCharts({
         {nullValueData?.length >= 1 && (
           <RowDataTable
             headerTitle="Data completion"
+            width={finalAfterWidth}
           >
             <BarGraphHorizontal
               data={nullValueData.map(({ feature, value }) => ({
@@ -57,6 +60,7 @@ function BlockCharts({
         {uniqueValueData?.length >= 1 && (
           <RowDataTable
             headerTitle="Number of unique values"
+            width={finalAfterWidth}
           >
             <BarGraphHorizontal
               data={uniqueValueData.map(({ feature, value }) => ({
@@ -74,6 +78,7 @@ function BlockCharts({
         {distributionData.length >= 1 && (
           <RowDataTable
             headerTitle="Distribution of values"
+            width={finalAfterWidth}
           >
             <BarGraphHorizontal
               data={distributionData.map(({

--- a/mage_ai/frontend/components/Sidekick/constants.ts
+++ b/mage_ai/frontend/components/Sidekick/constants.ts
@@ -19,7 +19,6 @@ export enum ViewKeyEnum {
 export const FULL_WIDTH_VIEWS = [
   ViewKeyEnum.REPORTS,
   ViewKeyEnum.DATA,
-  ViewKeyEnum.GRAPHS,
 ];
 
 export const SIDEKICK_VIEWS = [

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -255,6 +255,7 @@ function Sidekick({
         }
         {activeView === ViewKeyEnum.GRAPHS &&
           <BlockCharts
+            afterWidth={afterWidth}
             features={features}
             insightsOverview={insightsOverview}
             statistics={statistics}

--- a/mage_ai/frontend/oracle/components/RowDataTable/index.style.ts
+++ b/mage_ai/frontend/oracle/components/RowDataTable/index.style.ts
@@ -25,6 +25,12 @@ type RowStyleProps = Pick<
   'border' | 'condensed' | 'last' | 'secondary' | 'noHorizontalPadding'
 >;
 
+export const TableStyle = styled.div<{ width: number }>`
+  ${props => props.width && `
+    width: ${props.width}px;
+  `}
+`;
+
 export const RowContainerStyle = styled.div<RowContainerStyleProps>`
   border-bottom-left-radius: ${BORDER_RADIUS}px;
   border-bottom-right-radius: ${BORDER_RADIUS}px;

--- a/mage_ai/frontend/oracle/components/RowDataTable/index.tsx
+++ b/mage_ai/frontend/oracle/components/RowDataTable/index.tsx
@@ -5,6 +5,7 @@ import Text from '@oracle/elements/Text';
 
 import {
   RowContainerStyle,
+  TableStyle,
   TitleStyle,
 } from './index.style';
 
@@ -15,6 +16,7 @@ export type RowDataTableProps = {
   headerTitle: string;
   minHeight?: number;
   scrollable?: boolean;
+  width?: number;
 };
 
 function RowDataTable({
@@ -24,9 +26,10 @@ function RowDataTable({
   headerTitle,
   minHeight,
   scrollable,
+  width,
 }: RowDataTableProps) {
   return (
-    <>
+    <TableStyle width={width}>
       <TitleStyle>
         <FlexContainer alignItems="center" justifyContent="space-between">
           <Text bold default>
@@ -52,7 +55,7 @@ function RowDataTable({
           },
         ))}
       </RowContainerStyle>
-    </>
+    </TableStyle>
   );
 }
 


### PR DESCRIPTION
# Summary
- The Correlations chart requires larger width than the Sidekick panel size, but the other charts will fit the panel width.

# Tests
![2022-07-07 12 21 50](https://user-images.githubusercontent.com/78053898/177855552-72ba0597-260e-4a75-bc57-571e3bbc2827.gif)


cc:
@shrey-mage 