### PR TITLE
[dy] Escape single quotes in custom code

### DIFF
--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -140,6 +140,8 @@ __custom_output()
 
 
 def add_execution_code(pipeline_uuid: str, block_uuid: str, code: str) -> str:
+    escaped_code = re.escape(code)
+
     return f"""
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.data_preparation.repo_manager import get_repo_path
@@ -153,7 +155,7 @@ def execute_custom_code():
     block = pipeline.get_block(block_uuid)
 
     code = \'\'\'
-{code}
+{escaped_code}
     \'\'\'
 
     block_output = block.execute_sync(custom_code=code)

--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -140,7 +140,7 @@ __custom_output()
 
 
 def add_execution_code(pipeline_uuid: str, block_uuid: str, code: str) -> str:
-    escaped_code = re.escape(code)
+    escaped_code = code.replace("'", "\\'")
 
     return f"""
 from mage_ai.data_preparation.models.pipeline import Pipeline


### PR DESCRIPTION
# Summary

Escape single quotes so that the comment syntax doesn't cause issues when running the custom code
<!-- Brief summary of what your code does -->

# Tests

<img width="1239" alt="Screen Shot 2022-07-11 at 6 33 42 PM" src="https://user-images.githubusercontent.com/14357209/178388954-189a2093-593a-49a3-8748-635f5e53e5bf.png">

<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
