### PR TITLE
[xy] Allow automatically add new fields.

### DIFF
--- a/mage_integrations/mage_integrations/destinations/base.py
+++ b/mage_integrations/mage_integrations/destinations/base.py
@@ -251,7 +251,7 @@ class Destination():
 
             try:
                 row = json.loads(line)
-            except json.decoder.JSONDecodeError as err:
+            except json.decoder.JSONDecodeError:
                 self.logger.info(f'Unable to parse: {line}', tags=tags)
                 continue
 

--- a/mage_integrations/mage_integrations/destinations/bigquery/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/bigquery/__init__.py
@@ -6,6 +6,7 @@ from mage_integrations.destinations.bigquery.utils import (
 from mage_integrations.destinations.constants import UNIQUE_CONFLICT_METHOD_UPDATE
 from mage_integrations.destinations.sql.base import Destination, main
 from mage_integrations.destinations.sql.utils import (
+    build_alter_table_command,
     build_create_table_command,
     build_insert_command,
     column_type_mapping,
@@ -47,6 +48,44 @@ class BigQuery(Destination):
                 full_table_name=f'{schema_name}.{table_name}',
                 # BigQuery doesn't support unique constraints
                 unique_constraints=None,
+            ),
+        ]
+
+    def build_alter_table_commands(
+        self,
+        schema: Dict,
+        schema_name: str,
+        stream: str,
+        table_name: str,
+        database_name: str = None,
+        unique_constraints: List[str] = None,
+    ) -> List[str]:
+        results = self.build_connection().load(f"""
+SELECT
+    column_name
+    , data_type
+FROM {schema_name}.INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_NAME = '{table_name}'
+        """)
+        current_columns = [r[0] for r in results]
+        schema_columns = schema['properties'].keys()
+        new_columns = [c for c in schema_columns if c not in current_columns]
+
+        if not new_columns:
+            return []
+
+        # TODO: Support alter column types
+        return [
+            build_alter_table_command(
+                column_type_mapping=column_type_mapping(
+                    schema,
+                    convert_column_type,
+                    lambda item_type_converted: 'ARRAY',
+                    number_type='FLOAT64',
+                    string_type='STRING',
+                ),
+                columns=new_columns,
+                full_table_name=f'{schema_name}.{table_name}',
             ),
         ]
 

--- a/mage_integrations/mage_integrations/destinations/sql/base.py
+++ b/mage_integrations/mage_integrations/destinations/sql/base.py
@@ -73,6 +73,21 @@ class Destination(BaseDestination):
                     table_name=table_name,
                     unique_constraints=unique_constraints,
                 )
+            else:
+                """
+                Check whether any new columns are added
+                """
+                alter_table_commands = self.build_alter_table_commands(
+                    database_name=database_name,
+                    schema=schema,
+                    schema_name=schema_name,
+                    stream=stream,
+                    table_name=table_name,
+                    unique_constraints=unique_constraints,
+                )
+                if len(alter_table_commands) > 0:
+                    query_strings += alter_table_commands
+
         else:
             message = f'Replication method {replication_method} not supported.'
             self.logger.exception(message, tags=tags)
@@ -133,6 +148,17 @@ class Destination(BaseDestination):
         unique_constraints: List[str] = None,
     ) -> List[str]:
         raise Exception('Subclasses must implement the build_create_table_commands method.')
+
+    def build_alter_table_commands(
+        self,
+        schema: Dict,
+        schema_name: str,
+        stream: str,
+        table_name: str,
+        database_name: str = None,
+        unique_constraints: List[str] = None,
+    ) -> List[str]:
+        return []
 
     def build_insert_commands(
         self,

--- a/mage_integrations/mage_integrations/destinations/sql/utils.py
+++ b/mage_integrations/mage_integrations/destinations/sql/utils.py
@@ -36,6 +36,22 @@ def build_create_table_command(
     return f"CREATE TABLE {full_table_name} ({', '.join(columns_and_types)})"
 
 
+def build_alter_table_command(
+    column_type_mapping: Dict,
+    columns: List[str],
+    full_table_name: str,
+) -> str:
+    if not columns:
+        return None
+
+    columns_and_types = [
+        f"ADD COLUMN {clean_column_name(col)} {column_type_mapping[col]['type_converted']}" for col
+        in columns
+    ]
+    # TODO: support add new unique constraints
+    return f"ALTER TABLE {full_table_name} q{', '.join(columns_and_types)}"
+
+
 def convert_column_type(
     column_type: str,
     column_settings: Dict,

--- a/mage_integrations/mage_integrations/sources/bigquery/__init__.py
+++ b/mage_integrations/mage_integrations/sources/bigquery/__init__.py
@@ -31,7 +31,7 @@ FROM {dataset}.INFORMATION_SCHEMA.COLUMNS
 
         if streams:
             table_names = ', '.join([f"'{n}'" for n in streams])
-            query = f'{query}\nAND TABLE_NAME IN ({table_names})'
+            query = f'{query}\nWHERE TABLE_NAME IN ({table_names})'
         return query
 
 


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Allow automatically add new fields.
If `auto_add_new_fields` field is set to true in stream metadata, we'll automatically discover and add new fields.

Example config:
<img width="412" alt="image" src="https://user-images.githubusercontent.com/80284865/201043580-dcf5066f-accc-46c0-bf86-773efa21f68e.png">

For destination, if new columns are in records, we'll alter table schema automatically. Example alter command:
`ALTER TABLE test_dataset.test_table_google_search_console ADD COLUMN ctr FLOAT64, ADD COLUMN position FLOAT64`

This PR only adds the alter command for bigquery. Will add alter commands for other destinations in a later PR.

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
