### PR TITLE
[xy] Kill scheduler before autoreload.

### DIFF
--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -73,6 +73,7 @@ from mage_ai.server.subscriber import get_messages
 from mage_ai.server.websocket import WebSocketServer
 from mage_ai.shared.hash import group_by, merge_dict
 from sqlalchemy.orm import aliased
+from tornado import autoreload
 from tornado.log import enable_pretty_logging
 import argparse
 import asyncio
@@ -541,6 +542,7 @@ def make_app():
         (r'/api/pipelines/(?P<pipeline_uuid>\w+)/logs', ApiPipelineLogListHandler),
         (r'/api/status', ApiStatusHandler),
     ]
+    autoreload.add_reload_hook(scheduler_manager.stop_scheduler)
     return tornado.web.Application(
         routes,
         autoreload=True,


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Kill scheduler before autoreload so that there won't be multiple schedulers running simultaneously.

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
