### PR TITLE
[sk] Strip whitespace and newlines from around query

### DIFF
--- a/mage_ai/io/base.py
+++ b/mage_ai/io/base.py
@@ -210,7 +210,7 @@ class BaseFile(BaseIO):
 class BaseSQLDatabase(BaseIO):
     """
     Base data loader for connecting to a SQL database. This adds `query` method which allows a user
-    to send queries to the databse server.
+    to send queries to the database server.
     """
 
     @abstractmethod
@@ -238,6 +238,19 @@ class BaseSQLDatabase(BaseIO):
             DataFrame: Sampled data from the data frame.
         """
         return self.load(f'SELECT * FROM {schema}.{table} LIMIT {str(size)};', **kwargs)
+
+    def _clean_query(self, query_string: str) -> str:
+        """
+        Cleans query before sending to database. Cleaning steps include:
+        - Removing surrounding whitespace, newlines, and tabs
+
+        Args:
+            query_string (str): Query string to clean
+
+        Returns:
+            str: Clean query string
+        """
+        return query_string.strip(' \n\t')
 
 
 class BaseSQLConnection(BaseSQLDatabase):

--- a/mage_ai/io/bigquery.py
+++ b/mage_ai/io/bigquery.py
@@ -68,8 +68,8 @@ class BigQuery(BaseSQLDatabase):
         Returns:
             DataFrame: Data frame associated with the given query.
         """
-        query_string = self._clean_query(query_string)
         with self.printer.print_msg(f'Loading data frame with query \'{query_string}\''):
+            query_string = self._clean_query(query_string)
             return self.client.query(
                 self._enforce_limit(query_string, limit), *kwargs
             ).to_dataframe()

--- a/mage_ai/io/bigquery.py
+++ b/mage_ai/io/bigquery.py
@@ -68,6 +68,7 @@ class BigQuery(BaseSQLDatabase):
         Returns:
             DataFrame: Data frame associated with the given query.
         """
+        query_string = self._clean_query(query_string)
         with self.printer.print_msg(f'Loading data frame with query \'{query_string}\''):
             return self.client.query(
                 self._enforce_limit(query_string, limit), *kwargs

--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -64,8 +64,8 @@ class Postgres(BaseSQLConnection):
             query_string (str): SQL query string to apply on the connected database.
             query_vars: Variable values to fill in when using format strings in query.
         """
-        query_string = self._clean_query(query_string)
         with self.printer.print_msg(f'Executing query \'{query_string}\''):
+            query_string = self._clean_query(query_string)
             with self.conn.cursor() as cur:
                 cur.execute(query_string, **query_vars)
 
@@ -84,8 +84,8 @@ class Postgres(BaseSQLConnection):
         Returns:
             DataFrame: The data frame corresponding to the data returned by the given query.
         """
-        query_string = self._clean_query(query_string)
         with self.printer.print_msg(f'Loading data frame with query \'{query_string}\''):
+            query_string = self._clean_query(query_string)
             return read_sql(self._enforce_limit(query_string, limit), self.conn, **kwargs)
 
     def export(

--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -64,6 +64,7 @@ class Postgres(BaseSQLConnection):
             query_string (str): SQL query string to apply on the connected database.
             query_vars: Variable values to fill in when using format strings in query.
         """
+        query_string = self._clean_query(query_string)
         with self.printer.print_msg(f'Executing query \'{query_string}\''):
             with self.conn.cursor() as cur:
                 cur.execute(query_string, **query_vars)
@@ -83,6 +84,7 @@ class Postgres(BaseSQLConnection):
         Returns:
             DataFrame: The data frame corresponding to the data returned by the given query.
         """
+        query_string = self._clean_query(query_string)
         with self.printer.print_msg(f'Loading data frame with query \'{query_string}\''):
             return read_sql(self._enforce_limit(query_string, limit), self.conn, **kwargs)
 

--- a/mage_ai/io/redshift.py
+++ b/mage_ai/io/redshift.py
@@ -30,6 +30,7 @@ class Redshift(BaseSQLConnection):
             query_string (str): The query to execute on the Redshift cluster.
             **kwargs: Additional parameters to pass to the query.
         """
+        query_string = self._clean_query(query_string)
         with self.printer.print_msg(f'Executing query \'{query_string}\''):
             with self.conn.cursor() as cur:
                 cur.execute(query_string, **kwargs)
@@ -51,6 +52,7 @@ class Redshift(BaseSQLConnection):
         Returns:
             DataFrame: Data frame associated with the given query.
         """
+        query_string = self._clean_query(query_string)
         with self.printer.print_msg(f'Loading data frame with query \'{query_string}\''):
             with self.conn.cursor() as cur:
                 return cur.execute(

--- a/mage_ai/io/redshift.py
+++ b/mage_ai/io/redshift.py
@@ -30,8 +30,8 @@ class Redshift(BaseSQLConnection):
             query_string (str): The query to execute on the Redshift cluster.
             **kwargs: Additional parameters to pass to the query.
         """
-        query_string = self._clean_query(query_string)
         with self.printer.print_msg(f'Executing query \'{query_string}\''):
+            query_string = self._clean_query(query_string)
             with self.conn.cursor() as cur:
                 cur.execute(query_string, **kwargs)
 
@@ -52,8 +52,8 @@ class Redshift(BaseSQLConnection):
         Returns:
             DataFrame: Data frame associated with the given query.
         """
-        query_string = self._clean_query(query_string)
         with self.printer.print_msg(f'Loading data frame with query \'{query_string}\''):
+            query_string = self._clean_query(query_string)
             with self.conn.cursor() as cur:
                 return cur.execute(
                     self._enforce_limit(query_string, limit), *args, **kwargs

--- a/mage_ai/io/snowflake.py
+++ b/mage_ai/io/snowflake.py
@@ -46,8 +46,8 @@ class Snowflake(BaseSQLConnection):
             query_string (str): The query to execute on Snowflake's platform.
             **kwargs: Additional parameters to provide to the query
         """
-        query_string = self._clean_query(query_string)
         with self.printer.print_msg(f'Executing query \'{query_string}\''):
+            query_string = self._clean_query(query_string)
             with self.conn.cursor() as cur:
                 return cur.execute(query_string, **kwargs)
 
@@ -67,8 +67,8 @@ class Snowflake(BaseSQLConnection):
         Returns:
             DataFrame: Data frame associated with the given query.
         """
-        query_string = self._clean_query(query_string)
         with self.printer.print_msg(f'Loading data frame with query \'{query_string}\''):
+            query_string = self._clean_query(query_string)
             with self.conn.cursor() as cur:
                 return cur.execute(
                     self._enforce_limit(query_string, limit), *args, **kwargs

--- a/mage_ai/io/snowflake.py
+++ b/mage_ai/io/snowflake.py
@@ -46,6 +46,7 @@ class Snowflake(BaseSQLConnection):
             query_string (str): The query to execute on Snowflake's platform.
             **kwargs: Additional parameters to provide to the query
         """
+        query_string = self._clean_query(query_string)
         with self.printer.print_msg(f'Executing query \'{query_string}\''):
             with self.conn.cursor() as cur:
                 return cur.execute(query_string, **kwargs)
@@ -66,6 +67,7 @@ class Snowflake(BaseSQLConnection):
         Returns:
             DataFrame: Data frame associated with the given query.
         """
+        query_string = self._clean_query(query_string)
         with self.printer.print_msg(f'Loading data frame with query \'{query_string}\''):
             with self.conn.cursor() as cur:
                 return cur.execute(


### PR DESCRIPTION
# Summary
Strips whitespace and newlines from around query to prevent formatting errors when used inside limiting subquery.

# Tests
Tested locally by trying out different combinations of newlines, tabs, and whitespace around main query and testing if query can be successfully made.

cc:
@wangxiaoyou1993 
