### PR TITLE
[jk] Fetch pipeline after running block

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
@@ -404,12 +404,12 @@ function CommandButtons({
             items={
               [
                 {
-                  label: () => `Execute with upstream blocks`,
+                  label: () => 'Execute with upstream blocks',
                   onClick: () => runBlock({ block, runUpstream: true }),
                   uuid: 'execute_upstream',
                 },
                 {
-                  label: () => `Execute block and run tests`,
+                  label: () => 'Execute block and run tests',
                   onClick: () => runBlock({ block, runTests: true }),
                   uuid: 'run_tests',
                 },

--- a/mage_ai/frontend/components/DependencyGraph/GraphNode.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/GraphNode.tsx
@@ -2,7 +2,6 @@ import { ThemeContext } from 'styled-components';
 import { useContext } from 'react';
 
 import BlockType from '@interfaces/BlockType';
-import Button from '@oracle/elements/Button';
 import Circle from '@oracle/elements/Circle';
 import FlexContainer from '@oracle/components/FlexContainer';
 import Spacing from '@oracle/elements/Spacing';
@@ -10,7 +9,7 @@ import Spinner from '@oracle/components/Spinner';
 import Text from '@oracle/elements/Text';
 import dark from '@oracle/styles/themes/dark';
 import { Check, Close } from '@oracle/icons';
-import { INVERTED_TEXT_COLOR_BLOCK_TYPES, MIN_NODE_WIDTH } from './constants';
+import { INVERTED_TEXT_COLOR_BLOCK_TYPES } from './constants';
 import { NodeStyle } from './index.style';
 import { ThemeType } from '@oracle/styles/themes/constants';
 import { UNIT } from '@oracle/styles/units/spacing';
@@ -66,16 +65,6 @@ function GraphNode({
       key={uuid}
       selected={selected}
     >
-      {/*<Button
-        basic
-        disabled={disabled}
-        id={uuid}
-        noBackground
-        noBorder
-        noPadding
-        onClick={(onClick && !disabled) ? () => onClick(block) : null}
-      >
-      </Button>*/}
       <Spacing p={1}>
         <FlexContainer alignItems="center">
           <FlexContainer

--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -355,7 +355,6 @@ function DependencyGraph({
 
       <GraphContainerStyle height={height - (UNIT * 10) }>
         <Canvas
-          // arrow={<MarkerArrow style={{ fill: '#b1b1b7' }} />}
           arrow={null}
           disabled={false}
           edge={(edge) => {
@@ -390,23 +389,12 @@ function DependencyGraph({
                   }
                 }
               }}
-              // port={(
-              //   <Port
-              //     rx={10}
-              //     ry={10}
-              //     style={{
-              //       fill: themeContext.accent.alert,
-              //       stroke: themeContext.accent.alert,
-              //     }}
-              //   />
-              // )}
               port={null}
               style={{
                 fill: 'transparent',
                 stroke: 'transparent',
                 strokeWidth: 0,
               }}
-              // label={<div style={{ display: 'none' }} />}
             >
               {(event) => {
                 const {

--- a/mage_ai/frontend/oracle/components/Tooltip/index.tsx
+++ b/mage_ai/frontend/oracle/components/Tooltip/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled, { css } from 'styled-components';
 
 import FlexContainer from '@oracle/components/FlexContainer';
@@ -7,10 +7,7 @@ import TooltipWrapper, { TooltipWrapperProps } from './TooltipWrapper';
 import dark from '@oracle/styles/themes/dark';
 import { BORDER_RADIUS_SMALL } from '@oracle/styles/units/borders';
 import { Info } from '@oracle/icons';
-import { OUTLINE_OFFSET, OUTLINE_WIDTH } from '@oracle/styles/units/borders';
 import { UNIT, WIDTH_OF_SINGLE_CHARACTER } from '@oracle/styles/units/spacing';
-import { selectOutlineColor } from '@oracle/elements/Button';
-import { transition } from '@oracle/styles/mixins';
 
 export type TooltipProps = {
   keyboardShortcuts?: any[];

--- a/mage_ai/frontend/pages/pipelines/[...slug].tsx
+++ b/mage_ai/frontend/pages/pipelines/[...slug].tsx
@@ -1048,7 +1048,7 @@ function PipelineDetailPage({
         ]);
         if (ExecutionStateEnum.IDLE === executionState) {
           setRunningBlocks([]);
-          fetchPipeline()
+          fetchPipeline();
 
           if (!uuid) {
             setIsPipelineExecuting(false);
@@ -1151,8 +1151,8 @@ function PipelineDetailPage({
       });
     }
 
-    // Tommy Dang: what was this for?!
-    // fetchPipeline();
+    // Need to fetch pipeline to refresh block status in dependency graph
+    fetchPipeline();
   }, [
     fetchPipeline,
     pipeline,


### PR DESCRIPTION
# Summary
- Refresh block status in dependency graph after running a block.

# Tests
Block execution (Note: The status changes to a circle first to indicate that it was "updated"):
![2022-08-18 11 25 49](https://user-images.githubusercontent.com/78053898/185468309-73185ecd-6e20-449c-9d1c-971a34f71467.gif)

Pipeline execution:
![2022-08-18 11 52 52](https://user-images.githubusercontent.com/78053898/185472502-38ba50b9-4176-4192-bddd-e25b6b497bae.gif)


cc:
@wangxiaoyou1993 @tommydangerous 
