### PR TITLE
[jk] Remove overflow so kernel dropdown is visible

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/index.style.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.style.tsx
@@ -34,7 +34,6 @@ export const OverlayStyle = styled.div`
 
 export const PipelineHeaderStyle = styled.div`
   height: ${ASIDE_HEADER_HEIGHT}px;
-  overflow-x: auto;
   position: sticky;
   top: ${ASIDE_HEADER_HEIGHT}px;
   width: 100%;


### PR DESCRIPTION
# Summary
- See title.

## Note
- When there are many tabs for adding back blocks, some tabs may be hidden. Will need to address in separate PR.

# Tests
<img width="821" alt="image" src="https://user-images.githubusercontent.com/78053898/194430017-c6201b5c-e946-4b50-8531-0fb1c471a061.png">


cc:
@tommydangerous 
