### PR TITLE
[xy] More improvements on spark kernel

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -18,12 +18,12 @@ RUN ${PIP} install jupyterlab
 COPY ./mage_ai /home/src/mage_ai
 
 # Set up spark kernel (Uncomment the code below to set it up)
-# RUN ${PIP} install sparkmagic
-# RUN mkdir ~/.sparkmagic
-# RUN wget https://raw.githubusercontent.com/jupyter-incubator/sparkmagic/master/sparkmagic/example_config.json
-# RUN mv example_config.json ~/.sparkmagic/config.json
-# RUN sed -i 's/localhost:8998/host.docker.internal:9999/g' ~/.sparkmagic/config.json
-# RUN jupyter-kernelspec install --user $(pip show sparkmagic | grep Location | cut -d" " -f2)/sparkmagic/kernels/pysparkkernel
+RUN ${PIP} install sparkmagic
+RUN mkdir ~/.sparkmagic
+RUN wget https://raw.githubusercontent.com/jupyter-incubator/sparkmagic/master/sparkmagic/example_config.json
+RUN mv example_config.json ~/.sparkmagic/config.json
+RUN sed -i 's/localhost:8998/host.docker.internal:9999/g' ~/.sparkmagic/config.json
+RUN jupyter-kernelspec install --user $(pip show sparkmagic | grep Location | cut -d" " -f2)/sparkmagic/kernels/pysparkkernel
 
 
 # Install node modules used in front-end

--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -36,18 +36,7 @@ class BlockExecutor:
         if on_start is not None:
             on_start(self.block_uuid)
         try:
-            self.block.execute_sync(
-                analyze_outputs=analyze_outputs,
-                execution_partition=self.execution_partition,
-                global_vars=global_vars,
-                logger=self.logger,
-                run_all_blocks=True,
-                update_status=update_status,
-            )
-            self.block.run_tests(
-                logger=self.logger,
-                update_tests=False,
-            )
+            self._execute()
         except Exception as e:
             self.logger.info('Failed to execute block.', **tags)
             if on_failure is not None:
@@ -60,6 +49,26 @@ class BlockExecutor:
             on_complete(self.block_uuid)
         elif callback_url is not None:
             self.__update_block_run_status(callback_url, 'completed', tags)
+
+    def _execute(
+        self,
+        analyze_outputs: bool = False,
+        callback_url: str = None,
+        global_vars: Dict = None,
+        update_status: bool = False,
+    ):
+        self.block.execute_sync(
+            analyze_outputs=analyze_outputs,
+            execution_partition=self.execution_partition,
+            global_vars=global_vars,
+            logger=self.logger,
+            run_all_blocks=True,
+            update_status=update_status,
+        )
+        self.block.run_tests(
+            logger=self.logger,
+            update_tests=False,
+        )
 
     def __update_block_run_status(self, callback_url: str, status: str, tags: dict):
         response = requests.put(

--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -32,7 +32,7 @@ class BlockExecutor:
     ) -> None:
         tags = self.__build_tags(**kwargs.get('tags', {}))
 
-        self.logger.info('Start executing block.', **tags)
+        self.logger.info(f'Start executing block with {self.__class__.__name__}.', **tags)
         if on_start is not None:
             on_start(self.block_uuid)
         try:
@@ -44,7 +44,7 @@ class BlockExecutor:
             elif callback_url is not None:
                 self.__update_block_run_status(callback_url, 'failed')
             raise e
-        self.logger.info('Finish executing block.', **tags)
+        self.logger.info(f'Finish executing block with {self.__class__.__name__}.', **tags)
         if on_complete is not None:
             on_complete(self.block_uuid)
         elif callback_url is not None:

--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -30,13 +30,19 @@ class BlockExecutor:
         on_start: Callable[[str], None] = None,
         **kwargs,
     ) -> None:
-        tags = self.__build_tags(**kwargs.get('tags', {}))
+        tags = self._build_tags(**kwargs.get('tags', {}))
 
         self.logger.info(f'Start executing block with {self.__class__.__name__}.', **tags)
         if on_start is not None:
             on_start(self.block_uuid)
         try:
-            self._execute()
+            self._execute(
+                analyze_outputs=analyze_outputs,
+                callback_url=callback_url,
+                global_vars=global_vars,
+                update_status=update_status,
+                **kwargs,
+            )
         except Exception as e:
             self.logger.info('Failed to execute block.', **tags)
             if on_failure is not None:
@@ -56,6 +62,7 @@ class BlockExecutor:
         callback_url: str = None,
         global_vars: Dict = None,
         update_status: bool = False,
+        **kwargs,
     ):
         self.block.execute_sync(
             analyze_outputs=analyze_outputs,
@@ -87,7 +94,7 @@ class BlockExecutor:
             **tags,
         )
 
-    def __build_tags(self, **kwargs):
+    def _build_tags(self, **kwargs):
         return merge_dict(kwargs, dict(
             block_type=self.block.type,
             block_uuid=self.block.uuid,

--- a/mage_ai/data_preparation/executors/pyspark_block_executor.py
+++ b/mage_ai/data_preparation/executors/pyspark_block_executor.py
@@ -9,8 +9,8 @@ import os
 
 
 class PySparkBlockExecutor(BlockExecutor):
-    def __init__(self, pipeline: Pipeline, block_uuid: str):
-        super().__init__(pipeline, block_uuid)
+    def __init__(self, pipeline: Pipeline, block_uuid: str, execution_partition: str = None):
+        super().__init__(pipeline, block_uuid, execution_partition=execution_partition)
         self.resource_manager = EmrResourceManager(
             pipeline.repo_config.s3_bucket,
             pipeline.repo_config.s3_path_prefix,
@@ -23,6 +23,7 @@ class PySparkBlockExecutor(BlockExecutor):
         analyze_outputs: bool = False,
         global_vars: Dict = None,
         update_status: bool = False,
+        **kwargs,
     ) -> None:
         """
         Run block in a spark cluster

--- a/mage_ai/data_preparation/executors/pyspark_block_executor.py
+++ b/mage_ai/data_preparation/executors/pyspark_block_executor.py
@@ -18,7 +18,7 @@ class PySparkBlockExecutor(BlockExecutor):
         self.s3_bucket = pipeline.repo_config.s3_bucket
         self.s3_path_prefix = pipeline.repo_config.s3_path_prefix
 
-    def execute(
+    def _execute(
         self,
         analyze_outputs: bool = False,
         global_vars: Dict = None,

--- a/mage_ai/data_preparation/executors/pyspark_block_executor.py
+++ b/mage_ai/data_preparation/executors/pyspark_block_executor.py
@@ -51,6 +51,8 @@ class PySparkBlockExecutor(BlockExecutor):
             'pipeline_execution/spark_script.jinja',
         ).render(
             block_uuid=f'\'{self.block_uuid}\'',
+            execution_partition_str=f'\'{self.execution_partition}\''
+                                    if self.execution_partition is not None else None,
             global_vars=global_vars,
             pipeline_config=self.pipeline.to_dict(include_content=True),
             pipeline_uuid=self.pipeline.uuid,

--- a/mage_ai/data_preparation/executors/pyspark_block_executor.py
+++ b/mage_ai/data_preparation/executors/pyspark_block_executor.py
@@ -1,4 +1,6 @@
+from contextlib import redirect_stdout
 from mage_ai.data_preparation.executors.block_executor import BlockExecutor
+from mage_ai.data_preparation.logger_manager import StreamToLogger
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.data_preparation.templates.utils import template_env
 from mage_ai.services.aws.emr import emr
@@ -31,9 +33,11 @@ class PySparkBlockExecutor(BlockExecutor):
         2. Launch or connect to an EMR spark cluster
         3. Submit a spark job
         """
-        self.upload_block_execution_script(global_vars=global_vars)
-        self.resource_manager.upload_bootstrap_script()
-        self.submit_spark_job()
+        stdout = StreamToLogger(self.logger)
+        with redirect_stdout(stdout):
+            self.upload_block_execution_script(global_vars=global_vars)
+            self.resource_manager.upload_bootstrap_script()
+            self.submit_spark_job()
 
     @property
     def spark_script_path(self) -> str:

--- a/mage_ai/data_preparation/logger_manager.py
+++ b/mage_ai/data_preparation/logger_manager.py
@@ -2,6 +2,7 @@ from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.data_preparation.models.constants import LOGS_DIR
 import logging
 import os
+import sys
 
 
 class LoggerManager:
@@ -88,7 +89,14 @@ class StreamToLogger(object):
         self.logger = logger
         self.log_level = log_level
         self.linebuf = ''
+        self.terminal = sys.stdout
+
+    def __getattr__(self, attr):
+        return getattr(self.terminal, attr)
 
     def write(self, buf):
         for line in buf.rstrip().splitlines():
             self.logger.log(self.log_level, line.rstrip())
+
+    def flush(self):
+        pass

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -731,7 +731,8 @@ class Block:
     def get_outputs(
         self,
         execution_partition: str = None,
-        sample_count: int = DATAFRAME_SAMPLE_COUNT_PREVIEW
+        include_print_outputs: bool = True,
+        sample_count: int = DATAFRAME_SAMPLE_COUNT_PREVIEW,
     ) -> List[Dict]:
         if self.pipeline is None:
             return
@@ -748,6 +749,10 @@ class Block:
             self.uuid,
             partition=execution_partition,
         )
+
+        if not include_print_outputs:
+            all_variables = [v for v in all_variables if v in self.output_variables.keys()
+                             or v.startswith('output')]
 
         for v in all_variables:
             data = variable_manager.get_variable(

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -883,6 +883,10 @@ df = get_variable('{self.pipeline.uuid}', '{self.uuid}', 'df')
             self.__update_pipeline_block(widget=widget)
         return self
 
+    def update_status(self, status: BlockStatus):
+        self.status = status
+        self.__update_pipeline_block(widget=BlockType.CHART == self.type)
+
     def get_all_upstream_blocks(self) -> List['Block']:
         queue = Queue()
         visited = set()

--- a/mage_ai/data_preparation/templates/pipeline_execution/spark_script.jinja
+++ b/mage_ai/data_preparation/templates/pipeline_execution/spark_script.jinja
@@ -3,6 +3,7 @@ from pyspark.sql.types import StringType
 from pyspark.sql import SparkSession
 from mage_ai.data_preparation.models.pipeline import Pipeline
 import asyncio
+import datetime
 import logging
 import traceback
 

--- a/mage_ai/data_preparation/templates/pipeline_execution/spark_script.jinja
+++ b/mage_ai/data_preparation/templates/pipeline_execution/spark_script.jinja
@@ -71,6 +71,7 @@ if __name__ == '__main__':
                 block = pipeline.get_block(block_uuid)
                 block.execute_sync(
                     analyze_outputs=False,
+                    execution_partition={{ execution_partition_str }},
                     global_vars=global_vars,
                     update_status=False,
                 )

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -107,7 +107,7 @@ class PipelineScheduler:
             completed_block_uuids = set(b.block_uuid for b in completed_block_runs)
             block = self.pipeline.get_block(b.block_uuid)
             if block is not None and \
-                block.all_upstream_blocks_completed(completed_block_uuids):
+                    block.all_upstream_blocks_completed(completed_block_uuids):
                 b.update(status=BlockRun.BlockRunStatus.QUEUED)
                 queued_block_runs.append(b)
 

--- a/mage_ai/server/active_kernel.py
+++ b/mage_ai/server/active_kernel.py
@@ -15,10 +15,12 @@ active_kernel = ActiveKernel()
 def switch_active_kernel(kernel_name: KernelName) -> None:
     print(f'Switch active kernel: {kernel_name}')
     if kernel_managers[kernel_name].is_alive():
+        print(f'Kernel {kernel_name} is already alive.')
         return
 
     for kernel in kernel_managers.values():
         if kernel.is_alive():
+            print(f'Shut down current kernel {kernel}.')
             kernel.request_shutdown()
 
     try:

--- a/mage_ai/server/api/blocks.py
+++ b/mage_ai/server/api/blocks.py
@@ -122,5 +122,5 @@ class ApiPipelineBlockOutputHandler(BaseHandler):
         block = pipeline.get_block(block_uuid)
         if block is None:
             raise Exception(f'Block {block_uuid} does not exist in pipeline {pipeline_uuid}')
-        outputs = block.get_outputs(sample_count=None)
+        outputs = block.get_outputs(include_print_outputs=False, sample_count=None)
         self.write(dict(outputs=outputs))

--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -295,7 +295,9 @@ def get_block_output_process_code(
             block_type not in [BlockType.DATA_LOADER, BlockType.TRANSFORMER]:
         return None
     return f"""%%local
+from mage_ai.data_preparation.models.constants import BlockStatus
 from mage_ai.data_preparation.models.pipeline import Pipeline
+
 import pandas
 
 block_uuid=\'{block_uuid}\'
@@ -306,6 +308,7 @@ block = pipeline.get_block(block_uuid)
 variable_mapping = dict(df=df)
 block.store_variables(variable_mapping)
 block.analyze_outputs(variable_mapping)
+block.update_status(BlockStatus.EXECUTED)
     """
 
 

--- a/mage_ai/services/aws/emr/emr.py
+++ b/mage_ai/services/aws/emr/emr.py
@@ -312,12 +312,12 @@ def __status_poller(intro, done_status, func):
         done_status,
     ]
 
-    base_sleep_time = 60
+    base_sleep_time = 30
     tries = 0
 
     random.seed()
     time.sleep(random.randrange(base_sleep_time))
-    while status not in statuses:
+    while True:
         tries += 1
         prev_status = status
         try:
@@ -335,6 +335,8 @@ def __status_poller(intro, done_status, func):
         else:
             print(status, end='')
         sys.stdout.flush()
+        if status in statuses:
+            break
         time.sleep(sleep_time)
     print()
     emr_basics.logger.setLevel(logging.INFO)


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
* Not return print output when fetching block output. (Otherwise, expanding table doesn't show the correct data)
* Enable spark kernel in dev dockerfile by default
* Update block execution status correctly
* Fix "FileNotFoundError: [Errno 2] No such file or directory: '/mnt/var/lib/livy/metadata.yaml'" error in data exporter block
* Fix pyspark executor initialization.
* Fix missing import in pyspark execution script.
<img width="650" alt="image" src="https://user-images.githubusercontent.com/80284865/191358588-6249a51e-e1bc-4226-9a2b-1a8de57ad160.png">

* Update block status when pyspark executor completes.
* Include execution_partition in pyspark block execution.
* Speed up EMR status polling.
* Add more pyspark executor loggings


TODOs
- [ ] Store sample pyspark block run output
- [ ] Terminate spark cluster if it's idle for 1 hour
- [ ] More efficient spark resource management

# Tests
<!-- How did you test your change? -->
tested with spark kernel locally
<img width="920" alt="image" src="https://user-images.githubusercontent.com/80284865/191374523-c52bd143-4f3a-48d4-a4f2-092988d22695.png">


cc:
<!-- Optionally mention someone to let them know about this pull request -->
