### PR TITLE
[xy] Automatically set active cluster when switching to pyspark kernel

### DIFF
--- a/mage_ai/cluster_manager/aws/emr_cluster_manager.py
+++ b/mage_ai/cluster_manager/aws/emr_cluster_manager.py
@@ -21,7 +21,9 @@ class EmrClusterManager(ClusterManager):
         ) for c in clusters]
 
     def create_cluster(self):
-        create_cluster(get_repo_path(), done_status=None)
+        cluster_id = create_cluster(get_repo_path(), done_status=None)
+        cluster_info = describe_cluster(cluster_id)
+        print(cluster_info)
 
     def set_active_cluster(self, cluster_id=None):
         self.active_cluster_id = cluster_id

--- a/mage_ai/cluster_manager/aws/emr_cluster_manager.py
+++ b/mage_ai/cluster_manager/aws/emr_cluster_manager.py
@@ -21,15 +21,23 @@ class EmrClusterManager(ClusterManager):
         ) for c in clusters]
 
     def create_cluster(self):
-        cluster_id = create_cluster(get_repo_path(), done_status=None)
-        cluster_info = describe_cluster(cluster_id)
-        print(cluster_info)
+        create_cluster(
+            get_repo_path(),
+            done_status=None,
+            tags=dict(name='mage-data-prep'),
+        )
 
-    def set_active_cluster(self, cluster_id=None):
-        self.active_cluster_id = cluster_id
-
+    def set_active_cluster(self, auto_selection=False, cluster_id=None):
+        if cluster_id is None and auto_selection:
+            clusters = self.list_clusters()
+            if len(clusters) > 0:
+                cluster_id = clusters[0]['id']
+            else:
+                self.create_cluster()
         if cluster_id is None:
             return
+
+        self.active_cluster_id = cluster_id
 
         # Fetch cluster master instance public DNS
         cluster_info = describe_cluster(cluster_id)

--- a/mage_ai/cluster_manager/aws/emr_cluster_manager.py
+++ b/mage_ai/cluster_manager/aws/emr_cluster_manager.py
@@ -2,9 +2,12 @@ from mage_ai.cluster_manager.cluster_manager import ClusterManager
 from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.services.aws.emr.emr import describe_cluster, list_clusters
 from mage_ai.services.aws.emr.launcher import create_cluster
+from mage_ai.shared.array import find
 from pathlib import Path
 import json
 import os
+
+CLUSTER_NAME = 'mage-data-prep'
 
 
 class EmrClusterManager(ClusterManager):
@@ -13,18 +16,27 @@ class EmrClusterManager(ClusterManager):
 
     def list_clusters(self):
         clusters = list_clusters()['Clusters']
+        valid_clusters = []
+        for c in clusters:
+            cluster_info = describe_cluster(c['Id'])
+            cluster_tags = cluster_info['Tags']
+            if find(
+                lambda t: t['Key'] == 'name' and t['Value'] == CLUSTER_NAME,
+                cluster_tags,
+            ):
+                valid_clusters.append(c)
         return [dict(
             id=c['Id'],
             name=c['Name'],
             status=c['Status']['State'],
             is_active=c['Id'] == self.active_cluster_id,
-        ) for c in clusters]
+        ) for c in valid_clusters]
 
     def create_cluster(self):
         create_cluster(
             get_repo_path(),
             done_status=None,
-            tags=dict(name='mage-data-prep'),
+            tags=dict(name=CLUSTER_NAME),
         )
 
     def set_active_cluster(self, auto_selection=False, cluster_id=None):

--- a/mage_ai/server/active_kernel.py
+++ b/mage_ai/server/active_kernel.py
@@ -13,6 +13,7 @@ active_kernel = ActiveKernel()
 
 
 def switch_active_kernel(kernel_name: KernelName) -> None:
+    print(f'Switch active kernel: {kernel_name}')
     if kernel_managers[kernel_name].is_alive():
         return
 
@@ -25,6 +26,9 @@ def switch_active_kernel(kernel_name: KernelName) -> None:
         new_kernel.start_kernel()
         active_kernel.kernel = new_kernel
         active_kernel.kernel_client = new_kernel.client()
+        if kernel_name == KernelName.PYSPARK:
+            from mage_ai.cluster_manager.aws.emr_cluster_manager import emr_cluster_manager
+            emr_cluster_manager.set_active_cluster(auto_selection=True)
     except NoSuchKernel as e:
         if kernel_name == KernelName.PYSPARK:
             raise Exception(

--- a/mage_ai/services/aws/emr/emr.py
+++ b/mage_ai/services/aws/emr/emr.py
@@ -40,6 +40,7 @@ def create_a_new_cluster(
     idle_timeout=0,
     keep_alive=False,
     log_uri=None,
+    tags=dict(),
 ):
     region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
     config = Config(region_name=region_name)
@@ -67,6 +68,7 @@ def create_a_new_cluster(
         JobFlowRole='EMR_EC2_DefaultRole',
         ServiceRole='EMR_DefaultRole',
         EbsRootVolumeSize=10,
+        Tags=[dict(Key=k, Value=v) for k, v in tags.items()],
         VisibleToAllUsers=True,
     )
     if log_uri is not None:

--- a/mage_ai/services/aws/emr/launcher.py
+++ b/mage_ai/services/aws/emr/launcher.py
@@ -3,7 +3,7 @@ from mage_ai.services.aws.emr.emr import create_a_new_cluster
 from mage_ai.services.aws.emr.resource_manager import EmrResourceManager
 
 
-def create_cluster(project_path, done_status='WAITING'):
+def create_cluster(project_path, done_status='WAITING', tags=dict()):
     print(f'Creating EMR cluster for project: {project_path}')
     repo_config = RepoConfig(project_path)
     # Upload bootstrap script
@@ -22,5 +22,6 @@ def create_cluster(project_path, done_status='WAITING'):
         done_status=done_status,
         keep_alive=True,
         log_uri=resource_manager.log_uri,
+        tags=tags,
     )
     print(f'Cluster {cluster_id} is created')


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Automatically set active cluster when switching to pyspark kernel

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
