### PR TITLE
[jk] Reposition tooltips in line series chart

### DIFF
--- a/mage_ai/frontend/components/charts/LineSeries.tsx
+++ b/mage_ai/frontend/components/charts/LineSeries.tsx
@@ -29,12 +29,12 @@ import { FONT_FAMILY_REGULAR as fontFamily } from '@oracle/styles/fonts/primary'
 import { SMALL_FONT_SIZE } from '@oracle/styles/fonts/sizes';
 import { UNIT, UNIT as unit } from '@oracle/styles/units/spacing';
 import { binarySearch } from '@utils/array';
-import { formatNumberLabel } from './utils/label';
+import { formatNumberLabel, getTooltipContentLength } from './utils/label';
 import { getChartColors } from './constants';
 
 const tooltipStyles = {
   ...defaultStyles,
-  backgroundColor: dark.background.page,
+  backgroundColor: dark.background.muted,
   border: 'none',
 };
 
@@ -111,7 +111,7 @@ const LineSeries = withTooltip<LineSeriesProps>(({
   const border = dark.monotone.gray;
   const purplePastel = dark.brand.wind200;
   const text = dark.content.muted;
-  const { black, gray } = dark.monotone;
+  const { gray } = dark.monotone;
 
   const xValues = data.map(d => Number(getX(d)));
 
@@ -121,6 +121,7 @@ const LineSeries = withTooltip<LineSeriesProps>(({
 
   const xMax = width - margin.left - margin.right;
   const yMax = height - margin.top - margin.bottom;
+  const xHalfwayPoint = xMax / 2;
 
   const maxNumberOfYValues = Math.max(...data.map(({ y }) => y?.length || 0));
   const xScale = useMemo(() => scaleLinear<number>({
@@ -177,15 +178,16 @@ const LineSeries = withTooltip<LineSeriesProps>(({
 
       const tooltipTopData = range(0, maxNumberOfYValues).map(i => yScale(getY(d, i)));
 
-      if (getY(d))
-      showTooltip({
-        tooltipData: {
-          ...d,
-          index,
-        },
-        tooltipLeft: x,
-        tooltipTop: tooltipTopData,
-      });
+      if (getY(d)) {
+        showTooltip({
+          tooltipData: {
+            ...d,
+            index,
+          },
+          tooltipLeft: x,
+          tooltipTop: tooltipTopData,
+        });
+      }
     },
     [
       data,
@@ -412,7 +414,10 @@ const LineSeries = withTooltip<LineSeriesProps>(({
             return (
               <Tooltip
                 key={idx}
-                left={tooltipLeft + unit}
+                left={tooltipLeft > xHalfwayPoint
+                  ? (tooltipLeft - (getTooltipContentLength(renderYTooltipContent, tooltipData, idx) * unit))
+                  : (tooltipLeft + unit)
+                }
                 style={tooltipStyles}
                 top={top - 2 * unit}
               >
@@ -427,7 +432,9 @@ const LineSeries = withTooltip<LineSeriesProps>(({
           })}
 
           <Tooltip
-            left={tooltipLeft}
+            left={tooltipLeft > xHalfwayPoint
+              ? (tooltipLeft - (getTooltipContentLength(renderXTooltipContent, tooltipData) * 4))
+              : tooltipLeft}
             style={{
               ...tooltipStyles,
               transform: 'translateX(-65%)',

--- a/mage_ai/frontend/components/charts/utils/label.ts
+++ b/mage_ai/frontend/components/charts/utils/label.ts
@@ -1,24 +1,40 @@
-import { isNumeric, roundNumber } from "@utils/string";
+import { isNumeric, roundNumber } from '@utils/string';
 
 export const SCATTER_PLOT_X_LABEL_MAX_LENGTH = 20;
 export const SCATTER_PLOT_Y_LABEL_MAX_LENGTH = 10;
 
 const numberFormat = Intl.NumberFormat('en-US', {
-  notation: "compact",
+  notation: 'compact',
   maximumFractionDigits: 2,
-})
+});
 
 export function formatNumberLabel(label) {
   if (typeof label !== 'number') {
-    return label
+    return label;
   } 
   return label >= 10000 ? numberFormat.format(label) : label.toString();
 }
 
 export function truncateLabel(label, length) {
-  const labelString = isNumeric(label) ? String(roundNumber(label, 1)) : String(label)
+  const labelString = isNumeric(label) ? String(roundNumber(label, 1)) : String(label);
 
   return labelString.length > length
           ? `${labelString.substring(0, length)}...`
           : labelString;
+}
+
+export function getTooltipContentLength(
+  renderContentFunction: any,
+  tooltipData: {
+    x: any,
+    y: any[],
+    index: number,
+  },
+  index?: number,
+) {
+  if (typeof renderContentFunction === 'undefined' || typeof tooltipData === 'undefined') {
+    return 0;
+  }
+
+  return renderContentFunction?.(tooltipData, index)?.props?.children?.join('').length;
 }


### PR DESCRIPTION
# Summary
- Fix tooltip cutoff issue in line series charts.

# Tests
Before:
<img width="1075" alt="image" src="https://user-images.githubusercontent.com/78053898/194434063-76337266-6133-4bc0-841a-c93936379eb7.png">

After:
<img width="1060" alt="image" src="https://user-images.githubusercontent.com/78053898/194434162-62ede361-ea54-46c5-96dd-9584d24ab90d.png">
