### PR TITLE
[xy] Only pass global_vars when method definition has kwargs.

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -622,7 +622,9 @@ class Block:
             else:
                 block_function = self.__validate_execution(decorated_functions, input_vars)
                 if block_function is not None:
-                    if global_vars is not None and len(global_vars) != 0:
+                    sig = signature(block_function)
+                    has_kwargs = any([p.kind == p.VAR_KEYWORD for p in sig.parameters.values()])
+                    if has_kwargs and global_vars is not None and len(global_vars) != 0:
                         outputs = block_function(*input_vars, **global_vars)
                     else:
                         outputs = block_function(*input_vars)


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Only pass global_vars when method definition has kwargs.

# Tests
<!-- How did you test your change? -->
tested locally with the data loader
<img width="380" alt="image" src="https://user-images.githubusercontent.com/80284865/188993621-843b978b-d1c3-4972-a26d-4af80193c941.png">

before and after fix
<img width="1293" alt="image" src="https://user-images.githubusercontent.com/80284865/188993306-0a7fc957-5e88-4f5b-ad3c-7e26ff8c2dec.png">

cc:
<!-- Optionally mention someone to let them know about this pull request -->
