### PR TITLE
[sk] Hide pycache from file tree

### DIFF
--- a/mage_ai/data_preparation/models/file.py
+++ b/mage_ai/data_preparation/models/file.py
@@ -2,7 +2,7 @@ from mage_ai.data_preparation.repo_manager import get_repo_path
 from typing import Dict
 import os
 
-BLACKLISTED_DIRS = frozenset(['venv', 'env', '.git', '.DS_Store'])
+BLACKLISTED_DIRS = frozenset(['venv', 'env', '.git', '.DS_Store', '__pycache__'])
 INACCESSIBLE_DIRS = frozenset(['__pycache__'])
 MAX_DEPTH = 30
 


### PR DESCRIPTION
# Summary
File tree now doesn't render `__pycache__` files.

# Tests
Tested locally.

cc:
@tommydangerous @wangxiaoyou1993 
