### PR TITLE
[td] Install mage-integrations in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG PIP=pip3
 USER root
 
 # Install Mage
-RUN ${PIP} install "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations\&subdirectory=mage_integrations"
+RUN ${PIP} install "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations&subdirectory=mage_integrations"
 RUN ${PIP} install "mage-ai[all]"
 
 # Install NFS dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN ${PIP} install "mage-ai[all]"
 # Install NFS dependencies
 RUN apt -y update && apt -y install nfs-common
 
-
 # Set up spark kernel
 RUN ${PIP} install sparkmagic
 RUN mkdir ~/.sparkmagic
@@ -17,9 +16,6 @@ RUN wget https://raw.githubusercontent.com/jupyter-incubator/sparkmagic/master/s
 RUN mv example_config.json ~/.sparkmagic/config.json
 RUN sed -i 's/localhost:8998/host.docker.internal:9999/g' ~/.sparkmagic/config.json
 RUN jupyter-kernelspec install --user $(pip show sparkmagic | grep Location | cut -d" " -f2)/sparkmagic/kernels/pysparkkernel
-
-COPY mage_integrations mage_integrations
-RUN ${PIP} install mage_integrations/
 
 EXPOSE 6789
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG PIP=pip3
 USER root
 
 # Install Mage
+RUN ${PIP} install "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations\&subdirectory=mage_integrations"
 RUN ${PIP} install "mage-ai[all]"
 
 # Install NFS dependencies

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -14,6 +14,7 @@ RUN apt install nodejs
 COPY requirements.txt requirements.txt
 RUN ${PIP} install -r requirements.txt
 RUN ${PIP} install jupyterlab
+RUN ${PIP} install "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations\&subdirectory=mage_integrations"
 
 COPY ./mage_ai /home/src/mage_ai
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -14,7 +14,7 @@ RUN apt install nodejs
 COPY requirements.txt requirements.txt
 RUN ${PIP} install -r requirements.txt
 RUN ${PIP} install jupyterlab
-RUN ${PIP} install "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations\&subdirectory=mage_integrations"
+RUN ${PIP} install "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations&subdirectory=mage_integrations"
 
 COPY ./mage_ai /home/src/mage_ai
 

--- a/mage_ai/data_integrations/logger/utils.py
+++ b/mage_ai/data_integrations/logger/utils.py
@@ -1,8 +1,9 @@
 import json
-from mage_integrations.utils.logger.constants import TYPE_LOG
 
 
 def print_logs_from_output(output):
+    from mage_integrations.utils.logger.constants import TYPE_LOG
+
     for line in output.split('\n'):
         try:
             data = json.loads(line)
@@ -10,4 +11,3 @@ def print_logs_from_output(output):
                 print(json.dumps(data))
         except json.decoder.JSONDecodeError:
             pass
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,3 @@ azure-storage-blob
 kafka-python
 opensearch-py
 requests_aws4auth
-
-# Mage integrations
-git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations\&subdirectory=mage_integrations

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,6 @@ azure-storage-blob
 kafka-python
 opensearch-py
 requests_aws4auth
+
+# Mage integrations
+git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations\&subdirectory=mage_integrations


### PR DESCRIPTION
# Summary
- Add `mage-integrations` package to Dockerfiles (dev and prod)
- Lazy import `mage_integrations` only when it’s needed

In order to use this, you must use Mage in Docker.

Currently, it won’t work if you install via `pip` or `conda`.

TODO:
- [ ] Add `mage-integrations` as a PyPi and Conda package