### PR TITLE
[dy] Show print statements when executing pipeline

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -610,7 +610,7 @@ class Block:
         if logger is not None:
             stdout = StreamToLogger(logger)
         elif redirect_outputs:
-            stdout =  StringIO() if redirect_stdout is None else redirect_stdout 
+            stdout =  StringIO() if redirect_stdout is None else redirect_stdout(self.uuid) 
         else:
             stdout = sys.stdout
         results = {}
@@ -666,10 +666,6 @@ class Block:
                         outputs = [outputs]
 
         output_message = dict(output=outputs)
-        if redirect_outputs:
-            output_message['stdout'] = stdout.getvalue()
-        else:
-            output_message['stdout'] = ''
 
         return output_message
 

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -1,4 +1,4 @@
-from contextlib import redirect_stdout
+from contextlib import redirect_stdout as redirect_stdout_func
 from datetime import datetime
 from inspect import Parameter, signature
 from io import StringIO
@@ -44,6 +44,7 @@ async def run_blocks(
     log_func: Callable = None,
     parallel: bool = True,
     redirect_outputs: bool = False,
+    redirect_stdout=None,
     run_tests: bool = False,
     selected_blocks: Set[str] = None,
     update_status: bool = True,
@@ -64,6 +65,7 @@ async def run_blocks(
                     global_vars=global_vars,
                     log_func=log_func,
                     redirect_outputs=redirect_outputs,
+                    redirect_stdout=redirect_stdout,
                     run_all_blocks=True,
                     update_status=update_status,
                     parallel=parallel,
@@ -120,6 +122,7 @@ def run_blocks_sync(
     log_func: Callable = None,
     global_vars: Dict = None,
     redirect_outputs: bool = False,
+    redirect_stdout=None,
     run_tests: bool = False,
     selected_blocks: Set[str] = None,
 ) -> None:
@@ -163,6 +166,7 @@ def run_blocks_sync(
                 analyze_outputs=analyze_outputs,
                 global_vars=global_vars,
                 redirect_outputs=redirect_outputs,
+                redirect_stdout=redirect_stdout,
                 run_all_blocks=True,
             )
             if run_tests:
@@ -406,6 +410,7 @@ class Block:
         global_vars: Dict = None,
         logger: Logger = None,
         redirect_outputs: bool = False,
+        redirect_stdout=None,
         run_all_blocks: bool = False,
         update_status: bool = True,
     ):
@@ -426,6 +431,7 @@ class Block:
                 global_vars=global_vars,
                 logger=logger,
                 redirect_outputs=redirect_outputs,
+                redirect_stdout=redirect_stdout,
             )
             block_output = output['output']
             if BlockType.CHART == self.type:
@@ -478,6 +484,7 @@ class Block:
         global_vars=None,
         log_func: Callable = None,
         redirect_outputs: bool = False,
+        redirect_stdout=None,
         run_all_blocks: bool = False,
         update_status: bool = True,
         parallel: bool = True,
@@ -492,6 +499,7 @@ class Block:
                     custom_code=custom_code,
                     global_vars=global_vars,
                     redirect_outputs=redirect_outputs,
+                    redirect_stdout=redirect_stdout,
                     run_all_blocks=run_all_blocks,
                     update_status=update_status,
                 )
@@ -502,6 +510,7 @@ class Block:
                 custom_code=custom_code,
                 global_vars=global_vars,
                 redirect_outputs=redirect_outputs,
+                redirect_stdout=redirect_stdout,
                 run_all_blocks=run_all_blocks,
                 update_status=update_status,
             )
@@ -576,6 +585,7 @@ class Block:
         execution_partition: str = None,
         logger: Logger = None,
         redirect_outputs: bool = False,
+        redirect_stdout=None,
         global_vars: Dict = None,
     ) -> Dict:
         upstream_block_uuids = []
@@ -600,7 +610,7 @@ class Block:
         if logger is not None:
             stdout = StreamToLogger(logger)
         elif redirect_outputs:
-            stdout = StringIO()
+            stdout =  StringIO() if redirect_stdout is None else redirect_stdout 
         else:
             stdout = sys.stdout
         results = {}
@@ -611,7 +621,7 @@ class Block:
             outputs_from_input_vars[upstream_block_uuid] = input_var
             outputs_from_input_vars[f'df_{idx + 1}'] = input_var
 
-        with redirect_stdout(stdout):
+        with redirect_stdout_func(stdout):
             results = {
                 self.type: self.__block_decorator(decorated_functions),
                 'test': self.__block_decorator(test_functions),

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -179,11 +179,10 @@ class Pipeline:
     async def execute(
         self,
         analyze_outputs: bool = True,
+        block_output_stdout: Callable[[str], object] = None,
         global_vars=None,
         log_func: Callable[[str], None] = None,
         parallel: bool = True,
-        redirect_outputs: bool = False,
-        redirect_stdout=None,
         run_tests: bool = False,
         update_status: bool = True,
     ) -> None:
@@ -201,11 +200,10 @@ class Pipeline:
             run_blocks(
                 root_blocks,
                 analyze_outputs=analyze_outputs,
+                block_output_stdout=block_output_stdout,
                 global_vars=global_vars,
                 log_func=log_func,
                 parallel=parallel,
-                redirect_outputs=redirect_outputs,
-                redirect_stdout=redirect_stdout,
                 run_tests=run_tests,
                 update_status=update_status,
             )
@@ -215,10 +213,9 @@ class Pipeline:
     def execute_sync(
         self,
         analyze_outputs: bool = True,
+        block_output_stdout: Callable[[str], object] = None,
         global_vars=None,
         log_func: Callable[[str], None] = None,
-        redirect_outputs: bool = False,
-        redirect_stdout=None,
         run_tests: bool = False,
     ) -> None:
         """
@@ -238,10 +235,9 @@ class Pipeline:
         run_blocks_sync(
             root_blocks,
             analyze_outputs=analyze_outputs,
+            block_output_stdout=block_output_stdout,
             global_vars=global_vars,
             log_func=log_func,
-            redirect_outputs=redirect_outputs,
-            redirect_stdout=redirect_stdout,
             run_tests=run_tests,
         )
 

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -179,9 +179,8 @@ class Pipeline:
     async def execute(
         self,
         analyze_outputs: bool = True,
-        block_output_stdout: Callable[[str], object] = None,
+        build_block_output_stdout: Callable[..., object] = None,
         global_vars=None,
-        log_func: Callable[[str], None] = None,
         parallel: bool = True,
         run_tests: bool = False,
         update_status: bool = True,
@@ -200,9 +199,8 @@ class Pipeline:
             run_blocks(
                 root_blocks,
                 analyze_outputs=analyze_outputs,
-                block_output_stdout=block_output_stdout,
+                build_block_output_stdout=build_block_output_stdout,
                 global_vars=global_vars,
-                log_func=log_func,
                 parallel=parallel,
                 run_tests=run_tests,
                 update_status=update_status,
@@ -213,9 +211,8 @@ class Pipeline:
     def execute_sync(
         self,
         analyze_outputs: bool = True,
-        block_output_stdout: Callable[[str], object] = None,
+        build_block_output_stdout: Callable[..., object] = None,
         global_vars=None,
-        log_func: Callable[[str], None] = None,
         run_tests: bool = False,
     ) -> None:
         """
@@ -235,9 +232,8 @@ class Pipeline:
         run_blocks_sync(
             root_blocks,
             analyze_outputs=analyze_outputs,
-            block_output_stdout=block_output_stdout,
+            build_block_output_stdout=build_block_output_stdout,
             global_vars=global_vars,
-            log_func=log_func,
             run_tests=run_tests,
         )
 

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -183,6 +183,7 @@ class Pipeline:
         log_func: Callable[[str], None] = None,
         parallel: bool = True,
         redirect_outputs: bool = False,
+        redirect_stdout=None,
         run_tests: bool = False,
         update_status: bool = True,
     ) -> None:
@@ -204,6 +205,7 @@ class Pipeline:
                 log_func=log_func,
                 parallel=parallel,
                 redirect_outputs=redirect_outputs,
+                redirect_stdout=redirect_stdout,
                 run_tests=run_tests,
                 update_status=update_status,
             )
@@ -216,10 +218,11 @@ class Pipeline:
         global_vars=None,
         log_func: Callable[[str], None] = None,
         redirect_outputs: bool = False,
+        redirect_stdout=None,
         run_tests: bool = False,
     ) -> None:
         """
-        Async function for parallel processing
+        Function for synchronous block processing.
         This function will schedule the block execution in topological
         order based on a block's upstream dependencies.
         """
@@ -238,6 +241,7 @@ class Pipeline:
             global_vars=global_vars,
             log_func=log_func,
             redirect_outputs=redirect_outputs,
+            redirect_stdout=redirect_stdout,
             run_tests=run_tests,
         )
 

--- a/mage_ai/server/api/blocks.py
+++ b/mage_ai/server/api/blocks.py
@@ -52,7 +52,7 @@ class ApiPipelineBlockExecuteHandler(BaseHandler):
         block = pipeline.get_block(block_uuid)
         if block is None:
             raise Exception(f'Block {block_uuid} does not exist in pipeline {pipeline_uuid}')
-        asyncio.run(block.execute(redirect_outputs=True))
+        asyncio.run(block.execute())
         self.write(
             dict(
                 block=block.to_dict(

--- a/mage_ai/server/websocket.py
+++ b/mage_ai/server/websocket.py
@@ -68,33 +68,24 @@ def run_pipeline(
         )
         queue.put(msg)
 
-    def add_block_message(
-        message: str,
+    def build_block_output_stdout(
+        block_uuid: str,
         execution_state: str = 'busy',
-        msg_type: str = 'stream_pipeline',
-        block_uuid: str = None,
     ):
-        add_pipeline_message(
-            message,
+        return StreamBlockOutputToQueue(
+            queue,
+            block_uuid,
             execution_state=execution_state,
             metadata=dict(
                 block_uuid=block_uuid,
                 pipeline_uuid=pipeline.uuid,
             ),
-            msg_type=msg_type,
         )
 
     try:
         pipeline.execute_sync(
             global_vars=global_vars,
-            log_func=add_block_message,
-            block_output_stdout=lambda block_uuid: StreamBlockOutputToQueue(
-                queue,
-                block_uuid,
-                metadata=dict(
-                    pipeline_uuid=pipeline.uuid,
-                ),
-            ),
+            build_block_output_stdout=build_block_output_stdout,
         )
         add_pipeline_message(
             f'Pipeline {pipeline.uuid} execution complete.\n'

--- a/mage_ai/server/websocket.py
+++ b/mage_ai/server/websocket.py
@@ -88,8 +88,7 @@ def run_pipeline(
         pipeline.execute_sync(
             global_vars=global_vars,
             log_func=add_block_message,
-            redirect_outputs=True,
-            redirect_stdout=lambda block_uuid: StreamToQueue(
+            block_output_stdout=lambda block_uuid: StreamBlockOutputToQueue(
                 queue,
                 block_uuid,
                 metadata=dict(
@@ -369,9 +368,10 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
             task = asyncio.create_task(check_for_messages())
             set_current_message_task(task)
 
-class StreamToQueue(object):
+class StreamBlockOutputToQueue(object):
     """
-    Fake file-like stream object that redirects writes to a queue.
+    Fake file-like stream object that redirects block output to a queue
+    to be streamed to the websocket.
     """
     def __init__(
         self,


### PR DESCRIPTION
# Summary

Show print statements in pipeline execution. I also refactored the logging logic for block execution to remove the `log_func` and `redirect_outputs` arguments and replaced it with `build_block_output_stdout`.
<!-- Brief summary of what your code does -->

# Tests

tested locally. verified that existing functionality still works
<img width="611" alt="Screen Shot 2022-09-09 at 10 24 21 AM" src="https://user-images.githubusercontent.com/14357209/189409282-3bc2515f-281b-47d5-93d5-c4424c31d184.png">


<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
