### PR TITLE
[sk] Overflowing integers don't raise errors

### DIFF
--- a/mage_ai/data_cleaner/column_types/column_type_detector.py
+++ b/mage_ai/data_cleaner/column_types/column_type_detector.py
@@ -9,8 +9,6 @@ import pandas as pd
 import re
 
 DATETIME_MATCHES_THRESHOLD = 0.5
-MAX_SIGNED_INTEGER_VALUE = np.iinfo(np.int).max
-MAX_UNSIGNED_INTEGER_VALUE = np.iinfo(np.uint).max
 MAXIMUM_WORD_LENGTH_FOR_CATEGORY_FEATURES = 40
 MULTITHREAD_MAX_NUM_ENTRIES = 50000
 NUMBER_TYPE_MATCHES_THRESHOLD = 0.8
@@ -174,15 +172,13 @@ def infer_object_type(series, column_name, kwargs):
             ):
                 return ColumnType.ZIP_CODE
             else:
-                clean_series = clean_series.astype(float)
-                if clean_series.min() > 0:
-                    max_val = MAX_UNSIGNED_INTEGER_VALUE
-                else:
-                    max_val = MAX_SIGNED_INTEGER_VALUE
-                if clean_series.max() > max_val:
-                    return ColumnType.CATEGORY_HIGH_CARDINALITY
-                else:
+                clean_series = clean_series.str.replace(r'\.0*', '')
+                try:
+                    clean_series.astype(int)
                     return ColumnType.NUMBER
+                except OverflowError:
+                    return ColumnType.CATEGORY_HIGH_CARDINALITY
+
     else:
         matches = clean_series.str.match(REGEX_DATETIME).sum()
         if matches / length >= DATETIME_MATCHES_THRESHOLD:

--- a/mage_ai/data_cleaner/column_types/column_type_detector.py
+++ b/mage_ai/data_cleaner/column_types/column_type_detector.py
@@ -9,6 +9,8 @@ import pandas as pd
 import re
 
 DATETIME_MATCHES_THRESHOLD = 0.5
+MAX_SIGNED_INTEGER_VALUE = np.iinfo(np.int).max
+MAX_UNSIGNED_INTEGER_VALUE = np.iinfo(np.uint).max
 MAXIMUM_WORD_LENGTH_FOR_CATEGORY_FEATURES = 40
 MULTITHREAD_MAX_NUM_ENTRIES = 50000
 NUMBER_TYPE_MATCHES_THRESHOLD = 0.8
@@ -172,11 +174,15 @@ def infer_object_type(series, column_name, kwargs):
             ):
                 return ColumnType.ZIP_CODE
             else:
-                try:
-                    clean_series.astype(float).astype(int)
-                    return ColumnType.NUMBER
-                except OverflowError:
+                clean_series = clean_series.astype(float)
+                if clean_series.min() > 0:
+                    max_val = MAX_UNSIGNED_INTEGER_VALUE
+                else:
+                    max_val = MAX_SIGNED_INTEGER_VALUE
+                if clean_series.max() > max_val:
                     return ColumnType.CATEGORY_HIGH_CARDINALITY
+                else:
+                    return ColumnType.NUMBER
     else:
         matches = clean_series.str.match(REGEX_DATETIME).sum()
         if matches / length >= DATETIME_MATCHES_THRESHOLD:

--- a/mage_ai/data_cleaner/column_types/column_type_detector.py
+++ b/mage_ai/data_cleaner/column_types/column_type_detector.py
@@ -177,7 +177,10 @@ def infer_object_type(series, column_name, kwargs):
                     clean_series.astype(int)
                     return ColumnType.NUMBER
                 except OverflowError:
-                    return ColumnType.CATEGORY_HIGH_CARDINALITY
+                    if clean_series_nunique <= kwargs.get('category_cardinality_threshold', 255):
+                        return ColumnType.CATEGORY
+                    else:
+                        return ColumnType.CATEGORY_HIGH_CARDINALITY
 
     else:
         matches = clean_series.str.match(REGEX_DATETIME).sum()

--- a/mage_ai/data_cleaner/column_types/column_type_detector.py
+++ b/mage_ai/data_cleaner/column_types/column_type_detector.py
@@ -172,7 +172,11 @@ def infer_object_type(series, column_name, kwargs):
             ):
                 return ColumnType.ZIP_CODE
             else:
-                return ColumnType.NUMBER
+                try:
+                    clean_series.astype(float).astype(int)
+                    return ColumnType.NUMBER
+                except OverflowError:
+                    return ColumnType.CATEGORY_HIGH_CARDINALITY
     else:
         matches = clean_series.str.match(REGEX_DATETIME).sum()
         if matches / length >= DATETIME_MATCHES_THRESHOLD:

--- a/mage_ai/tests/data_cleaner/test_column_type_detector.py
+++ b/mage_ai/tests/data_cleaner/test_column_type_detector.py
@@ -205,8 +205,8 @@ class ColumnTypeDetectorTests(TestCase):
             large_integers='number',
             large_integers_unsigned='number',
             str_large_integers='number',
-            too_large_integers='category_high_cardinality',
-            too_large_integers_version_2='category_high_cardinality',
+            too_large_integers='category',
+            too_large_integers_version_2='category',
         )
         self.assertEquals(ctypes, expected_ctypes)
 

--- a/mage_ai/tests/data_cleaner/test_column_type_detector.py
+++ b/mage_ai/tests/data_cleaner/test_column_type_detector.py
@@ -150,6 +150,9 @@ class ColumnTypeDetectorTests(TestCase):
         )
 
     def test_integer_recognition(self):
+        max_int = np.iinfo(np.int).max
+        max_int_unsigned = np.iinfo(np.uint).max
+        min_int = np.iinfo(np.int).min
         df = pd.DataFrame(
             dict(
                 integers=[1, 2, 3, 4, 5],
@@ -159,6 +162,35 @@ class ColumnTypeDetectorTests(TestCase):
                 not_integers_with_null=[1.1, np.nan, 2.0, 3.0, np.nan],
                 str_integers=['1.0', None, '2.0', '3.0', None],
                 str_not_integers=['1.000', None, '2.0002', '3.000', None],
+                large_integers=[max_int, min_int, max_int - 1, min_int + 1, max_int],
+                large_integers_unsigned=[
+                    max_int,
+                    max_int_unsigned,
+                    max_int - 1,
+                    0,
+                    max_int_unsigned,
+                ],
+                str_large_integers=[
+                    str(max_int),
+                    str(min_int),
+                    str(max_int - 1),
+                    str(min_int + 1),
+                    str(max_int),
+                ],
+                too_large_integers=[
+                    str(max_int),
+                    str(min_int),
+                    str(max_int + 1),
+                    str(min_int - 1),
+                    str(max_int),
+                ],
+                too_large_integers_version_2=[
+                    str(max_int),
+                    str(min_int),
+                    str(max_int_unsigned),
+                    str(min_int - 1),
+                    str(max_int),
+                ],
             )
         )
         ctypes = infer_column_types(df)
@@ -170,6 +202,11 @@ class ColumnTypeDetectorTests(TestCase):
             not_integers_with_null='number_with_decimals',
             str_integers='number',
             str_not_integers='number_with_decimals',
+            large_integers='number',
+            large_integers_unsigned='number',
+            str_large_integers='number',
+            too_large_integers='category_high_cardinality',
+            too_large_integers_version_2='category_high_cardinality',
         )
         self.assertEquals(ctypes, expected_ctypes)
 


### PR DESCRIPTION
# Summary
Any overflowing integers (including integer strings) that exist will now get mapped to `CATEGORY_HIGH_CARDINALITY` (as often these integers are ID numbers that technically are categorical). Note: when considering overflow, only signed types are considered currently (unsigned integers can hold larger values, but require manipulation on frontend to handle these values since JavaScript will overflow these integers)

# Tests
Local testing was performed, along with the addition of more unit tests to check how large integers are mapped.

cc:
@wangxiaoyou1993 @dy46 
