### PR TITLE
[sp] fix datetime chart tooltips not being visible

### DIFF
--- a/mage_ai/frontend/components/datasets/overview/utils.tsx
+++ b/mage_ai/frontend/components/datasets/overview/utils.tsx
@@ -273,7 +273,6 @@ export function buildRenderColumnHeader({
             x.min,
             x.max,
           ])}
-          getBarColor={([]) => light.brand.wind300}
           height={COLUMN_HEADER_CHART_HEIGHT}
           key={columnUUID}
           large
@@ -284,13 +283,13 @@ export function buildRenderColumnHeader({
             top: 0,
           }}
           renderTooltipContent={([, count, xLabelMin, xLabelMax]) => (
-            <Text small>
+            <p>
               Rows: {count}
               <br />
               Start: {xLabelMin}
               <br />
               End: {xLabelMax}
-            </Text>
+            </p>
           )}
           sortData={d => sortByKey(d, '[4]')}
         />


### PR DESCRIPTION
# Summary
- update datetime charts in the data table column header to match dark theme

# Tests
<img width="533" alt="image" src="https://user-images.githubusercontent.com/105667442/180051465-28c7b427-7301-4754-acea-26deb814104d.png">

cc: @johnson-mage 
