### PR TITLE
Add a missing "singer-python" module when running locally with a development environment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ pyyaml~=6.0
 requests==2.27.0
 scikit-learn>=1.0
 simplejson
+singer-python==5.12.2
 six>=1.15.0
 sqlalchemy>=1.4.20
 tornado==6.1


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

When I started a local development environment with the following commands:

```
$ ./scripts/init.sh demo_project
$ ./scripts/dev.sh demo_project
```

the following error message was encountered:

```
"ModuleNotFoundError: No module named 'singer'"
```

# Tests
<!-- How did you test your change? -->
Tested the changes locally with the above error messages resolved.

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@dy46 