### PR TITLE
[jk] Fix auto-unfocus bug when renaming pipeline or block with "Enter" keyboard shortcut

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -193,7 +193,7 @@ function CodeBlockProps({
       const {
         messages: messagesInit,
       } = initializeContentAndMessages([block]);
-      setMessages(messagesInit?.[block?.uuid] || [])
+      setMessages(messagesInit?.[block?.uuid] || []);
     }
   },
   [
@@ -426,13 +426,17 @@ function CodeBlockProps({
         && String(keyHistory[0]) === String(KEY_CODE_ENTER)
         && String(keyHistory[1]) !== String(KEY_CODE_META)
       ) {
-        // @ts-ignore
-        updateBlock({
-          block: {
-            ...block,
-            name: newBlockUuid,
-          },
-        });
+        if (block.uuid === newBlockUuid) {
+          event.target.blur();
+        } else {
+          // @ts-ignore
+          updateBlock({
+            block: {
+              ...block,
+              name: newBlockUuid,
+            },
+          });
+        }
       } else if (selected) {
         if (onlyKeysPresent([KEY_CODE_META, KEY_CODE_ENTER], keyMapping)
           || onlyKeysPresent([KEY_CODE_CONTROL, KEY_CODE_ENTER], keyMapping)
@@ -847,7 +851,7 @@ function CodeBlockProps({
                     id,
                     value,
                   }: DataProviderType) => (
-                    <option value={value}>
+                    <option key={id} value={value}>
                       {id}
                     </option>
                   ))}
@@ -867,7 +871,7 @@ function CodeBlockProps({
                 >
                   <option value="" />
                   {dataProviderProfiles?.map((id: string) => (
-                    <option value={id}>
+                    <option key={id} value={id}>
                       {id}
                     </option>
                   ))}

--- a/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
@@ -96,7 +96,7 @@ function KernelStatus({
     saveStatus = 'All changes saved';
   }
 
-  const uuidKeyboard = `KernelStatus`;
+  const uuidKeyboard = 'KernelStatus';
   const {
     registerOnKeyDown,
     unregisterOnKeyDown,
@@ -113,8 +113,12 @@ function KernelStatus({
         && String(keyHistory[0]) === String(KEY_CODE_ENTER)
         && String(keyHistory[1]) !== String(KEY_CODE_META)
       ) {
-        updatePipelineMetadata(newPipelineName);
-        setIsEditingPipeline(false);
+        if (pipeline?.uuid === newPipelineName) {
+          event.target.blur();
+        } else {
+          updatePipelineMetadata(newPipelineName);
+          setIsEditingPipeline(false);
+        }
       }
     },
     [


### PR DESCRIPTION
# Summary
- When clicking on a pipeline or block name but not changing the name and then pressing "Enter", the name input would immediately unfocus (i.e. blur) when clicking back into the input. This PR resolves this bug.

# Tests
Before:
![Bug - Rename pipeline](https://user-images.githubusercontent.com/78053898/185505426-364e8bb8-6d2b-4ad8-b8d3-747b540a22bb.gif)
![Bug - Rename block](https://user-images.githubusercontent.com/78053898/185505434-d9bb3607-3292-4845-8953-41f91f1602dc.gif)

After:
![Bugfix - Rename pipeline](https://user-images.githubusercontent.com/78053898/185505454-54cf2845-d70d-4f40-820a-37c8d1c4e461.gif)
![Bugfix - Rename block](https://user-images.githubusercontent.com/78053898/185505468-7f38577f-1741-4401-8636-74d53f5b917f.gif)
