### PR TITLE
[sk] Added *args to transformer template

### DIFF
--- a/mage_ai/data_preparation/models/block.py
+++ b/mage_ai/data_preparation/models/block.py
@@ -191,27 +191,28 @@ class Block:
             sig = signature(block_function)
 
             num_args = sum(arg.kind != Parameter.VAR_POSITIONAL for arg in sig.parameters.values())
-            includes_var_args = num_args != len(sig.parameters)
             num_inputs = len(input_vars)
             num_upstream = len(self.upstream_block_uuids)
+
+            has_var_args = num_args != len(sig.parameters)
 
             if num_args > num_inputs:
                 if num_upstream < num_args:
                     raise Exception(
                         f'Block {self.uuid} may be missing upstream dependencies. '
-                        f'It expected to have {"at least " if includes_var_args else ""}{num_args} arguments, '
+                        f'It expected to have {"at least " if has_var_args else ""}{num_args} arguments, '
                         f'but only received {num_inputs}. '
                         f'Confirm that the @{self.type} method declaration has the correct number of arguments.'
                     )
                 else:
                     raise Exception(
                         f'Block {self.uuid} is missing input arguments. '
-                        f'It expected to have {"at least " if includes_var_args else ""}{num_args} arguments, '
+                        f'It expected to have {"at least " if has_var_args else ""}{num_args} arguments, '
                         f'but only received {num_inputs}. '
                         f'Double check the @{self.type} method declaration has the correct number of arguments '
                         f'and that the upstream blocks have been executed.'
                     )
-            elif num_args < num_inputs and not includes_var_args:
+            elif num_args < num_inputs and not has_var_args:
                 if num_upstream > num_args:
                     raise Exception(
                         f'Block {self.uuid} may have too many upstream dependencies. '

--- a/mage_ai/data_preparation/models/block.py
+++ b/mage_ai/data_preparation/models/block.py
@@ -191,6 +191,7 @@ class Block:
             sig = signature(block_function)
 
             num_args = sum(arg.kind != Parameter.VAR_POSITIONAL for arg in sig.parameters.values())
+            includes_var_args = num_args != len(sig.parameters)
             num_inputs = len(input_vars)
             num_upstream = len(self.upstream_block_uuids)
 
@@ -198,17 +199,19 @@ class Block:
                 if num_upstream < num_args:
                     raise Exception(
                         f'Block {self.uuid} may be missing upstream dependencies. '
-                        f'It expected to have {num_args} arguments, but only received {num_inputs}. '
+                        f'It expected to have {"at least " if includes_var_args else ""}{num_args} arguments, '
+                        f'but only received {num_inputs}. '
                         f'Confirm that the @{self.type} method declaration has the correct number of arguments.'
                     )
                 else:
                     raise Exception(
                         f'Block {self.uuid} is missing input arguments. '
-                        f'It expected to have {num_args} arguments, but only received {num_inputs}. '
+                        f'It expected to have {"at least " if includes_var_args else ""}{num_args} arguments, '
+                        f'but only received {num_inputs}. '
                         f'Double check the @{self.type} method declaration has the correct number of arguments '
                         f'and that the upstream blocks have been executed.'
                     )
-            elif num_args < num_inputs and num_args == len(sig.parameters):
+            elif num_args < num_inputs and not includes_var_args:
                 if num_upstream > num_args:
                     raise Exception(
                         f'Block {self.uuid} may have too many upstream dependencies. '

--- a/mage_ai/data_preparation/templates/transformers/default.py
+++ b/mage_ai/data_preparation/templates/transformers/default.py
@@ -5,7 +5,7 @@ if 'transformer' not in globals():
 
 
 @transformer
-def transform_df(df: DataFrame) -> DataFrame:
+def transform_df(df: DataFrame, *args) -> DataFrame:
     """
     Template code for a transformer block.
 

--- a/mage_ai/data_preparation/templates/transformers/suggestion_fmt.jinja
+++ b/mage_ai/data_preparation/templates/transformers/suggestion_fmt.jinja
@@ -8,7 +8,7 @@ if 'transformer' not in globals():
 
 
 @transformer
-def {{ title }}(df: DataFrame) -> DataFrame:
+def {{ title }}(df: DataFrame, *args) -> DataFrame:
     """
     Transformer Action: {{ message }}
     """

--- a/mage_ai/data_preparation/templates/transformers/transformer_action_fmt.jinja
+++ b/mage_ai/data_preparation/templates/transformers/transformer_action_fmt.jinja
@@ -8,7 +8,7 @@ if 'transformer' not in globals():
 
 
 @transformer
-def execute_transformer_action(df: DataFrame) -> DataFrame:
+def execute_transformer_action(df: DataFrame, *args) -> DataFrame:
     """
     Execute Transformer Action: {{ action_type }}
     """

--- a/mage_ai/tests/data_preparation/test_templates.py
+++ b/mage_ai/tests/data_preparation/test_templates.py
@@ -39,7 +39,7 @@ if 'transformer' not in globals():
 
 
 @transformer
-def remove_rows_with_missing_entries(df: DataFrame) -> DataFrame:
+def remove_rows_with_missing_entries(df: DataFrame, *args) -> DataFrame:
     \"\"\"
     Transformer Action: Delete 3 rows to remove all missing values from the dataset.
     \"\"\"
@@ -164,7 +164,7 @@ if 'transformer' not in globals():
 
 
 @transformer
-def transform_df(df: DataFrame) -> DataFrame:
+def transform_df(df: DataFrame, *args) -> DataFrame:
     \"\"\"
     Template code for a transformer block.
 
@@ -199,7 +199,7 @@ if 'transformer' not in globals():
 
 
 @transformer
-def transform_df(df: DataFrame) -> DataFrame:
+def transform_df(df: DataFrame, *args) -> DataFrame:
     \"\"\"
     Template code for a transformer block.
 
@@ -237,7 +237,7 @@ if 'transformer' not in globals():
 
 
 @transformer
-def execute_transformer_action(df: DataFrame) -> DataFrame:
+def execute_transformer_action(df: DataFrame, *args) -> DataFrame:
     \"\"\"
     Execute Transformer Action: clean_column_name
     \"\"\"
@@ -265,7 +265,7 @@ if 'transformer' not in globals():
 
 
 @transformer
-def execute_transformer_action(df: DataFrame) -> DataFrame:
+def execute_transformer_action(df: DataFrame, *args) -> DataFrame:
     \"\"\"
     Execute Transformer Action: custom
     \"\"\"
@@ -294,7 +294,7 @@ if 'transformer' not in globals():
 
 
 @transformer
-def execute_transformer_action(df: DataFrame) -> DataFrame:
+def execute_transformer_action(df: DataFrame, *args) -> DataFrame:
     \"\"\"
     Execute Transformer Action: reformat
     \"\"\"
@@ -323,7 +323,7 @@ if 'transformer' not in globals():
 
 
 @transformer
-def execute_transformer_action(df: DataFrame) -> DataFrame:
+def execute_transformer_action(df: DataFrame, *args) -> DataFrame:
     \"\"\"
     Execute Transformer Action: add
     \"\"\"


### PR DESCRIPTION
# Summary
Added `*args` to transformer templates so errors are not thrown if parameters are unused. 

In addition, updated error checking so that if `*args` is specified as an input, a function with `n` upstream blocks can have _at most_ `n` parameters in the function signature (excluding `*args`). If more than `n` parameters are specified (excluding `*args`), an error is thrown since there are more parameters than inputs. If `*args` is not specified as an input, then the regular error checking is performed.

# Tests
Local tests were performed to make sure that errors are thrown properly.

cc:
@wangxiaoyou1993 @tommydangerous (bought up the issue)
