### PR TITLE
[xy] Add terraform script to deploy to GCP.

### DIFF
--- a/scripts/deploy/terraform/gcp/main.tf
+++ b/scripts/deploy/terraform/gcp/main.tf
@@ -47,7 +47,6 @@ resource "google_project_service" "resourcemanager" {
 # #############################################
 # # Create Artifact Registry Repository for Docker containers
 # resource "google_artifact_registry_repository" "my_docker_repo" {
-#   provider = google-beta
 #   location = var.region
 #   repository_id = var.repository
 #   description = "My docker repository"
@@ -56,14 +55,12 @@ resource "google_project_service" "resourcemanager" {
 # }
 # # Create a service account
 # resource "google_service_account" "docker_pusher" {
-#   provider = google-beta
 #   account_id   = "docker-pusher"
 #   display_name = "Docker Container Pusher"
 #   depends_on =[time_sleep.wait_30_seconds]
 # }
 # # Give service account permission to push to the Artifact Registry Repository
 # resource "google_artifact_registry_repository_iam_member" "docker_pusher_iam" {
-#   provider = google-beta
 #   location = google_artifact_registry_repository.my_docker_repo.location
 #   repository =  google_artifact_registry_repository.my_docker_repo.repository_id
 #   role   = "roles/artifactregistry.writer"
@@ -72,61 +69,6 @@ resource "google_project_service" "resourcemanager" {
 #     google_artifact_registry_repository.my_docker_repo,
 #     google_service_account.docker_pusher
 #     ]
-# }
-
-# ##############################################
-# #       Deploy API to Google Cloud Run       #
-# ##############################################
-# # Deploy image to Cloud Run
-# resource "google_cloud_run_service" "api_test" {
-#   provider = google-beta
-#   name     = "api-test"
-#   location = var.region
-#   template {
-#     spec {
-#         containers {
-#             image = "europe-west4-docker.pkg.dev/${var.project_id}/${var.repository}/${var.docker_image}"
-#             resources {
-#                 limits = {
-#                 "memory" = "1G"
-#                 "cpu" = "1"
-#                 }
-#             }
-#         }
-#     }
-#     metadata {
-#         annotations = {
-#             "autoscaling.knative.dev/minScale" = "0"
-#             "autoscaling.knative.dev/maxScale" = "1"
-#         }
-#     }
-#   }
-#   traffic {
-#     percent = 100
-#     latest_revision = true
-#   }
-#   depends_on = [google_artifact_registry_repository_iam_member.docker_pusher_iam]
-# }
-# # Create a policy that allows all users to invoke the API
-# data "google_iam_policy" "noauth" {
-#   provider = google-beta
-#   binding {
-#     role = "roles/run.invoker"
-#     members = [
-#       "allUsers",
-#     ]
-#   }
-# }
-# # Apply the no-authentication policy to our Cloud Run Service.
-# resource "google_cloud_run_service_iam_policy" "noauth" {
-#   provider = google-beta
-#   location    = var.region
-#   project     = var.project_id
-#   service     = google_cloud_run_service.api_test.name
-#   policy_data = data.google_iam_policy.noauth.policy_data
-# }
-# output "cloud_run_instance_url" {
-#   value = google_cloud_run_service.api_test.status.0.url
 # }
 
 
@@ -144,8 +86,8 @@ resource "google_cloud_run_service" "run_service" {
         }
         resources {
           limits = {
-            "memory" = var.container_memory
-            "cpu" = var.container_cpu
+            cpu     = var.container_cpu
+            memory  = var.container_memory
           }
         }
       }

--- a/scripts/deploy/terraform/gcp/main.tf
+++ b/scripts/deploy/terraform/gcp/main.tf
@@ -1,0 +1,169 @@
+# main.tf
+
+terraform {
+  required_version = ">= 0.14"
+
+  required_providers {
+    # Cloud Run support was added on 3.3.0
+    google = ">= 3.3"
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}
+
+# #############################################
+# #               Enable API's                #
+# #############################################
+# Enable IAM API
+resource "google_project_service" "iam" {
+  service            = "iam.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Enable Artifact Registry API
+resource "google_project_service" "artifactregistry" {
+  service            = "artifactregistry.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Enable Cloud Run API
+resource "google_project_service" "cloudrun" {
+  service            = "run.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Enable Cloud Resource Manager API
+resource "google_project_service" "resourcemanager" {
+  service            = "cloudresourcemanager.googleapis.com"
+  disable_on_destroy = false
+}
+
+# #############################################
+# #    Google Artifact Registry Repository    #
+# #############################################
+# # Create Artifact Registry Repository for Docker containers
+# resource "google_artifact_registry_repository" "my_docker_repo" {
+#   provider = google-beta
+#   location = var.region
+#   repository_id = var.repository
+#   description = "My docker repository"
+#   format = "DOCKER"
+#   depends_on = [time_sleep.wait_30_seconds]
+# }
+# # Create a service account
+# resource "google_service_account" "docker_pusher" {
+#   provider = google-beta
+#   account_id   = "docker-pusher"
+#   display_name = "Docker Container Pusher"
+#   depends_on =[time_sleep.wait_30_seconds]
+# }
+# # Give service account permission to push to the Artifact Registry Repository
+# resource "google_artifact_registry_repository_iam_member" "docker_pusher_iam" {
+#   provider = google-beta
+#   location = google_artifact_registry_repository.my_docker_repo.location
+#   repository =  google_artifact_registry_repository.my_docker_repo.repository_id
+#   role   = "roles/artifactregistry.writer"
+#   member = "serviceAccount:${google_service_account.docker_pusher.email}"
+#   depends_on = [
+#     google_artifact_registry_repository.my_docker_repo,
+#     google_service_account.docker_pusher
+#     ]
+# }
+
+# ##############################################
+# #       Deploy API to Google Cloud Run       #
+# ##############################################
+# # Deploy image to Cloud Run
+# resource "google_cloud_run_service" "api_test" {
+#   provider = google-beta
+#   name     = "api-test"
+#   location = var.region
+#   template {
+#     spec {
+#         containers {
+#             image = "europe-west4-docker.pkg.dev/${var.project_id}/${var.repository}/${var.docker_image}"
+#             resources {
+#                 limits = {
+#                 "memory" = "1G"
+#                 "cpu" = "1"
+#                 }
+#             }
+#         }
+#     }
+#     metadata {
+#         annotations = {
+#             "autoscaling.knative.dev/minScale" = "0"
+#             "autoscaling.knative.dev/maxScale" = "1"
+#         }
+#     }
+#   }
+#   traffic {
+#     percent = 100
+#     latest_revision = true
+#   }
+#   depends_on = [google_artifact_registry_repository_iam_member.docker_pusher_iam]
+# }
+# # Create a policy that allows all users to invoke the API
+# data "google_iam_policy" "noauth" {
+#   provider = google-beta
+#   binding {
+#     role = "roles/run.invoker"
+#     members = [
+#       "allUsers",
+#     ]
+#   }
+# }
+# # Apply the no-authentication policy to our Cloud Run Service.
+# resource "google_cloud_run_service_iam_policy" "noauth" {
+#   provider = google-beta
+#   location    = var.region
+#   project     = var.project_id
+#   service     = google_cloud_run_service.api_test.name
+#   policy_data = data.google_iam_policy.noauth.policy_data
+# }
+# output "cloud_run_instance_url" {
+#   value = google_cloud_run_service.api_test.status.0.url
+# }
+
+
+# Create the Cloud Run service
+resource "google_cloud_run_service" "run_service" {
+  name = var.app_name
+  location = var.region
+
+  template {
+    spec {
+      containers {
+        image = var.docker_image
+        ports {
+          container_port = 6789
+        }
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+
+  # Waits for the Cloud Run API to be enabled
+  depends_on = [google_project_service.cloudrun]
+}
+
+# Allow unauthenticated users to invoke the service
+resource "google_cloud_run_service_iam_member" "run_all_users" {
+  service  = google_cloud_run_service.run_service.name
+  location = google_cloud_run_service.run_service.location
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+# Display the service URL
+output "service_url" {
+  value = google_cloud_run_service.run_service.status[0].url
+}

--- a/scripts/deploy/terraform/gcp/main.tf
+++ b/scripts/deploy/terraform/gcp/main.tf
@@ -142,6 +142,12 @@ resource "google_cloud_run_service" "run_service" {
         ports {
           container_port = 6789
         }
+        resources {
+          limits = {
+            "memory" = var.container_memory
+            "cpu" = var.container_cpu
+          }
+        }
       }
     }
   }

--- a/scripts/deploy/terraform/gcp/variables.tf
+++ b/scripts/deploy/terraform/gcp/variables.tf
@@ -4,6 +4,16 @@ variable "app_name" {
   default     = "mage-data-prep"
 }
 
+variable "container_cpu" {
+  description = "ECS task cpu"
+  default     = "2"
+}
+
+variable "container_memory" {
+  description = "ECS task memory"
+  default     = "1G"
+}
+
 variable "project_id" {
   description = "The name of the project"
   type        = string

--- a/scripts/deploy/terraform/gcp/variables.tf
+++ b/scripts/deploy/terraform/gcp/variables.tf
@@ -1,0 +1,35 @@
+variable "app_name" {
+  type        = string
+  description = "Application Name"
+  default     = "mage-data-prep"
+}
+
+variable "project_id" {
+  description = "The name of the project"
+  type        = string
+  default     = "arched-glass-305223"
+}
+
+variable "region" {
+  description = "The default compute region"
+  type        = string
+  default     = "us-west2"
+}
+
+variable "zone" {
+  description = "The default compute zone"
+  type        = string
+  default     = "us-west2-a"
+}
+
+variable "repository" {
+  description = "The name of the Artifact Registry repository to be created"
+  type        = string
+  default     = "mage-data-prep"
+}
+
+variable "docker_image" {
+  description = "The name of the Docker image in the Artifact Registry repository to be deployed to Cloud Run"
+  type        = string
+  default     = "mageai"
+}

--- a/scripts/deploy/terraform/gcp/variables.tf
+++ b/scripts/deploy/terraform/gcp/variables.tf
@@ -17,7 +17,6 @@ variable "container_memory" {
 variable "project_id" {
   description = "The name of the project"
   type        = string
-  default     = "arched-glass-305223"
 }
 
 variable "region" {


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Add terraform script to deploy Mage to GCP.

References
* https://ruanmartinelli.com/posts/terraform-cloud-run
* https://www.fpgmaas.com/blog/deploying-a-flask-api-to-cloudrun

# Tests
<!-- How did you test your change? -->
tested locally
* Add GOOGLE_CREDENTIALS env variable
* Provide project id and docker image
* Run `terraform apply`

<img width="458" alt="image" src="https://user-images.githubusercontent.com/80284865/190786335-dd63e335-9fbd-4810-9a17-faa480b0c265.png">


cc:
<!-- Optionally mention someone to let them know about this pull request -->
