### PR TITLE
[xy] Allow pass aws access key via env var.

### DIFF
--- a/scripts/deploy/terraform/aws/env_vars.json
+++ b/scripts/deploy/terraform/aws/env_vars.json
@@ -5,11 +5,11 @@
     },
     {
         "name": "AWS_ACCESS_KEY_ID",
-        "value": "AWS_ACCESS_KEY_ID"
+        "value": "${aws_access_key_id}"
     },
     {
         "name": "AWS_SECRET_ACCESS_KEY",
-        "value": "AWS_SECRET_ACCESS_KEY"
+        "value": "${aws_secret_access_key}"
     },
     {
         "name": "LAMBDA_FUNCTION_ARN",

--- a/scripts/deploy/terraform/aws/main.tf
+++ b/scripts/deploy/terraform/aws/main.tf
@@ -34,6 +34,8 @@ data "template_file" "env_vars" {
   template = file("env_vars.json")
 
   vars = {
+    aws_access_key_id = var.AWS_ACCESS_KEY_ID
+    aws_secret_access_key = var.AWS_SECRET_ACCESS_KEY
     lambda_func_arn = "${aws_lambda_function.terraform_lambda_func.arn}"
     lambda_func_name = "${aws_lambda_function.terraform_lambda_func.function_name}"
   }

--- a/scripts/deploy/terraform/aws/variables.tf
+++ b/scripts/deploy/terraform/aws/variables.tf
@@ -1,3 +1,13 @@
+variable "AWS_ACCESS_KEY_ID" {
+  type = string
+  default = "AWS_ACCESS_KEY_ID"
+}
+
+variable "AWS_SECRET_ACCESS_KEY" {
+  type = string
+  default = "AWS_SECRET_ACCESS_KEY"
+}
+
 variable "app_count" {
   type = number
   default = 1


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Allow pass aws access key via env var.
* `TF_VAR_AWS_ACCESS_KEY_ID` for AWS_ACCESS_KEY_ID variable
* `TF_VAR_AWS_SECRET_ACCESS_KEY` for AWS_SECRET_ACCESS_KEY variable

Example usage
```
export TF_VAR_AWS_ACCESS_KEY_ID=xxxx
export TF_VAR_AWS_SECRET_ACCESS_KEY=yyyy
terraform apply
```
or
```
TF_VAR_AWS_ACCESS_KEY_ID=xxxx TF_VAR_AWS_SECRET_ACCESS_KEY=yyyy terraform apply
```
# Tests
<!-- How did you test your change? -->
tested locally

cc: @tommydangerous 
<!-- Optionally mention someone to let them know about this pull request -->
