### PR TITLE
[xy] Update API for streaming pipelines.

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -27,6 +27,7 @@ from mage_ai.server.kernel_output_parser import DataType
 from mage_ai.shared.constants import ENV_DEV
 from mage_ai.shared.logger import BlockFunctionExec
 from mage_ai.shared.parsers import encode_complex
+from mage_ai.shared.strings import format_enum
 from mage_ai.shared.utils import clean_name
 from queue import Queue
 from typing import Callable, Dict, List, Set
@@ -844,9 +845,6 @@ df = get_variable('{self.pipeline.uuid}', '{self.uuid}', 'df')
         if language and type(self.language) is not str:
             language = self.language.value
 
-        def __format_enum(v):
-            return v.value if type(v) is not str else v
-
         data = dict(
             all_upstream_blocks_executed=all(
                 block.status == BlockStatus.EXECUTED for block in self.get_all_upstream_blocks()
@@ -854,11 +852,11 @@ df = get_variable('{self.pipeline.uuid}', '{self.uuid}', 'df')
             configuration=self.configuration or {},
             downstream_blocks=self.downstream_block_uuids,
             executor_config=self.executor_config,
-            executor_type=__format_enum(self.executor_type),
+            executor_type=format_enum(self.executor_type),
             name=self.name,
             language=language,
-            status=__format_enum(self.status),
-            type=__format_enum(self.type),
+            status=format_enum(self.status),
+            type=format_enum(self.type),
             upstream_blocks=self.upstream_block_uuids,
             uuid=self.uuid,
         )

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -13,6 +13,7 @@ from mage_ai.data_preparation.models.constants import (
     BlockStatus,
     BlockType,
     ExecutorType,
+    BLOCK_LANGUAGE_TO_FILE_EXTENSION,
     CUSTOM_EXECUTION_BLOCK_TYPES,
     DATAFRAME_ANALYSIS_MAX_COLUMNS,
     DATAFRAME_ANALYSIS_MAX_ROWS,
@@ -211,7 +212,7 @@ class Block:
         self.executor_type = executor_type
         self.status = status
         self.pipeline = pipeline
-        self.language = language
+        self.language = language or BlockLanguage.PYTHON
         self.configuration = configuration
 
         self._outputs = None
@@ -261,7 +262,7 @@ class Block:
     @property
     def file_path(self):
         repo_path = self.pipeline.repo_path if self.pipeline is not None else get_repo_path()
-        file_extension = 'sql' if BlockLanguage.SQL == self.language else 'py'
+        file_extension = BLOCK_LANGUAGE_TO_FILE_EXTENSION[self.language]
 
         return os.path.join(
             repo_path or os.getcwd(),
@@ -325,7 +326,8 @@ class Block:
             with open(os.path.join(block_dir_path, '__init__.py'), 'w'):
                 pass
 
-        file_extension = 'sql' if BlockLanguage.SQL == language else 'py'
+        language = language or BlockLanguage.PYTHON
+        file_extension = BLOCK_LANGUAGE_TO_FILE_EXTENSION[language]
         file_path = os.path.join(block_dir_path, f'{uuid}.{file_extension}')
         if os.path.exists(file_path):
             if pipeline is not None and pipeline.has_block(uuid):

--- a/mage_ai/data_preparation/models/constants.py
+++ b/mage_ai/data_preparation/models/constants.py
@@ -51,6 +51,7 @@ class ExecutorType(str, Enum):
 class PipelineType(str, Enum):
     PYTHON = 'python'
     PYSPARK = 'pyspark'
+    STREAMING = 'streaming'
 
 
 CUSTOM_EXECUTION_BLOCK_TYPES = [

--- a/mage_ai/data_preparation/models/constants.py
+++ b/mage_ai/data_preparation/models/constants.py
@@ -23,6 +23,7 @@ LOGS_DIR = '.logs'
 class BlockLanguage(str, Enum):
     PYTHON = 'python'
     SQL = 'sql'
+    YAML = 'yaml'
 
 
 class BlockStatus(str, Enum):
@@ -53,6 +54,12 @@ class PipelineType(str, Enum):
     PYSPARK = 'pyspark'
     STREAMING = 'streaming'
 
+
+BLOCK_LANGUAGE_TO_FILE_EXTENSION = {
+    BlockLanguage.PYTHON: 'py',
+    BlockLanguage.SQL: 'sql',
+    BlockLanguage.YAML: 'yaml',
+}
 
 CUSTOM_EXECUTION_BLOCK_TYPES = [
     BlockType.CHART,

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -27,13 +27,13 @@ METADATA_FILE_NAME = 'metadata.yaml'
 class Pipeline:
     pipelines_cache = dict()
 
-    def __init__(self, uuid, repo_path=None, config=None, repo_config=None):
+    def __init__(self, uuid, pipeline_type=None, repo_path=None, config=None, repo_config=None):
         self.block_configs = []
         self.blocks_by_uuid = {}
         self.name = None
         self.repo_path = repo_path or get_repo_path()
         self.uuid = uuid
-        self.type = PipelineType.PYTHON
+        self.type = pipeline_type or PipelineType.PYTHON
         self.widget_configs = []
         if config is None:
             self.load_config_from_yaml()
@@ -77,7 +77,7 @@ class Pipeline:
         return f'v{self.version}'
 
     @classmethod
-    def create(self, name, repo_path):
+    def create(self, name, pipeline_type=PipelineType.PYTHON, repo_path=None):
         """
         1. Create a new folder for pipeline
         2. Create a new yaml file to store pipeline config
@@ -91,8 +91,16 @@ class Pipeline:
         copy_template_directory('pipeline', pipeline_path)
         # Update metadata.yaml with pipeline config
         with open(os.path.join(pipeline_path, METADATA_FILE_NAME), 'w') as fp:
-            yaml.dump(dict(name=name, uuid=uuid), fp)
-        pipeline = Pipeline(uuid, repo_path)
+            yaml.dump(dict(
+                name=name,
+                uuid=uuid,
+                type=pipeline_type or PipelineType.PYTHON,
+            ), fp)
+        pipeline = Pipeline(
+            uuid,
+            pipeline_type=pipeline_type,
+            repo_path=repo_path,
+        )
         self.pipelines_cache[pipeline.uuid] = pipeline
         return pipeline
 

--- a/mage_ai/data_preparation/templates/data_exporters/streaming/opensearch.yaml
+++ b/mage_ai/data_preparation/templates/data_exporters/streaming/opensearch.yaml
@@ -1,0 +1,3 @@
+connector_type: opensearch
+host: https://[cluster_name].[region].es.amazonaws.com
+index_name: test_index

--- a/mage_ai/data_preparation/templates/data_loaders/streaming/kafka.yaml
+++ b/mage_ai/data_preparation/templates/data_loaders/streaming/kafka.yaml
@@ -1,3 +1,3 @@
 connector_type: kafka
 broker_url: localhost:9092
-topic: test_topic
+topic: topic_name

--- a/mage_ai/data_preparation/templates/data_loaders/streaming/kafka.yaml
+++ b/mage_ai/data_preparation/templates/data_loaders/streaming/kafka.yaml
@@ -1,0 +1,3 @@
+connector_type: kafka
+broker_url: localhost:9092
+topic: test_topic

--- a/mage_ai/data_preparation/templates/template.py
+++ b/mage_ai/data_preparation/templates/template.py
@@ -56,7 +56,7 @@ def fetch_template_source(
 ) -> str:
     template_source = ''
 
-    if BlockLanguage.PYTHON == language:
+    if language in [BlockLanguage.PYTHON, BlockLanguage.YAML]:
         if block_type == BlockType.DATA_LOADER:
             template_source = __fetch_data_loader_templates(config, pipeline_type=pipeline_type)
         elif block_type == BlockType.TRANSFORMER:
@@ -89,8 +89,12 @@ def __fetch_data_loader_templates(
     pipeline_type: PipelineType = PipelineType.PYTHON,
 ) -> str:
     data_source = config.get('data_source')
+    file_extension = 'py'
     if pipeline_type == PipelineType.PYSPARK:
         template_folder = 'data_loaders/pyspark'
+    elif pipeline_type == PipelineType.STREAMING:
+        template_folder = 'data_loaders/streaming'
+        file_extension = 'yaml'
     else:
         template_folder = 'data_loaders'
 
@@ -98,7 +102,10 @@ def __fetch_data_loader_templates(
     if data_source is None:
         template_path = default_template
     else:
-        data_source_template = os.path.join(template_folder, f'{data_source.lower()}.py')
+        data_source_template = os.path.join(
+            template_folder,
+            f'{data_source.lower()}.{file_extension}',
+        )
         if template_exists(data_source_template):
             template_path = data_source_template
         else:
@@ -177,8 +184,12 @@ def __fetch_data_exporter_templates(
     pipeline_type: PipelineType = PipelineType.PYTHON,
 ) -> str:
     data_source = config.get('data_source')
+    file_extension = 'py'
     if pipeline_type == PipelineType.PYSPARK:
         template_folder = 'data_exporters/pyspark'
+    elif pipeline_type == PipelineType.STREAMING:
+        template_folder = 'data_exporters/streaming'
+        file_extension = 'yaml'
     else:
         template_folder = 'data_exporters'
 
@@ -186,7 +197,10 @@ def __fetch_data_exporter_templates(
     if data_source is None:
         template_path = default_template
     else:
-        data_source_template = os.path.join(template_folder, f'{data_source.lower()}.py')
+        data_source_template = os.path.join(
+            template_folder,
+            f'{data_source.lower()}.{file_extension}',
+        )
         if template_exists(data_source_template):
             template_path = data_source_template
         else:

--- a/mage_ai/io/base.py
+++ b/mage_ai/io/base.py
@@ -14,6 +14,8 @@ class DataSource(str, Enum):
     BIGQUERY = 'bigquery'
     FILE = 'file'
     GOOGLE_CLOUD_STORAGE = 'google_cloud_storage'
+    KAFKA = 'kafka'
+    OPENSEARCH = 'opensearch'
     POSTGRES = 'postgres'
     REDSHIFT = 'redshift'
     S3 = 's3'

--- a/mage_ai/io/base.py
+++ b/mage_ai/io/base.py
@@ -35,7 +35,7 @@ class ExportWritePolicy(str, Enum):
 
 class BaseIO(ABC):
     """
-    Data loader interface. All data loaders must inherit from this interface.
+    Data connector interface. All data connectors must inherit from this interface.
     """
 
     def __init__(self, verbose=False) -> None:
@@ -82,7 +82,7 @@ class BaseIO(ABC):
 
 class BaseFile(BaseIO):
     """
-    Data loader for file-like data sources (for example, loading from local
+    Data connector for file-like data sources (for example, loading from local
     filesystem or external file storages such as AWS S3)
     """
 
@@ -218,7 +218,7 @@ class BaseFile(BaseIO):
 
 class BaseSQLDatabase(BaseIO):
     """
-    Base data loader for connecting to a SQL database. This adds `query` method which allows a user
+    Base data connector for connecting to a SQL database. This adds `query` method which allows a user
     to send queries to the database server.
     """
 
@@ -264,16 +264,19 @@ class BaseSQLDatabase(BaseIO):
 
 class BaseSQLConnection(BaseSQLDatabase):
     """
-    Data loader for connected SQL data sources. Can be used as a context manager or by manually opening or closing the connection
-    to the SQL data source after data loading is complete.
+    Data connector for connected SQL data sources. Can be used as a context manager or by
+    manually opening or closing the connection to the SQL data source after data loading
+    is complete.
 
-    WARNING: queries may continue to run on data source unless connection manually closed. For this reason it is recommended to use a context
+    WARNING: queries may continue to run on data source unless connection manually closed.
+    For this reason it is recommended to use a context
     manager when connecting to external data sources.
     """
 
     def __init__(self, verbose=False, **kwargs) -> None:
         """
-        Initializes the connection with the settings given as keyword arguments. Specific data loaders will have access to different settings.
+        Initializes the connection with the settings given as keyword arguments.
+        Specific data connectors will have access to different settings.
         """
         super().__init__(verbose=verbose)
         self.settings = kwargs
@@ -298,7 +301,7 @@ class BaseSQLConnection(BaseSQLDatabase):
     def conn(self) -> Any:
         """
         Returns the connection object to the SQL data source. The exact connection type depends
-        on the source and the definition of the data loader.
+        on the source and the definition of the data connector.
         """
         try:
             return self._ctx

--- a/mage_ai/io/file.py
+++ b/mage_ai/io/file.py
@@ -48,7 +48,6 @@ class FileIO(BaseFile):
         with self.printer.print_msg(f'Exporting data frame to \'{filepath}\''):
             self._write(df, format, filepath, **kwargs)
 
-
     def exists(
         self, filepath: str
     ) -> bool:

--- a/mage_ai/server/kernels.py
+++ b/mage_ai/server/kernels.py
@@ -13,6 +13,7 @@ class KernelName(str, Enum):
 PIPELINE_TO_KERNEL_NAME = {
     PipelineType.PYTHON: KernelName.PYTHON3,
     PipelineType.PYSPARK: KernelName.PYSPARK,
+    PipelineType.STREAMING: KernelName.PYTHON3,
 }
 
 

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -251,8 +251,13 @@ class ApiPipelineListHandler(BaseHandler):
         pipeline = json.loads(self.request.body).get('pipeline', {})
         clone_pipeline_uuid = pipeline.get('clone_pipeline_uuid')
         name = pipeline.get('name')
+        pipeline_type = pipeline.get('type')
         if clone_pipeline_uuid is None:
-            pipeline = Pipeline.create(name, get_repo_path())
+            pipeline = Pipeline.create(
+                name,
+                pipeline_type=pipeline_type,
+                repo_path=get_repo_path(),
+            )
         else:
             source = Pipeline.get(clone_pipeline_uuid)
             pipeline = Pipeline.duplicate(source, name)

--- a/mage_ai/server/websocket.py
+++ b/mage_ai/server/websocket.py
@@ -200,13 +200,13 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
     def send_message(self, message: dict) -> None:
         def should_filter_message(message):
             if message.get('data') is None and message.get('error') is None \
-                and message.get('execution_state') is None and message.get('type') is None:
+                    and message.get('execution_state') is None and message.get('type') is None:
                 return True
 
             try:
                 # Filter out messages meant for jupyter widgets that we can't render
                 if message.get('msg_type') == 'display_data' and \
-                    message.get('data')[0].startswith('FloatProgress'):
+                        message.get('data')[0].startswith('FloatProgress'):
                     return True
             except IndexError:
                 pass

--- a/mage_ai/shared/strings.py
+++ b/mage_ai/shared/strings.py
@@ -6,3 +6,7 @@ def camel_to_snake_case(name):
     name = re.sub('__([A-Z])', r'_\1', name)
     name = re.sub('([a-z0-9])([A-Z])', r'\1_\2', name)
     return name.lower()
+
+
+def format_enum(v):
+    return v.value if type(v) is not str else v

--- a/mage_ai/tests/data_preparation/models/test_block.py
+++ b/mage_ai/tests/data_preparation/models/test_block.py
@@ -36,7 +36,10 @@ class BlockTest(TestCase):
         self.assertEqual(block2.type, 'data_loader')
 
     def test_execute(self):
-        pipeline = Pipeline.create('test pipeline', self.repo_path)
+        pipeline = Pipeline.create(
+            'test pipeline',
+            repo_path=self.repo_path,
+        )
         block1 = Block.create('test_data_loader', 'data_loader', self.repo_path, pipeline=pipeline)
         block2 = Block.create(
             'test_transformer',
@@ -86,7 +89,10 @@ def remove_duplicate_rows(df):
         self.assertTrue(len(analysis['insights']) > 0)
 
     def test_execute_multiple_upstream_blocks(self):
-        pipeline = Pipeline.create('test pipeline', self.repo_path)
+        pipeline = Pipeline.create(
+            'test pipeline',
+            repo_path=self.repo_path,
+        )
         block1 = Block.create('test_data_loader_1', 'data_loader', self.repo_path, pipeline=pipeline)
         block2 = Block.create('test_data_loader_2', 'data_loader', self.repo_path, pipeline=pipeline)
         block3 = Block.create(
@@ -150,7 +156,10 @@ def union_datasets(df1, df2):
         self.assertTrue(len(analysis['suggestions']) == 0)
 
     def test_execute_validation(self):
-        pipeline = Pipeline.create('test pipeline', self.repo_path)
+        pipeline = Pipeline.create(
+            'test pipeline',
+            repo_path=self.repo_path,
+        )
         block1 = Block.create('test_data_loader_1', 'data_loader', self.repo_path, pipeline=pipeline)
         block2 = Block.create('test_data_loader_2', 'data_loader', self.repo_path, pipeline=pipeline)
         block3 = Block.create(

--- a/mage_ai/tests/data_preparation/models/test_pipeline.py
+++ b/mage_ai/tests/data_preparation/models/test_pipeline.py
@@ -19,7 +19,10 @@ class PipelineTest(TestCase):
         return super().tearDown()
 
     def test_create(self):
-        pipeline = Pipeline.create('test pipeline', self.repo_path)
+        pipeline = Pipeline.create(
+            'test pipeline',
+            repo_path=self.repo_path,
+        )
         self.assertEqual(pipeline.uuid, 'test_pipeline')
         self.assertEqual(pipeline.name, 'test pipeline')
         self.assertEqual(pipeline.blocks_by_uuid, dict())
@@ -161,7 +164,10 @@ class PipelineTest(TestCase):
         ))
 
     def test_execute(self):
-        pipeline = Pipeline.create('test pipeline 3', self.repo_path)
+        pipeline = Pipeline.create(
+            'test pipeline 3',
+            repo_path=self.repo_path,
+        )
         block1 = self.__create_dummy_data_loader_block('block1', pipeline)
         block2 = self.__create_dummy_transformer_block('block2', pipeline)
         block3 = self.__create_dummy_transformer_block('block3', pipeline)
@@ -233,7 +239,10 @@ class PipelineTest(TestCase):
         ))
 
     def test_execute_multiple_paths(self):
-        pipeline = Pipeline.create('test pipeline 4', self.repo_path)
+        pipeline = Pipeline.create(
+            'test pipeline 4',
+            repo_path=self.repo_path,
+        )
         block1 = self.__create_dummy_data_loader_block('block1', pipeline)
         block2 = self.__create_dummy_transformer_block('block2', pipeline)
         block3 = self.__create_dummy_transformer_block('block3', pipeline)
@@ -350,7 +359,10 @@ class PipelineTest(TestCase):
         ))
 
     def test_delete(self):
-        pipeline = Pipeline.create('test pipeline 4', self.repo_path)
+        pipeline = Pipeline.create(
+            'test pipeline 4',
+            repo_path=self.repo_path,
+        )
         block1 = self.__create_dummy_data_loader_block('block1', pipeline)
         block2 = self.__create_dummy_transformer_block('block2', pipeline)
         block3 = self.__create_dummy_data_exporter_block('block3', pipeline)
@@ -409,7 +421,10 @@ class PipelineTest(TestCase):
             pipeline.update_block(block4)
 
     def __create_pipeline_with_blocks(self, name):
-        pipeline = Pipeline.create(name, self.repo_path)
+        pipeline = Pipeline.create(
+            name,
+            repo_path=self.repo_path,
+        )
         block1 = Block.create('block1', 'data_loader', self.repo_path, language='python')
         block2 = Block.create('block2', 'transformer', self.repo_path, language='python')
         block3 = Block.create('block3', 'transformer', self.repo_path, language='python')

--- a/mage_ai/tests/data_preparation/models/test_variable.py
+++ b/mage_ai/tests/data_preparation/models/test_variable.py
@@ -107,7 +107,10 @@ class VariableTest(TestCase):
         self.assertEquals(variable.read_data(), data)
 
     def __create_pipeline(self, name):
-        pipeline = Pipeline.create(name, self.repo_path)
+        pipeline = Pipeline.create(
+            name,
+            repo_path=self.repo_path,
+        )
         block1 = Block.create('block1', 'data_loader', self.repo_path)
         block2 = Block.create('block2', 'transformer', self.repo_path)
         pipeline.add_block(block1)

--- a/mage_ai/tests/data_preparation/test_templates.py
+++ b/mage_ai/tests/data_preparation/test_templates.py
@@ -1,6 +1,10 @@
 from mage_ai.data_cleaner.transformer_actions.constants import ActionType, Axis
 from mage_ai.io.base import DataSource
-from mage_ai.data_preparation.models.block import BlockType
+from mage_ai.data_preparation.models.constants import (
+    BlockLanguage,
+    BlockType,
+    PipelineType,
+)
 from mage_ai.data_preparation.templates.template import (
     build_template_from_suggestion,
     fetch_template_source,
@@ -238,6 +242,20 @@ def test_output(df) -> None:
         config = {'data_source': DataSource.API}
         api_template = fetch_template_source(BlockType.DATA_LOADER, config)
         self.assertEqual(api_template, expected_template)
+
+    def test_template_generation_data_loader_streaming(self):
+        kafka_template = """connector_type: kafka
+broker_url: localhost:9092
+topic: topic_name
+"""
+        config = {'data_source': DataSource.KAFKA}
+        new_kafka_template = fetch_template_source(
+            BlockType.DATA_LOADER,
+            config,
+            language=BlockLanguage.YAML,
+            pipeline_type=PipelineType.STREAMING,
+        )
+        self.assertEqual(kafka_template, new_kafka_template)
 
     def test_template_generation_transformer_default(self):
         expected_template = """from pandas import DataFrame
@@ -601,6 +619,20 @@ def export_data_to_snowflake(df: DataFrame, **kwargs) -> None:
         new_snowflake_template = fetch_template_source(BlockType.DATA_EXPORTER, config2)
         self.assertEqual(bigquery_template, new_bigquery_template)
         self.assertEqual(snowflake_template, new_snowflake_template)
+
+    def test_template_generation_data_exporter_streaming(self):
+        opensearch_template = """connector_type: opensearch
+host: https://[cluster_name].[region].es.amazonaws.com
+index_name: test_index
+"""
+        config = {'data_source': DataSource.OPENSEARCH}
+        new_opensearch_template = fetch_template_source(
+            BlockType.DATA_EXPORTER,
+            config,
+            language=BlockLanguage.YAML,
+            pipeline_type=PipelineType.STREAMING,
+        )
+        self.assertEqual(opensearch_template, new_opensearch_template)
 
     def test_template_generation_transformer_dwh(self):
         postgres_template = """from mage_ai.data_preparation.repo_manager import get_repo_path

--- a/mage_ai/tests/data_preparation/test_variable_manager.py
+++ b/mage_ai/tests/data_preparation/test_variable_manager.py
@@ -103,7 +103,10 @@ class VariableManagerTest(TestCase):
         self.assertEqual(get_global_variable('test_pipeline_3', 'var4'), dict(k1='v1', k2='v2'))
 
     def __create_pipeline(self, name):
-        pipeline = Pipeline.create(name, self.repo_path)
+        pipeline = Pipeline.create(
+            name,
+            repo_path=self.repo_path,
+        )
         block1 = Block.create('block1', 'data_loader', self.repo_path)
         block2 = Block.create('block2', 'transformer', self.repo_path)
         pipeline.add_block(block1)


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Update API for streaming pipelines.
* Add pipeline type: streaming
* Support yaml as a block language
* Add code template for kafka and opensearch

API doc: https://www.notion.so/mageai/Streaming-pipelines-Kafka-source-8abc1b65547c4982ba6568ccbba512ce#e25fb4ad7a3744878b6fa58a255ad052

TODOs
- [ ] Update block execution logic for streaming yaml blocks. Support test connections.
- [ ] Update pipeline execution logic for streaming pipelines.
- [ ] Support transformer block in streaming pipelines

# Tests
<!-- How did you test your change? -->
tested locally
<img width="800" alt="image" src="https://user-images.githubusercontent.com/80284865/194954479-0e75b4ac-e911-4f5c-a82b-355719107827.png">


cc:
<!-- Optionally mention someone to let them know about this pull request -->
