### PR TITLE
[xy] Use repo_path as the parameter in the run method.

### DIFF
--- a/mage_ai/__init__.py
+++ b/mage_ai/__init__.py
@@ -118,8 +118,8 @@ def clean(
 
 ### --------------- Data preparation methods --------------- ###
 
-def run(pipeline_uuid: str, repo_name: str = None) -> None:
-    repo_path = os.getcwd() if repo_name is None else os.path.join(os.getcwd(), repo_name)
+def run(pipeline_uuid: str, repo_path: str = None) -> None:
+    repo_path = os.getcwd() if repo_path is None else os.path.abspath(repo_path)
     pipeline = Pipeline(pipeline_uuid, repo_path)
 
     asyncio.run(pipeline.execute())


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Use repo_path as the parameter in the run method. Otherwise, we can't specify a repo_path outside of current folder.

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
