### PR TITLE
[sk] Added frozen dictionary type to handle lists with dictionary objects

### DIFF
--- a/mage_ai/data_cleaner/shared/utils.py
+++ b/mage_ai/data_cleaner/shared/utils.py
@@ -1,6 +1,6 @@
 from mage_ai.data_cleaner.column_types.constants import NUMBER_TYPES, ColumnType
-from mage_ai.shared.custom_types import FrozenDict
 from mage_ai.data_cleaner.transformer_actions.constants import CURRENCY_SYMBOLS
+from mage_ai.shared.custom_types import FrozenDict
 from pandas.core.indexes.frozen import FrozenList
 from typing import Any, List, Union
 import pandas as pd
@@ -88,10 +88,9 @@ def __parse_element(element: str) -> Any:
         return np.nan
     else:
         try:
-            parsed_element = eval(element)
+            return __resolve_type(eval(element))
         except:
-            parsed_element = None
-    return __resolve_type(parsed_element)
+            return None
 
 
 def __resolve_type(element: Any) -> Any:
@@ -105,9 +104,7 @@ def parse_list(list_literal: Union[str, List[Any]]) -> FrozenList:
     if dtype is FrozenList:
         return list_literal
     elif dtype in LIST_TYPES:
-        if any(not pd.api.types.is_hashable(literal) for literal in list_literal):
-            return FrozenList([__resolve_type(literal) for literal in list_literal])
-        return FrozenList(list_literal)
+        return FrozenList([__resolve_type(literal) for literal in list_literal])
     elif list_literal in NONE_TYPES:
         return list_literal
     elif dtype is not str:

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -341,7 +341,7 @@ class StatisticsCalculator:
                 data[f'{col}/mode'] = mode
 
             data[f'{col}/mode_ratio'] = (
-                df_value_counts.iloc[mode_idx].item() / df_value_counts.sum() if mode else 0
+                df_value_counts[mode].item() / df_value_counts.sum() if mode else 0
             )
 
         # Detect mismatched formats for some column types

--- a/mage_ai/data_cleaner/statistics/calculator.py
+++ b/mage_ai/data_cleaner/statistics/calculator.py
@@ -2,6 +2,7 @@ from mage_ai.data_cleaner.column_types.column_type_detector import find_syntax_e
 from mage_ai.data_cleaner.column_types.constants import NUMBER_TYPES, ColumnType
 from mage_ai.data_cleaner.shared.utils import clean_dataframe
 from mage_ai.shared.constants import SAMPLE_SIZE
+from mage_ai.shared.custom_types import FrozenDict
 from mage_ai.shared.hash import merge_dict
 from mage_ai.shared.logger import timer, VerboseFunctionExec
 import math
@@ -311,6 +312,12 @@ class StatisticsCalculator:
                 element_value_counts = elements.value_counts(dropna=False)
                 data[f'{col}/most_frequent_element'] = element_value_counts.index[0]
                 data[f'{col}/least_frequent_element'] = element_value_counts.index[-1]
+                if any(
+                    isinstance(idx, FrozenDict)
+                    for idx in element_value_counts.index[:VALUE_COUNT_LIMIT]
+                ):
+                    str_index = element_value_counts.index.astype(str)
+                    element_value_counts.index = str_index
                 data[f'{col}/element_distribution'] = element_value_counts.head(
                     VALUE_COUNT_LIMIT
                 ).to_dict()
@@ -334,7 +341,7 @@ class StatisticsCalculator:
                 data[f'{col}/mode'] = mode
 
             data[f'{col}/mode_ratio'] = (
-                df_value_counts[mode].item() / df_value_counts.sum() if mode else 0
+                df_value_counts.iloc[mode_idx].item() / df_value_counts.sum() if mode else 0
             )
 
         # Detect mismatched formats for some column types

--- a/mage_ai/shared/custom_types.py
+++ b/mage_ai/shared/custom_types.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+
+class FrozenDict(dict):
+    def __setitem__(self, __k, __v) -> None:
+        raise AttributeError('Cannot assign a value to frozen dictionary')
+
+    def __delitem__(self, __v) -> None:
+        raise AttributeError('Cannot delete a value from frozen dictionary')
+
+    def clear(self) -> None:
+        raise AttributeError('Cannot clear a frozen dictionary')
+
+    def pop(self, __k) -> Any:
+        raise AttributeError('Cannot remove item from a frozen dictionary')
+
+    def popitem(self) -> Any:
+        raise AttributeError('Cannot remove item from a frozen dictionary')
+
+    def setdefault(self, __k, __v=None) -> Any:
+        if __k in self.keys():
+            return self[__k]
+        else:
+            raise AttributeError('Cannot assign a value to frozen dictionary')
+
+    def update(self, other=None) -> Any:
+        raise AttributeError('Cannot assign a value to frozen dictionary')
+
+    def __hash__(self):
+        # TODO: Come up with better hash function
+        return hash(tuple((key, str(value)) for key, value in self.items()))

--- a/mage_ai/tests/data_cleaner/statistics/test_calculator.py
+++ b/mage_ai/tests/data_cleaner/statistics/test_calculator.py
@@ -396,6 +396,35 @@ class StatisticsCalculatorTest(TestCase):
         }
         self.assertEquals(expected_element_distribution, data['lists/element_distribution'])
 
+    def test_calculate_statistics_list_data_with_dictionaries(self):
+        lists = [
+            [{'e': 2}, 'string', False, None],
+            None,
+            [np.nan, 2.0, 'string', '3'],
+            ['not string?', True, True, 8, False, np.nan, None, {'another_dictionary': -2342.21}],
+            "['not string?'     ,  True,True   ,8, False, np.nan, None]",
+            [{'dictionary': 'weird'}],
+            [8, 9, 9, 8, 'pop', 'string'],
+        ]
+        df = pd.DataFrame({'lists': lists})
+        column_types = infer_column_types(df)
+        calculator = StatisticsCalculator(column_types)
+        data = calculator.calculate_statistics_overview(df, is_clean=False)
+        self.assertTrue(data['lists/most_frequent_element'] is np.nan)
+        self.assertEqual(data['lists/least_frequent_element'], 'pop')
+        self.assertEqual(data['lists/max_list_length'], 8)
+        self.assertEqual(data['lists/min_list_length'], 1)
+        self.assertAlmostEqual(data['lists/avg_list_length'], 5, 3)
+
+        expected_list_length_distribution = {
+            4: 2,
+            7: 1,
+            6: 1,
+            1: 1,
+            8: 1,
+        }
+        self.assertEquals(expected_list_length_distribution, data['lists/length_distribution'])
+
     def test_calculate_statistics_box_plot(self):
         df = pd.DataFrame(
             [


### PR DESCRIPTION
# Summary
A small edge case occurred when a list of dictionary objects was stored within a Pandas data frame. While support for lists was handled before, handling dictionary objects within these lists causes various problems throughout the data cleaning pipeline due to an inability to hash a dictionary (including in statistics calculation and graph generation). 

To solve this problem a `FrozenDict` type was created, an immutable key-value store that doesn't permit mutations. For this reason, this type can be hashable without any major concerns of mutability. All non-mutating operations are still supported (such as fetching values from the dictionary).

When parsing a dictionary item in a list, the dictionary is converted to a `FrozenDict`, allowing the dictionary objects to be handled by Pandas without any errors.

# Tests
Changes were tested locally alongside writing new unit test cases.

cc:
@wangxiaoyou1993 
