### PR TITLE
[sp] add data source transformer templates

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/utils.ts
+++ b/mage_ai/frontend/components/CodeBlock/utils.ts
@@ -1,4 +1,4 @@
-import BlockType, { BLOCK_TYPE_CONVERTIBLE, BLOCK_TYPE_NAME_MAPPING } from '@interfaces/BlockType';
+import BlockType, { CONVERTIBLE_BLOCK_TYPES, BLOCK_TYPE_NAME_MAPPING } from '@interfaces/BlockType';
 import { FlyoutMenuItemType } from '@oracle/components/FlyoutMenu';
 import { lowercase } from '@utils/string';
 
@@ -16,7 +16,7 @@ export const buildConvertBlockMenuItems = (
   }
 
   return (
-    BLOCK_TYPE_CONVERTIBLE.map(blockType => ({
+    CONVERTIBLE_BLOCK_TYPES.map(blockType => ({
       label: () => `Convert to ${lowercase(BLOCK_TYPE_NAME_MAPPING[blockType])}`,
       // @ts-ignore
       onClick: () => updateBlock({

--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
@@ -7,7 +7,7 @@ import KeyboardShortcutButton from '@oracle/elements/Button/KeyboardShortcutButt
 import Spacing from '@oracle/elements/Spacing';
 import { Add } from '@oracle/icons';
 import { AxisEnum } from '@interfaces/ActionPayloadType';
-import { BlockRequestPayloadType, BlockTypeEnum, BLOCK_TYPE_CONVERTIBLE } from '@interfaces/BlockType';
+import { BlockRequestPayloadType, BlockTypeEnum, CONVERTIBLE_BLOCK_TYPES } from '@interfaces/BlockType';
 import {
   COLUMN_ACTION_GROUPINGS,
   ROW_ACTION_GROUPINGS,
@@ -41,7 +41,7 @@ function AddNewBlocks({
   };
 
   const dataSourceMenuItems = useMemo(() => (
-    Object.fromEntries(BLOCK_TYPE_CONVERTIBLE.map(
+    Object.fromEntries(CONVERTIBLE_BLOCK_TYPES.map(
       (blockType: BlockTypeEnum) => ([
         blockType,
         createDataSourceMenuItems(blockType, addNewBlock),

--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import ClickOutside from '@oracle/components/ClickOutside';
 import FlexContainer from '@oracle/components/FlexContainer';
@@ -7,21 +7,16 @@ import KeyboardShortcutButton from '@oracle/elements/Button/KeyboardShortcutButt
 import Spacing from '@oracle/elements/Spacing';
 import { Add } from '@oracle/icons';
 import { AxisEnum } from '@interfaces/ActionPayloadType';
-import { BlockRequestPayloadType, BlockTypeEnum } from '@interfaces/BlockType';
+import { BlockRequestPayloadType, BlockTypeEnum, BLOCK_TYPE_CONVERTIBLE } from '@interfaces/BlockType';
 import {
   COLUMN_ACTION_GROUPINGS,
   ROW_ACTION_GROUPINGS,
 } from '@interfaces/TransformerActionType';
 import {
-  DATA_SOURCE_TYPES,
-  DATA_SOURCE_TYPE_HUMAN_READABLE_NAME_MAPPING,
-  DataSourceTypeEnum,
-} from '@interfaces/DataSourceType';
-import {
   ICON_SIZE,
   IconContainerStyle,
 } from './index.style';
-import { createActionMenuGroupings } from './utils';
+import { createActionMenuGroupings, createDataSourceMenuItems } from './utils';
 
 type AddNewBlocksProps = {
   addNewBlock: (block: BlockRequestPayloadType) => void;
@@ -45,35 +40,16 @@ function AddNewBlocks({
     inline: true,
   };
 
-  const dataLoaderMenuItems = (
-    DATA_SOURCE_TYPES[BlockTypeEnum.DATA_LOADER].map((sourceType: DataSourceTypeEnum) => ({
-      label: () => DATA_SOURCE_TYPE_HUMAN_READABLE_NAME_MAPPING[sourceType],
-      onClick: () => {
-        addNewBlock({
-          config: {
-            data_source: sourceType === DataSourceTypeEnum.GENERIC ? null : sourceType,
-          },
-          type: BlockTypeEnum.DATA_LOADER,
-        });
-      },
-      uuid: `data_loader/${sourceType}`,
-    }))
-  );
-
-  const dataExporterMenuItems = (
-    DATA_SOURCE_TYPES[BlockTypeEnum.DATA_EXPORTER].map((sourceType: DataSourceTypeEnum) => ({
-      label: () => DATA_SOURCE_TYPE_HUMAN_READABLE_NAME_MAPPING[sourceType],
-      onClick: () => {
-        addNewBlock({
-          config: {
-            data_source: sourceType === DataSourceTypeEnum.GENERIC ? null : sourceType,
-          },
-          type: BlockTypeEnum.DATA_EXPORTER,
-        });
-      },
-      uuid: `data_exporter/${sourceType}`,
-    }))
-  );
+  const dataSourceMenuItems = useMemo(() => (
+    Object.fromEntries(BLOCK_TYPE_CONVERTIBLE.map(
+      (blockType: BlockTypeEnum) => ([
+        blockType,
+        createDataSourceMenuItems(blockType, addNewBlock),
+      ]),
+    ),
+  )), [
+    addNewBlock,
+  ]);
 
   const columnActionMenuItems = createActionMenuGroupings(
     COLUMN_ACTION_GROUPINGS,
@@ -118,7 +94,7 @@ function AddNewBlocks({
       >
         <FlexContainer>
           <FlyoutMenuWrapper
-            items={dataLoaderMenuItems}
+            items={dataSourceMenuItems[BlockTypeEnum.DATA_LOADER]}
             onClickCallback={closeButtonMenu}
             open={buttonMenuOpenIndex === DATA_LOADER_BUTTON_INDEX}
             parentRef={dataLoaderButtonRef}
@@ -178,7 +154,7 @@ function AddNewBlocks({
           <Spacing ml={1} />
 
           <FlyoutMenuWrapper
-            items={dataExporterMenuItems}
+            items={dataSourceMenuItems[BlockTypeEnum.DATA_EXPORTER]}
             onClickCallback={closeButtonMenu}
             open={buttonMenuOpenIndex === DATA_EXPORTER_BUTTON_INDEX}
             parentRef={dataExporterButtonRef}

--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
@@ -61,16 +61,14 @@ function AddNewBlocks({
     AxisEnum.ROW,
     addNewBlock,
   );
+
   const allActionMenuItems = [
     {
-      label: () => 'Generic (no template)',
-      onClick: () => {
-        addNewBlock({
-          type: BlockTypeEnum.TRANSFORMER,
-        });
-      },
-      uuid: 'generic_transformer_action',
+      isGroupingTitle: true,
+      label: () => 'Data sources',
+      uuid: 'data_sources_grouping',
     },
+    ...dataSourceMenuItems[BlockTypeEnum.TRANSFORMER],
     {
       isGroupingTitle: true,
       label: () => 'Column actions',
@@ -84,6 +82,7 @@ function AddNewBlocks({
     },
     ...rowActionMenuItems,
   ];
+
   const closeButtonMenu = useCallback(() => setButtonMenuOpenIndex(null), []);
 
   return (

--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
@@ -64,6 +64,15 @@ function AddNewBlocks({
 
   const allActionMenuItems = [
     {
+      label: () => 'Generic (no template)',
+      onClick: () => {
+        addNewBlock({
+          type: BlockTypeEnum.TRANSFORMER,
+        });
+      },
+      uuid: 'generic_transformer_action',
+    },
+    {
       isGroupingTitle: true,
       label: () => 'Data sources',
       uuid: 'data_sources_grouping',

--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/utils.ts
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/utils.ts
@@ -1,12 +1,35 @@
-import { ActionTypeEnum, AxisEnum } from '@interfaces/ActionPayloadType';
 import {
   ACTION_GROUPING_MAPPING,
   ACTION_TYPE_HUMAN_READABLE_MAPPING,
   ActionGroupingEnum,
 } from '@interfaces/TransformerActionType';
+import { ActionTypeEnum, AxisEnum } from '@interfaces/ActionPayloadType';
 import { BlockRequestPayloadType, BlockTypeEnum } from '@interfaces/BlockType';
+import DataSourceTypeEnum, {
+  DATA_SOURCE_TYPES,
+  DATA_SOURCE_TYPE_HUMAN_READABLE_NAME_MAPPING,
+} from '@interfaces/DataSourceType';
 import { FlyoutMenuItemType } from '@oracle/components/FlyoutMenu';
 import { addUnderscores } from '@utils/string';
+
+export const createDataSourceMenuItems = (
+  blockType: BlockTypeEnum,
+  blockCallback: (block: BlockRequestPayloadType) => void,
+) => (
+  DATA_SOURCE_TYPES[blockType].map((sourceType: DataSourceTypeEnum) => ({
+    indent: blockType === BlockTypeEnum.TRANSFORMER,
+    label: () => DATA_SOURCE_TYPE_HUMAN_READABLE_NAME_MAPPING[sourceType],
+    onClick: () => {
+      blockCallback({
+        config: {
+          data_source: sourceType === DataSourceTypeEnum.GENERIC ? null : sourceType,
+        },
+        type: blockType,
+      });
+    },
+    uuid: `${blockType}/${sourceType}`,
+  }))
+);
 
 export function createActionMenuItems(
   actions: ActionTypeEnum[],

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -1,6 +1,5 @@
 import {
   createRef,
-  useCallback,
   useEffect,
   useMemo,
   useState,

--- a/mage_ai/frontend/interfaces/BlockType.ts
+++ b/mage_ai/frontend/interfaces/BlockType.ts
@@ -101,7 +101,7 @@ export const BLOCK_TYPE_NAME_MAPPING = {
   [BlockTypeEnum.TRANSFORMER]: 'Transformer',
 };
 
-export const BLOCK_TYPE_CONVERTIBLE = [
+export const CONVERTIBLE_BLOCK_TYPES = [
   BlockTypeEnum.DATA_EXPORTER,
   BlockTypeEnum.DATA_LOADER,
   BlockTypeEnum.TRANSFORMER,

--- a/mage_ai/frontend/interfaces/DataSourceType.ts
+++ b/mage_ai/frontend/interfaces/DataSourceType.ts
@@ -43,7 +43,6 @@ export const DATA_SOURCE_TYPES: { [blockType in BlockTypeEnum]?: DataSourceTypeE
     DataSourceTypeEnum.SNOWFLAKE,
   ],
   [BlockTypeEnum.TRANSFORMER]: [
-    DataSourceTypeEnum.GENERIC,
     DataSourceTypeEnum.BIGQUERY,
     DataSourceTypeEnum.POSTGRES,
     DataSourceTypeEnum.REDSHIFT,

--- a/mage_ai/frontend/interfaces/DataSourceType.ts
+++ b/mage_ai/frontend/interfaces/DataSourceType.ts
@@ -42,6 +42,13 @@ export const DATA_SOURCE_TYPES: { [blockType in BlockTypeEnum]?: DataSourceTypeE
     DataSourceTypeEnum.S3,
     DataSourceTypeEnum.SNOWFLAKE,
   ],
+  [BlockTypeEnum.TRANSFORMER]: [
+    DataSourceTypeEnum.GENERIC,
+    DataSourceTypeEnum.BIGQUERY,
+    DataSourceTypeEnum.POSTGRES,
+    DataSourceTypeEnum.REDSHIFT,
+    DataSourceTypeEnum.SNOWFLAKE,
+  ],
 };
 
 export default DataSourceTypeEnum;

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -206,7 +206,11 @@ function FlyoutMenu({
                   <Text noWrapping>
                     {label()}
                   </Text>
-                  {items && <ArrowRight />}
+                  {items && (
+                    <Spacing ml={2}>
+                      <ArrowRight />
+                    </Spacing>
+                  )}
 
                   {keyTextGroups && (
                     <Spacing ml={4} ref={keyTextGroupRef}>
@@ -221,7 +225,7 @@ function FlyoutMenu({
                     false,
                     depth,
                     refArg,
-                    (UNIT * maxItemLength) + (keyTextGroupRef.current?.clientWidth + UNIT || 0),
+                    (UNIT * maxItemLength) + (keyTextGroupRef.current?.clientWidth + UNIT || 0) + UNIT * 2,
                   )
                 )}
               </LinkStyle>

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -140,7 +140,7 @@ function FlyoutMenu({
           left: typeof rightOffset === 'undefined' && (
             depth === 1
               ? (left || 0)
-              : maxWidth
+              : ((depth - 1) * maxWidth)
           ),
           right: depth === 1
             ? rightOffset
@@ -206,15 +206,15 @@ function FlyoutMenu({
                   <Text noWrapping>
                     {label()}
                   </Text>
-                  {(items || keyTextGroups) && (
-                    <Spacing ml={4}>
-                      {items && (
-                        <ArrowRight />
-                      )}
-    
-                      {keyTextGroups && (
-                        <KeyboardTextGroup keyTextGroups={keyTextGroups} />
-                      )}
+                  {items && (
+                    <Spacing ml={2}>
+                      <ArrowRight />
+                    </Spacing>
+                  )}
+
+                  {keyTextGroups && (
+                    <Spacing ml={4} ref={keyTextGroupRef}>
+                      <KeyboardTextGroup keyTextGroups={keyTextGroups} />
                     </Spacing>
                   )}
                 </FlexContainer>
@@ -225,7 +225,7 @@ function FlyoutMenu({
                     false,
                     depth,
                     refArg,
-                    (UNIT * maxItemLength) + (keyTextGroupRef.current?.clientWidth || 0) + UNIT * 4,
+                    (UNIT * maxItemLength) + (keyTextGroupRef.current?.clientWidth + UNIT || 0) + UNIT * 2,
                   )
                 )}
               </LinkStyle>

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -140,7 +140,7 @@ function FlyoutMenu({
           left: typeof rightOffset === 'undefined' && (
             depth === 1
               ? (left || 0)
-              : ((depth - 1) * maxWidth)
+              : maxWidth
           ),
           right: depth === 1
             ? rightOffset
@@ -206,15 +206,15 @@ function FlyoutMenu({
                   <Text noWrapping>
                     {label()}
                   </Text>
-                  {items && (
-                    <Spacing ml={2}>
-                      <ArrowRight />
-                    </Spacing>
-                  )}
-
-                  {keyTextGroups && (
-                    <Spacing ml={4} ref={keyTextGroupRef}>
-                      <KeyboardTextGroup keyTextGroups={keyTextGroups} />
+                  {(items || keyTextGroups) && (
+                    <Spacing ml={4}>
+                      {items && (
+                        <ArrowRight />
+                      )}
+    
+                      {keyTextGroups && (
+                        <KeyboardTextGroup keyTextGroups={keyTextGroups} />
+                      )}
                     </Spacing>
                   )}
                 </FlexContainer>
@@ -225,7 +225,7 @@ function FlyoutMenu({
                     false,
                     depth,
                     refArg,
-                    (UNIT * maxItemLength) + (keyTextGroupRef.current?.clientWidth + UNIT || 0) + UNIT * 2,
+                    (UNIT * maxItemLength) + (keyTextGroupRef.current?.clientWidth || 0) + UNIT * 4,
                   )
                 )}
               </LinkStyle>


### PR DESCRIPTION
# Summary
- refactor data source menu items into builder util function
- add data source menu items to "add transformer block" dropdown

# Tests
<img width="543" alt="image" src="https://user-images.githubusercontent.com/105667442/181834502-77141b81-b2ba-4d09-8576-81c421a6f398.png">

(Waiting on backend bugfix from Sachchit, will update w/ live test then)

cc: @johnson-mage @skunichetty @wangxiaoyou1993 
