### PR TITLE
[sk] Fixed bug in datetime syntax error detection

### DIFF
--- a/mage_ai/data_cleaner/column_types/column_type_detector.py
+++ b/mage_ai/data_cleaner/column_types/column_type_detector.py
@@ -65,13 +65,14 @@ def find_syntax_errors(series, column_type):
     ):
         str_series = str_series.astype(str)
         pattern = REGEX_NUMBER
-    elif (
-        column_type == ColumnType.DATETIME
-        and not np.issubdtype(dtype, np.datetime64)
-        and not dtype is pd.Timestamp
-    ):
-        str_series = str_series.astype(str)
-        pattern = REGEX_DATETIME
+    elif column_type == ColumnType.DATETIME:
+        check_syntax_errors = False
+        if type(dtype) is pd.core.dtypes.dtypes.DatetimeTZDtype:
+            dtype = dtype.base
+        if not (np.issubdtype(dtype, np.datetime64) or dtype is pd.Timestamp):
+            check_syntax_errors = True
+            str_series = str_series.astype(str)
+            pattern = REGEX_DATETIME
     else:
         check_syntax_errors = False
         pattern = None

--- a/mage_ai/data_cleaner/column_types/column_type_detector.py
+++ b/mage_ai/data_cleaner/column_types/column_type_detector.py
@@ -66,13 +66,13 @@ def find_syntax_errors(series, column_type):
         str_series = str_series.astype(str)
         pattern = REGEX_NUMBER
     elif column_type == ColumnType.DATETIME:
-        check_syntax_errors = False
         if type(dtype) is pd.core.dtypes.dtypes.DatetimeTZDtype:
             dtype = dtype.base
         if not (np.issubdtype(dtype, np.datetime64) or dtype is pd.Timestamp):
-            check_syntax_errors = True
             str_series = str_series.astype(str)
             pattern = REGEX_DATETIME
+        else:
+            check_syntax_errors = False
     else:
         check_syntax_errors = False
         pattern = None


### PR DESCRIPTION
# Summary
Fixed error in syntax error detection where some datetime datatypes returned by `type()` were not actually valid Python or NumPy types, causing the syntax error detection to crash. Now for these types alone, the actual underlying type is extracted and used instead.

# Tests
Local test and were performed alongside running previous unit tests.

cc:
@wangxiaoyou1993 
