### PR TITLE
[xy] Batch consume events from kafka to improve performance

### DIFF
--- a/mage_ai/data_preparation/executors/streaming_pipeline_executor.py
+++ b/mage_ai/data_preparation/executors/streaming_pipeline_executor.py
@@ -80,12 +80,12 @@ class StreamingPipelineExecutor(PipelineExecutor):
         sink_config = yaml.safe_load(self.sink_block.content)
         source = SourceFactory.get_source(source_config)
         sink = SinkFactory.get_sink(sink_config)
-        for message in source.read():
+        for messages in source.batch_read():
             if self.transformer_block is not None:
-                message = self.transformer_block.execute_block(
-                    input_args=[[message]],
-                )['output'][0]
-            sink.write(message)
+                messages = self.transformer_block.execute_block(
+                    input_args=[messages],
+                )['output']
+            sink.batch_write(messages)
 
     def __excute_in_flink(self):
         """

--- a/mage_ai/streaming/sources/kafka.py
+++ b/mage_ai/streaming/sources/kafka.py
@@ -24,6 +24,7 @@ class KafkaSource:
             self.config.topic,
             group_id=self.config.consumer_group,
             bootstrap_servers=self.config.bootstrap_server,
+            enable_auto_commit=True,
         )
         print('Finish initializing kafka consumer.')
 

--- a/mage_ai/streaming/sources/kafka.py
+++ b/mage_ai/streaming/sources/kafka.py
@@ -4,12 +4,15 @@ from typing import Dict
 import json
 import time
 
+DEFAULT_BATCH_SIZE = 100
+
 
 @dataclass
 class KafkaSourceConfig:
     bootstrap_server: str
     consumer_group: str
     topic: str
+    batch_size: int = DEFAULT_BATCH_SIZE
 
 
 class KafkaSource:
@@ -29,12 +32,36 @@ class KafkaSource:
         print('Finish initializing kafka consumer.')
 
     def read(self):
-        print('Start reading messages.')
+        print('Start consuming messages from kafka.')
         for message in self.consumer:
-            print(f'[Kafka] Receive message {message.partition}:{message.offset}: '
-                  f'v={message.value}, time={time.time()}')
+            self.__print_message(message)
             data = json.loads(message.value.decode('utf-8'))
             yield data
 
+    def batch_read(self):
+        print('Start consuming messages from kafka.')
+        if self.config.batch_size > 0:
+            batch_size = self.config.batch_size
+        else:
+            batch_size = DEFAULT_BATCH_SIZE
+        while True:
+            # Response format is {TopicPartiton('topic1', 1): [msg1, msg2]}
+            msg_pack = self.consumer.poll(
+                max_records=batch_size,
+                timeout_ms=500,
+            )
+
+            message_values = []
+            for tp, messages in msg_pack.items():
+                for message in messages:
+                    self.__print_message(message)
+                    message_values.append(json.loads(message.value.decode('utf-8')))
+            if len(message_values) > 0:
+                yield message_values
+
     def test_connection(self):
         return True
+
+    def __print_message(self, message):
+        print(f'[Kafka] Receive message {message.partition}:{message.offset}: '
+              f'v={message.value}, time={time.time()}')


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Batch consume events from kafka to improve performance.
Default batch size is 100. Batch size can be configured in the data loader block.
<img width="480" alt="image" src="https://user-images.githubusercontent.com/80284865/195279826-3335dcb8-58a7-4776-b055-0d7eb6950ddf.png">


# Tests
<!-- How did you test your change? -->
tested locally. Increasing batch size can support more QPS.

cc:
<!-- Optionally mention someone to let them know about this pull request -->
