### PR TITLE
[jk] Log improvements

### DIFF
--- a/mage_ai/frontend/components/Logs/Toolbar/constants.ts
+++ b/mage_ai/frontend/components/Logs/Toolbar/constants.ts
@@ -1,5 +1,7 @@
 import { LogRangeEnum } from '@interfaces/LogType';
 
+export const LOG_ITEMS_PER_PAGE = 40;
+
 export const SPECIFIC_LOG_RANGES = [
   LogRangeEnum.LAST_HOUR,
   LogRangeEnum.LAST_DAY,

--- a/mage_ai/frontend/components/Logs/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/Logs/Toolbar/index.tsx
@@ -37,12 +37,16 @@ enum RangeQueryEnum {
 }
 
 type LogToolbarProps = {
+  logCount: number;
+  logOffset: number;
   selectedRange: LogRangeEnum;
   setLogOffset: (func: any) => void;
   setSelectedRange: (range: LogRangeEnum) => void;
 };
 
 function LogToolbar({
+  logCount,
+  logOffset,
   selectedRange,
   setLogOffset,
   setSelectedRange,
@@ -55,6 +59,7 @@ function LogToolbar({
     hour: padTime(String(new Date().getUTCHours())),
     minute: padTime(String(new Date().getUTCMinutes())),
   });
+  const allLogsLoaded = logOffset >= logCount;
 
   const q = queryFromUrl();
   const qPrev = usePrevious(q);
@@ -101,12 +106,12 @@ function LogToolbar({
       <FlexContainer alignItems="center">
         <KeyboardShortcutButton
           blackBorder
+          disabled={allLogsLoaded}
           inline
           onClick={() => setLogOffset((prev: number) => prev + LOG_ITEMS_PER_PAGE)}
-          sameColorAsText
           uuid="logs/load_older_logs"
         >
-          Load older logs
+          {allLogsLoaded ? 'All past logs loaded' : 'Load older logs'}
         </KeyboardShortcutButton>
 
         <Spacing mr={2} />

--- a/mage_ai/frontend/components/Logs/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/Logs/Toolbar/index.tsx
@@ -1,4 +1,3 @@
-import Router, { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 import Button from '@oracle/elements/Button';
@@ -12,7 +11,11 @@ import Text from '@oracle/elements/Text';
 import TextInput from '@oracle/elements/Inputs/TextInput';
 import usePrevious from '@utils/usePrevious';
 import { LogRangeEnum } from '@interfaces/LogType';
-import { LOG_RANGE_SEC_INTERVAL_MAPPING, SPECIFIC_LOG_RANGES } from './constants';
+import {
+  LOG_ITEMS_PER_PAGE,
+  LOG_RANGE_SEC_INTERVAL_MAPPING,
+  SPECIFIC_LOG_RANGES,
+} from './constants';
 import { UNIT } from '@oracle/styles/units/spacing';
 
 import { calculateStartTimestamp } from '@utils/number';
@@ -34,19 +37,16 @@ enum RangeQueryEnum {
 }
 
 type LogToolbarProps = {
-  fetchLogs: () => void;
   selectedRange: LogRangeEnum;
+  setLogOffset: (func: any) => void;
   setSelectedRange: (range: LogRangeEnum) => void;
 };
 
 function LogToolbar({
-  fetchLogs,
   selectedRange,
+  setLogOffset,
   setSelectedRange,
 }: LogToolbarProps) {
-  const router = useRouter();
-  const { pipeline: pipelineUUID } = router.query;
-
   const [showCalendarIndex, setShowCalendarIndex] = useState<number>(null);
   const [startDate, setStartDate] = useState<Date>(null);
   const [startTime, setStartTime] = useState<TimeType>({ hour: '00', minute: '00' });
@@ -102,11 +102,11 @@ function LogToolbar({
         <KeyboardShortcutButton
           blackBorder
           inline
-          onClick={fetchLogs}
+          onClick={() => setLogOffset((prev: number) => prev + LOG_ITEMS_PER_PAGE)}
           sameColorAsText
-          uuid="logs/toolbar/load_newest"
+          uuid="logs/load_older_logs"
         >
-          Load latest logs
+          Load older logs
         </KeyboardShortcutButton>
 
         <Spacing mr={2} />

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -129,7 +129,7 @@ function BlockRuns({
   ]);
   const filteredLogCount = logsFiltered.length;
   const logs: LogType[] = useMemo(() => logsFiltered.slice(
-    filteredLogCount - offset,
+    Math.max(0, (filteredLogCount - offset)),
   ), [
       filteredLogCount,
       logsFiltered,
@@ -198,6 +198,8 @@ function BlockRuns({
             <>
               {numberWithCommas(logs.length)} logs of {numberWithCommas(filteredLogCount)} found
               <LogToolbar
+                logCount={filteredLogCount}
+                logOffset={offset}
                 selectedRange={selectedRange}
                 setLogOffset={setOffset}
                 setSelectedRange={setSelectedRange}
@@ -337,19 +339,16 @@ function BlockRuns({
         />
       )}
 
-      {offset < filteredLogCount && (
-        <Spacing p={PADDING_UNITS}>
-          <KeyboardShortcutButton
-            blackBorder
-            inline
-            onClick={fetchLogs}
-            sameColorAsText
-            uuid="logs/toolbar/load_newest"
-          >
-            Load latest logs
-          </KeyboardShortcutButton>
-        </Spacing>
-      )}
+      <Spacing p={PADDING_UNITS}>
+        <KeyboardShortcutButton
+          blackBorder
+          inline
+          onClick={fetchLogs}
+          uuid="logs/toolbar/load_newest"
+        >
+          Load latest logs
+        </KeyboardShortcutButton>
+      </Spacing>
     </PipelineDetailPage>
   );
 }

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -25,6 +25,7 @@ import LogToolbar from '@components/Logs/Toolbar';
 import api from '@api';
 import usePrevious from '@utils/usePrevious';
 import { ChevronRight } from '@oracle/icons';
+import { LOG_ITEMS_PER_PAGE } from '@components/Logs/Toolbar/constants';
 import { LogLevelIndicatorStyle } from '@components/Logs/index.style';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
@@ -36,7 +37,6 @@ import { indexBy, sortByKey } from '@utils/array';
 import { numberWithCommas } from '@utils/string';
 import { queryFromUrl } from '@utils/url';
 
-const ITEMS_PER_PAGE = 40;
 const LOG_UUID_PARAM = 'log_uuid';
 
 type BlockRunsProp = {
@@ -51,7 +51,7 @@ function BlockRuns({
   const themeContext = useContext(ThemeContext);
   const pipelineUUID = pipelineProp.uuid;
 
-  const [offset, setOffset] = useState(ITEMS_PER_PAGE);
+  const [offset, setOffset] = useState(LOG_ITEMS_PER_PAGE);
   const [query, setQuery] = useState<FilterQueryType>(null);
   const [selectedLog, setSelectedLog] = useState<LogType>(null);
   const [selectedRange, setSelectedRange] = useState<LogRangeEnum>(null);
@@ -101,7 +101,6 @@ function BlockRuns({
         .concat(pipelineRunLogs)
         .reduce((acc, log) => acc.concat(initializeLogs(log)), []),
       ({ data }) => data?.timestamp || 0,
-      { ascending: false },
     ), [
     blockRunLogs,
     pipelineRunLogs,
@@ -137,7 +136,7 @@ function BlockRuns({
   const qPrev = usePrevious(q);
   useEffect(() => {
     if (!isEqual(q, qPrev)) {
-      setOffset(ITEMS_PER_PAGE);
+      setOffset(LOG_ITEMS_PER_PAGE);
       setQuery(q);
     }
   }, [
@@ -195,8 +194,8 @@ function BlockRuns({
             <>
               {numberWithCommas(logs.length)} logs of {numberWithCommas(logsFiltered.length)} found
               <LogToolbar
-                fetchLogs={fetchLogs}
                 selectedRange={selectedRange}
+                setLogOffset={setOffset}
                 setSelectedRange={setSelectedRange}
               />
             </>
@@ -339,11 +338,11 @@ function BlockRuns({
           <KeyboardShortcutButton
             blackBorder
             inline
-            onClick={() => setOffset(prev => prev + ITEMS_PER_PAGE)}
+            onClick={fetchLogs}
             sameColorAsText
-            uuid="logs/load_more"
+            uuid="logs/toolbar/load_newest"
           >
-            Load older logs
+            Load latest logs
           </KeyboardShortcutButton>
         </Spacing>
       )}

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -4,6 +4,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
@@ -49,12 +50,14 @@ function BlockRuns({
   pipeline: pipelineProp,
 }: BlockRunsProp) {
   const themeContext = useContext(ThemeContext);
+  const bottomOfPageButtonRef = useRef(null);
   const pipelineUUID = pipelineProp.uuid;
 
   const [offset, setOffset] = useState(LOG_ITEMS_PER_PAGE);
   const [query, setQuery] = useState<FilterQueryType>(null);
   const [selectedLog, setSelectedLog] = useState<LogType>(null);
   const [selectedRange, setSelectedRange] = useState<LogRangeEnum>(null);
+  const [scrollToBottom, setScrollToBottom] = useState(false);
 
   const { data: dataPipeline } = api.pipelines.detail(pipelineUUID);
   const pipeline = useMemo(() => ({
@@ -159,6 +162,16 @@ function BlockRuns({
     q,
     selectedLog,
     selectedLogPrev,
+  ]);
+
+  useEffect(() => {
+    if (scrollToBottom && !isLoading) {
+      bottomOfPageButtonRef?.current?.scrollIntoView();
+      setScrollToBottom(false);
+    }
+  }, [
+    scrollToBottom,
+    isLoading,
   ]);
 
   return (
@@ -339,11 +352,14 @@ function BlockRuns({
         />
       )}
 
-      <Spacing p={PADDING_UNITS}>
+      <Spacing p={PADDING_UNITS} ref={bottomOfPageButtonRef}>
         <KeyboardShortcutButton
           blackBorder
           inline
-          onClick={fetchLogs}
+          onClick={() => {
+            setScrollToBottom(true);
+            fetchLogs(null);
+          }}
           uuid="logs/toolbar/load_newest"
         >
           Load latest logs

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -127,7 +127,11 @@ function BlockRuns({
     logsAll,
     query,
   ]);
-  const logs: LogType[] = useMemo(() => logsFiltered.slice(0, offset), [
+  const filteredLogCount = logsFiltered.length;
+  const logs: LogType[] = useMemo(() => logsFiltered.slice(
+    filteredLogCount - offset,
+  ), [
+      filteredLogCount,
       logsFiltered,
       offset,
     ]);
@@ -192,7 +196,7 @@ function BlockRuns({
         <Text>
           {!isLoading && (
             <>
-              {numberWithCommas(logs.length)} logs of {numberWithCommas(logsFiltered.length)} found
+              {numberWithCommas(logs.length)} logs of {numberWithCommas(filteredLogCount)} found
               <LogToolbar
                 selectedRange={selectedRange}
                 setLogOffset={setOffset}
@@ -333,7 +337,7 @@ function BlockRuns({
         />
       )}
 
-      {offset < logsFiltered.length && (
+      {offset < filteredLogCount && (
         <Spacing p={PADDING_UNITS}>
           <KeyboardShortcutButton
             blackBorder


### PR DESCRIPTION
# Summary
- Sort logs in chronological order, but only show latest logs initially. User can load older logs at the top of page.
- Move button to load latest logs to bottom of page.

# Tests
![logs_7040548](https://user-images.githubusercontent.com/78053898/197070425-418d2076-a41e-477d-891d-15c4b01e44e7.gif)
