### PR TITLE
[sp] disable going back in browser when swiping

### DIFF
--- a/mage_ai/frontend/styles/globals.css
+++ b/mage_ai/frontend/styles/globals.css
@@ -122,6 +122,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
 
   overflow-x: hidden;
+  overscroll-behavior-x: none;
 }
 
 ol,


### PR DESCRIPTION
# Summary
- see above (browser history is preserved, but swiping left/right will not go back/forward in browser history)

# Tests
- seems to work correctly regardless of mouse's location / selected element when scrolling
- all existing scrollable elements still seem to function correctly

cc: @johnson-mage 
