### PR TITLE
[jk] Indicate unused block files in FileBrowser

### DIFF
--- a/mage_ai/frontend/components/FileBrowser/Folder.tsx
+++ b/mage_ai/frontend/components/FileBrowser/Folder.tsx
@@ -224,33 +224,34 @@ function Folder({
           {children && collapsed && <ChevronRight muted size={ICON_SIZE} />}
           {!children && <div style={{ width: ICON_SIZE }} />}
 
-        <div
-          style={{
-            marginLeft: UNIT / 2,
-            marginRight: UNIT / 2,
-          }}
-        >
-          {!color && <IconEl disabled={disabled} size={ICON_SIZE} />}
-          {color && (
-            <Circle
-              color={color}
-              size={ICON_SIZE}
-              square
-            />
-          )}
-        </div>
+          <div
+            style={{
+              marginLeft: UNIT / 2,
+              marginRight: UNIT / 2,
+            }}
+          >
+            {!color && <IconEl disabled={disabled} size={ICON_SIZE} />}
+            {color && (
+              <Circle
+                color={color}
+                size={ICON_SIZE}
+                square
+              />
+            )}
+          </div>
 
-        <Text
-          color={color}
-          default={!color && !disabled}
-          disabled={disabled || (isEditableCodeBlock && !fileUsedByPipeline)}
-          italic={isEditableCodeBlock && !fileUsedByPipeline && name !== SpecialFileEnum.INIT_PY}
-          monospace
-          small
-        >
-          {name}
-        </Text>
-      </div>
+          <Text
+            color={color}
+            default={!color && !disabled}
+            disabled={disabled || (isEditableCodeBlock && !fileUsedByPipeline)}
+            italic={isEditableCodeBlock && !fileUsedByPipeline && name !== SpecialFileEnum.INIT_PY}
+            monospace
+            small
+          >
+            {name}
+          </Text>
+        </div>
+      )}
 
       <div
         style={{

--- a/mage_ai/frontend/components/FileBrowser/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/index.tsx
@@ -1,13 +1,16 @@
 import React, { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 
+import BlockType from '@interfaces/BlockType';
 import FileType from '@interfaces/FileType';
 import Folder, { FolderSharedProps } from './Folder';
 import { ContainerStyle } from './index.style';
 import { ContextAreaProps } from '@components/ContextMenu';
 
 type FileBrowserProps = {
+  blocks: BlockType[];
   files: FileType[];
+  widgets?: BlockType[];
 } & FolderSharedProps & ContextAreaProps;
 
 export enum FileContextEnum {
@@ -19,10 +22,13 @@ export enum FileContextEnum {
 }
 
 function FileBrowser({
+  blocks = [],
   files,
+  widgets = [],
   ...props
 }: FileBrowserProps, ref) {
   const themeContext = useContext(ThemeContext);
+  const pipelineBlockUuids = blocks.concat(widgets).map(({ uuid }) => uuid);
 
   return (
     <ContainerStyle ref={ref}>
@@ -32,6 +38,7 @@ function FileBrowser({
           file={file}
           key={file.name}
           level={0}
+          pipelineBlockUuids={pipelineBlockUuids}
           theme={themeContext}
         />
       ))}

--- a/mage_ai/frontend/components/FileBrowser/utils.ts
+++ b/mage_ai/frontend/components/FileBrowser/utils.ts
@@ -32,3 +32,15 @@ export function getBlockFromFile(
     };
   }
 }
+
+export function getBlockUUIDFromFile(
+  file: FileType,
+) {
+  const filename = file.name;
+  const nameParts = filename.split('.');
+  if (nameParts[nameParts.length - 1] === FileExtensionEnum.PY) {
+    nameParts.pop();
+  }
+
+  return nameParts.join('');
+}

--- a/mage_ai/frontend/components/FileBrowser/utils.ts
+++ b/mage_ai/frontend/components/FileBrowser/utils.ts
@@ -1,4 +1,7 @@
-import FileType, { FileExtensionEnum } from '@interfaces/FileType';
+import FileType, {
+  CODE_BLOCK_FILE_EXTENSIONS,
+  FileExtensionEnum,
+} from '@interfaces/FileType';
 import { BLOCK_TYPES } from '@interfaces/BlockType';
 import { singularize } from '@utils/string';
 
@@ -38,7 +41,8 @@ export function getBlockUUIDFromFile(
 ) {
   const filename = file.name;
   const nameParts = filename.split('.');
-  if (nameParts[nameParts.length - 1] === FileExtensionEnum.PY) {
+  const fileExtension = nameParts[nameParts.length - 1] as FileExtensionEnum;
+  if (CODE_BLOCK_FILE_EXTENSIONS.includes(fileExtension)) {
     nameParts.pop();
   }
 

--- a/mage_ai/frontend/interfaces/FileType.ts
+++ b/mage_ai/frontend/interfaces/FileType.ts
@@ -12,6 +12,11 @@ export enum SpecialFileEnum {
   INIT_PY = '__init__.py',
 }
 
+export const CODE_BLOCK_FILE_EXTENSIONS = [
+  FileExtensionEnum.PY,
+  FileExtensionEnum.SQL,
+];
+
 const SUPPORTED_FILE_EXTENSIONS = [
   FileExtensionEnum.SQL,
   FileExtensionEnum.TXT,

--- a/mage_ai/frontend/interfaces/FileType.ts
+++ b/mage_ai/frontend/interfaces/FileType.ts
@@ -8,6 +8,10 @@ export enum FileExtensionEnum {
   YML = 'yml',
 }
 
+export enum SpecialFileEnum {
+  INIT_PY = '__init__.py',
+}
+
 const SUPPORTED_FILE_EXTENSIONS = [
   FileExtensionEnum.SQL,
   FileExtensionEnum.TXT,

--- a/mage_ai/frontend/pages/pipelines/[...slug].tsx
+++ b/mage_ai/frontend/pages/pipelines/[...slug].tsx
@@ -1508,6 +1508,7 @@ function PipelineDetailPage({
           type={ContextMenuEnum.FILE_BROWSER}
         >
           <FileBrowser
+            blocks={blocks}
             files={filesData?.files}
             onlyShowChildren
             onSelectBlockFile={onSelectBlockFile}
@@ -1518,6 +1519,7 @@ function PipelineDetailPage({
             }}
             openSidekickView={openSidekickView}
             ref={fileTreeRef}
+            widgets={widgets}
           />
         </ContextMenu>
       );
@@ -1531,6 +1533,7 @@ function PipelineDetailPage({
       );
     }
   }, [
+    blocks,
     page,
     pipelines,
     pipelineSchedules,


### PR DESCRIPTION
# Summary
- Unused files (files that don't have a corresponding code block that exists in the currently selected pipeline) will appear as muted and italicized in the file browser.

# Tests
![image](https://user-images.githubusercontent.com/78053898/186501484-93d76f9d-0057-4269-98a4-3598868db57e.png)

![unused files](https://user-images.githubusercontent.com/78053898/186512908-118cf083-e3ae-4049-b486-f6c21f940cf6.gif)

cc:
@wangxiaoyou1993 @tommydangerous @dy46 
