### PR TITLE
[sp] jump to chart when selecting file

### DIFF
--- a/mage_ai/frontend/components/ChartBlock/index.tsx
+++ b/mage_ai/frontend/components/ChartBlock/index.tsx
@@ -172,7 +172,7 @@ function ChartBlock({
     chartDataRaw = chartDataRaw.slice(1, chartDataRaw.length - 1);
     chartDataRaw = chartDataRaw
       .replaceAll('\\"', '\"')
-      .replaceAll("\\'", "\'");
+      .replaceAll('\\\'', '\'');
     if (isJsonString(chartDataRaw)) {
       chartData = JSON.parse(chartDataRaw);
     }
@@ -691,7 +691,7 @@ function ChartBlock({
           </Spacing>
         );
       }),
-    }
+    };
   }, {
     noCode: [],
   }), [
@@ -709,8 +709,8 @@ function ChartBlock({
         <Spacing mt={1} px={1}>
           <FlexContainer
             alignItems="center"
-            justifyContent="space-between"
             fullWidth
+            justifyContent="space-between"
           >
             <Select
               compact
@@ -722,7 +722,7 @@ function ChartBlock({
                 };
                 updateWidget(widget);
                 saveAndRun(widget);
-                setUpstreamBlocks(value)
+                setUpstreamBlocks(value);
               }}
               placeholder="Source block"
               small

--- a/mage_ai/frontend/components/ChartBlock/index.tsx
+++ b/mage_ai/frontend/components/ChartBlock/index.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
   useCallback,
   useContext,
   useEffect,
@@ -13,10 +13,8 @@ import BlockType, {
   OutputType,
   StatusTypeEnum,
 } from '@interfaces/BlockType';
-import Button from '@oracle/elements/Button';
 import ChartController from './ChartController';
 import Chip from '@oracle/components/Chip';
-import Circle from '@oracle/elements/Circle';
 import CodeEditor, { CodeEditorSharedProps } from '@components/CodeEditor';
 import CodeOutput from '@components/CodeBlock/CodeOutput';
 import Col from '@components/shared/Grid/Col';
@@ -43,7 +41,6 @@ import {
   ChartTypeEnum,
   ConfigurationType,
   VARIABLE_NAMES,
-  VARIABLE_NAME_HEIGHT,
   VARIABLE_NAME_WIDTH_PERCENTAGE,
 } from '@interfaces/ChartBlockType';
 import {
@@ -54,7 +51,6 @@ import {
   VARIABLE_INFO_BY_CHART_TYPE,
 } from './constants';
 import {
-  CHART_HEIGHT_DEFAULT,
   ChartBlockStyle,
   CodeHelperStyle,
   CodeStyle,
@@ -77,6 +73,7 @@ import { isEmptyObject } from '@utils/hash';
 export type ChartPropsShared = {
   blockRefs: any;
   blocks: BlockType[];
+  chartRefs: any;
   deleteWidget: (block: BlockType) => void;
   runBlock: (payload: {
     block: BlockType;
@@ -115,7 +112,7 @@ function ChartBlock({
   textareaFocused,
   updateWidget,
   width,
-}: ChartBlockType) {
+}: ChartBlockType, ref) {
   const refChartContainer = useRef(null);
   const themeContext = useContext(ThemeContext);
   const {
@@ -705,7 +702,7 @@ function ChartBlock({
 
   return (
     <Col sm={12} md={12 * widthPercentage}>
-      <ChartBlockStyle>
+      <ChartBlockStyle ref={ref}>
         <Spacing mt={1} px={1}>
           <FlexContainer
             alignItems="center"
@@ -957,4 +954,4 @@ function ChartBlock({
   );
 }
 
-export default ChartBlock;
+export default React.forwardRef(ChartBlock);

--- a/mage_ai/frontend/components/FileBrowser/Folder.tsx
+++ b/mage_ai/frontend/components/FileBrowser/Folder.tsx
@@ -13,6 +13,7 @@ import {
   ChevronRight,
   FileFill,
   Folder as FolderIcon,
+  NavGraph,
   Pipeline,
 } from '@oracle/icons';
 import { ContextAreaProps } from '@components/ContextMenu';
@@ -96,12 +97,14 @@ function Folder({
   let IconEl = FileFill;
   if (isPipelineFolder && !disabled) {
     IconEl = Pipeline;
+  } else if (name === FOLDER_NAME_CHARTS) {
+    IconEl = NavGraph;
   } else if (children) {
     IconEl = FolderIcon;
   }
 
   let color;
-  if (children && BLOCK_TYPES.includes(singularize(name))) {
+  if (children && BLOCK_TYPES.includes(singularize(name)) && singularize(name) !== BlockTypeEnum.CHART) {
     color = getColorsForBlockType(singularize(name), { theme }).accent;
   }
 
@@ -225,8 +228,8 @@ function Folder({
         <Text
           color={color}
           default={!color && !disabled}
-          monospace
           disabled={disabled}
+          monospace
           small
         >
           {name}

--- a/mage_ai/frontend/components/FileBrowser/Folder.tsx
+++ b/mage_ai/frontend/components/FileBrowser/Folder.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 
 import Circle from '@oracle/elements/Circle';
 import FileType, {
+  FOLDER_NAME_CHARTS,
   FOLDER_NAME_PIPELINES,
   SUPPORTED_FILE_EXTENSIONS_REGEX,
 } from '@interfaces/FileType';
@@ -23,12 +24,14 @@ import {
 import { SpecialFileEnum } from '@components/FileTree/constants';
 import { ThemeType } from '@oracle/styles/themes/constants';
 import { UNIT, WIDTH_OF_SINGLE_CHARACTER } from '@oracle/styles/units/spacing';
+import { VIEW_QUERY_PARAM } from '@components/Sidekick/constants';
 import { get, set } from '@storage/localStorage';
 import { getColorsForBlockType } from '@components/CodeBlock/index.style';
 import {
   getBlockFromFile,
   getFullPath,
 } from './utils';
+import { goToWithQuery } from '@utils/routing';
 import { singularize } from '@utils/string';
 import { sortByKey } from '@utils/array';
 
@@ -40,6 +43,7 @@ export type FolderSharedProps = {
   ) => void;
   openFile: (path: string) => void;
   openPipeline: (uuid: string) => void;
+  setAfterHidden: (value: boolean) => void;
 };
 
 type FolderProps = {
@@ -54,6 +58,7 @@ function Folder({
   onSelectBlockFile,
   openFile,
   openPipeline,
+  setAfterHidden,
   setContextItem,
   theme,
 }: FolderProps) {
@@ -112,6 +117,7 @@ function Folder({
       onSelectBlockFile={onSelectBlockFile}
       openFile={openFile}
       openPipeline={openPipeline}
+      setAfterHidden={setAfterHidden}
       setContextItem={setContextItem}
       theme={theme}
     />
@@ -132,6 +138,12 @@ function Folder({
             return;
           }
 
+          if (parentFile?.name === FOLDER_NAME_CHARTS) {
+            goToWithQuery({
+              [VIEW_QUERY_PARAM]: 'charts',
+            });
+            setAfterHidden(false);
+          }
           if (isPipelineFolder) {
             openPipeline(name);
           } else if (children) {

--- a/mage_ai/frontend/components/FileBrowser/Folder.tsx
+++ b/mage_ai/frontend/components/FileBrowser/Folder.tsx
@@ -24,14 +24,13 @@ import {
 import { SpecialFileEnum } from '@components/FileTree/constants';
 import { ThemeType } from '@oracle/styles/themes/constants';
 import { UNIT, WIDTH_OF_SINGLE_CHARACTER } from '@oracle/styles/units/spacing';
-import { VIEW_QUERY_PARAM } from '@components/Sidekick/constants';
+import { ViewKeyEnum } from '@components/Sidekick/constants';
 import { get, set } from '@storage/localStorage';
 import { getColorsForBlockType } from '@components/CodeBlock/index.style';
 import {
   getBlockFromFile,
   getFullPath,
 } from './utils';
-import { goToWithQuery } from '@utils/routing';
 import { singularize } from '@utils/string';
 import { sortByKey } from '@utils/array';
 
@@ -43,7 +42,7 @@ export type FolderSharedProps = {
   ) => void;
   openFile: (path: string) => void;
   openPipeline: (uuid: string) => void;
-  setAfterHidden: (value: boolean) => void;
+  openSidekickView: (newView: ViewKeyEnum, pushHistory?: boolean) => void;
 };
 
 type FolderProps = {
@@ -58,7 +57,7 @@ function Folder({
   onSelectBlockFile,
   openFile,
   openPipeline,
-  setAfterHidden,
+  openSidekickView,
   setContextItem,
   theme,
 }: FolderProps) {
@@ -117,7 +116,7 @@ function Folder({
       onSelectBlockFile={onSelectBlockFile}
       openFile={openFile}
       openPipeline={openPipeline}
-      setAfterHidden={setAfterHidden}
+      openSidekickView={openSidekickView}
       setContextItem={setContextItem}
       theme={theme}
     />
@@ -139,10 +138,15 @@ function Folder({
           }
 
           if (parentFile?.name === FOLDER_NAME_CHARTS) {
-            goToWithQuery({
-              [VIEW_QUERY_PARAM]: 'charts',
-            });
-            setAfterHidden(false);
+            openSidekickView(ViewKeyEnum.CHARTS);
+            const block = getBlockFromFile(file);
+            if (block) {
+              onSelectBlockFile(
+                block.uuid,
+                block.type,
+                getFullPath(file).split('/').slice(1).join('/'),
+              );
+            }
           }
           if (isPipelineFolder) {
             openPipeline(name);

--- a/mage_ai/frontend/components/FileBrowser/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/index.tsx
@@ -20,8 +20,6 @@ export enum FileContextEnum {
 
 function FileBrowser({
   files,
-  setAfterHidden,
-  setContextItem,
   ...props
 }: FileBrowserProps, ref) {
   const themeContext = useContext(ThemeContext);
@@ -34,8 +32,6 @@ function FileBrowser({
           file={file}
           key={file.name}
           level={0}
-          setAfterHidden={setAfterHidden}
-          setContextItem={setContextItem}
           theme={themeContext}
         />
       ))}

--- a/mage_ai/frontend/components/FileBrowser/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/index.tsx
@@ -20,6 +20,7 @@ export enum FileContextEnum {
 
 function FileBrowser({
   files,
+  setAfterHidden,
   setContextItem,
   ...props
 }: FileBrowserProps, ref) {
@@ -33,6 +34,7 @@ function FileBrowser({
           file={file}
           key={file.name}
           level={0}
+          setAfterHidden={setAfterHidden}
           setContextItem={setContextItem}
           theme={themeContext}
         />

--- a/mage_ai/frontend/components/Sidekick/Charts/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/Charts/index.tsx
@@ -74,11 +74,8 @@ function Charts({
               : ExecutionStateEnum.QUEUED
              )
             : ExecutionStateEnum.IDLE;
-            
-          console.log(chartRefs);
           
           chartRefs.current[uuid] = createRef();
-
 
           return (
             <ChartBlock

--- a/mage_ai/frontend/components/Sidekick/Charts/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/Charts/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { createRef, useMemo } from 'react';
 
 import BlockType from '@interfaces/BlockType';
 import ChartBlock, { ChartPropsShared } from '@components/ChartBlock';
@@ -20,6 +20,7 @@ export type ChartsPropsShared = {
 function Charts({
   blockRefs,
   blocks,
+  chartRefs,
   deleteWidget,
   fetchWidgets,
   messages,
@@ -73,17 +74,24 @@ function Charts({
               : ExecutionStateEnum.QUEUED
              )
             : ExecutionStateEnum.IDLE;
+            
+          console.log(chartRefs);
+          
+          chartRefs.current[uuid] = createRef();
+
 
           return (
             <ChartBlock
               block={block}
               blockRefs={blockRefs}
               blocks={blocks}
+              chartRefs={chartRefs}
               deleteWidget={deleteWidget}
               executionState={executionState}
               key={uuid}
               messages={messages[uuid]}
               onChangeContent={(value: string) => onChangeChartBlock(uuid, value)}
+              ref={chartRefs.current[uuid]}
               runBlock={runBlock}
               runningBlocks={runningBlocks}
               savePipelineContent={savePipelineContent}

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -68,6 +68,7 @@ function Sidekick({
   afterWidth,
   blockRefs,
   blocks,
+  chartRefs,
   deleteWidget,
   editingBlock,
   fetchPipeline,
@@ -313,6 +314,7 @@ function Sidekick({
           <Charts
             blockRefs={blockRefs}
             blocks={blocks}
+            chartRefs={chartRefs}
             deleteWidget={deleteWidget}
             fetchWidgets={fetchWidgets}
             messages={messages}

--- a/mage_ai/frontend/interfaces/BlockType.ts
+++ b/mage_ai/frontend/interfaces/BlockType.ts
@@ -13,6 +13,7 @@ export enum BlockTypeEnum {
 }
 
 export const BLOCK_TYPES = [
+  BlockTypeEnum.CHART,
   BlockTypeEnum.DATA_EXPORTER,
   BlockTypeEnum.DATA_LOADER,
   BlockTypeEnum.SCRATCHPAD,

--- a/mage_ai/frontend/interfaces/FileType.ts
+++ b/mage_ai/frontend/interfaces/FileType.ts
@@ -23,6 +23,7 @@ export default interface FileType {
   path?: string;
 }
 
+export const FOLDER_NAME_CHARTS = 'charts';
 export const FOLDER_NAME_PIPELINES = 'pipelines';
 export const FILE_EXTENSION_TO_LANGUAGE_MAPPING = {
   [FileExtensionEnum.PY]: 'python',

--- a/mage_ai/frontend/pages/pipelines/[...slug].tsx
+++ b/mage_ai/frontend/pages/pipelines/[...slug].tsx
@@ -971,6 +971,7 @@ function PipelineDetailPage({
           router.push('/pipelines/[...slug]', `/pipelines/${uuid}`);
         }}
         ref={fileTreeRef}
+        setAfterHidden={setAfterHidden}
       />
     </ContextMenu>
   ), [

--- a/mage_ai/frontend/pages/pipelines/[...slug].tsx
+++ b/mage_ai/frontend/pages/pipelines/[...slug].tsx
@@ -126,14 +126,20 @@ function PipelineDetailPage({
         pushHistory,
       });
     }
-  }, [
-    activeSidekickView,
-  ]);
+  }, []);
   useEffect(() => {
     if (!activeSidekickView) {
       setActiveSidekickView(ViewKeyEnum.TREE, false);
     }
   }, [activeSidekickView]);
+  
+  const openSidekickView = useCallback((
+    newView: ViewKeyEnum,
+    pushHistory?: boolean,
+  ) => {
+    setActiveSidekickView(newView, pushHistory);
+    setAfterHidden(false);
+  }, [setActiveSidekickView]);
 
   const blockRefs = useRef({});
   const contentByBlockUUID = useRef({});
@@ -840,6 +846,11 @@ function PipelineDetailPage({
         const blockRef = blockRefs.current[`${block.type}s/${block.uuid}.py`];
         blockRef?.current?.scrollIntoView();
       }
+    } else if (blockType === BlockTypeEnum.CHART) {
+      const chart = widgets.find(({ uuid }) => uuid === blockUUID);
+      if (chart) {
+        setSelectedBlock(chart);
+      }
     } else {
       openFile(filePath);
     }
@@ -970,8 +981,8 @@ function PipelineDetailPage({
           resetState();
           router.push('/pipelines/[...slug]', `/pipelines/${uuid}`);
         }}
+        openSidekickView={openSidekickView}
         ref={fileTreeRef}
-        setAfterHidden={setAfterHidden}
       />
     </ContextMenu>
   ), [

--- a/mage_ai/frontend/pages/pipelines/[...slug].tsx
+++ b/mage_ai/frontend/pages/pipelines/[...slug].tsx
@@ -142,6 +142,7 @@ function PipelineDetailPage({
   }, [setActiveSidekickView]);
 
   const blockRefs = useRef({});
+  const chartRefs = useRef({});
   const contentByBlockUUID = useRef({});
   const contentByWidgetUUID = useRef({});
   const mainContainerRef = useRef(null);
@@ -847,6 +848,10 @@ function PipelineDetailPage({
       const chart = widgets.find(({ uuid }) => uuid === blockUUID);
       if (chart) {
         setSelectedBlock(chart);
+        if (chartRefs?.current) {
+          const chartRef = chartRefs.current[chart.uuid];
+          chartRef?.current?.scrollIntoView();
+        }
       }
     } else {
       openFile(filePath);
@@ -996,6 +1001,7 @@ function PipelineDetailPage({
       afterWidth={afterWidthForChildren}
       blockRefs={blockRefs}
       blocks={blocks}
+      chartRefs={chartRefs}
       deleteWidget={deleteWidget}
       editingBlock={editingBlock}
       fetchPipeline={fetchPipeline}
@@ -1078,9 +1084,9 @@ function PipelineDetailPage({
       runningBlocks={runningBlocks}
       savePipelineContent={savePipelineContent}
       selectedBlock={selectedBlock}
+      setActiveSidekickView={setActiveSidekickView}
       setEditingBlock={setEditingBlock}
       setMessages={setMessages}
-      setActiveSidekickView={setActiveSidekickView}
       setOutputBlocks={setOutputBlocks}
       setPipelineContentTouched={setPipelineContentTouched}
       setRunningBlocks={setRunningBlocks}

--- a/mage_ai/frontend/pages/pipelines/[...slug].tsx
+++ b/mage_ai/frontend/pages/pipelines/[...slug].tsx
@@ -549,7 +549,6 @@ function PipelineDetailPage({
         response, {
           callback: ({
             widget: {
-              type,
               uuid,
             },
           }) => {
@@ -558,9 +557,7 @@ function PipelineDetailPage({
               widgetsPrevious.findIndex(({ uuid: uuid2 }: BlockType) => uuid === uuid2),
             ));
             fetchPipeline();
-            if (type === BlockTypeEnum.SCRATCHPAD) {
-              fetchFileTree();
-            }
+            fetchFileTree();
           },
           onErrorCallback: ({
             url_parameters: urlParameters,


### PR DESCRIPTION
# Summary
- expand sideview, switch to charts tab, and scroll to chart when its corresponding file is clicked in the file browser
- refresh file browser when chart block is deleted
- update charts folder icon

# Tests
![2022-07-26 15 20 30](https://user-images.githubusercontent.com/105667442/181093985-fb7a80b7-7e02-42b1-bb1e-a9150f8f8aa1.gif)

cc: @johnson-mage @tommydangerous @wangxiaoyou1993 
