### PR TITLE
[jk] Add tooltip for log message

### DIFF
--- a/mage_ai/frontend/components/Logs/Detail/index.tsx
+++ b/mage_ai/frontend/components/Logs/Detail/index.tsx
@@ -139,11 +139,16 @@ function LogDetail({
         <Table
           columnFlex={[null, 1]}
           columnMaxWidth={(idx: number) => idx === 1 ? '100px' : null}
-          rows={rows.map(([k, v]) => [
-            <Text monospace muted>
+          rows={rows.map(([k, v], idx) => [
+            <Text
+              key={`${k}_${idx}_key`}
+              monospace
+              muted
+            >
               {k}
             </Text>,
             <Text
+              key={`${k}_${idx}_val`}
               monospace
               textOverflow
               title={v}

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -357,6 +357,7 @@ function BlockRuns({
                 key="log_message"
                 monospace
                 textOverflow
+                title={message || content}
               >
                 {message || content}
               </Text>,


### PR DESCRIPTION
# Summary
- User can hover over a log message to view its full content in a tooltip.

# Tests
<img width="1110" alt="image" src="https://user-images.githubusercontent.com/78053898/199365296-8315b002-887c-4af0-8d34-28e92dfdc8c9.png">

<img width="782" alt="image" src="https://user-images.githubusercontent.com/78053898/199365412-971a5a14-2b41-4695-87ca-2e68c2f646dc.png">

