### PR TITLE
[xy] Continue improving spark kernel and pipeline

### DIFF
--- a/mage_ai/data_preparation/templates/pipeline_execution/spark_script.jinja
+++ b/mage_ai/data_preparation/templates/pipeline_execution/spark_script.jinja
@@ -75,3 +75,6 @@ if __name__ == '__main__':
                     global_vars=global_vars,
                     update_status=False,
                 )
+                block.run_tests(
+                    update_tests=False,
+                )

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -282,7 +282,11 @@ class ApiPipelineVariableListHandler(BaseHandler):
             dict(
                 block=dict(uuid=uuid),
                 pipeline=dict(uuid=pipeline_uuid),
-                variables=[get_variable_value(uuid, var) for var in arr],
+                variables=[
+                            get_variable_value(uuid, var) for var in arr
+                            # Not return printed outputs
+                            if var == 'df' or var.startswith('output') or uuid == 'global'
+                          ],
             )
             for uuid, arr in variables_dict.items()
         ]

--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -118,10 +118,8 @@ def add_internal_output_info(code: str) -> str:
         elif triple_quotes_content:
             return f'{code}\nprint("""\n{triple_quotes_content}\n""")'
 
-    if not last_line or last_line_in_block or re.match('^from|^import', last_line.strip()):
-        return f"""
-{code}
-"""
+    if not last_line or last_line_in_block or re.match('^from|^import|^\%\%', last_line.strip()):
+        return code
     else:
         if matches:
             end_index = len(code_lines)

--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -84,6 +84,8 @@ def get_content_inside_triple_quotes(parts):
 
 
 def add_internal_output_info(code: str) -> str:
+    if code.startswith('%%sql'):
+        return code
     code_lines = remove_comments(code.split('\n'))
     code_lines = remove_empty_last_lines(code_lines)
 

--- a/mage_ai/server/websocket.py
+++ b/mage_ai/server/websocket.py
@@ -190,6 +190,9 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
         msg_id = message.get('msg_id')
         if msg_id is None:
             return
+        if message.get('data') is None and message.get('error') is None \
+           and message.get('execution_state') is None and message.get('type') is None:
+            return
 
         execution_metadata = message.get('execution_metadata')
         msg_id_value = execution_metadata if execution_metadata is not None \

--- a/mage_ai/services/aws/emr/emr.py
+++ b/mage_ai/services/aws/emr/emr.py
@@ -93,25 +93,13 @@ def create_a_new_cluster(
     cluster_id = response['JobFlowId']
     print(f'Cluster ID: {cluster_id}')
 
-    # There are two levels of auto-termination:
-    #     * Instance level
-    #     * Cluster level
-    # For instance level settings, we already set it to be auto-terminated, i.e.,
-    #
-    #     'KeepJobFlowAliveWhenNoSteps': False,
-    #
-    # which over-writes cluster-level settings at present. For instance level settings,
-    # there were hanging instances if we don’t set it to be auto-terminate somehow. Thus
-    # the cluster-level AutoTerminationPolicy didn’t take effects so far, and would be
-    # commented out for now
-    #
-    # if idle_timeout > 0:
-    #    emr_client.put_auto_termination_policy(
-    #        ClusterId=cluster_id,
-    #        AutoTerminationPolicy={
-    #            'IdleTimeout': idle_timeout
-    #        }
-    #    )
+    if keep_alive and idle_timeout > 0:
+        emr_client.put_auto_termination_policy(
+            ClusterId=cluster_id,
+            AutoTerminationPolicy={
+                'IdleTimeout': idle_timeout
+            }
+        )
 
     if done_status is None:
         return cluster_id

--- a/mage_ai/services/aws/emr/launcher.py
+++ b/mage_ai/services/aws/emr/launcher.py
@@ -1,9 +1,15 @@
 from mage_ai.data_preparation.repo_manager import RepoConfig
 from mage_ai.services.aws.emr.emr import create_a_new_cluster
 from mage_ai.services.aws.emr.resource_manager import EmrResourceManager
+from typing import Dict
 
 
-def create_cluster(project_path, done_status='WAITING', tags=dict()):
+def create_cluster(
+    project_path: str,
+    done_status: str = 'WAITING',
+    idle_timeout: int = 30 * 60,
+    tags: Dict = dict(),
+):
     print(f'Creating EMR cluster for project: {project_path}')
     repo_config = RepoConfig(project_path)
     # Upload bootstrap script
@@ -20,6 +26,7 @@ def create_cluster(project_path, done_status='WAITING', tags=dict()):
         repo_config.emr_config,
         bootstrap_script_path=resource_manager.bootstrap_script_path,
         done_status=done_status,
+        idle_timeout=idle_timeout,
         keep_alive=True,
         log_uri=resource_manager.log_uri,
         tags=tags,


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
* Run tests when executing pyspark blocks
* Not return printed outputs when fetching variables
* Allow running magic commands that start with "%%"
* Filter out empty websocket messages
* Auto-terminate cluster if it’s idle for 30 minutes

TODOs
- [ ] Show correct row count
- [ ] Verify sampling strategy
- [ ] Show sample output after executing in kernel
- [ ] Show sample block run output in orchestration tool
- [ ] Use one cluster for the whole pipeline run
- [x] Verify whether transformer actions work for pyspark kernel (not supported)
- [ ] Better logs



# Tests
<!-- How did you test your change? -->

cc:
<!-- Optionally mention someone to let them know about this pull request -->
