### PR TITLE
[sp] fix typo on variables tab

### DIFF
--- a/mage_ai/frontend/components/Sidekick/GlobalVariables.tsx
+++ b/mage_ai/frontend/components/Sidekick/GlobalVariables.tsx
@@ -69,7 +69,7 @@ function GlobalVariables({
     <Spacing p={PADDING_UNITS}>
       <Spacing mb={PADDING_UNITS}>
         <Text>
-          The variables listed blow can be used in any <Text
+          The variables listed below can be used in any <Text
             bold
             inline
             monospace


### PR DESCRIPTION
# Summary
- see above

# Tests
<img width="458" alt="image" src="https://user-images.githubusercontent.com/105667442/178609255-f5a9eefe-1fd4-42bd-8429-459a115db2ac.png">

cc: @johnson-mage 
