### PR TITLE
[xy] Catch empty sample data exception.

### DIFF
--- a/mage_ai/data_preparation/models/variable.py
+++ b/mage_ai/data_preparation/models/variable.py
@@ -113,7 +113,10 @@ class Variable:
         if not os.path.exists(file_path):
             return pd.DataFrame()
         if sample and os.path.exists(sample_file_path):
-            df = pd.read_parquet(sample_file_path, engine='pyarrow')
+            try:
+                df = pd.read_parquet(sample_file_path, engine='pyarrow')
+            except Exception:
+                df = pd.read_parquet(file_path, engine='pyarrow')
         else:
             df = pd.read_parquet(file_path, engine='pyarrow')
         if sample:


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Catch empty sample data exception and read from full path as a fallback.
```
server_1  | HTTPServerRequest(protocol='http', host='localhost:6789', method='GET', uri='/api/pipelines/demo_pipeline1', version='HTTP/1.1', remote_ip='172.20.0.1')
server_1  | Traceback (most recent call last):
server_1  |   File "/usr/local/lib/python3.10/site-packages/tornado/web.py", line 1702, in _execute
server_1  |     result = method(*self.path_args, **self.path_kwargs)
server_1  |   File "/home/src/mage_ai/server/server.py", line 122, in get
server_1  |     pipeline=pipeline.to_dict(
server_1  |   File "/home/src/mage_ai/data_preparation/models/pipeline.py", line 156, in to_dict
server_1  |     blocks=[
server_1  |   File "/home/src/mage_ai/data_preparation/models/pipeline.py", line 157, in <listcomp>
server_1  |     b.to_dict(
server_1  |   File "/home/src/mage_ai/data_preparation/models/block.py", line 375, in to_dict
server_1  |     data['outputs'] = self.get_outputs(sample_count=sample_count)
server_1  |   File "/home/src/mage_ai/data_preparation/models/block.py", line 331, in get_outputs
server_1  |     data = variable_manager.get_variable(
server_1  |   File "/home/src/mage_ai/data_preparation/variable_manager.py", line 60, in get_variable
server_1  |     return variable.read_data(sample=sample, sample_count=sample_count)
server_1  |   File "/home/src/mage_ai/data_preparation/models/variable.py", line 67, in read_data
server_1  |     return self.__read_parquet(sample=sample, sample_count=sample_count)
server_1  |   File "/home/src/mage_ai/data_preparation/models/variable.py", line 116, in __read_parquet
server_1  |     df = pd.read_parquet(sample_file_path, engine='pyarrow')
server_1  |   File "/usr/local/lib/python3.10/site-packages/pandas/io/parquet.py", line 495, in read_parquet
server_1  |     return impl.read(
server_1  |   File "/usr/local/lib/python3.10/site-packages/pandas/io/parquet.py", line 239, in read
server_1  |     result = self.api.parquet.read_table(
server_1  |   File "/usr/local/lib/python3.10/site-packages/pyarrow/parquet/__init__.py", line 2737, in read_table
server_1  |     dataset = _ParquetDatasetV2(
server_1  |   File "/usr/local/lib/python3.10/site-packages/pyarrow/parquet/__init__.py", line 2340, in __init__
server_1  |     [fragment], schema=schema or fragment.physical_schema,
server_1  |   File "pyarrow/_dataset.pyx", line 870, in pyarrow._dataset.Fragment.physical_schema.__get__
server_1  |   File "pyarrow/error.pxi", line 144, in pyarrow.lib.pyarrow_internal_check_status
server_1  |   File "pyarrow/error.pxi", line 100, in pyarrow.lib.check_status
server_1  | pyarrow.lib.ArrowInvalid: Could not open Parquet input source '<Buffer>': Parquet file size is 0 bytes
server_1  | 500 GET /api/pipelines/demo_pipeline1 (172.20.0.1) 81.40ms
```

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
