### PR TITLE
[xy] Support connecting to MySQL via SSH tunnel.

### DIFF
--- a/mage_integrations/mage_integrations/connections/mysql/__init__.py
+++ b/mage_integrations/mage_integrations/connections/mysql/__init__.py
@@ -67,3 +67,9 @@ class MySQL(Connection):
             port=port,
             user=self.username,
         )
+
+    def close_connection(self, connection):
+        connection.close()
+        if self.ssh_tunnel is not None:
+            self.ssh_tunnel.stop()
+            self.ssh_tunnel = None

--- a/mage_integrations/mage_integrations/connections/mysql/__init__.py
+++ b/mage_integrations/mage_integrations/connections/mysql/__init__.py
@@ -1,5 +1,12 @@
 from mage_integrations.connections.sql.base import Connection
 from mysql.connector import connect
+from sshtunnel import SSHTunnelForwarder
+import enum
+
+
+class ConnectionMethod(str, enum.Enum):
+    DIRECT = 'direct'
+    SSH_TUNNEL = 'ssh_tunnel'
 
 
 class MySQL(Connection):
@@ -10,20 +17,53 @@ class MySQL(Connection):
         password: str,
         username: str,
         port: int = None,
+        connection_method: ConnectionMethod = ConnectionMethod.DIRECT,
+        ssh_host: str = None,
+        ssh_port: int = 22,
+        ssh_username: str = None,
+        ssh_password: str = None,
+        ssh_pkey: str = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
+        self.connection_method = connection_method
         self.database = database
         self.host = host
         self.password = password
         self.port = port or 3306
         self.username = username
+        self.ssh_host = ssh_host
+        self.ssh_port = ssh_port
+        self.ssh_username = ssh_username
+        self.ssh_password = ssh_password
+        self.ssh_pkey = ssh_pkey
+
+        self.ssh_tunnel = None
 
     def build_connection(self):
+        host = self.host
+        port = self.port
+        if self.connection_method == ConnectionMethod.SSH_TUNNEL:
+            ssh_setting = dict(ssh_username=self.ssh_username)
+            if self.ssh_pkey is not None:
+                ssh_setting['ssh_pkey'] = self.ssh_pkey
+            else:
+                ssh_setting['ssh_password'] = self.ssh_password
+            self.ssh_tunnel = SSHTunnelForwarder(
+                (self.ssh_host, self.ssh_port),
+                remote_bind_address=(self.host, self.port),
+                local_bind_address=('', self.port),
+                **ssh_setting,
+            )
+            self.ssh_tunnel.start()
+            self.ssh_tunnel._check_is_started()
+
+            host = '127.0.0.1'
+            port = self.ssh_tunnel.local_bind_port
         return connect(
             database=self.database,
-            host=self.host,
+            host=host,
             password=self.password,
-            port=self.port,
+            port=port,
             user=self.username,
         )

--- a/mage_integrations/mage_integrations/connections/sql/base.py
+++ b/mage_integrations/mage_integrations/connections/sql/base.py
@@ -5,6 +5,9 @@ from typing import List
 
 
 class Connection(BaseConnection):
+    def close_connection(self, connection):
+        connection.close()
+
     def execute(
         self,
         query_strings: List[str],
@@ -23,7 +26,8 @@ class Connection(BaseConnection):
 
         if commit:
             connection.commit()
-        connection.close()
+
+        self.close_connection(connection)
 
         return data
 

--- a/mage_integrations/mage_integrations/destinations/mysql/README.md
+++ b/mage_integrations/mage_integrations/destinations/mysql/README.md
@@ -12,9 +12,14 @@ You must enter the following credentials when configuring this source:
 | --- | --- | --- |
 | `database` | The name of the database you want to export data to. | `demo` |
 | `host` | The host name of your database. | `mage.abc.us-west-2.rds.amazonaws.com` |
-| `password` | Password for the user to access the database. | `abc123...` |
 | `port` | Port of the running database (typically 3306). | `3306` |
-| `table` | Name of the table that will be created to store data from your source. | `dim_users_v1` |
 | `username` | Name of the user that will access the database (must have permissions to read and write to specified schema). | `root` |
-
+| `password` | Password for the user to access the database. | `abc123...` |
+| `table` | Name of the table that will be created to store data from your source. | `dim_users_v1` |
+| `connection_method` | The method used to connect to MySQL server, either "direct" or "ssh_tunnel". | `direct` or `ssh_tunnel` |
+| `ssh_host` | (Optional) The host of the intermediate bastion server. | `123.45.67.89` |
+| `ssh_port` | (Optional) The port of the intermediate bastion server. Default value: 22 | `22` |
+| `ssh_username` | (Optional) The username used to connect to the bastion server. | `username` |
+| `ssh_password` | (Optional) The password used to connect to the bastion server. It should be set if you authenticate with the bastion server with password. | `password` |
+| `ssh_pkey` | (Optional) The path to the private key used to connect to the bastion server. It should be set if you authenticate with the bastion server with private key. | `/path/to/private/key` |
 <br />

--- a/mage_integrations/mage_integrations/sources/mysql/__init__.py
+++ b/mage_integrations/mage_integrations/sources/mysql/__init__.py
@@ -1,4 +1,7 @@
-from mage_integrations.connections.mysql import MySQL as MySQLConnection
+from mage_integrations.connections.mysql import (
+    ConnectionMethod,
+    MySQL as MySQLConnection
+)
 from mage_integrations.sources.base import main
 from mage_integrations.sources.sql.base import Source
 from typing import List
@@ -10,8 +13,14 @@ class MySQL(Source):
             database=self.config['database'],
             host=self.config['host'],
             password=self.config['password'],
-            port=self.config.get('port'),
+            port=self.config.get('port', 3306),
             username=self.config['username'],
+            connection_method=self.config.get('connection_method', ConnectionMethod.DIRECT),
+            ssh_host=self.config.get('ssh_host'),
+            ssh_port=self.config.get('ssh_port', 22),
+            ssh_username=self.config.get('ssh_username'),
+            ssh_password=self.config.get('ssh_password'),
+            ssh_pkey=self.config.get('ssh_pkey'),
             verbose=0 if self.discover_mode or self.discover_streams_mode else 1,
         )
 

--- a/mage_integrations/mage_integrations/sources/mysql/templates/config.json
+++ b/mage_integrations/mage_integrations/sources/mysql/templates/config.json
@@ -1,9 +1,9 @@
 {
   "database": "",
   "host": "",
-  "password": "",
   "port": 3306,
   "username": "",
+  "password": "",
   "connection_method": "direct",
   "ssh_host": "",
   "ssh_port": 22,

--- a/mage_integrations/mage_integrations/sources/mysql/templates/config.json
+++ b/mage_integrations/mage_integrations/sources/mysql/templates/config.json
@@ -3,5 +3,11 @@
   "host": "",
   "password": "",
   "port": 3306,
-  "username": ""
+  "username": "",
+  "connection_method": "direct",
+  "ssh_host": "",
+  "ssh_port": 22,
+  "ssh_username": "",
+  "ssh_password": "",
+  "ssh_pkey": ""
 }

--- a/mage_integrations/requirements.txt
+++ b/mage_integrations/requirements.txt
@@ -10,5 +10,6 @@ requests==2.28.1
 simplejson==3.11.1
 singer-python==5.12.2
 snowflake-connector-python==2.7.9
+sshtunnel==0.4.0
 stripe==4.2.0
 xmltodict==0.13.0


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Support connecting to MySQL via SSH tunnel.

# Tests
<!-- How did you test your change? -->
tested locally
`python3 mage_integrations/sources/mysql/__init__.py --config TEST_CONFIG_MYSQL_SSH.json  --discover > TEST_CATALOG_MYSQL_SSH.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
