### PR TITLE
[dy] Publish error trace for pipeline failure

### DIFF
--- a/mage_ai/data_preparation/models/block.py
+++ b/mage_ai/data_preparation/models/block.py
@@ -55,7 +55,8 @@ async def run_blocks(
                 break
         if skip:
             continue
-        await asyncio.gather(*[tasks[u.uuid] for u in block.upstream_blocks])
+        upstream_tasks = [tasks[u.uuid] for u in block.upstream_blocks]
+        await asyncio.gather(*upstream_tasks)
         task = asyncio.create_task(
             block.execute(
                 analyze_outputs=analyze_outputs,

--- a/mage_ai/server/websocket.py
+++ b/mage_ai/server/websocket.py
@@ -1,5 +1,3 @@
-from jupyter_client import KernelClient, KernelManager
-from jupyter_client.session import Session
 from mage_ai.data_preparation.models.constants import (
     BlockType,
     CUSTOM_EXECUTION_BLOCK_TYPES,
@@ -9,11 +7,15 @@ from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.server.kernel_output_parser import DataType
 from mage_ai.server.utils.output_display import add_internal_output_info, add_execution_code
 from mage_ai.shared.hash import merge_dict
+from jupyter_client import KernelClient, KernelManager
+from jupyter_client.session import Session
+from typing import List
 import asyncio
 import json
 import os
 import threading
 import tornado.websocket
+import traceback
 import uuid
 
 
@@ -61,7 +63,7 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
             )
 
             def run_pipeline() -> None:
-                def publish_message(message: str, execution_state: str = 'busy') -> None:
+                def publish_message(message: str or List[str], execution_state: str = 'busy') -> None:
                     msg_id = str(uuid.uuid4())
                     WebSocketServer.running_executions_mapping[msg_id] = value
                     self.send_message(
@@ -73,9 +75,14 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
                             type=DataType.TEXT_PLAIN,
                         )
                     )
-
-                asyncio.run(pipeline.execute(log_func=publish_message, redirect_outputs=True))
-                publish_message(f'Pipeline {pipeline.uuid} execution complete.', 'idle')
+                
+                try:
+                    asyncio.run(pipeline.execute(log_func=publish_message, redirect_outputs=True))
+                    publish_message(f'Pipeline {pipeline.uuid} execution complete.', 'idle')
+                except:
+                    trace = traceback.format_exc().splitlines()
+                    publish_message(f'Pipeline {pipeline.uuid} execution failed with error:')
+                    publish_message(trace, 'idle')
 
             threading.Thread(target=run_pipeline).start()
         elif custom_code:


### PR DESCRIPTION
# Summary

Show error trace when the pipeline execution fails. Also, fix bug where the execute pipeline button just keeps spinning.
<!-- Brief summary of what your code does -->

# Tests

local

<img width="1103" alt="Screen Shot 2022-07-22 at 10 20 34 AM" src="https://user-images.githubusercontent.com/14357209/180491604-4d683419-b070-439d-b8e2-23b09832202e.png">

<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
