### PR TITLE
[jk] Increase number of axis tick labels for vertical bar chart

### DIFF
--- a/mage_ai/frontend/components/ChartBlock/ChartController.tsx
+++ b/mage_ai/frontend/components/ChartBlock/ChartController.tsx
@@ -138,8 +138,9 @@ function ChartController({
 
             return ts;
           }}
+          xNumTicks={xy.length}
           yAxisLabel={yAxisLabel}
-          yNumTicks={3}
+          yNumTicks={5}
         />
       );
     }


### PR DESCRIPTION
# Summary
- Some x-axis labels were missing in the vertical bar charts.

# Tests
Before:
<img width="1081" alt="image" src="https://user-images.githubusercontent.com/78053898/194436137-2aa9a822-5473-4eb4-9425-e59d27b89ee6.png">

After:
<img width="1067" alt="image" src="https://user-images.githubusercontent.com/78053898/194436163-2de974c4-84a0-4cd3-b530-3448c2781a38.png">

