### PR TITLE
[sk] Added docs for data loaders

### DIFF
--- a/docs/blocks/README.md
+++ b/docs/blocks/README.md
@@ -6,11 +6,10 @@ Blocks can be reused and shared across multiple pipelines within the same projec
 
 Current block types:
 
-- [Blocks](#blocks)
-    - [1. Scratchpad](#1-scratchpad)
-    - [2. Data loader](#2-data-loader)
-    - [3. Transformer](#3-transformer)
-    - [4. Data exporter](#4-data-exporter)
+1. [Scratchpad](#1-scratchpad)
+1. [Data loader](#2-data-loader)
+1. [Transformer](#3-transformer)
+1. [Data exporter](#4-data-exporter)
 
 ### 1. Scratchpad
 
@@ -44,6 +43,7 @@ def load_data() -> DataFrame:
     # Specify your data loading logic here
     return DataFrame({})
 ```
+
 To read about Mage's data loading clients that interface with popular data storage systems, see docs on [Data Loading](./data_loading.md).
 
 ### 3. Transformer
@@ -97,4 +97,5 @@ def export_data(df: DataFrame) -> None:
     """
     # Specify your data exporting logic here
 ```
+
 To read about Mage's data loading clients that interface with popular data storage systems, see docs on [Data Loading](./data_loading.md).

--- a/docs/blocks/README.md
+++ b/docs/blocks/README.md
@@ -6,10 +6,11 @@ Blocks can be reused and shared across multiple pipelines within the same projec
 
 Current block types:
 
-1. [Scratchpad](#1-scratchpad)
-1. [Data loader](#2-data-loader)
-1. [Transformer](#3-transformer)
-1. [Data exporter](#4-data-exporter)
+- [Blocks](#blocks)
+    - [1. Scratchpad](#1-scratchpad)
+    - [2. Data loader](#2-data-loader)
+    - [3. Transformer](#3-transformer)
+    - [4. Data exporter](#4-data-exporter)
 
 ### 1. Scratchpad
 
@@ -43,6 +44,7 @@ def load_data() -> DataFrame:
     # Specify your data loading logic here
     return DataFrame({})
 ```
+To read about Mage's data loading clients that interface with popular data storage systems, see docs on [Data Loading](./data_loading.md).
 
 ### 3. Transformer
 
@@ -95,3 +97,4 @@ def export_data(df: DataFrame) -> None:
     """
     # Specify your data exporting logic here
 ```
+To read about Mage's data loading clients that interface with popular data storage systems, see docs on [Data Loading](./data_loading.md).

--- a/docs/blocks/data_loading.md
+++ b/docs/blocks/data_loading.md
@@ -1,6 +1,5 @@
-# Table of Contents
+<h1> Table of Contents </h1>
 
-- [Table of Contents](#table-of-contents)
 - [Data Loading Overview](#data-loading-overview)
   - [Example: Loading data from a file](#example-loading-data-from-a-file)
   - [Example: Loading data from Snowflake warehouse](#example-loading-data-from-snowflake-warehouse)
@@ -31,7 +30,7 @@ Mage provides data loading clients that simplify loading and exporting data in y
 Mage's data loading clients fall into two categories:
 
 -   **File-Loading Clients** - import/export data between files and your pipeline. Includes both local filesystem storage and external filesystem storage (like AWS S3)
--   **Database Clients** - imports data from an external database into your pipeline and exports data frames back into that database.
+-   **Database Clients** - imports data from an external database into your pipeline and exports data frames back into that database. These database clients include the `execute` method which execute your queries in the connected database. The Google BigQuery client follows this structure.
     -   A subcategory of database clients are **connection-based clients**, which wrap a connection to the database. This connection is used to execute transactions (sets of queries) on the database, which are either committed (saved to database) or rolled-back (deleted). Clients for PostgreSQL, Redshift, and Snowflake follow this structure.
 
 ## Example: Loading data from a file
@@ -87,7 +86,7 @@ default:
 with which a Snowflake data loading client can be constructed as:
 
 ```python
-config = ConfigFileLoader('io_config.py', 'default')
+config = ConfigFileLoader('io_config.yaml', 'default')
 loader = Snowflake.with_config(config, verbose=True)
 ```
 
@@ -131,10 +130,24 @@ Handles data transfer between a Redshift cluster and the Mage app. Mage uses tem
     REDSHIFT_TEMP_CRED_PASSWORD: Redshift temp credentials password
     ```
 2. Provide an IAM Profile to automatically generate temporary credentials for connection. The IAM profile is read from `~/.aws/` and is used with the `GetClusterCredentials` endpoint to generate temporary credentials. Add the following keys to the configuration settings for `Redshift` to generate temporary credentials
-   `yaml REDSHIFT_DBNAME: Name of Redshift database to connect toName of Redshift database to connect to REDSHIFT_DBUSER: Redshift database user to generate credentials for REDSHIFT_CLUSTER_ID: Redshift cluster ID REDSHIFT_IAM_PROFILE: Name of the IAM profile to generate temp credentials with `
-   If an IAM profile is not setup using `aws configure`, manually specify the AWS credentials in the configuration settings as well.
-   `yaml AWS_ACCESS_KEY_ID: AWS Access Key ID credential AWS_SECRET_ACCESS_KEY: AWS Secret Access Key credential AWS_SESSION_TOKEN: AWS Session Token (used to generate temp DB credentials) AWS_REGION: AWS Region `
-     <h3> Constructor </h3>
+
+    ```yaml
+    REDSHIFT_DBNAME: Name of Redshift database to connect toName of Redshift database to connect to
+    REDSHIFT_DBUSER: Redshift database user to generate credentials for
+    REDSHIFT_CLUSTER_ID: Redshift cluster ID
+    REDSHIFT_IAM_PROFILE: Name of the IAM profile to generate temp credentials with `
+    ```
+
+    If an IAM profile is not setup using `aws configure`, manually specify the AWS credentials in the configuration settings as well.
+
+    ```yaml
+    AWS_ACCESS_KEY_ID: AWS Access Key ID credential
+    AWS_SECRET_ACCESS_KEY: AWS Secret Access Key credential
+    AWS_SESSION_TOKEN: AWS Session Token (used to generate temp DB credentials)
+    AWS_REGION: AWS Region `
+    ```
+
+<h3> Constructor </h3>
 
 `__init__(**kwargs)`
 
@@ -753,7 +766,7 @@ Currently, the following sources (and their corresponding configuration loader) 
 -   Configuration File - `ConfigFileLoader`
 -   Environment Variables - `EnvironmentVariableLoader`
 -   AWS Secrets Manager - `AWSSecretLoader`
-
+s
 For example, the code below constructs a Redshift data loading client using secrets stored in AWS Secrets Manager
 
 ```python
@@ -767,11 +780,11 @@ loader = Redshift.from_config(config)
 The following are the set of allowed key names that you must name your secrets with in order for Mage's configuration loaders to recognize your secrets. In code you can refer to these keys by their string name or using the `mage_ai.io.config.ConfigKey` enum. Not all keys need be specified at once - only use the keys related to the services you utilize.
 
 | Key Name                        | Service                      | Client Constructor Parameter | Description                                                             | Notes                                       |
-| ------------------------------- | ---------------------------- | ---------------------------- | ----------------------------------------------------------------------- | ------------------------------------------- | --- |
+| ------------------------------- | ---------------------------- | ---------------------------- | ----------------------------------------------------------------------- | ------------------------------------------- |
 | AWS_ACCESS_KEY_ID               | AWS General                  | -                            | AWS Access Key ID credential                                            | Used by [Redshift](#redshift) and [S3](#s3) |
-| AWS_SECRET_ACCESS_KEY           | AWS General                  | -                            | AWS Secret Access Key credential                                        | Used by [Redshift](#redshift) and [S3](#s3) |     |
+| AWS_SECRET_ACCESS_KEY           | AWS General                  | -                            | AWS Secret Access Key credential                                        | Used by [Redshift](#redshift) and [S3](#s3) |
 | AWS_SESSION_TOKEN               | AWS General                  | -                            | AWS Session Token (used to generate temporary DB credentials)           | Used by Redshift                            |
-| AWS_REGION                      | AWS General                  | -                            | AWS Region                                                              | Used by [Redshift](#redshift) and [S3](#s3) |     |
+| AWS_REGION                      | AWS General                  | -                            | AWS Region                                                              | Used by [Redshift](#redshift) and [S3](#s3) |
 | REDSHIFT_DBNAME                 | [AWS Redshift](#redshift)    | database                     | Name of Redshift database to connect to                                 |                                             |
 | REDSHIFT_HOST                   | [AWS Redshift](#redshift)    | host                         | Redshift Cluster hostname                                               | Use with temporary credentials              |
 | REDSHIFT_PORT                   | [AWS Redshift](#redshift)    | port                         | Redshift Cluster port. Optional, defaults to 5439.                      | Use with temporary credentials              |
@@ -853,7 +866,7 @@ Initializes IO Configuration loader. Input configuration file can have two forma
     each data migration client. This format was used in previous versions of this tool, and exists
     for backwards compatibility. Below is an example configuration file using this format.
     ```yaml
-    version: 0.1.0
+    version: 0.0.0
     default:
         AWS:
             Redshift:
@@ -866,6 +879,13 @@ Initializes IO Configuration loader. Input configuration file can have two forma
             secret_access_key: AWS Secret Access Key credential
             region: AWS Region
     ```
+
+Use handlebars and `env_var` syntax to reference environment variables in either configuration file format.
+```yaml
+version: 0.1.0
+default:
+    GOOGLE_SERVICE_ACC_KEY_FILEPATH: "{{ env_var('GOOGLE_APPLICATION_CREDENTIALS') }}"
+```
 
 **Args**:
 

--- a/docs/blocks/data_loading.md
+++ b/docs/blocks/data_loading.md
@@ -252,9 +252,15 @@ Sample data from a table in the selected database in the Redshift cluster. Sampl
 
 ## S3
 
+WIP
+
 ## FileIO
 
+WIP
+
 ## BigQuery
+
+WIP
 
 ## PostgreSQL
 
@@ -513,27 +519,27 @@ The following are the set of allowed key names that you must name your secrets w
 | AWS_SECRET_ACCESS_KEY           | AWS General     | secret_access_key   | AWS Secret Access Key credential                                        | Used by Redshift and S3               |
 | AWS_SESSION_TOKEN               | AWS General     | session_token       | AWS Session Token (used to generate temporary DB credentials)           | Used by Redshift                      |
 | AWS_REGION                      | AWS General     | region              | AWS Region                                                              | Used by Redshift and S3               |
-| REDSHIFT_DBNAME                 | AWS Redshift    | database            | Name of Redshift database to connect to                                 |                                       |
-| REDSHIFT_HOST                   | AWS Redshift    | host                | Redshift Cluster hostname                                               | Use with temporary credentials        |
-| REDSHIFT_PORT                   | AWS Redshift    | port                | Redshift Cluster port. Optional, defaults to 5439.                      | Use with temporary credentials        |
-| REDSHIFT_TEMP_CRED_USER         | AWS Redshift    | user                | Redshift temporary credentials username.                                | Use with temporary credentials        |
-| REDSHIFT_TEMP_CRED_PASSWORD     | AWS Redshift    | password            | Redshift temporary credentials password.                                | Use with temporary credentials        |
-| REDSHIFT_DBUSER                 | AWS Redshift    | db_user             | Redshift database user to generate credentials for.                     | Use to generate temporary credentials |
-| REDSHIFT_CLUSTER_ID             | AWS Redshift    | cluster_identifier  | Redshift cluster ID                                                     | Use to generate temporary credentials |
-| REDSHIFT_IAM_PROFILE            | AWS Redshift    | profile             | Name of the IAM profile to generate temporary credentials with          | Use to generate temporary credentials |
-| POSTGRES_DBNAME                 | PostgreSQL      | dbname              | Database name                                                           |                                       |
-| POSTGRES_USER                   | PostgreSQL      | user                | Database login username                                                 |                                       |
-| POSTGRES_PASSWORD               | PostgreSQL      | password            | Database login password                                                 |                                       |
-| POSTGRES_HOST                   | PostgreSQL      | host                | Database hostname                                                       |                                       |
-| POSTGRES_PORT                   | PostgreSQL      | port                | PostgreSQL database port                                                |                                       |
-| SNOWFLAKE_USER                  | Snowflake       | user                | Snowflake username                                                      |                                       |
-| SNOWFLAKE_PASS                  | Snowflake       | password            | Snowflake password                                                      |                                       |
-| SNOWFLAKE_ACCOUNT               | Snowflake       | account             | Snowflake account ID (including region)                                 |                                       |
-| SNOWFLAKE_DEFAULT_DB            | Snowflake       | database            | Default database to use. Optional, no database chosen if unspecified.   |                                       |
-| SNOWFLAKE_DEFAULT_SCHEMA        | Snowflake       | schema              | Default schema to use. Optional, no schema chosen if unspecified.       |                                       |
-| SNOWFLAKE_DEFAULT_WH            | Snowflake       | warehouse           | Default warehouse to use. Optional, no warehouse chosen if unspecified. |                                       |
-| GOOGLE_SERVICE_ACC_KEY          | Google BigQuery | credentials_mapping | Service account key                                                     |                                       |
-| GOOGLE_SERVICE_ACC_KEY_FILEPATH | Google BigQuery | path_to_credentials | Path to service account key                                             |                                       |
+| REDSHIFT_DBNAME                 | [AWS Redshift](#redshift)    | database            | Name of Redshift database to connect to                                 |                                       |
+| REDSHIFT_HOST                   | [AWS Redshift](#redshift)    | host                | Redshift Cluster hostname                                               | Use with temporary credentials        |
+| REDSHIFT_PORT                   | [AWS Redshift](#redshift)    | port                | Redshift Cluster port. Optional, defaults to 5439.                      | Use with temporary credentials        |
+| REDSHIFT_TEMP_CRED_USER         | [AWS Redshift](#redshift)    | user                | Redshift temporary credentials username.                                | Use with temporary credentials        |
+| REDSHIFT_TEMP_CRED_PASSWORD     | [AWS Redshift](#redshift)    | password            | Redshift temporary credentials password.                                | Use with temporary credentials        |
+| REDSHIFT_DBUSER                 | [AWS Redshift](#redshift)    | db_user             | Redshift database user to generate credentials for.                     | Use to generate temporary credentials |
+| REDSHIFT_CLUSTER_ID             | [AWS Redshift](#redshift)    | cluster_identifier  | Redshift cluster ID                                                     | Use to generate temporary credentials |
+| REDSHIFT_IAM_PROFILE            | [AWS Redshift](#redshift)    | profile             | Name of the IAM profile to generate temporary credentials with          | Use to generate temporary credentials |
+| POSTGRES_DBNAME                 | [PostgreSQL](#postgresql)      | dbname              | Database name                                                           |                                       |
+| POSTGRES_USER                   | [PostgreSQL](#postgresql)      | user                | Database login username                                                 |                                       |
+| POSTGRES_PASSWORD               | [PostgreSQL](#postgresql)      | password            | Database login password                                                 |                                       |
+| POSTGRES_HOST                   | [PostgreSQL](#postgresql)      | host                | Database hostname                                                       |                                       |
+| POSTGRES_PORT                   | [PostgreSQL](#postgresql)      | port                | PostgreSQL database port                                                |                                       |
+| SNOWFLAKE_USER                  | [Snowflake](#snowflake)       | user                | Snowflake username                                                      |                                       |
+| SNOWFLAKE_PASS                  | [Snowflake](#snowflake)       | password            | Snowflake password                                                      |                                       |
+| SNOWFLAKE_ACCOUNT               | [Snowflake](#snowflake)       | account             | Snowflake account ID (including region)                                 |                                       |
+| SNOWFLAKE_DEFAULT_DB            | [Snowflake](#snowflake)       | database            | Default database to use. Optional, no database chosen if unspecified.   |                                       |
+| SNOWFLAKE_DEFAULT_SCHEMA        | [Snowflake](#snowflake)       | schema              | Default schema to use. Optional, no schema chosen if unspecified.       |                                       |
+| SNOWFLAKE_DEFAULT_WH            | [Snowflake](#snowflake)       | warehouse           | Default warehouse to use. Optional, no warehouse chosen if unspecified. |                                       |
+| GOOGLE_SERVICE_ACC_KEY          | [Google BigQuery](#bigquery) | credentials_mapping | Service account key                                                     |                                       |
+| GOOGLE_SERVICE_ACC_KEY_FILEPATH | [Google BigQuery](#bigquery) | path_to_credentials | Path to service account key                                             |                                       |
 
 ## Configuration Loader APIs
 

--- a/docs/blocks/data_loading.md
+++ b/docs/blocks/data_loading.md
@@ -1,0 +1,196 @@
+# Table of Contents
+
+-   [Data Loading Overview](#data-loading-overview)
+-   [Client APIs](#client-apis)
+    -   [FileIO](#fileio)
+    -   [BigQuery](#bigquery)
+    -   [PostgreSQL](#postgresql)
+    -   [Redshift](#redshift)
+    -   [S3](#s3)
+    -   [Snowflake](#snowflake)
+-   [Configuration Settings](#configuration-settings)
+
+# Data Loading Overview
+
+Mage provides data loading clients to load and export data from local and external sources, integrating directly into your pipelines so you can spend more time focusing on analyzing and transforming your data for ML tasks.
+
+Every data loader client includes the following functions:
+
+-   `load` - loads data from the requested source into a Pandas DataFrame for current use
+-   `export` - exports data in your pipeline to the requested source
+
+The following examples will examine how data loading clients use these functions to import and export your data.
+
+## Example: Loading data from a file
+
+While traditional Pandas IO procedures can be utilized to load files into your pipeline, Mage provides the `mage_ai.io.file.FileIO` client as a convenience wrapper. The following code uses the `load` function of the `FileIO` client to load the Titanic survival dataset from a CSV file into a Pandas DataFrame for use in your pipeline. All data loaders can be initialized with the `verbose = True` parameter to enable verbose output printing the current action the data loading client is performing. This parameter defaults to `False`.
+
+```python
+loader = FileIO(verbose=True)
+df = loader.load(
+    'https://raw.githubusercontent.com/datasciencedojo/datasets/master/titanic.csv'
+)
+```
+
+Then the `export` function is used to save this data frame back to file, this time in JSON format
+
+```python
+loader.export(df, './titanic_survival.json', orient='records')
+```
+
+Any formatting settings (such as specifying the JSON orient) can be passed as keyword arguments to `load` and `export`. These arguments are passed to Pandas IO procedures for the requested file format, allowing you the same level as control as the base Pandas IO procedures.
+
+As the data loader was constructed with the verbose parameter set to `True`, the above operations would print the following output describing the actions of the data loader.
+
+```bash
+FileIO initialized
+├─ Loading data frame from 'https://raw.githubusercontent.com/datasciencedojodatasets/master/titanic.csv'...DONE
+└─ Exporting data frame to './titanic_survival.json'...DONE
+```
+
+To read more about loading from files, see the [FileIO](#fileio) API for more details on member functions and usage.
+
+## Example: Loading data from Snowflake warehouse
+
+Loading data from a Snowflake data warehouse is made easy using the `mage_ai.io.snowflake.Snowflake` data loading client. In order to authenticate and access your Snowflake data, the client will require access to your Snowflake credentials:
+
+-   Account Username
+-   Account Password
+-   Account ID (including your region) (Ex: _example.us-west-2_)
+
+These parameters can be manually specified as input to the data loading client (see [Snowflake](#snowflake) API). However we recommend using a [Configuration Loader](#configuration-settings) to handle loading these secrets. If you used `mage init` to create your project repository, you can store these values in your `io_config.yaml` file and using a `mage_ai.io.config.ConfigFileLoader` to construct the data loader client.
+
+An example `io_config.yaml` file in this instance would be:
+
+```yaml
+default:
+    SNOWFLAKE_USER: my_username
+    SNOWFLAKE_PASSWORD: my_password
+    SNOWFLAKE_ACCOUNT_ID: example.us-west-2
+```
+
+with which a Snowflake data loading client can be constructed as:
+
+```python
+config = ConfigFileLoader('io_config.py', 'default')
+loader = Snowflake.with_config(config, verbose=True)
+```
+
+To learn more about using configuration settings, see [Configuration Settings](#configuration-settings).
+
+Then the following code uses the functions:
+
+-   `execute` to execute an arbitrary query on your data warehouse. In this case, the warehouse, database, and schema to use are selected.
+-   `load` to load the results of a SELECT query into a Pandas DataFrame.
+-   `export` to export the data frame to a table in your data warehouse. If the table exists, then the data is appended by default (and can be configured with other behavior, see [Snowflake](#snowflake) API). If the table doesn't exist, then the table is created with the given schema name and table name.
+
+```python
+with loader:
+    loader.execute('USE WAREHOUSE my_warehouse;')
+    loader.execute('USE DATABASE my_database;')
+    loader.execute('USE SCHEMA my_schema;')
+    df = loader.load('SELECT * FROM test_table;')
+    loader.export(df, 'my_schema', 'test_table')
+```
+
+The `loader` object manages a direct connection to your Snowflake data warehouse, so it is important to make sure that your connection is closed once your operations are completed. You can manually use `loader.open()` and `loader.close()` to open and close the connection to your data warehouse, or instead use the context manager syntax to automatically open and close the connection.
+
+To learn more about loading data from Snowflake, see the [Snowflake](#snowflake) API for more details on member functions and usage.
+
+# Client APIs
+
+This section covers the API for using the following data loaders.
+
+## Redshift
+
+## S3
+
+## FileIO
+
+## BigQuery
+
+## PostgreSQL
+
+## Snowflake
+
+# Configuration Settings
+
+Connections to third-party data storage require you to specify confidential information such as login information or access keys. While you can manually specify this information code while constructing data loading clients, it is recommended to not store the secrets directly in code.
+
+To help with this, Mage provides **configuration loaders** which load confidential configuration settings for use by data loading clients without exposing secrets in code.
+
+Currently, the following sources (and their corresponding configuration loader) can be used to load configuration settings:
+
+-   Configuration File - `ConfigFileLoader`
+-   Environment Variables - `EnvironmentVariableLoader`
+-   AWS Secrets Manager - `AWSSecretLoader`
+
+For example, the code below constructs a Redshift data loading client using secrets from an AWS Secrets Manager
+
+```python
+from mage_ai.io.config import AWSSecretLoader
+from mage_ai.io.redshift import Redshift
+
+config = AWSSecretLoader()
+loader = Redshift.from_config(config)
+```
+
+The following is a table of the names of configuration settings that can be read by a configuration loader. When storing secrets in a configuration file, in an environment variable, or on AWS Secrets Manager, use these key names to store your secrets. To access these keys in code, you can manually write the title as a string, or you can use the `mage_ai.io.config.ConfigKey` enum.
+
+| Key Name                        | Service         | Client Parameter    | Description                                                    | Notes                                 |
+| ------------------------------- | --------------- | ------------------- | -------------------------------------------------------------- | ------------------------------------- |
+| AWS_ACCESS_KEY_ID               | AWS General     | access_key_id       | AWS Access Key ID credential                                   | Used by Redshift and S3               |
+| AWS_SECRET_ACCESS_KEY           | AWS General     | secret_access_key   | AWS Secret Access Key credential                               | Used by Redshift and S3               |
+| AWS_SESSION_TOKEN               | AWS General     | session_token       | AWS Session Token (used to generate temporary DB credentials)  | Used by Redshift                      |
+| AWS_REGION                      | AWS General     | region              | AWS Region                                                     | Used by Redshift and S3               |
+| REDSHIFT_DBNAME                 | AWS Redshift    | database            | Name of Redshift database to connect to                        |                                       |
+| REDSHIFT_HOST                   | AWS Redshift    | host                | Redshift Cluster hostname                                      | Use with temporary credentials        |
+| REDSHIFT_PORT                   | AWS Redshift    | port                | Redshift Cluster port. If not specified. Defaults to 5439.     | Use with temporary credentials        |
+| REDSHIFT_TEMP_CRED_USER         | AWS Redshift    | user                | Redshift temporary credentials username.                       | Use with temporary credentials        |
+| REDSHIFT_TEMP_CRED_PASSWORD     | AWS Redshift    | password            | Redshift temporary credentials password.                       | Use with temporary credentials        |
+| REDSHIFT_DBUSER                 | AWS Redshift    | db_user             | Redshift database user to generate credentials for.            | Use to generate temporary credentials |
+| REDSHIFT_CLUSTER_ID             | AWS Redshift    | cluster_identifier  | Redshift cluster ID                                            | Use to generate temporary credentials |
+| REDSHIFT_IAM_PROFILE            | AWS Redshift    | profile             | Name of the IAM profile to generate temporary credentials with | Use to generate temporary credentials |
+| POSTGRES_DBNAME                 | PostgreSQL      | dbname              | Database name                                                  |                                       |
+| POSTGRES_USER                   | PostgreSQL      | user                | Database login username                                        |                                       |
+| POSTGRES_PASSWORD               | PostgreSQL      | password            | Database login password                                        |                                       |
+| POSTGRES_HOST                   | PostgreSQL      | host                | Database hostname                                              |                                       |
+| POSTGRES_PORT                   | PostgreSQL      | port                | PostgreSQL database port                                       |                                       |
+| SNOWFLAKE_USER                  | Snowflake       | user                | Snowflake username                                             |                                       |
+| SNOWFLAKE_PASS                  | Snowflake       | password            | Snowflake password                                             |                                       |
+| SNOWFLAKE_ACCOUNT               | Snowflake       | account             | Snowflake account ID (including region)                        |                                       |
+| SNOWFLAKE_DEFAULT_DB            | Snowflake       | database            | Default database to use                                        |                                       |
+| SNOWFLAKE_DEFAULT_SCHEMA        | Snowflake       | schema              | Default schema to use                                          |                                       |
+| SNOWFLAKE_DEFAULT_WH            | Snowflake       | warehouse           | Default warehouse to use.                                      |                                       |
+| GOOGLE_SERVICE_ACC_KEY          | Google BigQuery | credentials_mapping | Service account key                                            |                                       |
+| GOOGLE_SERVICE_ACC_KEY_FILEPATH | Google BigQuery | path_to_credentials | Path to service account key                                    |                                       |
+
+## Configuration Loader APIs
+
+This section contains the exact APIs and more detailed information on the configuration loaders. Every configuration loader has two functions:
+
+-   `contains` - checks if the configuration source contains the requested key. Commonly, the `in` operation is used to check for setting existence (but is not necessarily identical as `contains` can accept multiple parameters while the `in` keyword only accepts the key).
+
+    ```python
+    if config.contains(ConfigKey.POSTGRES_PORT):
+        ...
+    # alternatively
+    if ConfigKey.POSTGRES_PORT in config:
+        ...
+    ```
+
+-   `get` - gets the configuration setting associated with the given key. If the key doesn't exist, returns None. Commonly, the data model overload `__getitem__` is used to fetch a configuration setting (but is not necessarily identical as `get` can accept multiple parameters while `__getitem__` does not).
+
+    ```python
+    user = config.get(ConfigKey.REDSHIFT_DBUSER)
+    # alternatively
+    user = config[ConfigKey.REDSHIFT_DBUSER]
+    ```
+
+These functions are shared among all configuration loaders, but depending on the source some function signatures may differ.
+
+### Configuration File
+
+### Environment Variables
+
+### AWSSecretLoader

--- a/docs/blocks/data_loading.md
+++ b/docs/blocks/data_loading.md
@@ -1,4 +1,5 @@
 # Table of Contents
+
 - [Table of Contents](#table-of-contents)
 - [Data Loading Overview](#data-loading-overview)
   - [Example: Loading data from a file](#example-loading-data-from-a-file)
@@ -18,20 +19,26 @@
 
 # Data Loading Overview
 
-Mage provides data loading clients that simplify loading and exporting data in your pipelines, allowing you to spend more time analyzing and transforming your data for ML tasks. Currently, Mage contains clients for the following data sources:
+Mage provides data loading clients that simplify loading and exporting data in your pipelines, allowing you to spend more time analyzing and transforming your data for ML tasks. Currently, Mage includes clients for the following data sources:
 
 -   AWS Redshift
 -   AWS S3
--   File Loading
+-   Filesystem
 -   Google BigQuery
 -   PostgreSQL Database
 -   Snowflake
+
+Mage's data loading clients fall into two categories:
+
+-   **File-Loading Clients** - import/export data between files and your pipeline. Includes both local filesystem storage and external filesystem storage (like AWS S3)
+-   **Database Clients** - imports data from an external database into your pipeline and exports data frames back into that database.
+    -   A subcategory of database clients are **connection-based clients**, which wrap a connection to the database. This connection is used to execute transactions (sets of queries) on the database, which are either committed (saved to database) or rolled-back (deleted). Clients for PostgreSQL, Redshift, and Snowflake follow this structure.
 
 ## Example: Loading data from a file
 
 While traditional Pandas IO procedures can be utilized to load files into your pipeline, Mage provides the `mage_ai.io.file.FileIO` client as a convenience wrapper.
 
-The following code uses the `load` function of the `FileIO` client to load the Titanic survival dataset from a CSV file into a Pandas DataFrame for use in your pipeline. All data loaders can be initialized with the `verbose = True` parameter to enable verbose output printing the current action the data loading client is performing. This parameter defaults to `False`.
+The following code uses the `load` function of the `FileIO` client to load the Titanic survival dataset from a CSV file into a Pandas DataFrame for use in your pipeline. All data loaders can be initialized with the `verbose = True` parameter, which will print the current action the data loading client is performing. This parameter defaults to `False`.
 
 ```python
 loader = FileIO(verbose=True)
@@ -46,7 +53,7 @@ Then the `export` function is used to save this data frame back to file, this ti
 loader.export(df, './titanic_survival.json', orient='records')
 ```
 
-Any formatting settings (such as specifying the JSON orient) can be passed as keyword arguments to `load` and `export`. These arguments are passed to Pandas IO procedures for the requested file format, allowing you finer-grained control over how your data is loaded and exported.
+Any formatting settings (such as specifying the data frame _orient_) can be passed as keyword arguments to `load` and `export`. These arguments are passed to Pandas IO procedures for the requested file format, enabling fine-grained control over how your data is loaded and exported.
 
 As the data loader was constructed with the verbose parameter set to `True`, the above operations would print the following output describing the actions of the data loader.
 
@@ -56,19 +63,17 @@ FileIO initialized
 └─ Exporting data frame to './titanic_survival.json'...DONE
 ```
 
-To read more about loading from files, see the [FileIO](#fileio) API for more details on member functions and usage.
+See the [FileIO](#fileio) API to learn more about loading data from filesystem.
 
 ## Example: Loading data from Snowflake warehouse
 
-Loading data from a Snowflake data warehouse is made easy using the `mage_ai.io.snowflake.Snowflake` data loading client. In order to authenticate and access your Snowflake data, the client will require access to your Snowflake credentials:
+Loading data from a Snowflake data warehouse is made easy using the `mage_ai.io.snowflake.Snowflake` data loading client. In order to authenticate access to a Snowflake warehouse, the client requires the associated Snowflake credentials:
 
 -   Account Username
 -   Account Password
 -   Account ID (including your region) (Ex: _example.us-west-2_)
 
-These parameters can be manually specified as input to the data loading client (see [Snowflake](#snowflake) API). However we recommend using a [Configuration Loader](#configuration-settings) to handle loading these secrets. If you used `mage init` to create your project repository, you can store these values in your `io_config.yaml` file and use
-
-`mage_ai.io.config.ConfigFileLoader` to construct the data loader client.
+These parameters can be manually specified as input to the data loading client (see [Snowflake](#snowflake) API). However we recommend using a [Configuration Loader](#configuration-settings) to handle loading these secrets. If you used `mage init` to create your project repository, you can store these values in your `io_config.yaml` file and use `mage_ai.io.config.ConfigFileLoader` to construct the data loader client.
 
 An example `io_config.yaml` file in this instance would be:
 
@@ -90,9 +95,9 @@ To learn more about using configuration settings, see [Configuration Settings](#
 
 Then the following code uses the functions:
 
--   `execute` to execute an arbitrary query on your data warehouse. In this case, the warehouse, database, and schema to use are selected.
--   `load` to load the results of a SELECT query into a Pandas DataFrame.
--   `export` to export the data frame to a table in your data warehouse. If the table exists, then the data is appended by default (and can be configured with other behavior, see [Snowflake](#snowflake) API). If the table doesn't exist, then the table is created with the given schema name and table name.
+-   `execute()` - executes an arbitrary query on your data warehouse. In this case, the warehouse, database, and schema to use are selected.
+-   `load()` - loads the results of a `SELECT` query into a Pandas DataFrame.
+-   `export()` - stores data frame as a table in your data warehouse. If the table exists, then the data is appended by default (and can be configured with other behavior, see [Snowflake](#snowflake) API). If the table doesn't exist, then the table is created with the given schema name and table name (the table data types are inferred from the Python data type).
 
 ```python
 with loader:
@@ -116,7 +121,8 @@ This section covers the API for using the following data loaders.
 `mage_ai.io.redshift.Redshift`
 
 Handles data transfer between a Redshift cluster and the Mage app. Mage uses temporary credentials to authenticate access to a Redshift cluster. There are two ways to specify these credentials:
-- Pre-generate your temporary credentials and specify them in your configuration settings. Use the following keys to add your credentials:
+
+1. Pre-generate temporary credentials and specify them in the configuration settings. Add the following keys to the configuration settings for `Redshift` to use the temporary credentials:
     ```yaml
     REDSHIFT_DBNAME: Name of Redshift database to connect to
     REDSHIFT_HOST: Redshift Cluster hostname
@@ -124,57 +130,47 @@ Handles data transfer between a Redshift cluster and the Mage app. Mage uses tem
     REDSHIFT_TEMP_CRED_USER: Redshift temp credentials username
     REDSHIFT_TEMP_CRED_PASSWORD: Redshift temp credentials password
     ```
-- Provide your IAM Profile to automatically generate temporary credentials for connection. Your IAM profile is read from `~/.aws/` and used alongside the information stored in the following keys to generate temporary credentials.
-    ```yaml
-    REDSHIFT_DBNAME: Name of Redshift database to connect toName of Redshift database to connect to
-    REDSHIFT_DBUSER: Redshift database user to generate credentials for
-    REDSHIFT_CLUSTER_ID: Redshift cluster ID
-    REDSHIFT_IAM_PROFILE: Name of the IAM profile to generate temp credentials with
-    ```
-    If you do not have your IAM profile setup using `aws configure` , manually specify your AWS credentials in your configuration settings as well.
-    ```yaml
-    AWS_ACCESS_KEY_ID: AWS Access Key ID credential
-    AWS_SECRET_ACCESS_KEY: AWS Secret Access Key credential
-    AWS_SESSION_TOKEN: AWS Session Token (used to generate temp DB credentials)
-    AWS_REGION: AWS Region
-    ```
-<h3> Constructor </h3> 
+2. Provide an IAM Profile to automatically generate temporary credentials for connection. The IAM profile is read from `~/.aws/` and is used with the `GetClusterCredentials` endpoint to generate temporary credentials. Add the following keys to the configuration settings for `Redshift` to generate temporary credentials
+   `yaml REDSHIFT_DBNAME: Name of Redshift database to connect toName of Redshift database to connect to REDSHIFT_DBUSER: Redshift database user to generate credentials for REDSHIFT_CLUSTER_ID: Redshift cluster ID REDSHIFT_IAM_PROFILE: Name of the IAM profile to generate temp credentials with `
+   If an IAM profile is not setup using `aws configure`, manually specify the AWS credentials in the configuration settings as well.
+   `yaml AWS_ACCESS_KEY_ID: AWS Access Key ID credential AWS_SECRET_ACCESS_KEY: AWS Secret Access Key credential AWS_SESSION_TOKEN: AWS Session Token (used to generate temp DB credentials) AWS_REGION: AWS Region `
+     <h3> Constructor </h3>
 
 `__init__(**kwargs)`
-- **Keyword Arguments**
-  - `verbose`: Enables verbose output. Defaults to `False`.
 
-  See other keyword arguments in [Redshift's Python connector](https://docs.aws.amazon.com/redshift/latest/mgmt/python-configuration-options.html) docs.
+-   **Args**
+
+    -   `verbose`: Enables verbose output. Defaults to `False`.
+
+    See other keyword arguments in [Redshift's Python connector](https://docs.aws.amazon.com/redshift/latest/mgmt/python-configuration-options.html) docs.
 
 <h3> Attributes </h3>
 
-- _conn_ (`redshift_connector.Connection`) - the underlying [Redshift Connection](https://docs.aws.amazon.com/redshift/latest/mgmt/python-api-reference.html#python-api-connection) object.
+-   _conn_ (`redshift_connector.Connection`) - the underlying [Redshift Connection](https://docs.aws.amazon.com/redshift/latest/mgmt/python-api-reference.html#python-api-connection) object.
 
 <h3> Factory Methods </h3>
 
 **_with_config_** - `with_config(config: BaseConfigLoader, **kwargs) -> Redshift`
 
-Initializes Redshift client from configuration loader.
+Initializes Redshift client from configuration settings.
 
-- **Args**:
-  - `config (BaseConfigLoader)`: Configuration loader object
-  - `verbose (bool)`: Enables verbose output printing. Defaults to False.
-  - `**kwargs`: Additional parameters passed to the loader constructor
+-   **Args**:
+    -   `config (BaseConfigLoader)`: Configuration loader object.
+    -   `**kwargs`: Additional parameters passed to the loader constructor.
+-   **Returns**: (`Redshift`) Redshift data loading client constructed using this method
 
 **_with_temporary_credentials_** - `with_temporary_credentials(database: str, host: str, user: str, password: str, port: int = 5439, **kwargs) -> Redshift`
 
+Creates a Redshift data loader with temporary database credentials.
 
-Creates a Redshift data loader from temporary database credentials.
-
-- **Args**:
-  - `database (str)`: Name of the database to connect to
-  - `host (str)`: The hostname of the Redshift cluster which the database belongs to
-  - `user (str)`: Temporary credentials username for authentication
-  - `password (str)`: Temporary credentials password for authentication
-  - `port (int, optional)`: Port number of the Redshift cluster. Defaults to 5439.
-  - `**kwargs`: Additional parameters passed to the loader constructor
-- **Returns**: (`Redshift`) the constructed dataloader using this method
-
+-   **Args**:
+    -   `database (str)`: Name of the database to connect to.
+    -   `host (str)`: The hostname of the Redshift cluster which the database belongs to.
+    -   `user (str)`: Temporary credentials username for use in authentication.
+    -   `password (str)`: Temporary credentials password for use in authentication.
+    -   `port (int, optional)`: Port number of the Redshift cluster. Defaults to 5439.
+    -   `**kwargs`: Additional parameters passed to the loader constructor.
+-   **Returns**: (`Redshift`) Redshift data loading client constructed using this method
 
 **_with_iam_** - `with_iam(cluster_identifier: str, database: str, db_user: str, profile: str, **kwargs) -> Redshift`
 
@@ -182,14 +178,14 @@ Creates a Redshift data loader using an IAM profile from `~/.aws`.
 
 The IAM Profile settings can also be manually specified as keyword arguments to this constructor, but is not recommended. If credentials are manually specified, the region of the Redshift cluster must also be specified.
 
-- **Args**:
-  - `cluster_identifier (str)`: Identifier of the cluster to connect to.
-  - `database (str)`: The database to connect to within the specified cluster.
-  - `db_user (str)`: Database username
-  - `profile (str, optional)`: The profile to use from stored credentials file.
-  Defaults to 'default'.
-  - `**kwargs`: Additional parameters passed to the loader constructor
-- **Returns**: (`Redshift`) The constructed dataloader using this method
+-   **Args**:
+    -   `cluster_identifier (str)`: Identifier of the cluster to connect to.
+    -   `database (str)`: The database to connect to within the specified cluster.
+    -   `db_user (str)`: Database username
+    -   `profile (str, optional)`: The profile to use from stored credentials file.
+        Defaults to 'default'.
+    -   `**kwargs`: Additional parameters passed to the loader constructor
+-   **Returns**: (`Redshift`) Redshift data loading client constructed using this method
 
 <h3> Methods </h3>
 
@@ -199,37 +195,38 @@ Closes connection to the Redshift cluster specified in the loader configuration.
 
 **_commit_** - `commit()`
 
-Writes all changes made to the database since the previous transaction.
+Saves all changes made to the database since the last transaction.
 
 **_execute_** - `execute(query_string: str, **kwargs) -> None`
 
-Sends query to the connected Redshift cluster.
+Sends query to the connected Redshift cluster. Any changes made to the database will not be saved unless `commit()` is called afterward.
 
-- **Args**:
-  - `query_string (str)`: The query to execute on the Redshift cluster.
-  - `**kwargs`: Additional parameters to pass to the query. See [`redshift-connector` docs](https://github.com/aws/amazon-redshift-python-driver#configuring-cursor-paramstyle) for configuring query parameters.
+-   **Args**:
+    -   `query_string (str)`: The query to execute on the Redshift cluster.
+    -   `**kwargs`: Additional parameters to pass to the query. See [`redshift-connector` docs](https://github.com/aws/amazon-redshift-python-driver#configuring-cursor-paramstyle) for configuring query parameters.
 
 **_export_** - `export(df: DataFrame, table_name: str) -> None`
 
-Exports a Pandas data frame to a Redshift cluster given table name.
+Exports a Pandas data frame to a Redshift cluster under the specified table. The changes made to the database will not be saved unless `commit()` is called afterward.
 
-- **Args**:
-  - `df (DataFrame)`: Data frame to export to a Redshift cluster.
-  - `table_name (str)`: Name of the table to export the data to. Table must already exist.
-
+-   **Args**:
+    -   `df (DataFrame)`: Data frame to export to database in Redshift cluster.
+    -   `table_name (str)`: Name of the table to export the data to. Table must already exist.
 
 **_load_** - `load(query_string: str, limit: int, *args, **kwargs) -> DataFrame`
 
-Uses query to load data from Redshift cluster into a Pandas data frame. This will fail if the query returns no data from the database. When a select query is provided, this function will load at maximum 100,000 rows of data. To operate on more data, consider performing data transformations in warehouse using `execute`.
+Loads data from the results of a query into a Pandas data frame. This will fail if the query returns no data from the database.
 
+This function will load at maximum 100,000 rows of data (this limit is configurable). To operate on more data, consider performing data transformations in warehouse using `execute`.
 
-- **Args**:
-  - `query_string (str)`: Query to fetch a table or subset of a table.
-  - `limit (int, Optional)`: The number of rows to limit the loaded dataframe to. Defaults to 100000.
-  - `*args, **kwargs`: Additional parameters to send to query, including parameters
-  for use with format strings. See [`redshift-connector` docs](https://github.com/aws/amazon-redshift-python-driver#configuring-cursor-paramstyle) for configuring query parameters.
+-   **Args**:
 
-- **Returns**: (`DataFrame`) Data frame containing the queried data
+    -   `query_string (str)`: Query to fetch a table or subset of a table.
+    -   `limit (int, Optional)`: The number of rows to limit the loaded data frame to. Defaults to 100,000.
+    -   `*args, **kwargs`: Additional parameters to send to query, including parameters
+        for use with format strings. See [`redshift-connector` docs](https://github.com/aws/amazon-redshift-python-driver#configuring-cursor-paramstyle) for configuring query parameters.
+
+-   **Returns**: (`DataFrame`) Data frame containing the queried data.
 
 **_open_** - `open()`
 
@@ -237,32 +234,35 @@ Opens a connection to the Redshift cluster specified in the loader configuration
 
 **_rollback_** - `rollback()`
 
-Rolls back (deletes) all database operations made since the last transaction.
+Rolls back (deletes) all database changes made since the last transaction.
 
 **_sample_** - `sample(schema: str, table: str, size: int, **kwargs) -> DataFrame`
 
 Sample data from a table in the selected database in the Redshift cluster. Sample is not guaranteed to be random.
 
-- **Args**:
-  - `schema (str)`: The schema to select the table from.
-  - `size (int)`: The number of rows to sample. Defaults to 100,000
-  - `table (str)`: The table to sample from in the connected database.
+-   **Args**:
 
-- **Returns**: (`DataFrame`) Sampled data from the data frame.
+    -   `schema (str)`: The schema to select the table from.
+    -   `size (int)`: The number of rows to sample. Defaults to 100,000.
+    -   `table (str)`: The table to sample from in the connected database.
 
+-   **Returns**: (`DataFrame`) Sampled data from the table.
 
 ## S3
 
 `mage_ai.io.s3.S3`
 
-Handles data transfer between the filesystem and the Mage app. The `S3` client currently supports importing and exporting with the following file formats:
-- CSV
-- JSON
-- Parquet
-- HDF5
+Handles data transfer between an S3 bucket and the Mage app. The `S3` client supports importing and exporting with the following file formats:
 
-If IAM profile is not set up using `aws configure`, then AWS credentials can be manually specified through either Mage's [configuration loader](#configuration-settings) system or through keyword arguments in the constructor (see constructor). If using configuration settings,
-specify the following keys:
+-   CSV
+-   JSON
+-   Parquet
+-   HDF5
+
+If an IAM profile is not set up using `aws configure`, then AWS credentials for accesses the S3 bucket can be manually specified through either Mage's [configuration loader](#configuration-settings) system or through keyword arguments in the constructor (see constructor).
+
+If using configuration settings, specify the following keys:
+
 ```yaml
 AWS_ACCESS_KEY_ID: AWS Access Key ID credential
 AWS_SECRET_ACCESS_KEY: AWS Secret Access Key credential
@@ -273,14 +273,25 @@ AWS_REGION: AWS Region
 
 `__init__(self, verbose: bool)`
 
-Initializes the BigQuery data loading client. I
+Initializes the S3 data loading client.
 
-- **Args**
-    - `verbose (bool)`: Enables verbose output printing. Defaults to False.
-    - If IAM profile is not set up using `aws configure` and Mage's configuration loader is not used, then specify your AWS credentials through the following keyword arguments:
-      - `aws_access_key_id (str)`: AWS Access Key ID credential
-      - `aws_secret_access_key (str)`: AWS Secret Access Key credential
-      - `aws_region (str)`: Region of S3 service to connect to
+-   **Args**
+    -   `verbose (bool)`: Enables verbose output printing. Defaults to False.
+    -   If IAM profile is not set up using `aws configure` and Mage's configuration loader is not used, then specify your AWS credentials through the following keyword arguments:
+        -   `aws_access_key_id (str)`: AWS Access Key ID credential
+        -   `aws_secret_access_key (str)`: AWS Secret Access Key credential
+        -   `aws_region (str)`: Region associated with AWS IAM profile
+
+<h3> Factory Methods </h3>
+
+**_with_config_** - `with_config(config: BaseConfigLoader, **kwargs) -> S3`
+
+Creates S3 data loading client from configuration settings.
+
+-   **Args**:
+    -   `config (BaseConfigLoader)`: Configuration loader object.
+    -   `**kwargs`: Additional parameters passed to the loader constructor
+-   **Returns**: (`S3`) The constructed dataloader using this method
 
 <h3> Methods </h3>
 
@@ -288,63 +299,63 @@ Initializes the BigQuery data loading client. I
 
 Exports data frame to an S3 bucket.
 
-If the format is HDF5, the default key under which the data frame is stored is the stem of the filename. For example, if the file to write the HDF5 file to is 'storage/my_data_frame.hdf5', the key would be 'my_data_frame'. This can be overridden using the `key` keyword argument.
+If the format is HDF5, the default key under which the data frame is stored is the stem of the filename. For example, if the file to write the data frame to is 'storage/my_data_frame.hdf5', the key would be 'my_data_frame'. This can be overridden using the `key` keyword argument.
 
-- **Args**:
-  - `df (DataFrame)`: Data frame to export.
-  - `bucket_name (str)`: Name of the bucket to export data frame to0.
-  - `object_key (str)`: Key of the object in S3 bucket to export data frame to.
-  - `format (FileFormat | str, Optional)`: Format of the file to export data frame to.
-    Defaults to None, in which case the format is inferred.
-  - `**kwargs` - Additional keyword arguments to pass to the file writer. See possible arguments by file formats at:
+-   **Args**:
 
-    |Format|Pandas Writer|
-    |------|----------------|
-    |CSV|[_DataFrame.to_csv_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_csv.html)|
-    |JSON|[_DataFrame.to_json_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_json.html)|
-    |Parquet|[_DataFrame.to_parquet_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_parquet.html)|
-    |HDF5|[_DataFrame.to_hdf_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_hdf.html)|
+    -   `df (DataFrame)`: Data frame to export.
+    -   `bucket_name (str)`: Name of the bucket to export data frame to.
+    -   `object_key (str)`: Object key in S3 bucket to export data frame to.
+    -   `format (FileFormat | str, Optional)`: Format of the file to export data frame to. Defaults to `None`, in which case the format is inferred.
+    -   `**kwargs` - Additional keyword arguments to pass to the file writer. See possible arguments by file formats at:
 
-
+        | Format  | Pandas Writer                                                                                                         |
+        | ------- | --------------------------------------------------------------------------------------------------------------------- |
+        | CSV     | [_DataFrame.to_csv_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_csv.html)         |
+        | JSON    | [_DataFrame.to_json_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_json.html)       |
+        | Parquet | [_DataFrame.to_parquet_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_parquet.html) |
+        | HDF5    | [_DataFrame.to_hdf_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_hdf.html)         |
 
 **_load_** - `load(bucket_name: str, object_key: str, format: FileFormat | str = None, limit: int = QUERY_ROW_LIMIT **kwargs) -> DataFrame`
 
-Loads data from S3 into a Pandas data frame. This function will load at maximum 100,000 rows of data from the specified file.
+Loads data from object in S3 bucket into a Pandas data frame. This function will load at maximum 100,000 rows of data from the specified file (this limit is configurable).
 
-- **Args**:
-  - `bucket_name (str)`: Name of the bucket to load data from.
-  - `object_key (str)`: Key of the object in S3 bucket to load data from.
-  - `format (FileFormat | str, Optional)`: Format of the file to load data frame from. Defaults to None, in which case the format is inferred.
-  - `limit (int, optional)`: The number of rows to limit the loaded data frame to.
-    Defaults to 100000.
-  - `**kwargs` - Additional keyword arguments to pass to the file writer. See possible arguments by file formats at:
+-   **Args**:
 
-    |Format|Pandas Reader|
-    |------|----------------|
-    |CSV|[_read_csv_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html)|
-    |JSON|[_read_json_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_json.html)|
-    |Parquet|[_read_parquet_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_parquet.html)|
-    |HDF5|[_read_hdf_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_hdf.html)|
-- **Returns**: (`DataFrame`) Data frame object loaded from the specified data frame.
+    -   `bucket_name (str)`: Name of the bucket to load data from.
+    -   `object_key (str)`: Key of the object in S3 bucket to load data from.
+    -   `format (FileFormat | str, Optional)`: Format of the file to load data frame from. Defaults to None, in which case the format is inferred.
+    -   `limit (int, optional)`: The number of rows to limit the loaded data frame to. Defaults to 100,000.
+    -   `**kwargs` - Additional keyword arguments to pass to the file writer. See possible arguments by file formats at:
+
+        | Format  | Pandas Reader                                                                                         |
+        | ------- | ----------------------------------------------------------------------------------------------------- |
+        | CSV     | [_read_csv_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html)         |
+        | JSON    | [_read_json_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_json.html)       |
+        | Parquet | [_read_parquet_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_parquet.html) |
+        | HDF5    | [_read_hdf_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_hdf.html)         |
+
+-   **Returns**: (`DataFrame`) Data frame object loaded from data in the specified file.
 
 ## FileIO
 
 `mage_ai.io.file.FileIO`
 
 Handles data transfer between the filesystem and the Mage app. The `FileIO` client currently supports importing and exporting with the following file formats:
-- CSV
-- JSON
-- Parquet
-- HDF5
+
+-   CSV
+-   JSON
+-   Parquet
+-   HDF5
 
 <h3> Constructor </h3>
 
 `__init__(self, verbose: bool)`
 
-Initializes the BigQuery data loading client.
+Initializes the FileIO data loading client.
 
-- **Args**
-    - `verbose (bool)`: Enables verbose output printing. Defaults to False.
+-   **Args**
+    -   `verbose (bool)`: Enables verbose output printing. Defaults to False.
 
 <h3> Methods </h3>
 
@@ -352,42 +363,41 @@ Initializes the BigQuery data loading client.
 
 Exports the input data frame to the file specified.
 
-If the format is HDF5, the default key under which the data frame is stored is the stem of the filename. For example, if the file to write the HDF5 file to is 'storage/my_data_frame.hdf5', the key would be 'my_data_frame'. This can be overridden using the `key` keyword argument.
+If the format is HDF5, the default key under which the data frame is stored is the stem of the filename. For example, if the file to write the data frame to is 'storage/my_data_frame.hdf5', the key would be 'my_data_frame'. This can be overridden using the `key` keyword argument.
 
-- **Args**:
-    - `df (DataFrame)`: Data frame to export.
-    - `filepath (os.PathLike)`: Filepath to export data frame to.
-    - `format (FileFormat | str, Optional)`: Format of the file to export data frame to.
-    Defaults to None, in which case the format is inferred.
-    - `**kwargs` - Additional keyword arguments to pass to the file writer. See possible arguments by file formats at:
+-   **Args**:
 
-        |Format|Pandas Writer|
-        |------|----------------|
-        |CSV|[_DataFrame.to_csv_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_csv.html)|
-        |JSON|[_DataFrame.to_json_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_json.html)|
-        |Parquet|[_DataFrame.to_parquet_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_parquet.html)|
-        |HDF5|[_DataFrame.to_hdf_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_hdf.html)|
+    -   `df (DataFrame)`: Data frame to export.
+    -   `filepath (os.PathLike)`: Filepath to export data frame to.
+    -   `format (FileFormat | str, Optional)`: Format of the file to export data frame to. Defaults to None, in which case the format is inferred.
+    -   `**kwargs` - Additional keyword arguments to pass to the file writer. See possible arguments by file formats at:
 
-
+        | Format  | Pandas Writer                                                                                                         |
+        | ------- | --------------------------------------------------------------------------------------------------------------------- |
+        | CSV     | [_DataFrame.to_csv_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_csv.html)         |
+        | JSON    | [_DataFrame.to_json_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_json.html)       |
+        | Parquet | [_DataFrame.to_parquet_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_parquet.html) |
+        | HDF5    | [_DataFrame.to_hdf_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_hdf.html)         |
 
 **_load_** - `load(filepath: os.PathLike, format: FileFormat | str = None, limit: int = QUERY_ROW_LIMIT **kwargs) -> DataFrame`
 
-Loads the data frame from the filepath specified. This function will load at maximum 100,000 rows of data from the specified file.
+Loads the data frame from the filepath specified. This function will load at maximum 100,000 rows of data from the specified file (this limit is configurable).
 
-- **Args**:
-  - `filepath (os.PathLike)`: Filepath to load data frame from.
-  - `format (FileFormat | str, Optional)`: Format of the file to load data frame from. Defaults to None, in which case the format is inferred.
-  - `limit (int, optional)`: The number of rows to limit the loaded data frame to.
-    Defaults to 100000.
-  - `**kwargs` - Additional keyword arguments to pass to the file writer. See possible arguments by file formats at:
+-   **Args**:
 
-    |Format|Pandas Reader|
-    |------|----------------|
-    |CSV|[_read_csv_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html)|
-    |JSON|[_read_json_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_json.html)|
-    |Parquet|[_read_parquet_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_parquet.html)|
-    |HDF5|[_read_hdf_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_hdf.html)|
-- **Returns**: (`DataFrame`) Data frame object loaded from the specified data frame.
+    -   `filepath (os.PathLike)`: Filepath to load data frame from.
+    -   `format (FileFormat | str, Optional)`: Format of the file to load data frame from. Defaults to None, in which case the format is inferred.
+    -   `limit (int, optional)`: The number of rows to limit the loaded data frame to. Defaults to 100,000.
+    -   `**kwargs` - Additional keyword arguments to pass to the file writer. See possible arguments by file formats at:
+
+        | Format  | Pandas Reader                                                                                         |
+        | ------- | ----------------------------------------------------------------------------------------------------- |
+        | CSV     | [_read_csv_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html)         |
+        | JSON    | [_read_json_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_json.html)       |
+        | Parquet | [_read_parquet_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_parquet.html) |
+        | HDF5    | [_read_hdf_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_hdf.html)         |
+
+-   **Returns**: (`DataFrame`) Data frame object loaded from data in the specified file.
 
 ## BigQuery
 
@@ -396,11 +406,12 @@ Loads the data frame from the filepath specified. This function will load at max
 Handles data transfer between a BigQuery data warehouse and the Mage app.
 
 Authentication with a Google BigQuery warehouse requires specifying the service account key for the service account that has access to the BigQuery warehouse. There are four ways to provide this service key:
-- Define the `GOOGLE_APPLICATION_CREDENTIALS` environment variable holding the filepath to your service account key
-- Define the `GOOGLE_SERVICE_ACC_KEY_FILEPATH` key with your [configuration loader](#configuration-settings) or the `path_to_credentials` keyword argument with the client constructor holding the filepath to your service account key
-- Define the `GOOGLE_SERVICE_ACC_KEY` key with your [configuration loader](#configuration-settings) or the `credentials_mapping` keyword argument with the client constructor holding a mapping sharing the same contents as your service key
-  - if using a configuration file, be careful to wrap your service key values in quote so YAML parses the settings correctly
-- Manually pass the `google.oauth2.service_account.Credentials` object with the keyword argument `credentials`
+
+-   Define the `GOOGLE_APPLICATION_CREDENTIALS` environment variable holding the filepath to your service account key
+-   Define the `GOOGLE_SERVICE_ACC_KEY_FILEPATH` key with your [configuration loader](#configuration-settings) or the `path_to_credentials` keyword argument with the client constructor holding the filepath to your service account key
+-   Define the `GOOGLE_SERVICE_ACC_KEY` key with your [configuration loader](#configuration-settings) or the `credentials_mapping` keyword argument with the client constructor holding a mapping sharing the same contents as your service key
+    -   if using a configuration file, be careful to wrap your service key values in quotes so the YAML parser reads the settings correctly
+-   Manually pass the `google.oauth2.service_account.Credentials` object with the keyword argument `credentials`
 
 <h3> Constructor </h3>
 
@@ -408,10 +419,11 @@ Authentication with a Google BigQuery warehouse requires specifying the service 
 
 Initializes the BigQuery data loading client.
 
-- **Args**
-    - `verbose (bool)`: Enables verbose output printing. Defaults to False.
-    - `credentials_mapping (Mapping[str, str])` - Mapping object corresponding to your service account key. See instructions above on when to use this keyword argument
-    - `path_to_credentials (str)` - Filepath to service account key. See instructions above on when to use this keyword argument.
+-   **Args**
+
+    -   `verbose (bool)`: Enables verbose output printing. Defaults to `False`.
+    -   `credentials_mapping (Mapping[str, str])` - Mapping object corresponding to your service account key. See instructions above on when to use this keyword argument
+    -   `path_to_credentials (str)` - Filepath to service account key. See instructions above on when to use this keyword argument.
 
     All other keyword arguments can be found in the [Google BigQuery Python Client docs](https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.client.Client.html?highlight=client#google-cloud-bigquery-client-client)
 
@@ -421,33 +433,28 @@ Initializes the BigQuery data loading client.
 
 Creates BigQuery data loading client from configuration settings.
 
-- **Args**:
-  - `config (BaseConfigLoader)`: Configuration loader object.
-  - `verbose (bool)`: Enables verbose output printing. Defaults to False.
-  - `**kwargs`: Additional parameters passed to the loader constructor
-- **Returns**: (`Postgres`) The constructed dataloader using this method
+-   **Args**:
+    -   `config (BaseConfigLoader)`: Configuration loader object.
+    -   `**kwargs`: Additional parameters passed to the loader constructor
+-   **Returns**: (`BigQuery`) BigQuery data loading client constructed using this method
 
 **_with_credentials_file_** - `with_credentials_file(cls, path_to_credentials: str, **kwargs) -> BigQuery`
 
 Constructs BigQuery data loader using the file containing the service account key.
 
-- **Args**:
-    - `path_to_credentials (str)`: Path to the credentials file.
-    - `verbose (bool)`: Enables verbose output printing. Defaults to False.
-    - `**kwargs`: Additional parameters to pass to BigQuery client constructor.
-- **Returns**:
-    BigQuery: BigQuery data loader
+-   **Args**:
+    -   `path_to_credentials (str)`: Path to the credentials file.
+    -   `**kwargs`: Additional parameters to pass to BigQuery client constructor.
+-   **Returns**: (`BigQuery`) BigQuery data loading client constructed using this method
 
 **_with_credentials_object_** - `with_credentials_object(cls, credentials: Mapping[str, str], **kwargs) -> BigQuery`
 
 Constructs BigQuery data loader using manually specified service account key credentials.
 
-- **Args**:
-    - `credentials (Mapping[str, str])`: Mapping containing same key-value pairs as a service account key.
-    - `verbose (bool)`: Enables verbose output printing. Defaults to False.
-    - `**kwargs`: Additional parameters to pass to BigQuery client constructor.
-- **Returns**:
-    BigQuery: BigQuery data loader
+-   **Args**:
+    -   `credentials (Mapping[str, str])`: Mapping containing same key-value pairs as a service account key.
+    -   `**kwargs`: Additional parameters to pass to BigQuery client constructor.
+-   **Returns**: (`BigQuery`) BigQuery data loading client constructed using this method
 
 <h3> Methods </h3>
 
@@ -455,61 +462,57 @@ Constructs BigQuery data loader using manually specified service account key cre
 
 Sends query to the connected BigQuery warehouse.
 
-- **Args**:
-    - `query_string (str)`: Query to execute on the BigQuery warehouse.
-    - `**kwargs`: Additional arguments to pass to query, such as query configurations. See [_Client.query()_](https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.client.Client.html?highlight=client#google.cloud.bigquery.client.Client.query) docs for additional arguments.
+-   **Args**:
+    -   `query_string (str)`: Query to execute on the BigQuery warehouse.
+    -   `**kwargs`: Additional arguments to pass to query, such as query configurations. See [_Client.query()_](https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.client.Client.html?highlight=client#google.cloud.bigquery.client.Client.query) docs for additional arguments.
 
 **_export_** - `export(df: DataFrame, table_name: str, database: str, schema: str, if_exists: str, **kwargs) -> None`
 
-Exports a data frame to a Google BigQuery warehouse.  If table doesn't exist, the table is automatically created.
+Exports a data frame to a Google BigQuery warehouse. If table doesn't exist, the table is automatically created.
 
-- **Args**:
-    - `df (DataFrame)`: Data frame to export
-    - `table_id (str)`: ID of the table to export the data frame to. If of the format
-    `"your-project.your_dataset.your_table_name"`. If this table exists,
-    the table schema must match the data frame schema. If this table doesn't exist,
-    the table schema is automatically inferred.
-    - `if_exists (str)`: Specifies export policy if table exists. Either
-        - `'fail'`: throw an error.
-        - `'replace'`: drops existing table and creates new table of same name.
-        - `'append'`: appends data frame to existing table. In this case the schema must match the original table.
-    Defaults to `'replace'`. If `write_disposition` is specified as a keyword argument, this parameter
-    is ignored (as both define the same functionality).
-    - `**configuration_params`: Configuration parameters for export job. See valid configuration parameters at [_LoadJobConfig_](https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.job.LoadJobConfig.html#google.cloud.bigquery.job.LoadJobConfig) docs.
-
+-   **Args**:
+    -   `df (DataFrame)`: Data frame to export
+    -   `table_id (str)`: ID of the table to export the data frame to. If of the format
+        `"your-project.your_dataset.your_table_name"`. If this table exists, the table schema must match the data frame schema. If this table doesn't exist, the table schema is automatically inferred.
+    -   `if_exists (str)`: Specifies export policy if table exists. Either - `'fail'`: throw an error. - `'replace'`: drops existing table and creates new table of same name. - `'append'`: appends data frame to existing table. In this case the schema must match the original table.
+        Defaults to `'replace'`. If `write_disposition` is specified as a keyword argument, this parameter
+        is ignored (as both define the same functionality).
+    -   `**configuration_params`: Configuration parameters for export job. See valid configuration parameters at [_LoadJobConfig_](https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.job.LoadJobConfig.html#google.cloud.bigquery.job.LoadJobConfig) docs.
 
 **_load_** - `load(query_string: str, limit: int, *args, **kwargs) -> DataFrame`
 
-Loads data from BigQuery into a Pandas data frame based on the query given. This will fail if the query returns no data from the database. When a select query is provided, this function will load at maximum 100,000 rows of data. To operate on more data, consider performing data transformations in warehouse.
+Loads data from the results of a query into a Pandas data frame. This will fail if the query returns no data from the database.
 
+When a select query is provided, this function will load at maximum 100,000 rows of data (this limit is configurable). To operate on more data, consider performing data transformations in warehouse.
 
-- **Args**:
-  - `query_string (str)`: Query to fetch a table or subset of a table.
-  - `limit (int, Optional)`: The number of rows to limit the loaded data frame to. Defaults to 100000.
-  - `**kwargs`: Additional parameters to pass to the query. See [Google BigQuery Python client](https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.client.Client.html?highlight=client#google.cloud.bigquery.client.Client.query) docs for additional arguments.
+-   **Args**:
+    -   `query_string (str)`: Query to fetch a table or subset of a table.
+    -   `limit (int, Optional)`: The number of rows to limit the loaded data frame to. Defaults to 100,000.
+    -   `**kwargs`: Additional parameters to pass to the query. See [Google BigQuery Python client](https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.client.Client.html?highlight=client#google.cloud.bigquery.client.Client.query) docs for additional arguments.
 
 **_sample_** - `sample(schema: str, table: str, size: int, **kwargs) -> DataFrame`
 
 Sample data from a table in the BigQuery warehouse. Sample is not guaranteed to be random.
 
-- **Args**:
-  - `schema (str)`: The schema to select the table from.
-  - `size (int)`: The number of rows to sample. Defaults to 100,000
-  - `table (str)`: The table to sample from in the connected database.
+-   **Args**:
 
-- **Returns**: (`DataFrame`) Sampled data from the data frame.
+    -   `schema (str)`: The schema to select the table from.
+    -   `size (int)`: The number of rows to sample. Defaults to 100,000
+    -   `table (str)`: The table to sample from in the connected database.
+
+-   **Returns**: (`DataFrame`) Sampled data from the table.
 
 ## PostgreSQL
 
 `mage_ai.io.postgres.Postgres`
 
-Handles data transfer between a PostgreSQL database and the Mage app. Constructing a Postgres loader includes using the following configuration setting keys with your configuration loader:
+Handles data transfer between a PostgreSQL database and the Mage app. The `Postgres` client utilizes the following keys to connect the PostgreSQL database.
 
 ```yaml
-POSTGRES_DBNAME: Database name
-POSTGRES_USER: Database login username
-POSTGRES_PASSWORD: Database login password
-POSTGRES_HOST: Database hostname
+POSTGRES_DBNAME: PostgreSQL database name
+POSTGRES_USER: PostgreSQL database login username
+POSTGRES_PASSWORD: PostgreSQL database login password
+POSTGRES_HOST: PostgreSQL database hostname
 POSTGRES_PORT: PostgreSQL database port
 ```
 
@@ -519,30 +522,29 @@ POSTGRES_PORT: PostgreSQL database port
 
 Initializes the Postgres data loading client.
 
-- **Args**:
-  - `dbname (str)`: The name of the database to connect to.
-  - `user (str)`: The user with which to connect to the database with.
-  - `password (str)`: The login password for the user.
-  - `host (str)`: Host address for database.
-  - `port (str)`: Port on which the database is running.
-  - `verbose (bool)`: Enables verbose output printing. Defaults to False.
-  - `**kwargs`: Additional settings for creating psycopg2 connection
+-   **Args**:
+    -   `dbname (str)`: The name of the database to connect to.
+    -   `user (str)`: The user with which to connect to the database with.
+    -   `password (str)`: The login password for the user.
+    -   `host (str)`: Host address for database.
+    -   `port (str)`: Port on which the database is running.
+    -   `verbose (bool)`: Enables verbose output printing. Defaults to `False`.
+    -   `**kwargs`: Additional settings for creating psycopg2 connection
 
 <h3> Attributes </h3>
 
-- _conn_ (`psycopg2.connection.Connection`) - underlying [psycopg2 Connection](https://www.psycopg.org/docs/connection.html) object
-
+-   _conn_ (`psycopg2.connection.Connection`) - underlying [psycopg2 Connection](https://www.psycopg.org/docs/connection.html) object
 
 <h3> Factory Methods </h3>
 
 **_with_config_** - `with_config(config: BaseConfigLoader, **kwargs) -> Postgres`
+
 Creates Postgres data loading client from configuration settings.
 
-- **Args**:
-  - `config (BaseConfigLoader)`: Configuration loader object.
-  - `verbose (bool)`: Enables verbose output printing. Defaults to False.
-  - `**kwargs`: Additional parameters passed to the loader constructor
-- **Returns**: (`Postgres`) The constructed dataloader using this method
+-   **Args**:
+    -   `config (BaseConfigLoader)`: Configuration loader object.
+    -   `**kwargs`: Additional parameters passed to the loader constructor
+-   **Returns**: (`Postgres`) The constructed dataloader using this method
 
 <h3> Methods </h3>
 
@@ -552,45 +554,50 @@ Closes connection to PostgreSQL database.
 
 **_commit_** - `commit()`
 
-Writes all changes made to the database since the previous transaction.
+Saves all changes made to the database since the previous transaction.
 
 **_execute_** - `execute(query_string: str, **kwargs) -> None`
 
-Sends query to the connected PostgreSQL database.
+Sends query to the connected PostgreSQL database. Any changes made to the database will not be saved unless `commit()` is called afterward.
 
-- **Args**:
-  - `query_string (str)`: The query to execute on the PostgreSQL database.
-  - `**kwargs`: Additional parameters to pass to the query. See [`psycopg2` docs](https://www.psycopg.org/docs/usage.html#query-parameters) for configuring query parameters.
+-   **Args**:
+    -   `query_string (str)`: The query to execute on the PostgreSQL database.
+    -   `**kwargs`: Additional parameters to pass to the query. See [`psycopg2` docs](https://www.psycopg.org/docs/usage.html#query-parameters) for configuring query parameters.
 
 **_export_** - `export(df: DataFrame, table_name: str, database: str, schema: str, if_exists: str, index: bool, **kwargs) -> None`
 
 Exports data frame to the PostgreSQL database from a Pandas data frame. If table doesn't exist, the table is automatically created. If the schema doesn't exist, the schema is also created.
 
-- **Args**:
-  - `df (DataFrame)`: Data frame to export to the PostgreSQL database.
-  - `table_name (str)`: Name of the table to export data to (excluding database and schema).
-  - `database (str)`: Name of the database in which the table is located.
-  - `schema (str)`: Name of the schema in which the table is located.
-  - `if_exists (ExportWritePolicy)`: Specifies export policy if table exists. Either
-      - `'fail'`: throw an error.
-      - `'replace'`: drops existing table and creates new table of same name.
-      - `'append'`: appends data frame to existing table.
+Any changes made to the database will not be saved unless `commit()` is called afterward.
 
-    Defaults to `'replace'`.
-  - `index (bool)`: If `True`, the data frame index is also exported alongside the table. Defaults to `False`.
-  - `**kwargs`: Additional arguments to pass to writer.
+-   **Args**:
 
+    -   `df (DataFrame)`: Data frame to export to the PostgreSQL database.
+    -   `table_name (str)`: Name of the table to export data to (excluding database and schema).
+    -   `database (str)`: Name of the database in which the table is located.
+    -   `schema (str)`: Name of the schema in which the table is located.
+    -   `if_exists (ExportWritePolicy)`: Specifies export policy if table exists. Either
+
+        -   `'fail'`: throw an error.
+        -   `'replace'`: drops existing table and creates new table of same name.
+        -   `'append'`: appends data frame to existing table.
+
+        Defaults to `'replace'`.
+
+    -   `index (bool)`: If `True`, the data frame index is also exported alongside the table. Defaults to `False`.
+    -   `**kwargs`: Additional arguments to pass to writer.
 
 **_load_** - `load(query_string: str, limit: int, *args, **kwargs) -> DataFrame`
 
-Loads data from the connected database into a Pandas data frame based on the query given. This will fail if the query returns no data from the database. This function will load at maximum 100,000 rows of data. To operate on more data, consider performing data transformations in warehouse.
+Loads data from the results of a query into a Pandas data frame. This will fail if the query returns no data from the database.
 
+This function will load at maximum 100,000 rows of data (this limit is configurable). To operate on more data, consider performing data transformations in warehouse.
 
-- **Args**:
-  - `query_string (str)`: Query to fetch a table or subset of a table.
-  - `limit (int, Optional)`: The number of rows to limit the loaded data frame to. Defaults to 100000.
-  - `**kwargs`: Additional parameters to pass to the query. See [`psycopg2` docs](https://www.psycopg.org/docs/usage.html#query-parameters) for configuring query parameters.
-- **Returns**: (`DataFrame`) Data frame containing the queried data.
+-   **Args**:
+    -   `query_string (str)`: Query to fetch a table or subset of a table.
+    -   `limit (int, Optional)`: The number of rows to limit the loaded data frame to. Defaults to 100,000.
+    -   `**kwargs`: Additional parameters to pass to the query. See [`psycopg2` docs](https://www.psycopg.org/docs/usage.html#query-parameters) for configuring query parameters.
+-   **Returns**: (`DataFrame`) Data frame containing the queried data.
 
 **_open_** - `open()`
 
@@ -598,25 +605,25 @@ Opens a connection to PostgreSQL database.
 
 **_rollback_** - `rollback()`
 
-Rolls back (deletes) all database operations made since the last transaction.
+Rolls back (deletes) all database changes made since the last transaction.
 
 **_sample_** - `sample(schema: str, table: str, size: int, **kwargs) -> DataFrame`
 
 Sample data from a table in the PostgreSQL database. Sample is not guaranteed to be random.
 
-- **Args**:
-  - `schema (str)`: The schema to select the table from.
-  - `size (int)`: The number of rows to sample. Defaults to 100,000
-  - `table (str)`: The table to sample from in the connected database.
+-   **Args**:
 
-- **Returns**: (`DataFrame`) Sampled data from the data frame.
+    -   `schema (str)`: The schema to select the table from.
+    -   `size (int)`: The number of rows to sample. Defaults to 100,000.
+    -   `table (str)`: The table to sample from in the connected database.
 
+-   **Returns**: (`DataFrame`) Sampled data from the table.
 
 ## Snowflake
 
 `mage_ai.io.snowflake.Snowflake`
 
-Handles data transfer between a Snowflake data warehouse and the Mage app. Constructing a Snowflake loader includes using the following configuration setting keys with your configuration loader:
+Handles data transfer between a Snowflake data warehouse and the Mage app. The `Snowflake` client utilizes the following keys to authenticate access and connect to Snowflake servers.
 
 ```yaml
 SNOWFLAKE_USER: Snowflake username
@@ -636,31 +643,32 @@ The following arguments must be provided to the connector, all other
 arguments are optional.
 
 _Required Arguments_:
-- `user (str)`: Username for the Snowflake user.
-- `password (str)`: Login Password for the user.
-- `account (str)`: Snowflake account identifier (including region, excluding `snowflake-computing.com` suffix).
+
+-   `user (str)`: Username for the Snowflake user.
+-   `password (str)`: Login Password for the user.
+-   `account (str)`: Snowflake account identifier (including region, excluding `snowflake-computing.com` suffix).
 
 _Optional Arguments_:
-- `verbose (bool)`: Specify whether to print verbose output.
-- `database (str)`: Name of the default database to use. If unspecified no database is selected on login.
-- `schema (str)`: Name of the default schema to use. If unspecified no schema is selected on login.
-- `warehouse (str)`: Name of the default warehouse to use. If unspecified no warehouse is selected on login.
+
+-   `verbose (bool)`: Specify whether to print verbose output.
+-   `database (str)`: Name of the default database to use. If unspecified no database is selected on login.
+-   `schema (str)`: Name of the default schema to use. If unspecified no schema is selected on login.
+-   `warehouse (str)`: Name of the default warehouse to use. If unspecified no warehouse is selected on login.
 
 <h3> Attributes </h3>
 
-- _conn_ (`snowflake.connector.Connection`) - underlying [Snowflake Connection](https://docs.snowflake.com/en/user-guide/python-connector-api.html#object-connection) object
-
+-   _conn_ (`snowflake.connector.Connection`) - underlying [Snowflake Connection](https://docs.snowflake.com/en/user-guide/python-connector-api.html#object-connection) object
 
 <h3> Factory Methods </h3>
 
 **_with_config_** - `with_config(config: BaseConfigLoader, **kwargs) -> Snowflake`
 Creates Snowflake data loading client from configuration settings.
 
-- **Args**:
-  - `config (BaseConfigLoader)`: Configuration loader object.
-  - `verbose (bool)`: Enables verbose output printing. Defaults to False.
-  - `**kwargs`: Additional parameters passed to the loader constructor
-- **Returns**: (`Snowflake`) The constructed dataloader using this method
+-   **Args**:
+    -   `config (BaseConfigLoader)`: Configuration loader object.
+    -   `verbose (bool)`: Enables verbose output printing. Defaults to False.
+    -   `**kwargs`: Additional parameters passed to the loader constructor
+-   **Returns**: (`Snowflake`) The constructed dataloader using this method
 
 <h3> Methods </h3>
 
@@ -670,44 +678,49 @@ Closes connection to Snowflake server.
 
 **_commit_** - `commit()`
 
-Writes all changes made to the warehouse since the previous transaction.
+Saves all changes made to the warehouse since the previous transaction.
 
 **_execute_** - `execute(query_string: str, **kwargs) -> None`
 
-Sends query to the connected Snowflake warehouse.
+Sends query to the connected Snowflake warehouse. Any changes made to the database will not be saved unless `commit()` is called afterward.
 
-- **Args**:
-  - `query_string (str)`: The query to execute on the Snowflake warehouse.
-  - `**kwargs`: Additional parameters to pass to the query. See [Snowflake Connector Docs](https://docs.snowflake.com/en/user-guide/python-connector-api.html#execute) for additional parameters.
+-   **Args**:
+    -   `query_string (str)`: The query to execute on the Snowflake warehouse.
+    -   `**kwargs`: Additional parameters to pass to the query. See [Snowflake Connector Docs](https://docs.snowflake.com/en/user-guide/python-connector-api.html#execute) for additional parameters.
 
 **_export_** - `export(df: DataFrame, table_name: str, database: str, schema: str, if_exists: str, **kwargs) -> None`
 
 Exports a Pandas data frame to a Snowflake warehouse based on the table name. If table doesn't exist, the table is automatically created.
 
-- **Args**:
-  - `df (DataFrame)`: Data frame to export to a Snowflake warehouse.
-  - `table_name (str)`: Name of the table to export data to (excluding database and schema).
-  - `database (str)`: Name of the database in which the table is located.
-  - `schema (str)`: Name of the schema in which the table is located.
-  - `if_exists (str, optional)`: Specifies export policy if table exists. Either
-      - `'fail'`: throw an error.
-      - `'replace'`: drops existing table and creates new table of same name.
-      - `'append'`: appends data frame to existing table.
+Any changes made to the database will not be saved unless `commit()` is called afterward.
 
-    Defaults to `'append'`.
-  - **kwargs: Additional arguments to pass to writer
+-   **Args**:
 
+    -   `df (DataFrame)`: Data frame to export to a Snowflake warehouse.
+    -   `table_name (str)`: Name of the table to export data to (excluding database and schema).
+    -   `database (str)`: Name of the database in which the table is located.
+    -   `schema (str)`: Name of the schema in which the table is located.
+    -   `if_exists (str, optional)`: Specifies export policy if table exists. Either
+
+        -   `'fail'`: throw an error.
+        -   `'replace'`: drops existing table and creates new table of same name.
+        -   `'append'`: appends data frame to existing table.
+
+        Defaults to `'append'`.
+
+    -   `**kwargs`: Additional arguments to pass to writer
 
 **_load_** - `load(query_string: str, limit: int, *args, **kwargs) -> DataFrame`
 
-Loads data from Snowflake into a Pandas data frame based on the query given. This will fail unless a `SELECT` query is provided. This function will load at maximum 100,000 rows of data. To operate on more data, consider performing data transformations in warehouse using `execute`.
+Loads data from Snowflake into a Pandas data frame based on the query given. This will fail unless a `SELECT` query is provided.
 
+This function will load at maximum 100,000 rows of data (this limit is configurable). To operate on more data, consider performing data transformations in warehouse using `execute`.
 
-- **Args**:
-  - `query_string (str)`: Query to fetch a table or subset of a table.
-  - `limit (int, Optional)`: The number of rows to limit the loaded dataframe to. Defaults to 100000.
-  - `*args, **kwargs`: Additional parameters to pass to the query. See [Snowflake Connector Docs](https://docs.snowflake.com/en/user-guide/python-connector-api.html#execute) for additional parameters.
-- **Returns**: (`DataFrame`) Data frame containing the queried data
+-   **Args**:
+    -   `query_string (str)`: Query to fetch a table or subset of a table.
+    -   `limit (int, Optional)`: The number of rows to limit the loaded data frame to. Defaults to 100,000.
+    -   `*args, **kwargs`: Additional parameters to pass to the query. See [Snowflake Connector Docs](https://docs.snowflake.com/en/user-guide/python-connector-api.html#execute) for additional parameters.
+-   **Returns**: (`DataFrame`) Data frame containing the queried data
 
 **_open_** - `open()`
 
@@ -715,25 +728,25 @@ Opens a connection to Snowflake servers.
 
 **_rollback_** - `rollback()`
 
-Rolls back (deletes) all database operations made since the last transaction.
+Rolls back (deletes) all database changes made since the last transaction.
 
 **_sample_** - `sample(schema: str, table: str, size: int, **kwargs) -> DataFrame`
 
 Sample data from a table in the Snowflake warehouse. Sample is not guaranteed to be random.
 
-- **Args**:
-  - `schema (str)`: The schema to select the table from.
-  - `size (int)`: The number of rows to sample. Defaults to 100,000
-  - `table (str)`: The table to sample from in the connected database.
+-   **Args**:
 
-- **Returns**: (`DataFrame`) Sampled data from the data frame.
+    -   `schema (str)`: The schema to select the table from.
+    -   `size (int)`: The number of rows to sample. Defaults to 100,000
+    -   `table (str)`: The table to sample from in the connected database.
 
+-   **Returns**: (`DataFrame`) Sampled data from the data frame.
 
 # Configuration Settings
 
 Connections to third-party data storage require you to specify confidential information such as login information or access keys. While you can manually specify this information code while constructing data loading clients, it is recommended to not store the secrets directly in code.
 
-To help with this, Mage provides **configuration loaders** which allow data loading clients to use your secrets without explicitly writing them in code.
+Instead, Mage provides **configuration loaders** which allow data loading clients to use your secrets without explicitly writing them in code.
 
 Currently, the following sources (and their corresponding configuration loader) can be used to load configuration settings:
 
@@ -751,35 +764,35 @@ config = AWSSecretLoader()
 loader = Redshift.from_config(config)
 ```
 
-The following are the set of allowed key names that you must name your secrets with in order Mage's configuration loaders to recognize your secrets. In code you can refer to these keys by their string name or using the `mage_ai.io.config.ConfigKey` enumeration. Not all keys need be specified at once - only use the keys related to the services you utilize.
+The following are the set of allowed key names that you must name your secrets with in order for Mage's configuration loaders to recognize your secrets. In code you can refer to these keys by their string name or using the `mage_ai.io.config.ConfigKey` enum. Not all keys need be specified at once - only use the keys related to the services you utilize.
 
-| Key Name                        | Service         | Client Parameter    | Description                                                             | Notes                                 |
-| ------------------------------- | --------------- | ------------------- | ----------------------------------------------------------------------- | ------------------------------------- |
-| AWS_ACCESS_KEY_ID               | AWS General     | access_key_id       | AWS Access Key ID credential                                            | Used by Redshift and S3               |
-| AWS_SECRET_ACCESS_KEY           | AWS General     | secret_access_key   | AWS Secret Access Key credential                                        | Used by Redshift and S3               |
-| AWS_SESSION_TOKEN               | AWS General     | session_token       | AWS Session Token (used to generate temporary DB credentials)           | Used by Redshift                      |
-| AWS_REGION                      | AWS General     | region              | AWS Region                                                              | Used by Redshift and S3               |
-| REDSHIFT_DBNAME                 | [AWS Redshift](#redshift)    | database            | Name of Redshift database to connect to                                 |                                       |
-| REDSHIFT_HOST                   | [AWS Redshift](#redshift)    | host                | Redshift Cluster hostname                                               | Use with temporary credentials        |
-| REDSHIFT_PORT                   | [AWS Redshift](#redshift)    | port                | Redshift Cluster port. Optional, defaults to 5439.                      | Use with temporary credentials        |
-| REDSHIFT_TEMP_CRED_USER         | [AWS Redshift](#redshift)    | user                | Redshift temporary credentials username.                                | Use with temporary credentials        |
-| REDSHIFT_TEMP_CRED_PASSWORD     | [AWS Redshift](#redshift)    | password            | Redshift temporary credentials password.                                | Use with temporary credentials        |
-| REDSHIFT_DBUSER                 | [AWS Redshift](#redshift)    | db_user             | Redshift database user to generate credentials for.                     | Use to generate temporary credentials |
-| REDSHIFT_CLUSTER_ID             | [AWS Redshift](#redshift)    | cluster_identifier  | Redshift cluster ID                                                     | Use to generate temporary credentials |
-| REDSHIFT_IAM_PROFILE            | [AWS Redshift](#redshift)    | profile             | Name of the IAM profile to generate temporary credentials with          | Use to generate temporary credentials |
-| POSTGRES_DBNAME                 | [PostgreSQL](#postgresql)      | dbname              | Database name                                                           |                                       |
-| POSTGRES_USER                   | [PostgreSQL](#postgresql)      | user                | Database login username                                                 |                                       |
-| POSTGRES_PASSWORD               | [PostgreSQL](#postgresql)      | password            | Database login password                                                 |                                       |
-| POSTGRES_HOST                   | [PostgreSQL](#postgresql)      | host                | Database hostname                                                       |                                       |
-| POSTGRES_PORT                   | [PostgreSQL](#postgresql)      | port                | PostgreSQL database port                                                |                                       |
-| SNOWFLAKE_USER                  | [Snowflake](#snowflake)       | user                | Snowflake username                                                      |                                       |
-| SNOWFLAKE_PASS                  | [Snowflake](#snowflake)       | password            | Snowflake password                                                      |                                       |
-| SNOWFLAKE_ACCOUNT               | [Snowflake](#snowflake)       | account             | Snowflake account ID (including region)                                 |                                       |
-| SNOWFLAKE_DEFAULT_DB            | [Snowflake](#snowflake)       | database            | Default database to use. Optional, no database chosen if unspecified.   |                                       |
-| SNOWFLAKE_DEFAULT_SCHEMA        | [Snowflake](#snowflake)       | schema              | Default schema to use. Optional, no schema chosen if unspecified.       |                                       |
-| SNOWFLAKE_DEFAULT_WH            | [Snowflake](#snowflake)       | warehouse           | Default warehouse to use. Optional, no warehouse chosen if unspecified. |                                       |
-| GOOGLE_SERVICE_ACC_KEY          | [Google BigQuery](#bigquery) | credentials_mapping | Service account key                                                     |                                       |
-| GOOGLE_SERVICE_ACC_KEY_FILEPATH | [Google BigQuery](#bigquery) | path_to_credentials | Path to service account key                                             |                                       |
+| Key Name                        | Service                      | Client Constructor Parameter | Description                                                             | Notes                                       |
+| ------------------------------- | ---------------------------- | ---------------------------- | ----------------------------------------------------------------------- | ------------------------------------------- | --- |
+| AWS_ACCESS_KEY_ID               | AWS General                  | -                            | AWS Access Key ID credential                                            | Used by [Redshift](#redshift) and [S3](#s3) |
+| AWS_SECRET_ACCESS_KEY           | AWS General                  | -                            | AWS Secret Access Key credential                                        | Used by [Redshift](#redshift) and [S3](#s3) |     |
+| AWS_SESSION_TOKEN               | AWS General                  | -                            | AWS Session Token (used to generate temporary DB credentials)           | Used by Redshift                            |
+| AWS_REGION                      | AWS General                  | -                            | AWS Region                                                              | Used by [Redshift](#redshift) and [S3](#s3) |     |
+| REDSHIFT_DBNAME                 | [AWS Redshift](#redshift)    | database                     | Name of Redshift database to connect to                                 |                                             |
+| REDSHIFT_HOST                   | [AWS Redshift](#redshift)    | host                         | Redshift Cluster hostname                                               | Use with temporary credentials              |
+| REDSHIFT_PORT                   | [AWS Redshift](#redshift)    | port                         | Redshift Cluster port. Optional, defaults to 5439.                      | Use with temporary credentials              |
+| REDSHIFT_TEMP_CRED_USER         | [AWS Redshift](#redshift)    | user                         | Redshift temporary credentials username.                                | Use with temporary credentials              |
+| REDSHIFT_TEMP_CRED_PASSWORD     | [AWS Redshift](#redshift)    | password                     | Redshift temporary credentials password.                                | Use with temporary credentials              |
+| REDSHIFT_DBUSER                 | [AWS Redshift](#redshift)    | db_user                      | Redshift database user to generate credentials for.                     | Use to generate temporary credentials       |
+| REDSHIFT_CLUSTER_ID             | [AWS Redshift](#redshift)    | cluster_identifier           | Redshift cluster ID                                                     | Use to generate temporary credentials       |
+| REDSHIFT_IAM_PROFILE            | [AWS Redshift](#redshift)    | profile                      | Name of the IAM profile to generate temporary credentials with          | Use to generate temporary credentials       |
+| POSTGRES_DBNAME                 | [PostgreSQL](#postgresql)    | dbname                       | Database name                                                           |                                             |
+| POSTGRES_USER                   | [PostgreSQL](#postgresql)    | user                         | Database login username                                                 |                                             |
+| POSTGRES_PASSWORD               | [PostgreSQL](#postgresql)    | password                     | Database login password                                                 |                                             |
+| POSTGRES_HOST                   | [PostgreSQL](#postgresql)    | host                         | Database hostname                                                       |                                             |
+| POSTGRES_PORT                   | [PostgreSQL](#postgresql)    | port                         | PostgreSQL database port                                                |                                             |
+| SNOWFLAKE_USER                  | [Snowflake](#snowflake)      | user                         | Snowflake username                                                      |                                             |
+| SNOWFLAKE_PASS                  | [Snowflake](#snowflake)      | password                     | Snowflake password                                                      |                                             |
+| SNOWFLAKE_ACCOUNT               | [Snowflake](#snowflake)      | account                      | Snowflake account ID (including region)                                 |                                             |
+| SNOWFLAKE_DEFAULT_DB            | [Snowflake](#snowflake)      | database                     | Default database to use. Optional, no database chosen if unspecified.   |                                             |
+| SNOWFLAKE_DEFAULT_SCHEMA        | [Snowflake](#snowflake)      | schema                       | Default schema to use. Optional, no schema chosen if unspecified.       |                                             |
+| SNOWFLAKE_DEFAULT_WH            | [Snowflake](#snowflake)      | warehouse                    | Default warehouse to use. Optional, no warehouse chosen if unspecified. |                                             |
+| GOOGLE_SERVICE_ACC_KEY          | [Google BigQuery](#bigquery) | credentials_mapping          | Service account key                                                     |                                             |
+| GOOGLE_SERVICE_ACC_KEY_FILEPATH | [Google BigQuery](#bigquery) | path_to_credentials          | Path to service account key                                             |                                             |
 
 ## Configuration Loader APIs
 
@@ -807,7 +820,10 @@ These functions are shared among all configuration loaders, but depending on the
 
 ### Configuration File
 
-**Example**: 
+Loads configuration settings from a configuration file.
+
+**Example**:
+
 ```python
 from mage_ai.io.config import ConfigKey, ConfigFileLoader
 
@@ -817,7 +833,8 @@ postgres_db = config[ConfigKey.POSTGRES_DBNAME]
 
 **Constructor**: `__init__(filepath: os.PathLike, profile: str)`
 Initializes IO Configuration loader. Input configuration file can have two formats:
-- _Standard_: contains a subset of the configuration keys specified in `ConfigKey`. This
+
+-   _Standard_: contains a subset of the configuration keys specified in `ConfigKey`. This
     is the default and recommended format. Below is an example configuration file using this format.
     ```yaml
     version: 0.1.0
@@ -831,7 +848,8 @@ Initializes IO Configuration loader. Input configuration file can have two forma
         REDSHIFT_TEMP_CRED_USER: Redshift temp credentials username
         REDSHIFT_TEMP_CRED_PASSWORD: Redshift temp credentials password
     ```
-- _Verbose_: Instead of configuration keys, each profile stores an object of settings associated with
+    The above configuration file has a single **profile** named `'default'`. Each profile organizes a set of keys to use (for example, distinguishing production keys versus development keys). A configuration file can have multiple profiles.
+-   _Verbose_: Instead of configuration keys, each profile stores an object of settings associated with
     each data migration client. This format was used in previous versions of this tool, and exists
     for backwards compatibility. Below is an example configuration file using this format.
     ```yaml
@@ -850,32 +868,34 @@ Initializes IO Configuration loader. Input configuration file can have two forma
     ```
 
 **Args**:
-  - `filepath (os.PathLike, optional)`: Path to IO configuration file. Defaults to '[repo_path]/io_config.yaml'
-  - `profile (str, optional)`: Profile to load configuration settings from. Defaults to 'default'.
+
+-   `filepath (os.PathLike, optional)`: Path to IO configuration file. Defaults to `'[repo_path]/io_config.yaml'`
+-   `profile (str, optional)`: Profile to load configuration settings from. Defaults to `'default'`.
 
 **Methods**
 
-**_contains_**: `contains(self, key: ConfigKey | str) -> Any`
+**_contains_** - `contains(self, key: ConfigKey | str) -> Any`
 
 Checks if the configuration setting stored under `key` is contained.
 
-- **Args**:
-  - `key (str)`: Name of the configuration setting to check.
-- **Returns** (`bool`) Returns true if configuration setting exists, otherwise returns false.
+-   **Args**:
+    -   `key (str)`: Name of the configuration setting to check.
+-   **Returns** (`bool`) Returns `True` if configuration setting exists, otherwise returns `False`.
 
-**_get_** `get(self, key: ConfigKey | str) -> Any`
+**_get_** - `get(self, key: ConfigKey | str) -> Any`
 
 Loads the configuration setting stored under `key`.
 
-- **Args**:
-  - `key (str)`: Key name of the configuration setting to load
-- **Returns**: (`Any`) Configuration setting corresponding to the given key
+-   **Args**:
+    -   `key (str)`: Key name of the configuration setting to load
+-   **Returns**: (`Any`) Configuration setting corresponding to the given key
 
 ### Environment Variables
 
-Loads secrets from environment variables in your current environment.
+Loads configuration settings from environment variables in your current environment.
 
 **Example**:
+
 ```python
 from mage_ai.io.config import ConfigKey, EnvironmentVariableLoader
 
@@ -887,7 +907,7 @@ postgres_db = config[ConfigKey.POSTGRES_DBNAME]
 
 **Methods**:
 
-**_contains_**: `contains(env_var: ConfigKey | str) -> bool`
+**_contains_** - `contains(env_var: ConfigKey | str) -> bool`
 
 Checks if the environment variable given by `env_var` exists.
 
@@ -895,9 +915,9 @@ Checks if the environment variable given by `env_var` exists.
 
     -   `key (ConfigKey | str)`: Name of the configuration setting to check existence of.
 
--   **Returns**: (`bool`) Returns true if configuration setting exists, otherwise returns false.
+-   **Returns** (`bool`) Returns `True` if configuration setting exists, otherwise returns `False`.
 
-**_get_**: `get(env_var: ConfigKey | str) -> Any`
+**_get_** - `get(env_var: ConfigKey | str) -> Any`
 
 Loads the config setting stored under the environment variable `env_var`.
 
@@ -907,23 +927,19 @@ Loads the config setting stored under the environment variable `env_var`.
 
 -   **Returns**: (`Any`) The configuration setting stored under `env_var`
 
-
 ### AWS Secret Loader
 
-Loads secrets from AWS Secrets Manager. To authenticate with AWS Secrets Manager, either 
-- Configure your AWS profile using the AWS CLI
+Loads secrets from AWS Secrets Manager. To authenticate access to AWS Secrets Manager, either
+
+-   Configure your AWS profile using the AWS CLI
     ```bash
     aws configure
     ```
-- Manually specify your AWS Credentials when constructing the configuration loader
-    ```python
-    config = AWSSecretLoader(
-        aws_access_key_id = 'your access key id',
-        aws_secret_access_key = 'your secret key',
-        aws_region = 'your region'
-    )
-    ```
+-   Manually specify your AWS Credentials when constructing the configuration loader
+    `python config = AWSSecretLoader( aws_access_key_id = 'your access key id', aws_secret_access_key = 'your secret key', aws_region = 'your region' ) `
+
 **Example**:
+
 ```python
 from mage_ai.io.config import ConfigKey, AWSSecretLoader
 
@@ -934,40 +950,44 @@ postgres_db = config.get(ConfigKey.POSTGRES_DBNAME, version_id='my_version_id')
 ```
 
 **Constructor** : `__init__(self, **kwargs)`:
-- **Keyword Arguments**:
-  - `aws_access_key_id (str, Optional)`: AWS access key ID credential
-  - `aws_secret_access_key (str, Optional)`: AWS secret access key credential
-  - `aws_region (str, Optional)`: AWS region which Secrets Manager is created in
+
+-   **Keyword Arguments**:
+    -   `aws_access_key_id (str, Optional)`: AWS access key ID credential.
+    -   `aws_secret_access_key (str, Optional)`: AWS secret access key credential.
+    -   `aws_region (str, Optional)`: AWS region which Secrets Manager is created in.
 
 **Methods**:
 
-**_contains_**: `contains( secret_id: ConfigKey | str, version_id: str, version_stage_label : str) -> bool`
+**_contains_** - `contains( secret_id: ConfigKey | str, version_id: str, version_stage_label : str) -> bool`
 Check if there is a secret with ID `secret_id` contained. Can also specify the version of the
 secret to check. If
-- both `version_id` and `version_stage_label` are specified, both must agree on the secret version
-- neither of `version_id` or `version_stage_label` are specified, any version is checked
-- one of `version_id` and `version_stage_label` are specified, the associated version is checked
+
+-   both `version_id` and `version_stage_label` are specified, both must agree on the secret version.
+-   neither of `version_id` or `version_stage_label` are specified, any version is checked.
+-   one of `version_id` and `version_stage_label` are specified, the associated version is checked.
 
 When using the `in` operator, comparisons to specific versions are not allowed.
 
-- **Args**:
-  - `secret_id (str)`: ID of the secret to load
-  - `version_id (str, Optional)`: ID of the version of the secret to load. Defaults to None.
-  - `version_stage_label (str, Optional)`: Staging label of the version of the secret to load. Defaults to None.
-- **Returns**: (`bool`) Returns true if secret exists, otherwise returns false.
+-   **Args**:
+    -   `secret_id (str)`: ID of the secret to load
+    -   `version_id (str, Optional)`: ID of the version of the secret to load. Defaults to `None`.
+    -   `version_stage_label (str, Optional)`: Staging label of the version of the secret to load. Defaults to `None`.
+-   **Returns**: (`bool`) Returns true if secret exists, otherwise returns false.
 
-**_get_**: `get(secret_id: ConfigKey | str, version_id: str, version_stage_label : str) -> bytes | str`
+**_get_** - `get(secret_id: ConfigKey | str, version_id: str, version_stage_label : str) -> bytes | str`
 Loads the secret stored under `secret_id`. Can also specify the version of the
 secret to fetch. If
-- both `version_id` and `version_stage_label` are specified, both must agree on the secret version
-- neither of `version_id` or `version_stage_label` are specified, the current version is loaded
-- one of `version_id` and `version_stage_label` are specified, the associated version is loaded
+
+-   both `version_id` and `version_stage_label` are specified, both must agree on the secret version.
+-   neither of `version_id` or `version_stage_label` are specified, the current version is loaded.
+-   one of `version_id` and `version_stage_label` are specified, the associated version is loaded.
 
 When using the `__getitem__` overload, comparisons to specific versions are not allowed.
 
-- **Args**:
-   - `secret_id (str)`: ID of the secret to load
-   - ` version_id (str, Optional)`: ID of the version of the secret to load. Defaults to None.
-   - `version_stage_label (str, Optional)`: Staging label of the version of the secret to load. Defaults to None.
+-   **Args**:
 
-- **Returns**: (`bytes | str`) The secret stored under `secret_id` in AWS secret manager. If secret is a binary value, returns a `bytes` object; else returns a `string` object
+    -   `secret_id (str)`: ID of the secret to load
+    -   ` version_id (str, Optional)`: ID of the version of the secret to load. Defaults to `None`.
+    -   `version_stage_label (str, Optional)`: Staging label of the version of the secret to load. Defaults to `None`.
+
+-   **Returns**: (`bytes | str`) The secret stored under `secret_id` in AWS secret manager. If secret is a binary value, returns a `bytes` object; else returns a `string` object

--- a/docs/blocks/data_loading.md
+++ b/docs/blocks/data_loading.md
@@ -1,29 +1,37 @@
 # Table of Contents
-
--   [Data Loading Overview](#data-loading-overview)
--   [Client APIs](#client-apis)
-    -   [FileIO](#fileio)
-    -   [BigQuery](#bigquery)
-    -   [PostgreSQL](#postgresql)
-    -   [Redshift](#redshift)
-    -   [S3](#s3)
-    -   [Snowflake](#snowflake)
--   [Configuration Settings](#configuration-settings)
+- [Table of Contents](#table-of-contents)
+- [Data Loading Overview](#data-loading-overview)
+  - [Example: Loading data from a file](#example-loading-data-from-a-file)
+  - [Example: Loading data from Snowflake warehouse](#example-loading-data-from-snowflake-warehouse)
+- [Client APIs](#client-apis)
+  - [Redshift](#redshift)
+  - [S3](#s3)
+  - [FileIO](#fileio)
+  - [BigQuery](#bigquery)
+  - [PostgreSQL](#postgresql)
+  - [Snowflake](#snowflake)
+- [Configuration Settings](#configuration-settings)
+  - [Configuration Loader APIs](#configuration-loader-apis)
+    - [Configuration File](#configuration-file)
+    - [Environment Variables](#environment-variables)
+    - [AWS Secret Loader](#aws-secret-loader)
 
 # Data Loading Overview
 
-Mage provides data loading clients to load and export data from local and external sources, integrating directly into your pipelines so you can spend more time focusing on analyzing and transforming your data for ML tasks.
+Mage provides data loading clients that simplify loading and exporting data in your pipelines, allowing you to spend more time analyzing and transforming your data for ML tasks. Currently, Mage contains clients for the following data sources:
 
-Every data loader client includes the following functions:
-
--   `load` - loads data from the requested source into a Pandas DataFrame for current use
--   `export` - exports data in your pipeline to the requested source
-
-The following examples will examine how data loading clients use these functions to import and export your data.
+-   AWS Redshift
+-   AWS S3
+-   File Loading
+-   Google BigQuery
+-   PostgreSQL Database
+-   Snowflake
 
 ## Example: Loading data from a file
 
-While traditional Pandas IO procedures can be utilized to load files into your pipeline, Mage provides the `mage_ai.io.file.FileIO` client as a convenience wrapper. The following code uses the `load` function of the `FileIO` client to load the Titanic survival dataset from a CSV file into a Pandas DataFrame for use in your pipeline. All data loaders can be initialized with the `verbose = True` parameter to enable verbose output printing the current action the data loading client is performing. This parameter defaults to `False`.
+While traditional Pandas IO procedures can be utilized to load files into your pipeline, Mage provides the `mage_ai.io.file.FileIO` client as a convenience wrapper.
+
+The following code uses the `load` function of the `FileIO` client to load the Titanic survival dataset from a CSV file into a Pandas DataFrame for use in your pipeline. All data loaders can be initialized with the `verbose = True` parameter to enable verbose output printing the current action the data loading client is performing. This parameter defaults to `False`.
 
 ```python
 loader = FileIO(verbose=True)
@@ -38,7 +46,7 @@ Then the `export` function is used to save this data frame back to file, this ti
 loader.export(df, './titanic_survival.json', orient='records')
 ```
 
-Any formatting settings (such as specifying the JSON orient) can be passed as keyword arguments to `load` and `export`. These arguments are passed to Pandas IO procedures for the requested file format, allowing you the same level as control as the base Pandas IO procedures.
+Any formatting settings (such as specifying the JSON orient) can be passed as keyword arguments to `load` and `export`. These arguments are passed to Pandas IO procedures for the requested file format, allowing you finer-grained control over how your data is loaded and exported.
 
 As the data loader was constructed with the verbose parameter set to `True`, the above operations would print the following output describing the actions of the data loader.
 
@@ -58,7 +66,9 @@ Loading data from a Snowflake data warehouse is made easy using the `mage_ai.io.
 -   Account Password
 -   Account ID (including your region) (Ex: _example.us-west-2_)
 
-These parameters can be manually specified as input to the data loading client (see [Snowflake](#snowflake) API). However we recommend using a [Configuration Loader](#configuration-settings) to handle loading these secrets. If you used `mage init` to create your project repository, you can store these values in your `io_config.yaml` file and using a `mage_ai.io.config.ConfigFileLoader` to construct the data loader client.
+These parameters can be manually specified as input to the data loading client (see [Snowflake](#snowflake) API). However we recommend using a [Configuration Loader](#configuration-settings) to handle loading these secrets. If you used `mage init` to create your project repository, you can store these values in your `io_config.yaml` file and use
+
+`mage_ai.io.config.ConfigFileLoader` to construct the data loader client.
 
 An example `io_config.yaml` file in this instance would be:
 
@@ -93,7 +103,7 @@ with loader:
     loader.export(df, 'my_schema', 'test_table')
 ```
 
-The `loader` object manages a direct connection to your Snowflake data warehouse, so it is important to make sure that your connection is closed once your operations are completed. You can manually use `loader.open()` and `loader.close()` to open and close the connection to your data warehouse, or instead use the context manager syntax to automatically open and close the connection.
+The `loader` object manages a direct connection to your Snowflake data warehouse, so it is important to make sure that your connection is closed once your operations are completed. You can manually use `loader.open()` and `loader.close()` to open and close the connection to your data warehouse or automatically manage the connection with a context manager.
 
 To learn more about loading data from Snowflake, see the [Snowflake](#snowflake) API for more details on member functions and usage.
 
@@ -117,7 +127,7 @@ This section covers the API for using the following data loaders.
 
 Connections to third-party data storage require you to specify confidential information such as login information or access keys. While you can manually specify this information code while constructing data loading clients, it is recommended to not store the secrets directly in code.
 
-To help with this, Mage provides **configuration loaders** which load confidential configuration settings for use by data loading clients without exposing secrets in code.
+To help with this, Mage provides **configuration loaders** which allow data loading clients to use your secrets without explicitly writing them in code.
 
 Currently, the following sources (and their corresponding configuration loader) can be used to load configuration settings:
 
@@ -125,7 +135,7 @@ Currently, the following sources (and their corresponding configuration loader) 
 -   Environment Variables - `EnvironmentVariableLoader`
 -   AWS Secrets Manager - `AWSSecretLoader`
 
-For example, the code below constructs a Redshift data loading client using secrets from an AWS Secrets Manager
+For example, the code below constructs a Redshift data loading client using secrets stored in AWS Secrets Manager
 
 ```python
 from mage_ai.io.config import AWSSecretLoader
@@ -135,41 +145,41 @@ config = AWSSecretLoader()
 loader = Redshift.from_config(config)
 ```
 
-The following is a table of the names of configuration settings that can be read by a configuration loader. When storing secrets in a configuration file, in an environment variable, or on AWS Secrets Manager, use these key names to store your secrets. To access these keys in code, you can manually write the title as a string, or you can use the `mage_ai.io.config.ConfigKey` enum.
+The following are the set of allowed key names that you must name your secrets with in order Mage's configuration loaders to recognize your secrets. In code you can refer to these keys by their string name or using the `mage_ai.io.config.ConfigKey` enumeration. Not all keys need be specified at once - only use the keys related to the services you utilize.
 
-| Key Name                        | Service         | Client Parameter    | Description                                                    | Notes                                 |
-| ------------------------------- | --------------- | ------------------- | -------------------------------------------------------------- | ------------------------------------- |
-| AWS_ACCESS_KEY_ID               | AWS General     | access_key_id       | AWS Access Key ID credential                                   | Used by Redshift and S3               |
-| AWS_SECRET_ACCESS_KEY           | AWS General     | secret_access_key   | AWS Secret Access Key credential                               | Used by Redshift and S3               |
-| AWS_SESSION_TOKEN               | AWS General     | session_token       | AWS Session Token (used to generate temporary DB credentials)  | Used by Redshift                      |
-| AWS_REGION                      | AWS General     | region              | AWS Region                                                     | Used by Redshift and S3               |
-| REDSHIFT_DBNAME                 | AWS Redshift    | database            | Name of Redshift database to connect to                        |                                       |
-| REDSHIFT_HOST                   | AWS Redshift    | host                | Redshift Cluster hostname                                      | Use with temporary credentials        |
-| REDSHIFT_PORT                   | AWS Redshift    | port                | Redshift Cluster port. If not specified. Defaults to 5439.     | Use with temporary credentials        |
-| REDSHIFT_TEMP_CRED_USER         | AWS Redshift    | user                | Redshift temporary credentials username.                       | Use with temporary credentials        |
-| REDSHIFT_TEMP_CRED_PASSWORD     | AWS Redshift    | password            | Redshift temporary credentials password.                       | Use with temporary credentials        |
-| REDSHIFT_DBUSER                 | AWS Redshift    | db_user             | Redshift database user to generate credentials for.            | Use to generate temporary credentials |
-| REDSHIFT_CLUSTER_ID             | AWS Redshift    | cluster_identifier  | Redshift cluster ID                                            | Use to generate temporary credentials |
-| REDSHIFT_IAM_PROFILE            | AWS Redshift    | profile             | Name of the IAM profile to generate temporary credentials with | Use to generate temporary credentials |
-| POSTGRES_DBNAME                 | PostgreSQL      | dbname              | Database name                                                  |                                       |
-| POSTGRES_USER                   | PostgreSQL      | user                | Database login username                                        |                                       |
-| POSTGRES_PASSWORD               | PostgreSQL      | password            | Database login password                                        |                                       |
-| POSTGRES_HOST                   | PostgreSQL      | host                | Database hostname                                              |                                       |
-| POSTGRES_PORT                   | PostgreSQL      | port                | PostgreSQL database port                                       |                                       |
-| SNOWFLAKE_USER                  | Snowflake       | user                | Snowflake username                                             |                                       |
-| SNOWFLAKE_PASS                  | Snowflake       | password            | Snowflake password                                             |                                       |
-| SNOWFLAKE_ACCOUNT               | Snowflake       | account             | Snowflake account ID (including region)                        |                                       |
-| SNOWFLAKE_DEFAULT_DB            | Snowflake       | database            | Default database to use                                        |                                       |
-| SNOWFLAKE_DEFAULT_SCHEMA        | Snowflake       | schema              | Default schema to use                                          |                                       |
-| SNOWFLAKE_DEFAULT_WH            | Snowflake       | warehouse           | Default warehouse to use.                                      |                                       |
-| GOOGLE_SERVICE_ACC_KEY          | Google BigQuery | credentials_mapping | Service account key                                            |                                       |
-| GOOGLE_SERVICE_ACC_KEY_FILEPATH | Google BigQuery | path_to_credentials | Path to service account key                                    |                                       |
+| Key Name                        | Service         | Client Parameter    | Description                                                             | Notes                                 |
+| ------------------------------- | --------------- | ------------------- | ----------------------------------------------------------------------- | ------------------------------------- |
+| AWS_ACCESS_KEY_ID               | AWS General     | access_key_id       | AWS Access Key ID credential                                            | Used by Redshift and S3               |
+| AWS_SECRET_ACCESS_KEY           | AWS General     | secret_access_key   | AWS Secret Access Key credential                                        | Used by Redshift and S3               |
+| AWS_SESSION_TOKEN               | AWS General     | session_token       | AWS Session Token (used to generate temporary DB credentials)           | Used by Redshift                      |
+| AWS_REGION                      | AWS General     | region              | AWS Region                                                              | Used by Redshift and S3               |
+| REDSHIFT_DBNAME                 | AWS Redshift    | database            | Name of Redshift database to connect to                                 |                                       |
+| REDSHIFT_HOST                   | AWS Redshift    | host                | Redshift Cluster hostname                                               | Use with temporary credentials        |
+| REDSHIFT_PORT                   | AWS Redshift    | port                | Redshift Cluster port. Optional, defaults to 5439.                      | Use with temporary credentials        |
+| REDSHIFT_TEMP_CRED_USER         | AWS Redshift    | user                | Redshift temporary credentials username.                                | Use with temporary credentials        |
+| REDSHIFT_TEMP_CRED_PASSWORD     | AWS Redshift    | password            | Redshift temporary credentials password.                                | Use with temporary credentials        |
+| REDSHIFT_DBUSER                 | AWS Redshift    | db_user             | Redshift database user to generate credentials for.                     | Use to generate temporary credentials |
+| REDSHIFT_CLUSTER_ID             | AWS Redshift    | cluster_identifier  | Redshift cluster ID                                                     | Use to generate temporary credentials |
+| REDSHIFT_IAM_PROFILE            | AWS Redshift    | profile             | Name of the IAM profile to generate temporary credentials with          | Use to generate temporary credentials |
+| POSTGRES_DBNAME                 | PostgreSQL      | dbname              | Database name                                                           |                                       |
+| POSTGRES_USER                   | PostgreSQL      | user                | Database login username                                                 |                                       |
+| POSTGRES_PASSWORD               | PostgreSQL      | password            | Database login password                                                 |                                       |
+| POSTGRES_HOST                   | PostgreSQL      | host                | Database hostname                                                       |                                       |
+| POSTGRES_PORT                   | PostgreSQL      | port                | PostgreSQL database port                                                |                                       |
+| SNOWFLAKE_USER                  | Snowflake       | user                | Snowflake username                                                      |                                       |
+| SNOWFLAKE_PASS                  | Snowflake       | password            | Snowflake password                                                      |                                       |
+| SNOWFLAKE_ACCOUNT               | Snowflake       | account             | Snowflake account ID (including region)                                 |                                       |
+| SNOWFLAKE_DEFAULT_DB            | Snowflake       | database            | Default database to use. Optional, no database chosen if unspecified.   |                                       |
+| SNOWFLAKE_DEFAULT_SCHEMA        | Snowflake       | schema              | Default schema to use. Optional, no schema chosen if unspecified.       |                                       |
+| SNOWFLAKE_DEFAULT_WH            | Snowflake       | warehouse           | Default warehouse to use. Optional, no warehouse chosen if unspecified. |                                       |
+| GOOGLE_SERVICE_ACC_KEY          | Google BigQuery | credentials_mapping | Service account key                                                     |                                       |
+| GOOGLE_SERVICE_ACC_KEY_FILEPATH | Google BigQuery | path_to_credentials | Path to service account key                                             |                                       |
 
 ## Configuration Loader APIs
 
 This section contains the exact APIs and more detailed information on the configuration loaders. Every configuration loader has two functions:
 
--   `contains` - checks if the configuration source contains the requested key. Commonly, the `in` operation is used to check for setting existence (but is not necessarily identical as `contains` can accept multiple parameters while the `in` keyword only accepts the key).
+-   `contains` - checks if the configuration source contains the requested key. Commonly, the `in` operation is used to check for setting existence (but is not always identical as `contains` can accept multiple parameters while the `in` keyword only accepts the key).
 
     ```python
     if config.contains(ConfigKey.POSTGRES_PORT):
@@ -179,7 +189,7 @@ This section contains the exact APIs and more detailed information on the config
         ...
     ```
 
--   `get` - gets the configuration setting associated with the given key. If the key doesn't exist, returns None. Commonly, the data model overload `__getitem__` is used to fetch a configuration setting (but is not necessarily identical as `get` can accept multiple parameters while `__getitem__` does not).
+-   `get` - gets the configuration setting associated with the given key. If the key doesn't exist, returns None. Commonly, the data model overload `__getitem__` is used to fetch a configuration setting (but is not always identical as `get` can accept multiple parameters while `__getitem__` does not).
 
     ```python
     user = config.get(ConfigKey.REDSHIFT_DBUSER)
@@ -191,6 +201,172 @@ These functions are shared among all configuration loaders, but depending on the
 
 ### Configuration File
 
+**Example**: 
+```python
+from mage_ai.io.config import ConfigKey, ConfigFileLoader
+
+config = ConfigFileLoader('path/to/my/config.yaml', 'my_profile')
+postgres_db = config[ConfigKey.POSTGRES_DBNAME]
+```
+
+**Constructor**: `__init__(filepath: os.PathLike, profile: str)`
+Initializes IO Configuration loader. Input configuration file can have two formats:
+- _Standard_: contains a subset of the configuration keys specified in `ConfigKey`. This
+    is the default and recommended format. Below is an example configuration file using this format.
+    ```yaml
+    version: 0.1.0
+    default:
+        AWS_ACCESS_KEY_ID: AWS Access Key ID credential
+        AWS_SECRET_ACCESS_KEY: AWS Secret Access Key credential
+        AWS_REGION: AWS Region
+        REDSHIFT_DBNAME: Name of Redshift database to connect to
+        REDSHIFT_HOST: Redshift Cluster hostname
+        REDSHIFT_PORT: Redshift Cluster port. Optional, defaults to 5439
+        REDSHIFT_TEMP_CRED_USER: Redshift temp credentials username
+        REDSHIFT_TEMP_CRED_PASSWORD: Redshift temp credentials password
+    ```
+- _Verbose_: Instead of configuration keys, each profile stores an object of settings associated with
+    each data migration client. This format was used in previous versions of this tool, and exists
+    for backwards compatibility. Below is an example configuration file using this format.
+    ```yaml
+    version: 0.1.0
+    default:
+        AWS:
+            Redshift:
+                database: Name of Redshift database to connect to
+                host: Redshift Cluster hostname
+                port: Redshift Cluster port. Optional, defaults to 5439
+                user: Redshift temp credentials username
+                password: Redshift temp credentials password
+            access_key_id: AWS Access Key ID credential
+            secret_access_key: AWS Secret Access Key credential
+            region: AWS Region
+    ```
+
+**Args**:
+  - `filepath (os.PathLike, optional)`: Path to IO configuration file. Defaults to '[repo_path]/io_config.yaml'
+  - `profile (str, optional)`: Profile to load configuration settings from. Defaults to 'default'.
+
+**Methods**
+
+**_contains_**: `contains(self, key: ConfigKey | str) -> Any`
+
+Checks if the configuration setting stored under `key` is contained.
+
+**Args**:
+- `key (str)`: Name of the configuration setting to check.
+
+**Returns** (`bool`) Returns true if configuration setting exists, otherwise returns false.
+
+<hr>
+
+**_get_** `get(self, key: ConfigKey | str) -> Any`
+
+Loads the configuration setting stored under `key`.
+
+**Args**:
+- `key (str)`: Key name of the configuration setting to load
+
+**Returns**: (`Any`) Configuration setting corresponding to the given key
+
 ### Environment Variables
 
-### AWSSecretLoader
+Loads secrets from environment variables in your current environment.
+
+**Example**:
+```python
+from mage_ai.io.config import ConfigKey, EnvironmentVariableLoader
+
+config = EnvironmentVariableLoader()
+postgres_db = config[ConfigKey.POSTGRES_DBNAME]
+```
+
+**Constructor** : `__init__(self)` - no parameters for construction.
+
+**Methods**:
+
+**_contains_**: `contains(env_var: ConfigKey | str) -> bool`
+
+Checks if the environment variable given by `env_var` exists.
+
+-   **Args**:
+
+    -   `key (ConfigKey | str)`: Name of the configuration setting to check existence of.
+
+-   **Returns**: (`bool`) Returns true if configuration setting exists, otherwise returns false.
+
+<hr>
+
+**_get_**: `get(env_var: ConfigKey | str) -> Any`
+
+Loads the config setting stored under the environment variable `env_var`.
+
+-   **Args**:
+
+    -   `env_var (str)`: Name of the environment variable to load configuration setting from
+
+-   **Returns**: (`Any`) The configuration setting stored under `env_var`
+
+
+### AWS Secret Loader
+
+Loads secrets from AWS Secrets Manager. To authenticate with AWS Secrets Manager, either 
+- Configure your AWS profile using the AWS CLI
+    ```bash
+    aws configure
+    ```
+- Manually specify your AWS Credentials when constructing the configuration loader
+    ```python
+    config = AWSSecretLoader(
+        aws_access_key_id = 'your access key id',
+        aws_secret_access_key = 'your secret key',
+        aws_region = 'your region'
+    )
+    ```
+**Example**:
+```python
+from mage_ai.io.config import ConfigKey, AWSSecretLoader
+
+config = AWSSecretLoader()
+postgres_db = config[ConfigKey.POSTGRES_DBNAME]
+# with finer control on version
+postgres_db = config.get(ConfigKey.POSTGRES_DBNAME, version_id='my_version_id')
+```
+
+**Constructor** : `__init__(self, **kwargs)`:
+- **Keyword Arguments**:
+  - `aws_access_key_id (str, Optional)`: AWS access key ID credential
+  - `aws_secret_access_key (str, Optional)`: AWS secret access key credential
+  - `aws_region (str, Optional)`: AWS region which Secrets Manager is created in
+
+**Methods**:
+
+**_contains_**: `contains( secret_id: ConfigKey | str, version_id: str, version_stage_label : str) -> bool`
+Check if there is a secret with ID `secret_id` contained. Can also specify the version of the
+secret to check. If
+- both `version_id` and `version_stage_label` are specified, both must agree on the secret version
+- neither of `version_id` or `version_stage_label` are specified, any version is checked
+- one of `version_id` and `version_stage_label` are specified, the associated version is checked
+
+**Args**:
+  - `secret_id (str)`: ID of the secret to load
+  - `version_id (str, Optional)`: ID of the version of the secret to load. Defaults to None.
+  - `version_stage_label (str, Optional)`: Staging label of the version of the secret to load. Defaults to None.
+
+**Returns**:(`bool`) Returns true if secret exists, otherwise returns false.
+
+<hr>
+
+**_get_**: `get(secret_id: ConfigKey | str, version_id: str, version_stage_label : str) -> bytes | str`
+Loads the secret stored under `secret_id`. Can also specify the version of the
+secret to fetch. If
+- both `version_id` and `version_stage_label` are specified, both must agree on the secret version
+- neither of `version_id` or `version_stage_label` are specified, the current version is loaded
+- one of `version_id` and `version_stage_label` are specified, the associated version is loaded
+
+**Args**:
+   - `secret_id (str)`: ID of the secret to load
+   - ` version_id (str, Optional)`: ID of the version of the secret to load. Defaults to None.
+   - `version_stage_label (str, Optional)`: Staging label of the version of the secret to load. Defaults to None.
+
+**Returns**: (`bytes | str`) The secret stored under `secret_id` in AWS secret manager. If secret is a binary value, returns a `bytes` object; else returns a `string` object

--- a/mage_ai/io/config.py
+++ b/mage_ai/io/config.py
@@ -100,10 +100,7 @@ class AWSSecretLoader(BaseConfigLoader):
             version_id (str, Optional): ID of the version of the secret to load. Defaults to None.
             version_stage_label (str, Optional): Staging label of the version of the secret to load. Defaults to None.
 
-        Returns:
-            Union(bytes, str): The secret stored under `secret_id` in AWS secret manager. If secret is:
-            - a binary value, returns a `bytes` object
-            - a string value, returns a `string` object
+        Returns: bool: Returns true if secret exists, otherwise returns false.
         """
         return self.__get_secret(secret_id, version_id, version_stage_label) is not None
 
@@ -256,9 +253,9 @@ class ConfigFileLoader(BaseConfigLoader):
     def __init__(self, filepath: os.PathLike = None, profile='default') -> None:
         """
         Initializes IO Configuration loader. Input configuration file can have two formats:
-        - Standard: contains a subset of the configuration keys specified in `ConfigKeys`. This
+        - Standard: contains a subset of the configuration keys specified in `ConfigKey`. This
           is the default and recommended format
-        - Verbose: Instead of configuration keys, each profiles stores an object of settings associated with
+        - Verbose: Instead of configuration keys, each profile stores an object of settings associated with
           each data migration client. This format was used in previous versions of this tool, and exists
           for backwards compatibility.
 
@@ -278,10 +275,13 @@ class ConfigFileLoader(BaseConfigLoader):
 
     def contains(self, key: Union[ConfigKey, str]) -> Any:
         """
-        Checks of the configuration setting stored under `key` is contained.
+        Checks if the configuration setting stored under `key` is contained.
 
         Args:
             key (str): Name of the configuration setting to check.
+
+        Returns:
+            (bool) Returns true if configuration setting exists, otherwise returns false
         """
         if self.use_verbose_format:
             return self.__traverse_verbose_config(key) is not None
@@ -293,6 +293,9 @@ class ConfigFileLoader(BaseConfigLoader):
 
         Args:
             key (str): Key name of the configuration setting to load
+
+        Returns:
+            (Any) Configuration setting corresponding to the given key.
         """
         if self.use_verbose_format:
             return self.__traverse_verbose_config(key)


### PR DESCRIPTION
# Summary
Added documentation for data loaders, including
- Example usage guide
- APIs for all clients
- How to use configuration settings for storing and loading secrets.

This new documentation was linked to `blocks/README.md` under the `data_loader` and `data_exporter` sections. In addition, some polish was performed to clean up some source code docs for configuration setting loaders.

cc:
@wangxiaoyou1993 @tommydangerous 
