### PR TITLE
[jk] Improve transformer action flyout menus

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
@@ -19,6 +19,7 @@ import {
   COLUMN_ACTION_GROUPINGS,
   ROW_ACTION_GROUPINGS,
 } from '@interfaces/TransformerActionType';
+import { FlyoutMenuItemType } from '@oracle/components/FlyoutMenu';
 import {
   ICON_SIZE,
   IconContainerStyle,
@@ -77,7 +78,7 @@ function AddNewBlocks({
     addNewBlock,
   );
 
-  const allActionMenuItems = [
+  const allActionMenuItems: FlyoutMenuItemType[] = [
     {
       label: () => 'Generic (no template)',
       onClick: () => {
@@ -89,23 +90,23 @@ function AddNewBlocks({
       uuid: 'generic_transformer_action',
     },
     {
-      isGroupingTitle: true,
+      bold: true,
+      items: dataSourceMenuItems[BlockTypeEnum.TRANSFORMER],
       label: () => 'Data sources',
       uuid: 'data_sources_grouping',
     },
-    ...dataSourceMenuItems[BlockTypeEnum.TRANSFORMER],
+    {
+      bold: true,
+      items: rowActionMenuItems,
+      label: () => 'Row actions',
+      uuid: 'row_actions_grouping',
+    },
     {
       isGroupingTitle: true,
       label: () => 'Column actions',
       uuid: 'column_actions_grouping',
     },
     ...columnActionMenuItems,
-    {
-      isGroupingTitle: true,
-      label: () => 'Row actions',
-      uuid: 'row_actions_grouping',
-    },
-    ...rowActionMenuItems,
   ];
 
   const closeButtonMenu = useCallback(() => setButtonMenuOpenIndex(null), []);
@@ -136,8 +137,8 @@ function AddNewBlocks({
                     uuid: 'data_loaders/sql',
                   },
                   {
-                    label: () => 'Python',
                     items: dataSourceMenuItems[BlockTypeEnum.DATA_LOADER],
+                    label: () => 'Python',
                     uuid: 'data_loaders/python',
                   },
                 ]
@@ -184,8 +185,8 @@ function AddNewBlocks({
                   uuid: 'transformers/sql',
                 },
                 {
-                  label: () => 'Python',
                   items: allActionMenuItems,
+                  label: () => 'Python',
                   uuid: 'transformers/python',
                 },
               ]

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -21,6 +21,7 @@ import { pauseEvent } from '@utils/events';
 import { useKeyboardContext } from '@context/Keyboard';
 
 export type FlyoutMenuItemType = {
+  bold?: boolean;
   disabled?: boolean;
   indent?: boolean;
   items?: FlyoutMenuItemType[];
@@ -154,6 +155,7 @@ function FlyoutMenu({
         width={width}
       >
         {items?.map(({
+          bold,
           disabled,
           items,
           indent,
@@ -211,6 +213,7 @@ function FlyoutMenu({
                   justifyContent="space-between"
                 >
                   <Text
+                    bold={bold}
                     disabled={disabled}
                     noWrapping
                   >

--- a/mage_ai/frontend/pages/pipelines/[...slug].tsx
+++ b/mage_ai/frontend/pages/pipelines/[...slug].tsx
@@ -1578,7 +1578,7 @@ function PipelineDetailPage({
 
         <Spacing
           pb={Math.max(
-            Math.floor((heightWindow / 2) / UNIT),
+            Math.floor((heightWindow * (2 / 3)) / UNIT),
             0,
           )}
         />


### PR DESCRIPTION
# Summary
- Group more items in transformer action flyout menu to minimize scrolling.
- Prevent flashing transformer action flyout menu when scrolled all the way to the bottom of the screen.

# Tests
![image](https://user-images.githubusercontent.com/78053898/185258659-8bfeb1f9-867e-454f-bc50-bfaf7a85327a.png)


