### PR TITLE
[xy] Store block run outputs with partitions.

### DIFF
--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -10,6 +10,7 @@ class BlockExecutor:
     def execute(
         self,
         analyze_outputs: bool = False,
+        execution_partition: str = None,
         global_vars: Dict = None,
         update_status: bool = False,
         on_complete: Callable[[str], None] = None,
@@ -18,6 +19,7 @@ class BlockExecutor:
         try:
             self.block.execute_sync(
                 analyze_outputs=analyze_outputs,
+                execution_partition=execution_partition,
                 global_vars=global_vars,
                 update_status=update_status,
             )

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -393,6 +393,7 @@ class Block:
                     )
             output = self.execute_block(
                 custom_code=custom_code,
+                execution_partition=execution_partition,
                 global_vars=global_vars,
                 redirect_outputs=redirect_outputs,
             )
@@ -535,6 +536,7 @@ class Block:
     def execute_block(
         self,
         custom_code: str = None,
+        execution_partition: str = None,
         redirect_outputs: bool = False,
         global_vars: Dict = None,
     ) -> Dict:
@@ -548,6 +550,7 @@ class Block:
                         self.pipeline.uuid,
                         upstream_block_uuid,
                         var,
+                        partition=execution_partition,
                         variable_type=VariableType.DATAFRAME,
                         spark=(global_vars or dict()).get('spark'),
                     )

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -640,7 +640,11 @@ class Block:
             analyses.append(data)
         return analyses
 
-    def get_outputs(self, sample_count=DATAFRAME_SAMPLE_COUNT_PREVIEW):
+    def get_outputs(
+        self,
+        execution_partition: str = None,
+        sample_count: int = DATAFRAME_SAMPLE_COUNT_PREVIEW
+    ) -> List[Dict]:
         if self.pipeline is None:
             return
         if self.type != BlockType.SCRATCHPAD and BlockType.CHART != self.type:
@@ -652,9 +656,17 @@ class Block:
         variable_manager = self.pipeline.variable_manager
         if self.type == BlockType.SCRATCHPAD:
             # For scratchpad blocks, return all variables in block variable folder
-            all_variables = variable_manager.get_variables_by_block(self.pipeline.uuid, self.uuid)
+            all_variables = variable_manager.get_variables_by_block(
+                self.pipeline.uuid,
+                self.uuid,
+                partition=execution_partition,
+            )
         elif BlockType.CHART == self.type:
-            all_variables = variable_manager.get_variables_by_block(self.pipeline.uuid, self.uuid)
+            all_variables = variable_manager.get_variables_by_block(
+                self.pipeline.uuid,
+                self.uuid,
+                partition=execution_partition,
+            )
         else:
             # For non-scratchpad blocks, return all variables in output_variables
             all_variables = self.output_variables.keys()
@@ -663,6 +675,7 @@ class Block:
                 self.pipeline.uuid,
                 self.uuid,
                 v,
+                partition=execution_partition,
                 sample=True,
                 sample_count=sample_count,
             )
@@ -671,6 +684,7 @@ class Block:
                     self.pipeline.uuid,
                     self.uuid,
                     v,
+                    partition=execution_partition,
                     variable_type=VariableType.DATAFRAME_ANALYSIS,
                 )
                 stats = analysis.get('statistics', {})

--- a/mage_ai/data_preparation/models/variable.py
+++ b/mage_ai/data_preparation/models/variable.py
@@ -21,14 +21,25 @@ class VariableType(str, Enum):
 
 class Variable:
     def __init__(
-        self, uuid: str, pipeline_path: str, block_uuid: str, variable_type: VariableType = None
+        self,
+        uuid: str,
+        pipeline_path: str,
+        block_uuid: str,
+        partition: str = None,
+        variable_type: VariableType = None
     ) -> None:
         self.uuid = uuid
         if not os.path.exists(pipeline_path):
             raise Exception(f'Pipeline {pipeline_path} does not exist.')
         self.pipeline_path = pipeline_path
         self.block_uuid = block_uuid
-        self.variable_dir_path = os.path.join(pipeline_path, VARIABLE_DIR, block_uuid)
+        self.partition = partition
+        self.variable_dir_path = os.path.join(
+            pipeline_path,
+            VARIABLE_DIR,
+            partition or '',
+            block_uuid,
+        )
         if not os.path.exists(self.variable_dir_path):
             os.makedirs(self.variable_dir_path)
 

--- a/mage_ai/data_preparation/variable_manager.py
+++ b/mage_ai/data_preparation/variable_manager.py
@@ -68,6 +68,7 @@ class VariableManager:
             pipeline_uuid,
             block_uuid,
             variable_uuid,
+            partition=partition,
             variable_type=variable_type,
             spark=spark,
         )

--- a/mage_ai/data_preparation/variable_manager.py
+++ b/mage_ai/data_preparation/variable_manager.py
@@ -21,6 +21,7 @@ class VariableManager:
         block_uuid: str,
         variable_uuid: str,
         data: Any,
+        partition: str = None,
         variable_type: VariableType = None
     ) -> None:
         if type(data) is pd.DataFrame:
@@ -31,6 +32,7 @@ class VariableManager:
             variable_uuid,
             self.__pipeline_path(pipeline_uuid),
             block_uuid,
+            partition=partition,
             variable_type=variable_type,
         )
         variable.write_data(data)
@@ -40,12 +42,14 @@ class VariableManager:
         pipeline_uuid: str,
         block_uuid: str,
         variable_uuid: str,
+        partition: str = None,
         variable_type: VariableType = None,
     ) -> None:
         Variable(
             variable_uuid,
             self.__pipeline_path(pipeline_uuid),
             block_uuid,
+            partition=partition,
             variable_type=variable_type,
         ).delete()
 
@@ -54,6 +58,7 @@ class VariableManager:
         pipeline_uuid: str,
         block_uuid: str,
         variable_uuid: str,
+        partition: str = None,
         variable_type: VariableType = None,
         sample: bool = False,
         sample_count: int = None,
@@ -73,6 +78,7 @@ class VariableManager:
         pipeline_uuid: str,
         block_uuid: str,
         variable_uuid: str,
+        partition: str = None,
         variable_type: VariableType = None,
         spark=None,
     ) -> Variable:
@@ -82,6 +88,7 @@ class VariableManager:
             variable_uuid,
             self.__pipeline_path(pipeline_uuid),
             block_uuid,
+            partition=partition,
             variable_type=variable_type,
         )
 
@@ -101,10 +108,16 @@ class VariableManager:
                 variables_by_block[d] = [v for v in variable_names if v != '']
         return variables_by_block
 
-    def get_variables_by_block(self, pipeline_uuid: str, block_uuid: str) -> List[str]:
+    def get_variables_by_block(
+        self,
+        pipeline_uuid: str,
+        block_uuid: str,
+        partition: str = None,
+    ) -> List[str]:
         variable_dir_path = os.path.join(
             self.__pipeline_path(pipeline_uuid),
             VARIABLE_DIR,
+            partition or '',
             block_uuid,
         )
         if not os.path.exists(variable_dir_path):

--- a/mage_ai/orchestration/db/models.py
+++ b/mage_ai/orchestration/db/models.py
@@ -90,10 +90,10 @@ class PipelineSchedule(BaseModel):
             return now.replace(second=0, microsecond=0, minute=0, hour=0)
         elif self.schedule_interval == '@hourly':
             return now.replace(second=0, microsecond=0, minute=0)
-        elif self.scheduel_interval == '@weekly':
+        elif self.schedule_interval == '@weekly':
             return now.replace(second=0, microsecond=0, minute=0, hour=0) - \
                 timedelta(days=now.weekday())
-        elif self.scheduel_interval == '@monthly':
+        elif self.schedule_interval == '@monthly':
             return now.replace(second=0, microsecond=0, minute=0, hour=0, day=1)
         # TODO: Support cron syntax
         return None

--- a/mage_ai/orchestration/db/models.py
+++ b/mage_ai/orchestration/db/models.py
@@ -101,6 +101,9 @@ class PipelineSchedule(BaseModel):
     def should_schedule(self) -> bool:
         if self.status != self.__class__.ScheduleStatus.ACTIVE:
             return False
+        if self.start_time is not None and datetime.now() < self.start_time:
+            return False
+
         if self.schedule_interval == '@once':
             if len(self.pipeline_runs) == 0:
                 return True

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -59,6 +59,10 @@ class PipelineScheduler:
             b.update(status=BlockRun.BlockRunStatus.RUNNING)
             ExecutorFactory.get_block_executor(self.pipeline, b.block_uuid).execute(
                 analyze_outputs=False,
+                execution_partition='/'.join([
+                    str(self.pipeline_run.pipeline_schedule_id),
+                    self.pipeline_run.execution_date.strftime(format='%Y%m%dT%H%M%S'),
+                ]),
                 update_status=False,
                 on_complete=self.on_block_complete,
                 on_failure=self.on_block_failure,

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -59,10 +59,7 @@ class PipelineScheduler:
             b.update(status=BlockRun.BlockRunStatus.RUNNING)
             ExecutorFactory.get_block_executor(self.pipeline, b.block_uuid).execute(
                 analyze_outputs=False,
-                execution_partition='/'.join([
-                    str(self.pipeline_run.pipeline_schedule_id),
-                    self.pipeline_run.execution_date.strftime(format='%Y%m%dT%H%M%S'),
-                ]),
+                execution_partition=self.pipeline_run.execution_partition,
                 update_status=False,
                 on_complete=self.on_block_complete,
                 on_failure=self.on_block_failure,

--- a/mage_ai/server/api/base.py
+++ b/mage_ai/server/api/base.py
@@ -1,4 +1,5 @@
 from mage_ai.shared.strings import camel_to_snake_case
+import dateutil.parser
 import json
 import simplejson
 import tornado.web
@@ -6,6 +7,7 @@ import traceback
 
 
 class BaseHandler(tornado.web.RequestHandler):
+    datetime_keys = []
     model_class = None
 
     def check_origin(self, origin):
@@ -54,4 +56,8 @@ class BaseHandler(tornado.web.RequestHandler):
         if self.model_class:
             key = camel_to_snake_case(self.model_class.__name__)
 
-        return json.loads(self.request.body).get(key, {})
+        payload = json.loads(self.request.body).get(key, {})
+        for key in self.datetime_keys:
+            if payload.get(key) is not None:
+                payload[key] = dateutil.parser.parse(payload[key])
+        return payload

--- a/mage_ai/server/api/orchestration.py
+++ b/mage_ai/server/api/orchestration.py
@@ -16,6 +16,13 @@ class ApiBlockRunListHandler(BaseHandler):
         self.finish()
 
 
+class ApiBlockRunOutputHandler(BaseHandler):
+    def get(self, block_run_id):
+        block_run = BlockRun.query.get(int(block_run_id))
+        outputs = block_run.get_outputs()
+        self.write(dict(outputs=outputs))
+
+
 class ApiPipelineRunListHandler(BaseHandler):
     model_class = PipelineRun
 

--- a/mage_ai/server/api/orchestration.py
+++ b/mage_ai/server/api/orchestration.py
@@ -43,6 +43,7 @@ class ApiPipelineRunListHandler(BaseHandler):
 
 
 class ApiPipelineScheduleDetailHandler(BaseHandler):
+    datetime_keys = ['start_time']
     model_class = PipelineSchedule
 
     def get(self, pipeline_schedule_id):
@@ -65,6 +66,7 @@ class ApiPipelineScheduleDetailHandler(BaseHandler):
 
 
 class ApiPipelineScheduleListHandler(BaseHandler):
+    datetime_keys = ['start_time']
     model_class = PipelineSchedule
 
     def get(self, pipeline_uuid=None):

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -23,6 +23,7 @@ from mage_ai.server.api.blocks import (
 from mage_ai.server.api.data_providers import ApiDataProvidersHandler
 from mage_ai.server.api.orchestration import (
     ApiBlockRunListHandler,
+    ApiBlockRunOutputHandler,
     ApiPipelineRunListHandler,
     ApiPipelineScheduleDetailHandler,
     ApiPipelineScheduleListHandler,
@@ -313,6 +314,7 @@ def make_app():
         ),
         (r'/websocket/', WebSocketServer),
         (r'/api/blocks/(?P<block_type_and_uuid_encoded>.+)', ApiBlockHandler),
+        (r'/api/block_runs/(?P<block_run_id>.+)/outputs', ApiBlockRunOutputHandler),
         (r'/api/files', ApiFileListHandler),
         (r'/api/file_contents/(?P<file_path_encoded>.+)', ApiFileContentHandler),
         (r'/api/pipelines/(?P<pipeline_uuid>\w+)/execute', ApiPipelineExecuteHandler),


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
* Store block run outputs with partitions when execution pipelines with schedules
  * Path: `{variables_dir}/{pipeline_uuid}/.variables/{pipeline_schedule_id}/{execution_date}/{block_uuid}/..`
* Add API to fetch block run outputs

Tech design: https://www.notion.so/mageai/Orchestration-engine-a5ed63c71c594801897fb9df3c9fefb7

# Tests
<!-- How did you test your change? -->
tested locally
<img width="327" alt="image" src="https://user-images.githubusercontent.com/80284865/185995693-8394e14f-6b06-4ac9-9c65-a0d385f0dc8b.png">

<img width="967" alt="image" src="https://user-images.githubusercontent.com/80284865/186024889-b6c9cc0b-210d-426b-b33c-d8cc90c2b0e6.png">


cc: @dy46 
<!-- Optionally mention someone to let them know about this pull request -->
