### PR TITLE
[sp] fix graphs tab crash on reload

### DIFF
--- a/mage_ai/frontend/components/BlockCharts/utils.ts
+++ b/mage_ai/frontend/components/BlockCharts/utils.ts
@@ -47,7 +47,7 @@ export const buildUniqueValueData = (features: FeatureType[], statistics) => (
 export const buildValueDistributionData = (features: FeatureType[], statistics) => (
   sortByKey(
     features?.map(feature => {
-      const [value, frequency] = Object.entries(statistics[`${feature.uuid}/value_counts`])[0];
+      const [value, frequency] = Object.entries(statistics[`${feature.uuid}/value_counts`] || {})[0] || [];
       const percentage = Number(frequency) / statistics.count;
       return {
         feature,


### PR DESCRIPTION
# Summary
- see above

# Tests
Click on graphs tab, reload the page, select a block. The frontend should no longer crash.

cc: @johnson-mage @tommydangerous 
