### PR TITLE
[sp] expand output on error deleting block

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import Ansi from 'ansi-to-react';
 
 import BlockType, {

--- a/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
@@ -1,10 +1,9 @@
-import { useContext, useMemo, useRef, useState } from 'react';
+import { useContext, useRef, useState } from 'react';
 import { ThemeContext } from 'styled-components';
 
 import AddChartMenu from './AddChartMenu';
 import BlockType, {
   BlockTypeEnum,
-  StatusTypeEnum,
 } from '@interfaces/BlockType';
 import Button from '@oracle/elements/Button';
 import Circle from '@oracle/elements/Circle';
@@ -42,6 +41,7 @@ export type CommandButtonsSharedProps = {
   deleteBlock: (block: BlockType) => void;
   executionState: ExecutionStateEnum;
   interruptKernel: () => void;
+  setOutputCollapsed: (value: boolean) => void;
 };
 
 type CommandButtonsProps = {
@@ -62,6 +62,7 @@ function CommandButtons({
   executionState,
   interruptKernel,
   runBlock,
+  setOutputCollapsed,
 }: CommandButtonsProps) {
   const {
     all_upstream_blocks_executed: upstreamBlocksExecuted = true,
@@ -231,8 +232,8 @@ function CommandButtons({
                 &nbsp;
                 <KeyboardTextGroup
                   inline
-                  monospace
                   keyTextGroups={[[KEY_SYMBOL_D], [KEY_SYMBOL_D]]}
+                  monospace
                   uuidForKey={uuid}
                 />
               </Text>
@@ -244,7 +245,10 @@ function CommandButtons({
               noBackground
               noBorder
               noPadding
-              onClick={() => deleteBlock(block)}
+              onClick={() => {
+                deleteBlock(block);
+                setOutputCollapsed(false);
+              }}
             >
               <Trash size={UNIT * 2.5} />
             </Button>

--- a/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
@@ -41,7 +41,6 @@ export type CommandButtonsSharedProps = {
   deleteBlock: (block: BlockType) => void;
   executionState: ExecutionStateEnum;
   interruptKernel: () => void;
-  setOutputCollapsed: (value: boolean) => void;
 };
 
 type CommandButtonsProps = {
@@ -53,6 +52,7 @@ type CommandButtonsProps = {
     runDownstream?: boolean;
     runUpstream?: boolean;
   }) => void;
+  setOutputCollapsed: (value: boolean) => void;
 } & CommandButtonsSharedProps;
 
 function CommandButtons({

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -686,6 +686,7 @@ function CodeBlockProps({
           executionState={executionState}
           interruptKernel={interruptKernel}
           runBlock={runBlockAndTrack}
+          setOutputCollapsed={setOutputCollapsed}
         />
       )}
 

--- a/mage_ai/frontend/components/PipelineDetail/PipelineExecution/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/PipelineExecution/index.tsx
@@ -53,15 +53,15 @@ function PipelineExecution({
     setMessages([]);
 
     sendMessage(JSON.stringify({
-      pipeline_uuid: pipelineUUID,
       execute_pipeline: true,
-    }))
+      pipeline_uuid: pipelineUUID,
+    }));
 
     setIsPipelineExecuting(true);
   }, [
     pipelineUUID,
     sendMessage,
-  ])
+  ]);
 
   useEffect(() => {
     if (lastMessage) {
@@ -167,7 +167,7 @@ function PipelineExecution({
         </CodeBlockStyle>
       </OutputContainerStyle>
     </>
-  )
+  );
 }
 
 export default PipelineExecution;

--- a/mage_ai/frontend/pages/pipelines/[...slug].tsx
+++ b/mage_ai/frontend/pages/pipelines/[...slug].tsx
@@ -539,7 +539,8 @@ function PipelineDetailPage({
             setMessages(messagesPrev => ({
               ...messagesPrev,
               [urlParameters.block_uuid]: messages.map(msg => ({
-                data: msg,
+                data: `${msg}\n`,
+                error: `${msg}\n`,
                 type: DataTypeEnum.TEXT_PLAIN,
               })),
             }));

--- a/mage_ai/frontend/pages/pipelines/[...slug].tsx
+++ b/mage_ai/frontend/pages/pipelines/[...slug].tsx
@@ -578,7 +578,8 @@ function PipelineDetailPage({
             setMessages(messagesPrev => ({
               ...messagesPrev,
               [urlParameters.block_uuid]: messages.map(msg => ({
-                data: msg,
+                data: `${msg}\n`,
+                error: `${msg}\n`,
                 type: DataTypeEnum.TEXT_PLAIN,
               })),
             }));


### PR DESCRIPTION
# Summary
- Expands code block output when deleting block (should have no effect on successful block delete)
- Format error messages with newlines so that they can be read like a stack trace (done for chart blocks too)
- Indicate error block status when error deleting block (red outline, error symbol, etc)

# Tests
![2022-07-26 21 26 06](https://user-images.githubusercontent.com/105667442/181140367-b1bc2b19-69b3-4213-b968-aa1774f69164.gif)

cc: @johnson-mage @tommydangerous 
