### PR TITLE
[xy] Not copy variables and logs when executing pipelines.

### DIFF
--- a/mage_ai/server/execution_manager.py
+++ b/mage_ai/server/execution_manager.py
@@ -1,4 +1,4 @@
-from distutils.dir_util import copy_tree
+from distutils.file_util import copy_file
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from typing import Callable
 import asyncio
@@ -56,7 +56,10 @@ def cancel_pipeline_execution(
     )
     config_path = pipeline_execution.previous_config_path
     if config_path is not None and os.path.isdir(config_path):
-        copy_tree(config_path, pipeline.dir_path)
+        copy_file(
+            os.path.join(config_path, 'metadata.yaml'),
+            os.path.join(pipeline.dir_path, 'metadata.yaml'),
+        )
         delete_pipeline_copy_config(config_path)
 
 


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Not copy variables and logs when executing pipelines. Otherwise, it'll take very long to copy the pipeline config folder.

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
