### PR TITLE
[sk] Running pipeline from command line now prints block debug messages

### DIFF
--- a/mage_ai/data_preparation/models/block.py
+++ b/mage_ai/data_preparation/models/block.py
@@ -18,6 +18,7 @@ from mage_ai.server.kernel_output_parser import DataType
 from mage_ai.shared.logger import VerboseFunctionExec
 import os
 import pandas as pd
+import sys
 
 
 class Block:
@@ -149,10 +150,10 @@ class Block:
             p.delete_block(p.get_block(self.uuid))
         os.remove(self.file_path)
 
-    async def execute(self, analyze_outputs=True, custom_code=None):
+    async def execute(self, analyze_outputs=True, custom_code=None, redirect_outputs=False):
         with VerboseFunctionExec(f'Executing {self.type} block: {self.uuid}'):
             try:
-                output = await self.execute_block(custom_code)
+                output = await self.execute_block(custom_code, redirect_outputs)
                 block_output = output['output']
                 self.__verify_outputs(block_output)
                 variable_mapping = dict(zip(self.output_variables.keys(), block_output))
@@ -228,7 +229,7 @@ class Block:
 
             return block_function
 
-    async def execute_block(self, custom_code=None):
+    async def execute_block(self, custom_code=None, redirect_outputs=False):
         def block_decorator(decorated_functions):
             def custom_code(function):
                 decorated_functions.append(function)
@@ -250,7 +251,7 @@ class Block:
                 ]
         outputs = []
         decorated_functions = []
-        stdout = StringIO()
+        stdout = StringIO() if redirect_outputs else sys.stdout
         with redirect_stdout(stdout):
             if custom_code is not None:
                 exec(custom_code, {self.type: block_decorator(decorated_functions)})
@@ -264,7 +265,12 @@ class Block:
                     outputs = []
                 if type(outputs) is not list:
                     outputs = [outputs]
-        return dict(output=outputs, stdout=stdout.getvalue())
+
+        output_message = dict(output=outputs)
+        if redirect_outputs:
+            output_message['stdout'] = stdout.getvalue()
+
+        return output_message
 
     def exists(self):
         return os.path.exists(self.file_path)

--- a/mage_ai/data_preparation/models/block.py
+++ b/mage_ai/data_preparation/models/block.py
@@ -269,6 +269,8 @@ class Block:
         output_message = dict(output=outputs)
         if redirect_outputs:
             output_message['stdout'] = stdout.getvalue()
+        else:
+            output_message['stdout'] = ''
 
         return output_message
 

--- a/mage_ai/data_preparation/models/block.py
+++ b/mage_ai/data_preparation/models/block.py
@@ -153,7 +153,9 @@ class Block:
     async def execute(self, analyze_outputs=True, custom_code=None, redirect_outputs=False):
         with VerboseFunctionExec(f'Executing {self.type} block: {self.uuid}'):
             try:
-                output = await self.execute_block(custom_code, redirect_outputs)
+                output = await self.execute_block(
+                    custom_code=custom_code, redirect_outputs=redirect_outputs
+                )
                 block_output = output['output']
                 self.__verify_outputs(block_output)
                 variable_mapping = dict(zip(self.output_variables.keys(), block_output))

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -104,11 +104,15 @@ class ApiPipelineHandler(BaseHandler):
         pipeline = Pipeline(pipeline_uuid, get_repo_path())
         include_content = self.get_bool_argument('include_content', True)
         include_outputs = self.get_bool_argument('include_outputs', True)
-        self.write(dict(pipeline=pipeline.to_dict(
-            include_content=include_content,
-            include_outputs=include_outputs,
-            sample_count=DATAFRAME_SAMPLE_COUNT_PREVIEW,
-        )))
+        self.write(
+            dict(
+                pipeline=pipeline.to_dict(
+                    include_content=include_content,
+                    include_outputs=include_outputs,
+                    sample_count=DATAFRAME_SAMPLE_COUNT_PREVIEW,
+                )
+            )
+        )
         self.finish()
 
     def put(self, pipeline_uuid):
@@ -119,21 +123,29 @@ class ApiPipelineHandler(BaseHandler):
         update_content = self.get_bool_argument('update_content', False)
         data = json.loads(self.request.body).get('pipeline', {})
         pipeline.update(data, update_content=update_content)
-        self.write(dict(pipeline=pipeline.to_dict(
-            include_content=update_content,
-            include_outputs=update_content,
-            sample_count=DATAFRAME_SAMPLE_COUNT_PREVIEW,
-        )))
+        self.write(
+            dict(
+                pipeline=pipeline.to_dict(
+                    include_content=update_content,
+                    include_outputs=update_content,
+                    sample_count=DATAFRAME_SAMPLE_COUNT_PREVIEW,
+                )
+            )
+        )
 
 
 class ApiPipelineExecuteHandler(BaseHandler):
     def post(self, pipeline_uuid):
         pipeline = Pipeline(pipeline_uuid, get_repo_path())
-        asyncio.run(pipeline.execute())
-        self.write(dict(pipeline=pipeline.to_dict(
-            include_outputs=True,
-            sample_count=DATAFRAME_SAMPLE_COUNT_PREVIEW,
-        )))
+        asyncio.run(pipeline.execute(redirect_outputs=True))
+        self.write(
+            dict(
+                pipeline=pipeline.to_dict(
+                    include_outputs=True,
+                    sample_count=DATAFRAME_SAMPLE_COUNT_PREVIEW,
+                )
+            )
+        )
         self.finish()
 
 
@@ -157,10 +169,14 @@ class ApiPipelineBlockHandler(BaseHandler):
         include_outputs = self.get_bool_argument('include_outputs', True)
         if block is None:
             raise Exception(f'Block {block_uuid} does not exist in pipeline {pipeline_uuid}')
-        self.write(dict(block=block.to_dict(
-            include_content=True,
-            include_outputs=include_outputs,
-        )))
+        self.write(
+            dict(
+                block=block.to_dict(
+                    include_content=True,
+                    include_outputs=include_outputs,
+                )
+            )
+        )
         self.finish()
 
     def put(self, pipeline_uuid, block_uuid):
@@ -190,10 +206,14 @@ class ApiPipelineBlockExecuteHandler(BaseHandler):
         block = pipeline.get_block(block_uuid)
         if block is None:
             raise Exception(f'Block {block_uuid} does not exist in pipeline {pipeline_uuid}')
-        asyncio.run(block.execute())
-        self.write(dict(block=block.to_dict(
-            include_outputs=True,
-        )))
+        asyncio.run(block.execute(redirect_outputs=True))
+        self.write(
+            dict(
+                block=block.to_dict(
+                    include_outputs=True,
+                )
+            )
+        )
         self.finish()
 
 
@@ -201,11 +221,15 @@ class ApiPipelineBlockListHandler(BaseHandler):
     def get(self, pipeline_uuid):
         pipeline = Pipeline(pipeline_uuid, get_repo_path())
         include_outputs = self.get_bool_argument('include_outputs', True)
-        self.write(dict(blocks=pipeline.to_dict(
-            include_content=True,
-            include_outputs=include_outputs,
-            sample_count=DATAFRAME_SAMPLE_COUNT_PREVIEW,
-        )['blocks']))
+        self.write(
+            dict(
+                blocks=pipeline.to_dict(
+                    include_content=True,
+                    include_outputs=include_outputs,
+                    sample_count=DATAFRAME_SAMPLE_COUNT_PREVIEW,
+                )['blocks']
+            )
+        )
         self.finish()
 
     def post(self, pipeline_uuid):
@@ -250,11 +274,14 @@ class ApiPipelineBlockOutputHandler(BaseHandler):
 class ApiPipelineVariableListHandler(BaseHandler):
     def get(self, pipeline_uuid):
         variables_dict = VariableManager(get_repo_path()).get_variables_by_pipeline(pipeline_uuid)
-        variables = [dict(
-            block=dict(uuid=uuid),
-            pipeline=dict(uuid=pipeline_uuid),
-            variables=arr,
-        ) for uuid, arr in variables_dict.items()]
+        variables = [
+            dict(
+                block=dict(uuid=uuid),
+                pipeline=dict(uuid=pipeline_uuid),
+                variables=arr,
+            )
+            for uuid, arr in variables_dict.items()
+        ]
         self.write(dict(variables=variables))
         self.finish()
 

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -137,7 +137,7 @@ class ApiPipelineHandler(BaseHandler):
 class ApiPipelineExecuteHandler(BaseHandler):
     def post(self, pipeline_uuid):
         pipeline = Pipeline(pipeline_uuid, get_repo_path())
-        asyncio.run(pipeline.execute(redirect_outputs=True))
+        asyncio.run(pipeline.execute())
         self.write(
             dict(
                 pipeline=pipeline.to_dict(

--- a/mage_ai/server/websocket.py
+++ b/mage_ai/server/websocket.py
@@ -61,13 +61,17 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
             stdout = None
             if block is not None and block.type in CUSTOM_EXECUTION_BLOCK_TYPES:
                 try:
-                    block_output = asyncio.run(block.execute(custom_code=code))
+                    block_output = asyncio.run(
+                        block.execute(custom_code=code, redirect_outputs=True)
+                    )
                     stdout = block_output['stdout']
                     output = block_output['output']
                     if len(output) > 0:
                         for out in output:
-                            if type(out) == pd.DataFrame \
-                                and out.shape[0] > DATAFRAME_SAMPLE_COUNT_PREVIEW:
+                            if (
+                                type(out) == pd.DataFrame
+                                and out.shape[0] > DATAFRAME_SAMPLE_COUNT_PREVIEW
+                            ):
 
                                 out = out.iloc[:DATAFRAME_SAMPLE_COUNT_PREVIEW]
                             final_output.append(out)
@@ -112,7 +116,7 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
                         data=stdout,
                         type=DataType.TEXT,
                         uuid=uuid,
-                    )
+                    ),
                 )
                 messages.append(stdout_message)
 
@@ -138,8 +142,10 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
             )
         )
 
-        print(f'[{uuid}] Sending {len(messages)} messages for {msg_id} to '
-              f'{len(self.clients)} client(s): {messages}')
+        print(
+            f'[{uuid}] Sending {len(messages)} messages for {msg_id} to '
+            f'{len(self.clients)} client(s): {messages}'
+        )
 
         for client in self.clients:
             for m in messages:


### PR DESCRIPTION
# Summary
Running the pipeline from the command line now all debug messages from the block. This was done by selectively enabling stdout redirection only when a server-side API call is made.

# Tests
Local tests were performed to confirm that the command line print debug messages as well as the frontend notebook.

cc:
@wangxiaoyou1993 
