### PR TITLE
Fix #! in shell scripts

### DIFF
--- a/scripts/deploy/cloudformation/ecs.sh
+++ b/scripts/deploy/cloudformation/ecs.sh
@@ -1,4 +1,4 @@
-# !/bin/bash
+#!/bin/bash
 
 SUBNET="$1"
 PARAMETERS=ParameterKey=SubnetID,ParameterValue=${SUBNET}

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,4 +1,4 @@
-# !/bin/bash
+#!/bin/bash
 PROJECT_NAME="$1"
 
 POSITIONAL=()

--- a/scripts/frontend/add.sh
+++ b/scripts/frontend/add.sh
@@ -1,4 +1,4 @@
-# !/bin/bash
+#!/bin/bash
 POSITIONAL=()
 while [[ $# -gt 0 ]]
 do

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,4 +1,4 @@
-# !/bin/bash
+#!/bin/bash
 PROJECT_NAME="$1"
 
 : "${PROJECT_NAME:="default_repo"}"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,4 +1,4 @@
-# !/bin/bash
+#!/bin/bash
 PROJECT_NAME="$1"
 PIPELINE="$2"
 

--- a/scripts/run_ec2.sh
+++ b/scripts/run_ec2.sh
@@ -1,4 +1,4 @@
-# !bin/bash
+#!bin/bash
 MAGE_CLI="python3 -m mage_ai.cli.main"
 PIP="python3 -m pip"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,4 +1,4 @@
-# !/bin/bash
+#!/bin/bash
 PROJECT_NAME="$1"
 
 POSITIONAL=()


### PR DESCRIPTION
# Summary
My default sh is dash, which does not support things like empty array assignment. Not sure exactly why.
	Ex: POSITIONAL=()
The space in '# !/bin/bash' caused the shebang line to be ignore, and ran using the default sh.

# Tests

```
~ % cat /tmp/bar.sh           
# !/bin/bash

ps aux | grep "$$"

~ % /tmp/bar.sh          
kestrel   260579  0.0  0.0   2704   912 pts/1    S+   23:02   0:00 sh /tmp/bar.sh
kestrel   260581  0.0  0.0   6336  2104 pts/1    S+   23:02   0:00 grep 260579

~ % cat /tmp/foo.sh
#!/bin/bash

ps aux | grep "$$"

~ % /tmp/foo.sh  
kestrel   260726  0.0  0.0   7028  3240 pts/1    S+   23:02   0:00 /bin/bash /tmp/foo.sh
kestrel   260728  0.0  0.0   6336  2232 pts/1    S+   23:02   0:00 grep 260726
```
