### PR TITLE
[dy] Fix dependency graph spacing

### DIFF
--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -271,7 +271,8 @@ function DependencyGraph({
         ports,
         width: (block.uuid.length * WIDTH_OF_SINGLE_CHARACTER_SMALL)
           + (UNIT * 5)
-          + (blockEditing?.uuid === block.uuid ? (19 * WIDTH_OF_SINGLE_CHARACTER_SMALL) : 0),
+          + (blockEditing?.uuid === block.uuid ? (19 * WIDTH_OF_SINGLE_CHARACTER_SMALL) : 0)
+          + (blockStatus?.[block.uuid]?.runtime ? 50 : 0),
       });
 
     });
@@ -282,6 +283,7 @@ function DependencyGraph({
     };
   }, [
     blockEditing,
+    blockStatus,
     blocks,
   ]);
 
@@ -453,7 +455,7 @@ function DependencyGraph({
                       // https://reaflow.dev/?path=/story/docs-advanced-custom-nodes--page#the-foreignobject-will-steal-events-onclick-onenter-onleave-etc-that-are-bound-to-the-rect-node
                       pointerEvents: 'none',
                     }}
-                    width={event.width + (typeof blockStatus.runtime !== 'undefined' ? 50 : 0)}
+                    width={event.width}
                     x={0}
                     y={0}
                   >


### PR DESCRIPTION
# Summary

Increasing the width was causing the nodes in the dependency graph to overlap.
<!-- Brief summary of what your code does -->

# Tests

<img width="587" alt="Screen Shot 2022-09-08 at 12 01 19 PM" src="https://user-images.githubusercontent.com/14357209/189204780-a7ed7f71-6c84-43cb-b670-dfc883cc252c.png">

<!-- How did you test your change? -->

cc: 
<!-- Optionally mention someone to let them know about this pull request -->
