### PR TITLE
[xy] Fix sql column names.

### DIFF
--- a/mage_integrations/mage_integrations/sources/sql/base.py
+++ b/mage_integrations/mage_integrations/sources/sql/base.py
@@ -139,9 +139,10 @@ class Source(BaseSource):
             else:
                 order_by_statement = ''
 
-            columns = self.update_column_names(extract_selected_columns(stream.metadata))
+            columns = extract_selected_columns(stream.metadata)
+            clean_columns = self.update_column_names(columns)
 
-            columns_statement = '\n, '.join(columns)
+            columns_statement = '\n, '.join(clean_columns)
             query_string = f"""
 SELECT
     {columns_statement}


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Fix sql column names. Use raw column names in the records so that the column name matches the schema.
Otherwise, we got null values from the postgres source due to mismatch column names.

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
