### PR TITLE
[sk] Added MIT Kerberos install message to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Open [http://localhost:6789](http://localhost:6789) in your browser and build a 
 pip install mage-ai
 ```
 
+You may need to install development libraries for MIT Kerberos to use some Mage features. On Ubuntu, this can be installed as:
+```bash
+apt install libkrb5-dev
+```
+
 ##### 2. Create new project
 ```bash
 mage init [project_name]


### PR DESCRIPTION
# Summary
Edited Quick Start to mention that MIT Kerberos development headers + libs need to be installed to use the `krb5` python package (used to connect to PySpark kernel). MacOS doesn't have this problem (Kerberos comes installed) but not all Linux distros have this library installed.

cc:
@tommydangerous 
