### PR TITLE
[xy] Fix google sheets number type.

### DIFF
--- a/mage_integrations/mage_integrations/sources/google_sheets/__init__.py
+++ b/mage_integrations/mage_integrations/sources/google_sheets/__init__.py
@@ -341,7 +341,7 @@ class GoogleSheets(Source):
                         # Interesting - order in the anyOf makes a difference.
                         # Number w/ singer.decimal must be listed last, otherwise errors occur.
                         col_properties = {
-                            'type': ['null', 'string'],
+                            'type': ['null', 'string', 'integer'],
                             'format': 'singer.decimal'
                         }
                         column_gs_type = 'numberType'


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Fix google sheets number type. "integer" type was not added to number columns.

# Tests
<!-- How did you test your change? -->
tested locally
<img width="362" alt="image" src="https://user-images.githubusercontent.com/80284865/201190351-96dcd511-018f-4a9b-9cf6-4233b21d6854.png">


cc:
<!-- Optionally mention someone to let them know about this pull request -->
