### PR TITLE
[jk] Fetch default log range

### DIFF
--- a/mage_ai/frontend/components/Logs/Filter/index.tsx
+++ b/mage_ai/frontend/components/Logs/Filter/index.tsx
@@ -24,9 +24,11 @@ export type FilterQueryType = {
   'block_run_id[]'?: string[];
   'block_type[]'?: string[];
   'block_uuid[]'?: string[];
+  end_timestamp?: string;
   'level[]'?: string[];
   'pipeline_run_id[]'?: string[];
   'pipeline_schedule_id[]'?: string[];
+  start_timestamp?: string;
 };
 
 type FilterProps = {

--- a/mage_ai/frontend/components/Logs/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/Logs/Toolbar/index.tsx
@@ -136,11 +136,6 @@ function LogToolbar({
                   [RangeQueryEnum.END]: null,
                 },
               );
-            } else if (range === LogRangeEnum.LAST_40_RUNS) {
-              goToWithQuery({
-                [RangeQueryEnum.START]: null,
-                [RangeQueryEnum.END]: null,
-              });
             }
           }}
           paddingRight={UNIT * 4}

--- a/mage_ai/frontend/components/Logs/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/Logs/Toolbar/index.tsx
@@ -81,6 +81,11 @@ function LogToolbar({
           hour: padTime(initialStartHour),
           minute: padTime(initialStartMinute),
         });
+
+        const secondsAgo = (Math.ceil(Date.now() / 1000) - initialStart);
+        if (Math.abs(secondsAgo - LOG_RANGE_SEC_INTERVAL_MAPPING[LogRangeEnum.LAST_DAY]) <= 5) {
+          setSelectedRange(LogRangeEnum.LAST_DAY);
+        }
       }
 
       if (initialEnd) {
@@ -111,7 +116,7 @@ function LogToolbar({
           onClick={() => setLogOffset((prev: number) => prev + LOG_ITEMS_PER_PAGE)}
           uuid="logs/load_older_logs"
         >
-          {allLogsLoaded ? 'All past logs loaded' : 'Load older logs'}
+          {allLogsLoaded ? 'All logs within range loaded' : 'Load older logs'}
         </KeyboardShortcutButton>
 
         <Spacing mr={2} />

--- a/mage_ai/frontend/interfaces/LogType.ts
+++ b/mage_ai/frontend/interfaces/LogType.ts
@@ -21,7 +21,6 @@ export const LOG_LEVELS = [
 ];
 
 export enum LogRangeEnum {
-  LAST_40_RUNS = 'Last 40 runs',
   LAST_HOUR = 'Last hour',
   LAST_DAY = 'Last day',
   LAST_WEEK = 'Last week',

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -26,10 +26,11 @@ import LogToolbar from '@components/Logs/Toolbar';
 import api from '@api';
 import usePrevious from '@utils/usePrevious';
 import { ChevronRight } from '@oracle/icons';
-import { LOG_ITEMS_PER_PAGE } from '@components/Logs/Toolbar/constants';
+import { LOG_ITEMS_PER_PAGE, LOG_RANGE_SEC_INTERVAL_MAPPING } from '@components/Logs/Toolbar/constants';
 import { LogLevelIndicatorStyle } from '@components/Logs/index.style';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
+import { calculateStartTimestamp } from '@utils/number';
 import { formatTimestamp, initializeLogs } from '@utils/models/log';
 import { getColorsForBlockType } from '@components/CodeBlock/index.style';
 import { goToWithQuery } from '@utils/routing';
@@ -141,6 +142,13 @@ function BlockRuns({
 
   const q = queryFromUrl();
   const qPrev = usePrevious(q);
+  useEffect(() => {
+    if (!q?.start_timestamp) {
+      goToWithQuery({
+        start_timestamp: calculateStartTimestamp(LOG_RANGE_SEC_INTERVAL_MAPPING[LogRangeEnum.LAST_DAY]),
+      });
+    }
+  }, []);
   useEffect(() => {
     if (!isEqual(q, qPrev)) {
       setOffset(LOG_ITEMS_PER_PAGE);

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -71,9 +71,18 @@ function BlockRuns({
   const blocks = useMemo(() => pipeline.blocks || [], [pipeline]);
   const blocksByUUID = useMemo(() => indexBy(blocks, ({ uuid }) => uuid), [blocks]);
 
+  const dayAgoTimestamp = calculateStartTimestamp(LOG_RANGE_SEC_INTERVAL_MAPPING[LogRangeEnum.LAST_DAY]);
   const { data: dataLogs, mutate: fetchLogs } = api.logs.pipelines.list(
     query ? pipelineUUID : null,
-    ignoreKeys(query, [LOG_UUID_PARAM]),
+    ignoreKeys(
+      query?.start_timestamp
+        ? query
+        : {
+          ...query,
+          start_timestamp: dayAgoTimestamp,
+        },
+      [LOG_UUID_PARAM],
+    ),
     {},
   );
   const isLoading = !dataLogs;
@@ -145,7 +154,7 @@ function BlockRuns({
   useEffect(() => {
     if (!q?.start_timestamp) {
       goToWithQuery({
-        start_timestamp: calculateStartTimestamp(LOG_RANGE_SEC_INTERVAL_MAPPING[LogRangeEnum.LAST_DAY]),
+        start_timestamp: dayAgoTimestamp,
       });
     }
   }, []);


### PR DESCRIPTION
# Summary
- Initially fetch only the last day's worth of logs to prevent unnecessary loading of excessive logs.
- Require time range on logs to mitigate large response payloads.

# Tests
![2022-10-26 11 15 09](https://user-images.githubusercontent.com/78053898/198104652-359fc82d-2bf0-4fc6-bf4b-947738dc17e0.gif)

