### PR TITLE
[sk] Filter out virtual environment

### DIFF
--- a/mage_ai/data_preparation/models/file.py
+++ b/mage_ai/data_preparation/models/file.py
@@ -3,6 +3,7 @@ from typing import Dict
 import os
 
 MAX_DEPTH = 30
+BLACKLISTED_DIRS = frozenset(['venv', 'env'])
 INACCESSIBLE_DIRS = frozenset(['__pycache__'])
 
 
@@ -73,6 +74,9 @@ def traverse(name: str, is_dir: str, path: str, disabled=False, depth=1) -> Dict
             can_access_children,
             depth + 1,
         )
-        for entry in sorted(os.scandir(path), key=lambda entry: entry.name)
+        for entry in sorted(
+            filter(lambda entry: entry.name not in BLACKLISTED_DIRS, os.scandir(path)),
+            key=lambda entry: entry.name,
+        )
     )
     return tree_entry

--- a/mage_ai/data_preparation/models/file.py
+++ b/mage_ai/data_preparation/models/file.py
@@ -2,9 +2,9 @@ from mage_ai.data_preparation.repo_manager import get_repo_path
 from typing import Dict
 import os
 
-MAX_DEPTH = 30
 BLACKLISTED_DIRS = frozenset(['venv', 'env'])
 INACCESSIBLE_DIRS = frozenset(['__pycache__'])
+MAX_DEPTH = 30
 
 
 class File:


### PR DESCRIPTION
# Summary
File tree now excludes `venv` and `env`, which often include the virtual environment.

# Tests
Tested locally.

cc:
@wangxiaoyou1993 
