### PR TITLE
[sp] update "convert scratchpad block"

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
@@ -45,7 +45,6 @@ export type CommandButtonsSharedProps = {
   deleteBlock: (block: BlockType) => void;
   executionState: ExecutionStateEnum;
   interruptKernel: () => void;
-  updateBlock: ({ block: BlockType }) => void;
 };
 
 type CommandButtonsProps = {
@@ -58,6 +57,7 @@ type CommandButtonsProps = {
     runUpstream?: boolean;
   }) => void;
   setOutputCollapsed: (value: boolean) => void;
+  updateBlock: ({ block: BlockType }) => void;
 } & CommandButtonsSharedProps;
 
 function CommandButtons({

--- a/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
@@ -34,7 +34,7 @@ import {
   KEY_SYMBOL_META,
 } from '@utils/hooks/keyboardShortcuts/constants';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
-import { buildConvertBlockMenu } from '../utils';
+import { buildConvertBlockMenuItems } from '../utils';
 import { getColorsForBlockType } from '../index.style';
 
 export type CommandButtonsSharedProps = {
@@ -91,7 +91,7 @@ function CommandButtons({
   const color = getColorsForBlockType(type, { theme: themeContext }).accent;
 
   const convertBlockMenuItems = useMemo(() => (
-    buildConvertBlockMenu(block, blocks, 'CommandButtons', updateBlock)
+    buildConvertBlockMenuItems(block, blocks, 'CommandButtons', updateBlock)
   ), [
     block,
     blocks,

--- a/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
@@ -196,7 +196,6 @@ function CommandButtons({
         {BlockTypeEnum.SCRATCHPAD === block.type && (
           <Spacing mt={PADDING_UNITS}>
             <FlyoutMenuWrapper
-              compact
               items={convertBlockMenuItems}
               left={-UNIT * 22}
               onClickCallback={() => setShowConvertMenu(false)}

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -11,8 +11,6 @@ import { useMutation } from 'react-query';
 
 import AddNewBlocks from '@components/PipelineDetail/AddNewBlocks';
 import BlockType, {
-  BLOCK_TYPE_NAME_MAPPING,
-  BLOCK_TYPE_CONVERTIBLE,
   BlockTypeEnum,
   SetEditingBlockType,
 } from '@interfaces/BlockType';

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -63,7 +63,7 @@ import {
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { SINGLE_LINE_HEIGHT } from '@components/CodeEditor/index.style';
 import { ViewKeyEnum } from '@components/Sidekick/constants';
-import { buildConvertBlockMenu } from './utils';
+import { buildConvertBlockMenuItems } from './utils';
 import { executeCode } from '@components/CodeEditor/keyboard_shortcuts/shortcuts';
 import { get, set } from '@storage/localStorage';
 import { indexBy } from '@utils/array';
@@ -383,7 +383,7 @@ function CodeBlockProps({
   const buildBlockMenu = (b: BlockType) => {
     const blockMenuItems = {
       [BlockTypeEnum.SCRATCHPAD]: [
-        ...buildConvertBlockMenu(b, blocks, 'block_menu/scratchpad', updateBlock),
+        ...buildConvertBlockMenuItems(b, blocks, 'block_menu/scratchpad', updateBlock),
       ],
     };
 
@@ -776,7 +776,7 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'df')
                   ...newBlock,
                   content,
                   upstream_blocks: upstreamBlocks,
-                })
+                });
               }}
               compact
             />

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -481,7 +481,6 @@ function CodeBlockProps({
             <Spacing mr={1} />
 
             <FlyoutMenuWrapper
-              compact
               items={buildBlockMenu(block)}
               onClickCallback={closeBlockMenu}
               onClickOutside={closeBlockMenu}

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -65,6 +65,7 @@ import {
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { SINGLE_LINE_HEIGHT } from '@components/CodeEditor/index.style';
 import { ViewKeyEnum } from '@components/Sidekick/constants';
+import { buildConvertBlockMenu } from './utils';
 import { executeCode } from '@components/CodeEditor/keyboard_shortcuts/shortcuts';
 import { get, set } from '@storage/localStorage';
 import { indexBy } from '@utils/array';
@@ -382,31 +383,9 @@ function CodeBlockProps({
   );
 
   const buildBlockMenu = (b: BlockType) => {
-    const upstreamBlocks = [];
-    const currentIndex = blocks.findIndex(({ uuid }) => uuid === b.uuid);
-    const previousBlock = blocks[currentIndex - 1];
-    if (previousBlock) {
-      upstreamBlocks.push(previousBlock.uuid);
-    }
-
     const blockMenuItems = {
       [BlockTypeEnum.SCRATCHPAD]: [
-        {
-          items: BLOCK_TYPE_CONVERTIBLE.map(blockType => ({
-            label: () => BLOCK_TYPE_NAME_MAPPING[blockType],
-            // @ts-ignore
-            onClick: () => updateBlock({
-              block: {
-                ...b,
-                type: blockType,
-                upstream_blocks: upstreamBlocks,
-              },
-            }),
-            uuid: `block_menu/scratchpad/convert_to/${blockType}`,
-          })),
-          label: () => 'Convert to',
-          uuid: 'block_menu/scratchpad/convert_to',
-        },
+        ...buildConvertBlockMenu(b, blocks, 'block_menu/scratchpad', updateBlock),
       ],
     };
 
@@ -682,11 +661,13 @@ function CodeBlockProps({
         <CommandButtons
           addWidget={addWidget}
           block={block}
+          blocks={blocks}
           deleteBlock={deleteBlock}
           executionState={executionState}
           interruptKernel={interruptKernel}
           runBlock={runBlockAndTrack}
           setOutputCollapsed={setOutputCollapsed}
+          updateBlock={updateBlock}
         />
       )}
 

--- a/mage_ai/frontend/components/CodeBlock/utils.ts
+++ b/mage_ai/frontend/components/CodeBlock/utils.ts
@@ -1,0 +1,31 @@
+import BlockType, { BLOCK_TYPE_CONVERTIBLE, BLOCK_TYPE_NAME_MAPPING } from '@interfaces/BlockType';
+import { lowercase } from '@utils/string';
+
+export const buildConvertBlockMenu = (
+  b: BlockType,
+  blocks: BlockType[],
+  baseUUID: string,
+  updateBlock: ({ block: BlockType }) => void,
+) => {
+  const upstreamBlocks = [];
+  const currentIndex = blocks.findIndex(({ uuid }) => uuid === b.uuid);
+  const previousBlock = blocks[currentIndex - 1];
+  if (previousBlock) {
+    upstreamBlocks.push(previousBlock.uuid);
+  }
+
+  return (
+    BLOCK_TYPE_CONVERTIBLE.map(blockType => ({
+      label: () => `Convert to ${lowercase(BLOCK_TYPE_NAME_MAPPING[blockType])}`,
+      // @ts-ignore
+      onClick: () => updateBlock({
+        block: {
+          ...b,
+          type: blockType,
+          upstream_blocks: upstreamBlocks,
+        },
+      }),
+      uuid: `${baseUUID}/convert_to/${blockType}`,
+    }))
+  );
+};

--- a/mage_ai/frontend/components/CodeBlock/utils.ts
+++ b/mage_ai/frontend/components/CodeBlock/utils.ts
@@ -1,12 +1,13 @@
 import BlockType, { BLOCK_TYPE_CONVERTIBLE, BLOCK_TYPE_NAME_MAPPING } from '@interfaces/BlockType';
+import { FlyoutMenuItemType } from '@oracle/components/FlyoutMenu';
 import { lowercase } from '@utils/string';
 
-export const buildConvertBlockMenu = (
+export const buildConvertBlockMenuItems = (
   b: BlockType,
   blocks: BlockType[],
   baseUUID: string,
   updateBlock: ({ block: BlockType }) => void,
-) => {
+): FlyoutMenuItemType[] => {
   const upstreamBlocks = [];
   const currentIndex = blocks.findIndex(({ uuid }) => uuid === b.uuid);
   const previousBlock = blocks[currentIndex - 1];

--- a/mage_ai/frontend/components/ContextMenu/index.tsx
+++ b/mage_ai/frontend/components/ContextMenu/index.tsx
@@ -131,7 +131,6 @@ function ContextMenu({
         top={anchorPoint.y}
       >
         <FlyoutMenu
-          compact
           items={contextItems[enableContextItem ? contextItem.type : type]}
           open={visible}
           parentRef={undefined}

--- a/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/index.tsx
@@ -136,7 +136,7 @@ function FileHeaderMenu({
         }), {}),
       ),
       uuid: 'Clear all outputs',
-    }
+    },
   ];
 
   const uuidKeyboard = 'FileHeaderMenu/index';

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/FlyoutMenuWrapper.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/FlyoutMenuWrapper.tsx
@@ -11,7 +11,6 @@ type FlyoutMenuWrapperProps = {
 
 function FlyoutMenuWrapper({
   children,
-  compact,
   items,
   open,
   onClickCallback,
@@ -32,7 +31,6 @@ function FlyoutMenuWrapper({
       </div>
       <FlyoutMenu
         {...props}
-        compact={compact}
         items={items}
         onClickCallback={onClickCallback}
         open={open}

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/FlyoutMenuWrapper.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/FlyoutMenuWrapper.tsx
@@ -18,6 +18,7 @@ function FlyoutMenuWrapper({
   onClickOutside,
   parentRef,
   uuid,
+  ...props
 }: FlyoutMenuWrapperProps) {
   const flyoutMenuEl = (
     <div
@@ -30,6 +31,7 @@ function FlyoutMenuWrapper({
         {children}
       </div>
       <FlyoutMenu
+        {...props}
         compact={compact}
         items={items}
         onClickCallback={onClickCallback}

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.style.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.style.tsx
@@ -8,20 +8,9 @@ type LinkProps = {
   indent?: boolean;
 };
 
-export const MENU_WIDTH = UNIT * 34;
-export const COMPACT_MENU_WIDTH = UNIT * 20;
-
 export const FlyoutMenuContainerStyle = styled.div<any>`
   position: absolute;
   max-height: ${UNIT * 58}px;
-
-  ${props => !props.compact && `
-    min-width: ${MENU_WIDTH}px;
-  `}
-
-  ${props => props.compact && `
-    min-width: ${COMPACT_MENU_WIDTH}px;
-  `}
 
   ${props => props.width && `
     min-width: 0px;
@@ -49,7 +38,6 @@ export const TitleContainerStyle = styled.div`
 
 export const LinkStyle = styled.div<LinkProps>`
   align-items: center;
-  display: flex;
   justify-content: space-between;
   padding: ${UNIT}px;
 

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -65,7 +65,8 @@ function FlyoutMenu({
     height,
   } = parentRef?.current?.getBoundingClientRect?.() || {};
   const menuRefs = useRef({});
-
+  const keyTextGroupRef = useRef(null);
+  
   const {
     registerOnKeyDown,
     unregisterOnKeyDown,
@@ -120,7 +121,7 @@ function FlyoutMenu({
       setHighlightedIndices([]);
     }
   }, [open]);
-
+  
   const buildMenuEl = (
     items: FlyoutMenuItemType[],
     uuid: string,
@@ -130,7 +131,6 @@ function FlyoutMenu({
     maxWidth: number = 0,
   ) => {
     depth += 1;
-
     const maxItemLength = Math.max(...items.map((item: FlyoutMenuItemType) => Number(item.label().length)));
 
     return (
@@ -209,13 +209,21 @@ function FlyoutMenu({
                   {items && <ArrowRight />}
 
                   {keyTextGroups && (
-                    <>
-                      <Spacing mr={4} />
+                    <Spacing ml={4} ref={keyTextGroupRef}>
                       <KeyboardTextGroup keyTextGroups={keyTextGroups} />
-                    </>
+                    </Spacing>
                   )}
                 </FlexContainer>
-                {items && buildMenuEl(items, uuid, false, depth, refArg, maxItemLength * UNIT)}
+                {items && (
+                  buildMenuEl(
+                    items,
+                    uuid,
+                    false,
+                    depth,
+                    refArg,
+                    (UNIT * maxItemLength) + (keyTextGroupRef.current?.clientWidth + UNIT || 0),
+                  )
+                )}
               </LinkStyle>
           );
         })}

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -121,7 +121,7 @@ function FlyoutMenu({
       setHighlightedIndices([]);
     }
   }, [open]);
-  
+
   const buildMenuEl = (
     items: FlyoutMenuItemType[],
     uuid: string,

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -3,13 +3,12 @@ import React, { createRef, useEffect, useRef, useState } from 'react';
 import FlexContainer from '@oracle/components/FlexContainer';
 import KeyboardShortcutType from '@interfaces/KeyboardShortcutType';
 import KeyboardTextGroup, { NumberOrString } from '@oracle/elements/KeyboardTextGroup';
+import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
 import { ArrowRight } from '@oracle/icons';
 import {
-  COMPACT_MENU_WIDTH,
   FlyoutMenuContainerStyle,
   LinkStyle,
-  MENU_WIDTH,
   TitleContainerStyle,
 } from './index.style';
 import {
@@ -17,6 +16,7 @@ import {
   KEY_CODE_ARROW_UP,
   KEY_CODE_ENTER,
 } from '@utils/hooks/keyboardShortcuts/constants';
+import { UNIT } from '@oracle/styles/units/spacing';
 import { pauseEvent } from '@utils/events';
 import { useKeyboardContext } from '@context/Keyboard';
 
@@ -36,7 +36,6 @@ export type FlyoutMenuItemType = {
 };
 
 export type FlyoutMenuProps = {
-  compact?: boolean;
   items: FlyoutMenuItemType[];
   left?: number;
   onClickCallback?: () => void;
@@ -49,7 +48,6 @@ export type FlyoutMenuProps = {
 };
 
 function FlyoutMenu({
-  compact,
   items,
   left,
   onClickCallback,
@@ -129,29 +127,29 @@ function FlyoutMenu({
     visible: boolean,
     depth: number = 0,
     refArg: React.RefObject<any>,
+    maxWidth: number = 0,
   ) => {
     depth += 1;
 
+    const maxItemLength = Math.max(...items.map((item: FlyoutMenuItemType) => Number(item.label().length)));
+
     return (
       <FlyoutMenuContainerStyle
-        compact={compact}
         style={{
           display: (visible || submenuVisible[uuid]) ? null : 'none',
           left: typeof rightOffset === 'undefined' && (
             depth === 1
               ? (left || 0)
-              : (compact
-                ? ((depth - 1) * COMPACT_MENU_WIDTH)
-                : ((depth - 1) * MENU_WIDTH))
+              : ((depth - 1) * maxWidth)
           ),
+          right: depth === 1
+            ? rightOffset
+            : null,
           top: (
             depth === 1
               ? (height || 0) + topOffset
               : (submenuTopOffset || 0)
           ),
-          right: depth === 1
-            ? rightOffset
-            : null,
         }}
         width={width}
       >
@@ -169,7 +167,7 @@ function FlyoutMenu({
           return (isGroupingTitle
             ?
               <TitleContainerStyle>
-                <Text bold key={uuid} muted>
+                <Text bold key={uuid} muted noWrapping>
                   {label()}
                 </Text>
               </TitleContainerStyle>
@@ -205,14 +203,19 @@ function FlyoutMenu({
                   fullWidth
                   justifyContent="space-between"
                 >
-                  <Text>
+                  <Text noWrapping>
                     {label()}
                   </Text>
                   {items && <ArrowRight />}
-                </FlexContainer>
 
-                {keyTextGroups && <KeyboardTextGroup keyTextGroups={keyTextGroups} />}
-                {items && buildMenuEl(items, uuid, false, depth, refArg)}
+                  {keyTextGroups && (
+                    <>
+                      <Spacing mr={4} />
+                      <KeyboardTextGroup keyTextGroups={keyTextGroups} />
+                    </>
+                  )}
+                </FlexContainer>
+                {items && buildMenuEl(items, uuid, false, depth, refArg, maxItemLength * UNIT)}
               </LinkStyle>
           );
         })}

--- a/mage_ai/frontend/oracle/icons/custom/Convert.tsx
+++ b/mage_ai/frontend/oracle/icons/custom/Convert.tsx
@@ -1,11 +1,7 @@
 import styled from 'styled-components';
+
 import { BaseIconProps } from '../BaseIcon';
 import { DEFAULT_SIZE } from '../shared/constants';
-
-export type LogoWithNameProps = {
-  height?: number;
-  width?: number;
-};
 
 const SVGStyle = styled.svg``;
 

--- a/mage_ai/frontend/oracle/icons/custom/Convert.tsx
+++ b/mage_ai/frontend/oracle/icons/custom/Convert.tsx
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+import { BaseIconProps } from '../BaseIcon';
+import { DEFAULT_SIZE } from '../shared/constants';
+
+export type LogoWithNameProps = {
+  height?: number;
+  width?: number;
+};
+
+const SVGStyle = styled.svg``;
+
+const Convert = ({
+  fill,
+  opacity,
+  size = DEFAULT_SIZE,
+  style,
+  viewBox = '0 0 12 12',
+}: BaseIconProps) => (
+  <SVGStyle
+    fill={fill}
+    height={size}
+    opacity={opacity}
+    style={style}
+    viewBox={viewBox}
+    width={size}
+  >
+    <path
+      clipRule="evenodd"
+      d="M2.5 1C1.67157 1 1 1.67157 1 2.5v.0625c0 .27614-.223858.5-.5.5s-.5-.22386-.5-.5V2.5C0 1.11929 1.11929 0 2.5 0h7C10.8807 0 12 1.11929 12 2.5v7c0 1.3807-1.1193 2.5-2.5 2.5h-7C1.11929 12 0 10.8807 0 9.5v-.0625c0-.27614.223858-.5.5-.5s.5.22386.5.5V9.5c0 .8284.67157 1.5 1.5 1.5h7c.8284 0 1.5-.6716 1.5-1.5v-7c0-.82843-.6716-1.5-1.5-1.5h-7z"
+      fill="url(#paint0_linear_1332_60037)"
+      fillRule="evenodd"
+    />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M6.05806 3.55806c.24408-.24408.6398-.24408.88388 0l2 2c.24408.24408.24408.6398 0 .88388l-2 2c-.24408.24408-.6398.24408-.88388 0-.24408-.24408-.24408-.6398 0-.88388l.93306-.93306H1C.654822 6.625.375 6.34518.375 6s.279822-.625.625-.625h5.99112l-.93306-.93306c-.24408-.24408-.24408-.6398 0-.88388z"
+      fill="#fff"
+    />
+    <defs>
+      <linearGradient id="paint0_linear_1332_60037" x1="-.618557" y1="-.000001" x2="10.5709" y2=".83113" gradientUnits="userSpaceOnUse">
+        <stop stopColor="#FFCC19" />
+        <stop offset=".585938" stopColor="#2ECDF7" />
+        <stop offset="1" stopColor="#9E7BFF" />
+      </linearGradient>
+    </defs>
+  </SVGStyle>
+);
+
+export default Convert;


### PR DESCRIPTION
# Summary
- add "convert block" icon to command buttons for scratchpad blocks
- reuse same "convert block" menu items for block dropdown & command button icon
- update `FlyoutMenuWrapper` to pass down props to `FlyoutMenu` (useful for relative positioning)

# Tests
![2022-07-28 01 25 00](https://user-images.githubusercontent.com/105667442/181427263-9a150897-3610-4c10-940b-5e164dbffd32.gif)

cc: @johnson-mage @tommydangerous 
