### PR TITLE
[xy] Support updating block type.

### DIFF
--- a/mage_ai/data_preparation/templates/data_exporters/default.jinja
+++ b/mage_ai/data_preparation/templates/data_exporters/default.jinja
@@ -13,3 +13,4 @@ def export_data(df: DataFrame) -> None:
         df (DataFrame): Data frame to export to
     """
     # Specify your data exporting logic here
+{{ code }}

--- a/mage_ai/data_preparation/templates/data_loaders/default.jinja
+++ b/mage_ai/data_preparation/templates/data_loaders/default.jinja
@@ -13,4 +13,5 @@ def load_data() -> DataFrame:
         DataFrame: Returned pandas data frame.
     """
     # Specify your data loading logic here
+{{ code }}
     return DataFrame({})

--- a/mage_ai/data_preparation/templates/template.py
+++ b/mage_ai/data_preparation/templates/template.py
@@ -108,9 +108,11 @@ def __fetch_data_loader_templates(config: Mapping[str, str]) -> str:
         _ = DataSource(data_source)
         template_path = f'data_loaders/{data_source.lower()}.py'
     except ValueError:
-        template_path = 'data_loaders/default.py'
+        template_path = 'data_loaders/default.jinja'
 
-    return template_env.get_template(template_path).render() + '\n'
+    return template_env.get_template(template_path).render(
+        code=config.get('existing_code', ''),
+    ) + '\n'
 
 
 def __fetch_transformer_templates(config: Mapping[str, str]) -> str:
@@ -138,7 +140,9 @@ def __fetch_transformer_templates(config: Mapping[str, str]) -> str:
             template.render(action_type=action_type, axis=axis, kwargs=additional_params_str) + '\n'
         )
     else:
-        return template_env.get_template('transformers/default.py').render() + '\n'
+        return template_env.get_template('transformers/default.jinja').render(
+            code=config.get('existing_code', ''),
+        ) + '\n'
 
 
 def __fetch_data_exporter_templates(config: Mapping[str, str]) -> str:
@@ -147,6 +151,8 @@ def __fetch_data_exporter_templates(config: Mapping[str, str]) -> str:
         _ = DataSource(data_source)
         template_path = f'data_exporters/{data_source.lower()}.py'
     except ValueError:
-        template_path = 'data_exporters/default.py'
+        template_path = 'data_exporters/default.jinja'
 
-    return template_env.get_template(template_path).render() + '\n'
+    return template_env.get_template(template_path).render(
+        code=config.get('existing_code', ''),
+    ) + '\n'

--- a/mage_ai/data_preparation/templates/transformers/default.jinja
+++ b/mage_ai/data_preparation/templates/transformers/default.jinja
@@ -19,4 +19,5 @@ def transform_df(df: DataFrame, *args) -> DataFrame:
         DataFrame: Transformed data frame
     """
     # Specify your transformation logic here
+{{ code }}
     return df

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -197,7 +197,7 @@ class ApiPipelineBlockHandler(BaseHandler):
 
     def put(self, pipeline_uuid, block_uuid):
         """
-        Allow updating block name, uuid, upstream_block, and downstream_blocks
+        Allow updating block name, uuid, type, upstream_block, and downstream_blocks
         """
         pipeline = Pipeline(pipeline_uuid, get_repo_path())
         data = json.loads(self.request.body).get('block', {})

--- a/mage_ai/tests/data_preparation/test_templates.py
+++ b/mage_ai/tests/data_preparation/test_templates.py
@@ -91,6 +91,7 @@ def load_data() -> DataFrame:
         DataFrame: Returned pandas data frame.
     \"\"\"
     # Specify your data loading logic here
+
     return DataFrame({})
 """
 
@@ -178,6 +179,7 @@ def transform_df(df: DataFrame, *args) -> DataFrame:
         DataFrame: Transformed data frame
     \"\"\"
     # Specify your transformation logic here
+
     return df
 """
 
@@ -213,6 +215,7 @@ def transform_df(df: DataFrame, *args) -> DataFrame:
         DataFrame: Transformed data frame
     \"\"\"
     # Specify your transformation logic here
+
     return df
 """
 
@@ -363,6 +366,7 @@ def export_data(df: DataFrame) -> None:
         df (DataFrame): Data frame to export to
     \"\"\"
     # Specify your data exporting logic here
+
 """
 
         config1 = {'data_source': 'default'}


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Support updating block type from scratchpad to data_loader, transformer, data_exporter

API for updating block type (Only allow updating from scratchpad to other block types)
```
PUT /api/pipelines/[pipeline_uuid]/blocks/[block_uuid]

{
  "block": {
    "type": "data_loader"/"transformer"/"data_exporter"
  }
}
```

# Tests
<!-- How did you test your change? -->
tested locally

<img width="924" alt="image" src="https://user-images.githubusercontent.com/80284865/179111518-0583f3ea-e48c-4189-a7b6-87633d79ba22.png">
<img width="1148" alt="image" src="https://user-images.githubusercontent.com/80284865/179112017-4fb03e4a-5cc0-4f78-ab8f-a2807a21fa95.png">
<img width="906" alt="image" src="https://user-images.githubusercontent.com/80284865/179112298-62facbc7-657c-4959-8ba8-774604a88845.png">

cc:
<!-- Optionally mention someone to let them know about this pull request -->
