### PR TITLE
[xy] Set docker image python version to 3.10.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python
+FROM python:3.10
 LABEL description="Deploy Mage on ECS"
 ARG PIP=pip3
 USER root

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM python
+FROM python:3.10
 
 LABEL description="Mage data management platform"
 


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Set docker image python version to 3.10.
Python 11 was released yesterday, which caused pip install errors. https://github.com/mage-ai/mage-ai/actions/runs/3319811249/jobs/5485428962

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
