### PR TITLE
Upgrade pip to the latest version to avoid warning messages in docker 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG PIP=pip3
 USER root
 
 # Install Mage
+RUN ${PIP} install --upgrade pip
 RUN ${PIP} install "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations&subdirectory=mage_integrations"
 RUN ${PIP} install "mage-ai[all]"
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -16,6 +16,7 @@ RUN R -e "install.packages('pacman', repos='http://cran.us.r-project.org')"
 
 # Install Python dependencies
 COPY requirements.txt requirements.txt
+RUN ${PIP} install --upgrade pip
 RUN ${PIP} install -r requirements.txt
 RUN ${PIP} install jupyterlab
 RUN ${PIP} install "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations&subdirectory=mage_integrations"


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

The built-in `pip` version in the docker image was not the latest, which led to unnecessary warnings.

# Tests
<!-- How did you test your change? -->

The added step completed without issues:
```
Step 11/26 : RUN ${PIP} install --upgrade pip
 ---> Running in d78a238520dd
Requirement already satisfied: pip in /usr/local/lib/python3.10/site-packages (22.2.2)
Collecting pip
  Downloading pip-22.3-py3-none-any.whl (2.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.1/2.1 MB 1.3 MB/s eta 0:00:00
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 22.2.2
    Uninstalling pip-22.2.2:
      Successfully uninstalled pip-22.2.2
Successfully installed pip-22.3
```

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@tommydangerous 