### PR TITLE
[xy] Clean dataframe column names before exporting to bigquery.

### DIFF
--- a/mage_ai/io/bigquery.py
+++ b/mage_ai/io/bigquery.py
@@ -177,6 +177,10 @@ WHERE table_id = '{table_name}'
                 elif len(parts) == 3:
                     schema = parts[1]
                 self.client.create_dataset(dataset=schema, exists_ok=True)
+
+                # Clean column names
+                df.columns = df.columns.str.replace(' ', '_')
+
                 self.client.load_table_from_dataframe(df, table_id, job_config=config).result()
 
         if verbose:


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Clean dataframe column names before exporting to bigquery. Column names can't contain empty spaces.

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
