### PR TITLE
[jk] Disable keyboard navigation in flyout menus for adding blocks

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
@@ -125,6 +125,7 @@ function AddNewBlocks({
       >
         <FlexContainer>
           <FlyoutMenuWrapper
+            disableKeyboardShortcuts
             items={isPySpark
               ? dataSourceMenuItems[BlockTypeEnum.DATA_LOADER]
               : [
@@ -173,6 +174,7 @@ function AddNewBlocks({
           <Spacing ml={1} />
 
           <FlyoutMenuWrapper
+            disableKeyboardShortcuts
             items={isPySpark
               ? allActionMenuItems
               : [
@@ -221,6 +223,7 @@ function AddNewBlocks({
           <Spacing ml={1} />
 
           <FlyoutMenuWrapper
+            disableKeyboardShortcuts
             items={isPySpark
               ? dataSourceMenuItems[BlockTypeEnum.DATA_EXPORTER]
               : [

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -38,6 +38,7 @@ export type FlyoutMenuItemType = {
 };
 
 export type FlyoutMenuProps = {
+  disableKeyboardShortcuts?: boolean;
   items: FlyoutMenuItemType[];
   left?: number;
   onClickCallback?: () => void;
@@ -50,6 +51,7 @@ export type FlyoutMenuProps = {
 };
 
 function FlyoutMenu({
+  disableKeyboardShortcuts,
   items,
   left,
   onClickCallback,
@@ -83,6 +85,11 @@ function FlyoutMenu({
     uuidKeyboard,
     (event, keyMapping, keyHistory) => {
       if (!open) {
+        return;
+      }
+
+      if (disableKeyboardShortcuts) {
+        pauseEvent(event);
         return;
       }
 


### PR DESCRIPTION
# Summary
- Navigating up and down in the flyout menus with the keyboard when adding a `Data loader`, `Transformer`, or `Data exporter` block had issues and would behave inconsistently, so this PR disables that functionality specific to those buttons.
- The keyboard navigation still works for other components using flyout menus, such as the `File` and `Run` buttons in the file browser header.

# Tests
Bug (keyboard navigation doesn't work as intended):
![2022-08-25 16 44 37](https://user-images.githubusercontent.com/78053898/186787951-356c0fba-c1ab-4f13-9677-13561b114f9d.gif)

