### PR TITLE
[sk] Added check for cycles in pipeline upon update

### DIFF
--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -505,12 +505,6 @@ class Pipeline:
         combined_blocks.update(self.widgets_by_uuid)
         status = {uuid: 'unvisited' for uuid in combined_blocks}
 
-        class StackFrame:
-            def __init__(self, block):
-                self.uuid = block.uuid
-                self.children = block.downstream_block_uuids
-                self.accessed = False
-
         def __print_cycle(start_uuid: str, virtual_stack: List[StackFrame]):
             index = 0
             while index < len(virtual_stack) and virtual_stack[index].uuid != start_uuid:
@@ -542,6 +536,13 @@ class Pipeline:
         for uuid in combined_blocks:
             if status[uuid] == 'unvisited':
                 __check_cycle(self.blocks_by_uuid[uuid])
+
+
+class StackFrame:
+    def __init__(self, block):
+        self.uuid = block.uuid
+        self.children = block.downstream_block_uuids
+        self.accessed = False
 
 
 class InvalidPipelineError(Exception):

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -501,7 +501,8 @@ class Pipeline:
             error_msg (str): Error message to print if cycle is found.
             Defaults to 'A cycle was detected'
         """
-        combined_blocks = {uuid: block for uuid, block in self.blocks_by_uuid.items()}
+        combined_blocks = dict()
+        combined_blocks.update(self.blocks_by_uuid)
         combined_blocks.update(self.widgets_by_uuid)
         status = {uuid: 'unvisited' for uuid in combined_blocks}
 

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -11,7 +11,7 @@ from mage_ai.data_preparation.repo_manager import RepoConfig, get_repo_config, g
 from mage_ai.data_preparation.templates.utils import copy_template_directory
 from mage_ai.data_preparation.variable_manager import VariableManager
 from mage_ai.shared.utils import clean_name
-from typing import Callable, List, Tuple
+from typing import Callable, List
 import os
 import shutil
 import yaml
@@ -501,8 +501,9 @@ class Pipeline:
             error_msg (str): Error message to print if cycle is found.
             Defaults to 'A cycle was detected'
         """
-
-        status = {uuid: 'unvisited' for uuid in self.blocks_by_uuid}
+        combined_blocks = {uuid: block for uuid, block in self.blocks_by_uuid.items()}
+        combined_blocks.update(self.widgets_by_uuid)
+        status = {uuid: 'unvisited' for uuid in combined_blocks}
 
         class StackFrame:
             def __init__(self, block):
@@ -535,10 +536,10 @@ class Pipeline:
                     status[frame.uuid] = 'validated'
                     virtual_stack.pop()
                 else:
-                    child_block = self.blocks_by_uuid[frame.children.pop()]
+                    child_block = combined_blocks[frame.children.pop()]
                     virtual_stack.append(StackFrame(child_block))
 
-        for uuid in self.blocks_by_uuid:
+        for uuid in combined_blocks:
             if status[uuid] == 'unvisited':
                 __check_cycle(self.blocks_by_uuid[uuid])
 


### PR DESCRIPTION
# Summary
Added `validate` function which checks for cycles in pipeline. If a cycle exists, an `InvalidPipelineError` is raised. The algorithm used to perform this check is a modified depth-first search which recursively checks if each subtree path contains a cycle - for some given block in the pipeline, does there exist a path of downstream blocks back to itself? If so, a cycle exists. This can be done efficiently by making use of the recursive nature of the problem - if a subgraph is validated to not have any cycles, there is no need to check that subgraph when considering its parents.

If a cycle is found, the error message printed shows the path of blocks that form the cycle:
```
bitter_frost --> crimson_dust --> cool_feather --> crimson_thunder --> proud_forest --> shy_haze --> silent_frog --> billowing_resonance --> morning_morning --> bitter_frost
```

Note: To avoid recursion issues in practice, an iterative solution was developed using a virtual call stack frame, which adds more boilerplate but avoids stack overflow errors. In addition, this solution allows full access to stack frame contents, which makes printing the offending cycle easier.

# Tests
Unit tests added to check cycle detection when adding a block or updating a block. Local testing also done with larger, more complex pipelines to check that longer cycles are detected.

cc:
@wangxiaoyou1993 
