### PR TITLE
[sp] add keyboard shortcuts for renaming pipeline

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
@@ -19,12 +19,14 @@ import Tooltip from '@oracle/components/Tooltip';
 import dark from '@oracle/styles/themes/dark';
 import { Close, FileFill } from '@oracle/icons';
 import { FileTabStyle, PipelineHeaderStyle } from './index.style';
+import { KEY_CODE_ENTER } from '@utils/hooks/keyboardShortcuts/constants';
 import { ThemeType } from '@oracle/styles/themes/constants';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { dateFormatLongFromUnixTimestamp } from '@utils/string';
 import { goToWithQuery } from '@utils/routing';
 import { remove } from '@utils/array';
 import { pauseEvent } from '@utils/events';
+import { useKeyboardContext } from '@context/Keyboard';
 
 type KernelStatusProps = {
   filePaths: string[];
@@ -82,6 +84,32 @@ function KernelStatus({
   } else {
     saveStatus = 'All changes saved';
   }
+
+  const uuidKeyboard = 'PipelineDetail/KernelStatus';
+  const {
+    registerOnKeyDown,
+    unregisterOnKeyDown,
+  } = useKeyboardContext();
+
+  useEffect(() => () => {
+    unregisterOnKeyDown(uuidKeyboard);
+  }, [unregisterOnKeyDown, uuidKeyboard]);
+
+  registerOnKeyDown(
+    uuidKeyboard,
+    (event, keyMapping, keyHistory) => {
+      if (isEditingPipeline && String(keyHistory[0]) === String(KEY_CODE_ENTER)) {
+        setIsEditingPipeline(false);
+        updatePipelineName(newPipelineName);
+      }
+    },
+    [
+      isEditingPipeline,
+      newPipelineName,
+      setIsEditingPipeline,
+      updatePipelineName,
+    ],
+  );
 
   const pipelineNameInput = useMemo(() => (
     <LabelWithValueClicker
@@ -179,8 +207,8 @@ function KernelStatus({
                     <Spacing ml={1} />
                     <Link
                       onClick={() => {
-                        updatePipelineName(newPipelineName);
                         setIsEditingPipeline(false);
+                        updatePipelineName(newPipelineName);
                       }}
                       preventDefault
                       sameColorAsText


### PR DESCRIPTION
[DRAFT, known bugs but wasn't sure how to fix. Hoping someone could take a look]

# Summary
- hitting "Enter" will hide the rename pipeline UI and rename the pipeline

# Known Issues
1. When hitting enter to rename the pipeline, it sometimes gets in this state where you click on the pipeline name, it shows the edit UI, and then instantly disappears. seems to be an issue with `LabelWithValueClicker`'s `onBlur`, but I was unsure how to fix.
2. If you hit enter without changing the pipeline's name, the pipeline UI doesn't get hidden.

# Tests
1. the "instant-hide" bug
![2022-07-11 16 00 47](https://user-images.githubusercontent.com/105667442/178372963-541a925e-7fae-4627-9b6a-7765d865f051.gif)
2. the "same name doesn't hide" bug: harder to reproduce, and might have been fixed by reordering function calls

cc: @tommydangerous @johnson-mage @dy46 
