### PR TITLE
[sp] fix min width of right click menu

### DIFF
--- a/mage_ai/frontend/components/ContextMenu/index.tsx
+++ b/mage_ai/frontend/components/ContextMenu/index.tsx
@@ -131,6 +131,7 @@ function ContextMenu({
         top={anchorPoint.y}
       >
         <FlyoutMenu
+          compact
           items={contextItems[enableContextItem ? contextItem.type : type]}
           open={visible}
           parentRef={undefined}

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.style.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.style.tsx
@@ -7,9 +7,15 @@ type LinkProps = {
   highlighted: boolean;
 };
 
-export const FlyoutMenuContainerStyle = styled.div`
+export const FlyoutMenuContainerStyle = styled.div<any>`
   position: absolute;
-  min-width: ${UNIT * 34}px;
+  ${props => !props.compact && `
+    min-width: ${UNIT * 34}px;
+  `}
+
+  ${props => props.compact && `
+    min-width: ${UNIT * 20}px;
+  `}
 
   ${props => `
     box-shadow: ${(props.theme.shadow || dark.shadow).popup};

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.style.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.style.tsx
@@ -9,6 +9,7 @@ type LinkProps = {
 
 export const FlyoutMenuContainerStyle = styled.div<any>`
   position: absolute;
+
   ${props => !props.compact && `
     min-width: ${UNIT * 34}px;
   `}

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -28,6 +28,7 @@ export type FlyoutMenuItemType = {
 };
 
 export type FlyoutMenuProps = {
+  compact?: boolean;
   items: FlyoutMenuItemType[];
   onClickCallback?: () => void;
   open: boolean;
@@ -36,6 +37,7 @@ export type FlyoutMenuProps = {
 };
 
 function FlyoutMenu({
+  compact,
   items,
   onClickCallback,
   open,
@@ -102,6 +104,7 @@ function FlyoutMenu({
 
   return (
     <FlyoutMenuContainerStyle
+      compact={compact}
       style={{
         display: !open ? 'none' : null,
         left: 0,


### PR DESCRIPTION
# Summary
- added a `compact` prop to `FlyoutMenu` that reduces the min width to `UNIT * 20`

# Tests
![image](https://user-images.githubusercontent.com/105667442/179328807-88f338b8-1489-4b38-b070-e537e69f2464.png)

cc: @johnson-mage 
