### PR TITLE
[xy] Support configuring Opensearch authentication.

### DIFF
--- a/mage_ai/data_preparation/templates/data_exporters/streaming/opensearch.yaml
+++ b/mage_ai/data_preparation/templates/data_exporters/streaming/opensearch.yaml
@@ -1,3 +1,12 @@
 connector_type: opensearch
 host: https://[cluster_name].[region].es.amazonaws.com
 index_name: test_index
+
+# # Whether to verify SSL certificates to authenticate.
+# verify_certs: true
+
+# # Authentication setting
+# # 1. "@awsauth": Authenticate with AWS Signature Version 4. Need to provide
+# #.             AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in environment variables.
+# # 2. "username:password": Authenticate with username and password.
+# http_auth: "@awsauth"

--- a/mage_ai/tests/data_preparation/test_templates.py
+++ b/mage_ai/tests/data_preparation/test_templates.py
@@ -634,6 +634,15 @@ def export_data_to_snowflake(df: DataFrame, **kwargs) -> None:
         opensearch_template = """connector_type: opensearch
 host: https://[cluster_name].[region].es.amazonaws.com
 index_name: test_index
+
+# # Whether to verify SSL certificates to authenticate.
+# verify_certs: true
+
+# # Authentication setting
+# # 1. "@awsauth": Authenticate with AWS Signature Version 4. Need to provide
+# #.             AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in environment variables.
+# # 2. "username:password": Authenticate with username and password.
+# http_auth: "@awsauth"
 """
         config = {'data_source': DataSource.OPENSEARCH}
         new_opensearch_template = fetch_template_source(


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Support configuring Opensearch authentication and authenticate with local opensearch.

Example config
```yaml
connector_type: opensearch
host: https://host.docker.internal:9200
index_name: test_index

verify_certs: false
http_auth: 'admin:admin'
```

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
