### PR TITLE
[dy] Add variable overwrites to schedules sidekick

### DIFF
--- a/mage_ai/frontend/components/PipelineDetailPage/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetailPage/index.tsx
@@ -28,7 +28,7 @@ import { useWindowSize } from '@utils/sizes';
 
 type PipelineDetailPageProps = {
   breadcrumbs: BreadcrumbType[];
-  buildDependencyTree?: (opts: {
+  buildSidekick?: (opts: {
     height: number;
     pipeline: PipelineType;
   }) => any;
@@ -50,7 +50,7 @@ function PipelineDetailPage({
   after: afterProp,
   afterWidth: afterWidthProp,
   breadcrumbs: breadcrumbsProp,
-  buildDependencyTree,
+  buildSidekick,
   children,
   headline,
   pageName,
@@ -72,8 +72,8 @@ function PipelineDetailPage({
   const after = useMemo(() => {
     if (afterProp) {
       return afterProp;
-    } else if (buildDependencyTree) {
-      return buildDependencyTree({
+    } else if (buildSidekick) {
+      return buildSidekick({
         height,
         pipeline,
       });
@@ -82,7 +82,7 @@ function PipelineDetailPage({
     return null;
   }, [
     afterProp,
-    buildDependencyTree,
+    buildSidekick,
     height,
     pipeline,
   ]);

--- a/mage_ai/frontend/components/VariableOverwrites/index.style.tsx
+++ b/mage_ai/frontend/components/VariableOverwrites/index.style.tsx
@@ -1,0 +1,25 @@
+import { ScrollbarStyledCss } from '@oracle/styles/scrollbars';
+import dark from '@oracle/styles/themes/dark';
+import { BORDER_RADIUS } from '@oracle/styles/units/borders';
+import { PADDING, UNIT } from '@oracle/styles/units/spacing';
+import styled from 'styled-components';
+
+export const ContainerStyle = styled.div`
+  border-bottom: 1px solid ${dark.borders.medium};
+  padding: ${PADDING}px;
+`;
+
+export const CardsStyle = styled.div`
+  ${ScrollbarStyledCss}
+
+  display: flex;
+  overflow-x: scroll;
+`;
+
+export const VariableCardStyle = styled.div`
+  background-color: ${dark.background.output};
+  border-radius: ${BORDER_RADIUS}px;
+  flex-shrink: 0;
+  margin-right: ${UNIT}px;
+  padding: ${PADDING}px;
+`;

--- a/mage_ai/frontend/components/VariableOverwrites/index.style.tsx
+++ b/mage_ai/frontend/components/VariableOverwrites/index.style.tsx
@@ -1,8 +1,9 @@
-import { ScrollbarStyledCss } from '@oracle/styles/scrollbars';
+import styled from 'styled-components';
+
 import dark from '@oracle/styles/themes/dark';
 import { BORDER_RADIUS } from '@oracle/styles/units/borders';
 import { PADDING, UNIT } from '@oracle/styles/units/spacing';
-import styled from 'styled-components';
+import { ScrollbarStyledCss } from '@oracle/styles/scrollbars';
 
 export const ContainerStyle = styled.div`
   border-bottom: 1px solid ${dark.borders.medium};

--- a/mage_ai/frontend/components/VariableOverwrites/index.tsx
+++ b/mage_ai/frontend/components/VariableOverwrites/index.tsx
@@ -1,0 +1,41 @@
+import PipelineScheduleType from '@interfaces/PipelineScheduleType';
+import FlexContainer from '@oracle/components/FlexContainer';
+import Spacing from '@oracle/elements/Spacing';
+import Text from '@oracle/elements/Text';
+import { LIME_DARK } from '@oracle/styles/colors/main';
+import React from 'react';
+import { CardsStyle, ContainerStyle, VariableCardStyle } from './index.style';
+
+type VariableOverwritesProps = {
+  pipelineSchedule: PipelineScheduleType;
+};
+
+function VariableOverwrites({
+  pipelineSchedule,
+}: VariableOverwritesProps) {
+  const { variables } = pipelineSchedule || {};
+
+  return (
+    <ContainerStyle>
+      <Spacing mb={2}>
+        <Text bold large monospace muted>
+          Variable overwrites  
+        </Text>
+      </Spacing>
+      <CardsStyle noScrollbarTrackBackground>
+        {variables && Object.entries(variables).map(([variable, value]) => (
+          <VariableCardStyle>
+            <Text monospace>
+              {variable}
+            </Text>
+            <Text color={LIME_DARK} monospace>
+              {value}
+            </Text>
+          </VariableCardStyle>
+        ))}
+      </CardsStyle>
+    </ContainerStyle>
+  );
+}
+
+export default VariableOverwrites;

--- a/mage_ai/frontend/components/VariableOverwrites/index.tsx
+++ b/mage_ai/frontend/components/VariableOverwrites/index.tsx
@@ -1,10 +1,10 @@
+import React from 'react';
+
 import PipelineScheduleType from '@interfaces/PipelineScheduleType';
-import FlexContainer from '@oracle/components/FlexContainer';
 import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
-import { LIME_DARK } from '@oracle/styles/colors/main';
-import React from 'react';
 import { CardsStyle, ContainerStyle, VariableCardStyle } from './index.style';
+import { LIME_DARK } from '@oracle/styles/colors/main';
 
 type VariableOverwritesProps = {
   pipelineSchedule: PipelineScheduleType;

--- a/mage_ai/frontend/oracle/components/FlexTable/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlexTable/index.tsx
@@ -10,8 +10,9 @@ import { transition } from '@oracle/styles/mixins';
 
 export type FlexTableProps = {
   buildLinkProps?: (rowIndex: number) => {
-    as: string;
-    href: string;
+    as?: string;
+    href?: string;
+    onClick?: () => void;
   };
   borderRadius?: boolean;
   columnFlex: number[];
@@ -99,23 +100,40 @@ function FlexTable({
     const cellEls = row.map((cell, colIndex) => Column(cell, rowIndex, colIndex));
 
     if (buildLinkProps) {
+      const linkProps = buildLinkProps(rowIndex)
       return (
-        <NextLink
-          {...buildLinkProps(rowIndex)}
-          key={`row-${rowIndex}`}
-          passHref
-        >
-          <Link
-            fullWidth
-            noHoverUnderline
-            noOutline
-            verticalAlignContent
-          >
-            <RowStyle>
-              {cellEls}
-            </RowStyle>
-          </Link>
-        </NextLink>
+        <>
+          {linkProps.as ? (
+            <NextLink
+              {...linkProps}
+              key={`row-${rowIndex}`}
+              passHref
+            >
+              <Link
+                fullWidth
+                noHoverUnderline
+                noOutline
+                verticalAlignContent
+              >
+                <RowStyle>
+                  {cellEls}
+                </RowStyle>
+              </Link>
+            </NextLink>
+          ) : (
+            <Link
+              fullWidth
+              noHoverUnderline
+              noOutline
+              onClick={linkProps.onClick}
+              verticalAlignContent
+            >
+              <RowStyle>
+                {cellEls}
+              </RowStyle>
+            </Link>
+          )}
+        </>
       );
     }
 

--- a/mage_ai/frontend/oracle/components/FlexTable/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlexTable/index.tsx
@@ -10,9 +10,8 @@ import { transition } from '@oracle/styles/mixins';
 
 export type FlexTableProps = {
   buildLinkProps?: (rowIndex: number) => {
-    as?: string;
-    href?: string;
-    onClick?: () => void;
+    as: string;
+    href: string;
   };
   borderRadius?: boolean;
   columnFlex: number[];
@@ -102,38 +101,22 @@ function FlexTable({
     if (buildLinkProps) {
       const linkProps = buildLinkProps(rowIndex)
       return (
-        <>
-          {linkProps.as ? (
-            <NextLink
-              {...linkProps}
-              key={`row-${rowIndex}`}
-              passHref
-            >
-              <Link
-                fullWidth
-                noHoverUnderline
-                noOutline
-                verticalAlignContent
-              >
-                <RowStyle>
-                  {cellEls}
-                </RowStyle>
-              </Link>
-            </NextLink>
-          ) : (
-            <Link
-              fullWidth
-              noHoverUnderline
-              noOutline
-              onClick={linkProps.onClick}
-              verticalAlignContent
-            >
-              <RowStyle>
-                {cellEls}
-              </RowStyle>
-            </Link>
-          )}
-        </>
+        <NextLink
+          {...linkProps}
+          key={`row-${rowIndex}`}
+          passHref
+        >
+          <Link
+            fullWidth
+            noHoverUnderline
+            noOutline
+            verticalAlignContent
+          >
+            <RowStyle>
+              {cellEls}
+            </RowStyle>
+          </Link>
+        </NextLink>
       );
     }
 

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/pipeline-runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/pipeline-runs/index.tsx
@@ -31,7 +31,7 @@ function PipelineRuns({
 
   return (
     <PipelineDetailPage
-      buildDependencyTree={props => <DependencyGraph {...props} />}
+      buildSidekick={props => <DependencyGraph {...props} />}
       breadcrumbs={[
         {
           label: () => 'Pipeline runs',

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/schedules/[...slug].tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/schedules/[...slug].tsx
@@ -102,7 +102,7 @@ function ScheduleDetailPage({
       let linkProps;
       if (subpath === PAGE_NAME_EDIT) {
         linkProps = {
-          as: `/pipelines/${pipelineUUID}/schedules/${pipelineSchedule.id}`,
+          as: `/pipelines/${pipelineUUID}/schedules/${pipelineSchedule.id}/edit`,
           href: '/pipelines/[pipeline]/schedules/[...slug]',
         };
       }
@@ -112,12 +112,6 @@ function ScheduleDetailPage({
         linkProps,
       });
 
-    }
-
-    if (subpath === PAGE_NAME_EDIT) {
-      arr.push({
-        label: () => 'Edit',
-      });
     }
 
     return arr;

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/schedules/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/schedules/index.tsx
@@ -1,24 +1,21 @@
 import { useMemo, useState } from 'react';
 import { useMutation } from 'react-query';
+import Router from 'next/router';
 
 import Button from '@oracle/elements/Button';
 import DependencyGraph from '@components/DependencyGraph';
-import Flex from '@oracle/components/Flex';
-import FlexContainer from '@oracle/components/FlexContainer';
 import FlexTable from '@oracle/components/FlexTable';
 import KeyboardShortcutButton from '@oracle/elements/Button/KeyboardShortcutButton';
 import PipelineDetailPage from '@components/PipelineDetailPage';
 import PipelineScheduleType, { ScheduleStatusEnum } from '@interfaces/PipelineScheduleType';
-import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
+import VariableOverwrites from '@components/VariableOverwrites';
 import api from '@api';
 import { Add, ChevronRight, Pause, PlayButtonFilled } from '@oracle/icons';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
-import { PURPLE } from '@oracle/styles/colors/main';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { onSuccess } from '@api/utils/response';
 import { pauseEvent } from '@utils/events';
-import VariableOverwrites from '@components/VariableOverwrites';
 
 type PipelineSchedulesProp = {
   pipeline: {
@@ -120,9 +117,6 @@ function PipelineSchedules({
       uuid={`${PageNameEnum.SCHEDULES}_${pipelineUUID}`}
     >
       <FlexTable
-        buildLinkProps={(rowIndex: number) => ({
-          onClick: () => setSelectedSchedule(pipelinesSchedules[rowIndex])
-        })}
         columnHeaders={[
           null,
           <Text bold monospace muted>
@@ -140,11 +134,15 @@ function PipelineSchedules({
           <Text bold monospace muted>
             Runs
           </Text>,
-          null,
+          <Text bold monospace muted>
+            Edit
+          </Text>,,
         ]}
-        columnFlex={[1, 3, 10, 10, 4, 1, 1]}
+        columnFlex={[1, 3, 10, 10, 4, 2, 1]}
+        onClickRow={(rowIndex: number) => setSelectedSchedule(pipelinesSchedules[rowIndex])}
         rows={pipelinesSchedules.map((pipelineSchedule: PipelineScheduleType) => {
           const {
+            id,
             pipeline_runs_count: pipelineRunsCount,
             name,
             schedule_interval: scheduleInterval,
@@ -191,9 +189,13 @@ function PipelineSchedules({
             <Text>
               {pipelineRunsCount}
             </Text>,
-            <Flex flex={1} justifyContent="flex-end">
+            <Button
+              iconOnly
+              noBackground
+              onClick={(e) => Router.push(`/pipelines/${pipelineUUID}/schedules/${id}/edit`)}
+            >
               <ChevronRight muted size={2 * UNIT} />
-            </Flex>,
+            </Button>
           ];
         })}
       />

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/schedules/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/schedules/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useMutation } from 'react-query';
 
 import Button from '@oracle/elements/Button';
@@ -18,6 +18,7 @@ import { PURPLE } from '@oracle/styles/colors/main';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { onSuccess } from '@api/utils/response';
 import { pauseEvent } from '@utils/events';
+import VariableOverwrites from '@components/VariableOverwrites';
 
 type PipelineSchedulesProp = {
   pipeline: {
@@ -63,6 +64,30 @@ function PipelineSchedules({
     },
   );
 
+  const [selectedSchedule, setSelectedSchedule] = useState<PipelineScheduleType>();
+  const buildSidekick = useMemo(() => {
+    const showVariables = selectedSchedule &&
+      selectedSchedule.variables &&
+      Object.entries(selectedSchedule.variables).length > 0;
+
+    return props => {
+      const dependencyGraphHeight = props.height - (showVariables ? 150 : 0);
+      return (
+        <>
+          {showVariables && (
+            <VariableOverwrites
+              pipelineSchedule={selectedSchedule}
+            />
+          )}
+          <DependencyGraph
+            {...props}
+            height={dependencyGraphHeight}
+          />
+        </>
+      )
+    };
+  }, [selectedSchedule]);
+
   return (
     <PipelineDetailPage
       breadcrumbs={[
@@ -70,7 +95,7 @@ function PipelineSchedules({
           label: () => 'Schedules',
         },
       ]}
-      buildDependencyTree={props => <DependencyGraph {...props} />}
+      buildSidekick={buildSidekick}
       pageName={PageNameEnum.SCHEDULES}
       pipeline={pipeline}
       subheaderBackgroundImage='/images/banner-shape-purple-peach.jpg'
@@ -96,8 +121,7 @@ function PipelineSchedules({
     >
       <FlexTable
         buildLinkProps={(rowIndex: number) => ({
-          as: `/pipelines/${pipelineUUID}/schedules/${pipelinesSchedules[rowIndex].id}`,
-          href: '/pipelines/[pipeline]/schedules/[...slug]',
+          onClick: () => setSelectedSchedule(pipelinesSchedules[rowIndex])
         })}
         columnHeaders={[
           null,


### PR DESCRIPTION
# Summary

Show variables overwrites when a schedule is selected in the schedules list view. Also update navigation from schedules page.
<!-- Brief summary of what your code does -->

# Tests

<img width="402" alt="Screen Shot 2022-09-01 at 11 48 01 AM" src="https://user-images.githubusercontent.com/14357209/187989985-61e6481b-638e-4c8f-bdf9-69cfeda97297.png">

<!-- How did you test your change? -->

cc:
<!-- Optionally mention someone to let them know about this pull request -->
