### PR TITLE
[sp] add "convert scratchpad block" functionality

### DIFF
--- a/mage_ai/frontend/components/ActionForm/index.tsx
+++ b/mage_ai/frontend/components/ActionForm/index.tsx
@@ -161,7 +161,7 @@ function ActionForm({
     >
       {!noHeader &&
         <>
-          <FlexContainer justifyContent={'space-between'}>
+          <FlexContainer justifyContent="space-between">
             <Spacing p={2}>
               <Text>
                 {title}

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -3,6 +3,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { ThemeContext } from 'styled-components';
@@ -11,6 +12,7 @@ import { useMutation } from 'react-query';
 import AddNewBlocks from '@components/PipelineDetail/AddNewBlocks';
 import BlockType, {
   BLOCK_TYPE_NAME_MAPPING,
+  BLOCK_TYPE_PERMANENT,
   BlockTypeEnum,
   SetEditingBlockType,
 } from '@interfaces/BlockType';
@@ -24,6 +26,7 @@ import CodeOutput from './CodeOutput';
 import CommandButtons, { CommandButtonsSharedProps } from './CommandButtons';
 import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
+import FlyoutMenuWrapper from '@oracle/components/FlyoutMenu/FlyoutMenuWrapper';
 import KernelOutputType, {
   DataTypeEnum,
   ExecutionStateEnum,
@@ -36,6 +39,7 @@ import Text from '@oracle/elements/Text';
 import Tooltip from '@oracle/components/Tooltip';
 import api from '@api';
 import usePrevious from '@utils/usePrevious';
+import { ArrowDown, FileFill, Stack } from '@oracle/icons';
 import {
   BlockDivider,
   BlockDividerInner,
@@ -46,7 +50,6 @@ import {
   CodeContainerStyle,
   getColorsForBlockType,
 } from './index.style';
-import { FileFill, Stack } from '@oracle/icons';
 import {
   KEY_CODE_CONTROL,
   KEY_CODE_ENTER,
@@ -59,7 +62,6 @@ import { executeCode } from '@components/CodeEditor/keyboard_shortcuts/shortcuts
 import { indexBy } from '@utils/array';
 import { onError, onSuccess } from '@api/utils/response';
 import { onlyKeysPresent } from '@utils/hooks/keyboardShortcuts/utils';
-import { pauseEvent } from '@utils/events';
 import { pluralize } from '@utils/string';
 import { useKeyboardContext } from '@context/Keyboard';
 
@@ -117,6 +119,7 @@ function CodeBlockProps({
 }: CodeBlockProps, ref) {
   const themeContext = useContext(ThemeContext);
   const [addNewBlocksVisible, setAddNewBlocksVisible] = useState(false);
+  const [blockMenuVisible, setBlockMenuVisible] = useState(false);
   const [content, setContent] = useState(defaultValue);
   const [errorMessages, setErrorMessages] = useState(null);
   const [isEditingBlock, setIsEditingBlock] = useState(false);
@@ -124,6 +127,8 @@ function CodeBlockProps({
   const [runCount, setRunCount] = useState<number>(0);
   const [runEndTime, setRunEndTime] = useState<number>(null);
   const [runStartTime, setRunStartTime] = useState<number>(null);
+
+  const blockMenuRef = useRef(null);
 
   const blocksMapping = useMemo(() => indexBy(blocks, ({ uuid }) => uuid), [blocks]);
 
@@ -249,10 +254,11 @@ function CodeBlockProps({
     {
       onSuccess: (response: any) => onSuccess(
         response, {
-          callback: () => {
+          callback: ({ block: { content } }) => {
             setIsEditingBlock(false);
             fetchPipeline();
             fetchFileTree();
+            setContent(content);
           },
           onErrorCallback: ({
             error: {
@@ -323,6 +329,31 @@ function CodeBlockProps({
     ],
   );
 
+  const buildBlockMenu = (b: BlockType) => {
+    const blockMenuItems = {
+      [BlockTypeEnum.SCRATCHPAD]: [
+        {
+          items: BLOCK_TYPE_PERMANENT.map(blockType => ({
+            label: () => BLOCK_TYPE_NAME_MAPPING[blockType],
+            // @ts-ignore
+            onClick: () => updateBlock({
+              block: {
+                ...b,
+                type: blockType,
+              },
+            }),
+            uuid: `block_menu/scratchpad/turn_into/${blockType}`,
+          })),
+          label: () => 'Turn into',
+          uuid: 'block_menu/scratchpad/turn_into',
+        },
+      ],
+    };
+
+    return blockMenuItems[b.type];
+  };
+
+
   const codeEditorEl = useMemo(() => (
     <CodeEditor
       autoHeight
@@ -387,21 +418,23 @@ function CodeBlockProps({
         }}
       >
         <Flex alignItems="center" flex={1}>
-          <Tooltip
-            block
-            label={BLOCK_TYPE_NAME_MAPPING[block.type]}
-            size={null}
-            widthFitContent
-          >
-            <FlexContainer alignItems="center">
-              <Circle
-                color={color}
-                size={UNIT * 1.5}
-                square
-              />
+          <FlexContainer alignItems="center">
+            <Circle
+              color={color}
+              size={UNIT * 1.5}
+              square
+            />
 
-              <Spacing mr={1} />
+            <Spacing mr={1} />
 
+            <FlyoutMenuWrapper
+              compact
+              items={buildBlockMenu(block)}
+              onClickOutside={() => setBlockMenuVisible(false)}
+              open={blockMenuVisible}
+              parentRef={blockMenuRef}
+              uuid="CodeBlock/block_menu"
+            >
               <Text
                 color={color}
                 monospace
@@ -413,22 +446,36 @@ function CodeBlockProps({
                 )}
                 {BlockTypeEnum.DATA_LOADER === block.type && (
                   <>
-                    DATA LOADER&nbsp;&nbsp;
+                    DATA LOADER&nbsp;
                   </>
                 )}
                 {BlockTypeEnum.SCRATCHPAD === block.type && (
                   <>
-                    SCRATCHPAD&nbsp;&nbsp;&nbsp;
+                    SCRATCHPAD&nbsp;
                   </>
                 )}
                 {BlockTypeEnum.TRANSFORMER === block.type && (
                   <>
-                    TRANSFORMER&nbsp;&nbsp;
+                    TRANSFORMER&nbsp;
                   </>
                 )}
               </Text>
-            </FlexContainer>
-          </Tooltip>
+            </FlyoutMenuWrapper>
+
+            {BlockTypeEnum.SCRATCHPAD === block.type && (
+              <Button
+                basic
+                iconOnly
+                noPadding
+                onClick={() => setBlockMenuVisible(true)}
+                transparent
+              >
+                <ArrowDown muted />
+              </Button>
+            )}
+
+            <Spacing mr={1} />
+          </FlexContainer>
 
           <Spacing mr={PADDING_UNITS} />
 

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -137,7 +137,7 @@ function CodeBlockProps({
       const {
         code,
         runUpstream,
-      } = payload || {}
+      } = payload || {};
       runBlock({
         block,
         code: code || content,

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -26,7 +26,7 @@ import CodeOutput from './CodeOutput';
 import CommandButtons, { CommandButtonsSharedProps } from './CommandButtons';
 import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
-import FlyoutMenuWrapper from '@oracle/components/FlyoutMenu/FlyoutMenuWrapper';
+import FlyoutMenuInteractive from '@oracle/components/FlyoutMenu/FlyoutMenuInteractive';
 import KernelOutputType, {
   DataTypeEnum,
   ExecutionStateEnum,
@@ -427,7 +427,7 @@ function CodeBlockProps({
 
             <Spacing mr={1} />
 
-            <FlyoutMenuWrapper
+            <FlyoutMenuInteractive
               compact
               items={buildBlockMenu(block)}
               onClickOutside={() => setBlockMenuVisible(false)}
@@ -460,7 +460,7 @@ function CodeBlockProps({
                   </>
                 )}
               </Text>
-            </FlyoutMenuWrapper>
+            </FlyoutMenuInteractive>
 
             {BlockTypeEnum.SCRATCHPAD === block.type && (
               <Button

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -342,10 +342,10 @@ function CodeBlockProps({
                 type: blockType,
               },
             }),
-            uuid: `block_menu/scratchpad/turn_into/${blockType}`,
+            uuid: `block_menu/scratchpad/convert_to/${blockType}`,
           })),
-          label: () => 'Turn into',
-          uuid: 'block_menu/scratchpad/turn_into',
+          label: () => 'Convert to',
+          uuid: 'block_menu/scratchpad/convert_to',
         },
       ],
     };

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -26,7 +26,7 @@ import CodeOutput from './CodeOutput';
 import CommandButtons, { CommandButtonsSharedProps } from './CommandButtons';
 import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
-import FlyoutMenuInteractive from '@oracle/components/FlyoutMenu/FlyoutMenuInteractive';
+import FlyoutMenuClickOutside from '@oracle/components/FlyoutMenu/FlyoutMenuClickOutside';
 import KernelOutputType, {
   DataTypeEnum,
   ExecutionStateEnum,
@@ -427,7 +427,7 @@ function CodeBlockProps({
 
             <Spacing mr={1} />
 
-            <FlyoutMenuInteractive
+            <FlyoutMenuClickOutside
               compact
               items={buildBlockMenu(block)}
               onClickOutside={() => setBlockMenuVisible(false)}
@@ -460,7 +460,7 @@ function CodeBlockProps({
                   </>
                 )}
               </Text>
-            </FlyoutMenuInteractive>
+            </FlyoutMenuClickOutside>
 
             {BlockTypeEnum.SCRATCHPAD === block.type && (
               <Button

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -12,7 +12,7 @@ import { useMutation } from 'react-query';
 import AddNewBlocks from '@components/PipelineDetail/AddNewBlocks';
 import BlockType, {
   BLOCK_TYPE_NAME_MAPPING,
-  BLOCK_TYPE_PERMANENT,
+  BLOCK_TYPE_CONVERTIBLE,
   BlockTypeEnum,
   SetEditingBlockType,
 } from '@interfaces/BlockType';
@@ -333,7 +333,7 @@ function CodeBlockProps({
     const blockMenuItems = {
       [BlockTypeEnum.SCRATCHPAD]: [
         {
-          items: BLOCK_TYPE_PERMANENT.map(blockType => ({
+          items: BLOCK_TYPE_CONVERTIBLE.map(blockType => ({
             label: () => BLOCK_TYPE_NAME_MAPPING[blockType],
             // @ts-ignore
             onClick: () => updateBlock({

--- a/mage_ai/frontend/components/FileEditor/index.tsx
+++ b/mage_ai/frontend/components/FileEditor/index.tsx
@@ -5,7 +5,7 @@ import {
 } from 'react';
 import { useMutation } from 'react-query';
 
-import BlockType from '@interfaces/BlockType';
+import BlockType, { BlockTypeEnum } from '@interfaces/BlockType';
 import CodeEditor from '@components/CodeEditor';
 import FileType, { FileExtensionEnum, FILE_EXTENSION_TO_LANGUAGE_MAPPING } from '@interfaces/FileType';
 import KeyboardShortcutButton from '@oracle/elements/Button/KeyboardShortcutButton';
@@ -130,7 +130,8 @@ function FileEditor({
     setFilesTouched,
   ]);
 
-  const addToPipelineEl = fileExtension === FileExtensionEnum.PY && (
+  const addToPipelineEl = fileExtension === FileExtensionEnum.PY
+    && getBlockType(file.path.split('/')) !== BlockTypeEnum.SCRATCHPAD && (
     <Spacing p={2}>
       <KeyboardShortcutButton
         inline

--- a/mage_ai/frontend/interfaces/BlockType.ts
+++ b/mage_ai/frontend/interfaces/BlockType.ts
@@ -100,6 +100,12 @@ export const BLOCK_TYPE_NAME_MAPPING = {
   [BlockTypeEnum.TRANSFORMER]: 'Transformer',
 };
 
+export const BLOCK_TYPE_PERMANENT = [
+  BlockTypeEnum.DATA_EXPORTER,
+  BlockTypeEnum.DATA_LOADER,
+  BlockTypeEnum.TRANSFORMER,
+];
+
 export const BLOCK_TYPE_ABBREVIATION_MAPPING = {
   [BlockTypeEnum.DATA_EXPORTER]: 'DE',
   [BlockTypeEnum.DATA_LOADER]: 'DL',

--- a/mage_ai/frontend/interfaces/BlockType.ts
+++ b/mage_ai/frontend/interfaces/BlockType.ts
@@ -100,7 +100,7 @@ export const BLOCK_TYPE_NAME_MAPPING = {
   [BlockTypeEnum.TRANSFORMER]: 'Transformer',
 };
 
-export const BLOCK_TYPE_PERMANENT = [
+export const BLOCK_TYPE_CONVERTIBLE = [
   BlockTypeEnum.DATA_EXPORTER,
   BlockTypeEnum.DATA_LOADER,
   BlockTypeEnum.TRANSFORMER,

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/FlyoutMenuClickOutside.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/FlyoutMenuClickOutside.tsx
@@ -1,12 +1,12 @@
 import ClickOutside from '@oracle/components/ClickOutside';
 import FlyoutMenu, { FlyoutMenuProps } from './index';
 
-type FlyoutMenuInteractiveProps = {
+type FlyoutMenuClickOutsideProps = {
   children: JSX.Element;
   onClickOutside: () => void;
 } & FlyoutMenuProps;
 
-function FlyoutMenuInteractive({
+function FlyoutMenuClickOutside({
   children,
   compact,
   items,
@@ -14,7 +14,7 @@ function FlyoutMenuInteractive({
   onClickOutside,
   parentRef,
   uuid,
-}: FlyoutMenuInteractiveProps) {
+}: FlyoutMenuClickOutsideProps) {
   return (
     <ClickOutside
       onClickOutside={onClickOutside}
@@ -40,4 +40,4 @@ function FlyoutMenuInteractive({
   );
 }
 
-export default FlyoutMenuInteractive;
+export default FlyoutMenuClickOutside;

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/FlyoutMenuInteractive.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/FlyoutMenuInteractive.tsx
@@ -1,12 +1,12 @@
 import ClickOutside from '@oracle/components/ClickOutside';
 import FlyoutMenu, { FlyoutMenuProps } from './index';
 
-type FlyoutMenuWrapperProps = {
+type FlyoutMenuInteractiveProps = {
   children: JSX.Element;
   onClickOutside: () => void;
 } & FlyoutMenuProps;
 
-function FlyoutMenuWrapper({
+function FlyoutMenuInteractive({
   children,
   compact,
   items,
@@ -14,7 +14,7 @@ function FlyoutMenuWrapper({
   onClickOutside,
   parentRef,
   uuid,
-}: FlyoutMenuWrapperProps) {
+}: FlyoutMenuInteractiveProps) {
   return (
     <ClickOutside
       onClickOutside={onClickOutside}
@@ -40,4 +40,4 @@ function FlyoutMenuWrapper({
   );
 }
 
-export default FlyoutMenuWrapper;
+export default FlyoutMenuInteractive;

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/FlyoutMenuInteractive.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/FlyoutMenuInteractive.tsx
@@ -1,0 +1,43 @@
+import ClickOutside from '@oracle/components/ClickOutside';
+import FlyoutMenu, { FlyoutMenuProps } from './index';
+
+type FlyoutMenuWrapperProps = {
+  children: JSX.Element;
+  onClickOutside: () => void;
+} & FlyoutMenuProps;
+
+function FlyoutMenuWrapper({
+  children,
+  compact,
+  items,
+  open,
+  onClickOutside,
+  parentRef,
+  uuid,
+}: FlyoutMenuWrapperProps) {
+  return (
+    <ClickOutside
+      onClickOutside={onClickOutside}
+      open
+    >
+      <div style={{
+        position: 'relative',
+        zIndex: 100,
+      }}>
+        <div ref={parentRef}>
+          {children}
+        </div>
+        <FlyoutMenu
+          compact={compact}
+          items={items}
+          onClickCallback={onClickOutside}
+          open={open}
+          parentRef={parentRef}
+          uuid={uuid}
+        />
+      </div>
+    </ClickOutside>
+  );
+}
+
+export default FlyoutMenuWrapper;

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/FlyoutMenuWrapper.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/FlyoutMenuWrapper.tsx
@@ -22,7 +22,7 @@ function FlyoutMenuWrapper({
     >
       <div style={{
         position: 'relative',
-        zIndex: 1,
+        zIndex: 100,
       }}>
         <div ref={parentRef}>
           {children}

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/FlyoutMenuWrapper.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/FlyoutMenuWrapper.tsx
@@ -20,7 +20,10 @@ function FlyoutMenuWrapper({
       onClickOutside={onClickOutside}
       open
     >
-      <div style={{ position: 'relative' }}>
+      <div style={{
+        position: 'relative',
+        zIndex: 1,
+      }}>
         <div ref={parentRef}>
           {children}
         </div>

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/FlyoutMenuWrapper.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/FlyoutMenuWrapper.tsx
@@ -8,6 +8,7 @@ type FlyoutMenuWrapperProps = {
 
 function FlyoutMenuWrapper({
   children,
+  compact,
   items,
   open,
   onClickOutside,
@@ -24,6 +25,7 @@ function FlyoutMenuWrapper({
           {children}
         </div>
         <FlyoutMenu
+          compact={compact}
           items={items}
           onClickCallback={onClickOutside}
           open={open}

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.style.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.style.tsx
@@ -7,15 +7,18 @@ type LinkProps = {
   highlighted: boolean;
 };
 
+export const MENU_WIDTH = UNIT * 34;
+export const COMPACT_MENU_WIDTH = UNIT * 20;
+
 export const FlyoutMenuContainerStyle = styled.div<any>`
   position: absolute;
 
   ${props => !props.compact && `
-    min-width: ${UNIT * 34}px;
+    min-width: ${MENU_WIDTH}px;
   `}
 
   ${props => props.compact && `
-    min-width: ${UNIT * 20}px;
+    min-width: ${COMPACT_MENU_WIDTH}px;
   `}
 
   ${props => props.width && `

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -123,7 +123,11 @@ function FlyoutMenu({
             ? left || 0
             : compact ? (depth * UNIT * 20) : (depth * UNIT * 34)
         ),
-        top: depth === 0 ? (height || 0) + topOffset : 0,
+        top: (
+          depth === 0
+            ? (height || 0) + topOffset
+            : 0
+        ),
       }}
       width={width}
     >

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -118,7 +118,11 @@ function FlyoutMenu({
       compact={compact}
       style={{
         display: !visible && !submenuVisible[uuid] ? 'none' : null,
-        left: depth === 0 ? left || 0 : (compact ? (depth * UNIT * 20) : (depth * UNIT * 34)),
+        left: (
+          depth === 0
+            ? left || 0
+            : compact ? (depth * UNIT * 20) : (depth * UNIT * 34)
+        ),
         top: depth === 0 ? (height || 0) + topOffset : 0,
       }}
       width={width}

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -6,15 +6,16 @@ import KeyboardTextGroup, { NumberOrString } from '@oracle/elements/KeyboardText
 import Text from '@oracle/elements/Text';
 import { ArrowRight } from '@oracle/icons';
 import {
+  COMPACT_MENU_WIDTH,
   FlyoutMenuContainerStyle,
   LinkStyle,
+  MENU_WIDTH,
 } from './index.style';
 import {
   KEY_CODE_ARROW_DOWN,
   KEY_CODE_ARROW_UP,
   KEY_CODE_ENTER,
 } from '@utils/hooks/keyboardShortcuts/constants';
-import { UNIT } from '@oracle/styles/units/spacing';
 import { useKeyboardContext } from '@context/Keyboard';
 
 export type FlyoutMenuItemType = {
@@ -121,7 +122,7 @@ function FlyoutMenu({
         left: (
           depth === 0
             ? left || 0
-            : compact ? (depth * UNIT * 20) : (depth * UNIT * 34)
+            : compact ? (depth * COMPACT_MENU_WIDTH) : (depth * MENU_WIDTH)
         ),
         top: (
           depth === 0

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -117,7 +117,7 @@ function FlyoutMenu({
     <FlyoutMenuContainerStyle
       compact={compact}
       style={{
-        display: !visible && !submenuVisible[uuid] ? 'none' : null,
+        display: (visible || submenuVisible[uuid]) ? null : 'none',
         left: (
           depth === 0
             ? left || 0

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -182,9 +182,7 @@ function FlyoutMenu({
   );
 
   return (
-    <>
-      {items && buildMenuEl(items, undefined, open)}
-    </>
+    items && buildMenuEl(items, undefined, open)
   );
 }
 


### PR DESCRIPTION
# Summary
- add dropdown to scratchpad blocks to convert into other block types
- remove "Add to current pipeline" button for scratchpad block files
- implement nested menu items for `FlyoutMenu`

# Tests
![2022-07-19 01 03 35](https://user-images.githubusercontent.com/105667442/179699485-bcdaa3e4-fa2f-450d-bd8f-f4b4ef81ebbf.gif)

cc: @johnson-mage @tommydangerous @dy46 @wangxiaoyou1993 
