### PR TITLE
[td] Update bookmark and state logic

### DIFF
--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
@@ -67,7 +67,7 @@ function SchemaTable({
   const {
     auto_add_new_fields: autoAddNewFields,
     bookmark_properties: bookmarkProperties,
-    destination_table: destinationTableInit,
+    destination_table: destinationTableInit = '',
     key_properties: keyProperties,
     metadata,
     replication_method: replicationMethod,
@@ -79,7 +79,7 @@ function SchemaTable({
     unique_conflict_method: uniqueConflictMethod,
   } = stream;
 
-  const [destinationTable, setDestinationTable] = useState<string>('');
+  const [destinationTable, setDestinationTable] = useState<string>(destinationTableInit);
 
   const streamUUIDPrev = usePrevious(streamUUID);
   useEffect(() => {

--- a/mage_ai/frontend/components/IntegrationPipeline/index.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/index.tsx
@@ -38,6 +38,7 @@ import { ChevronDown, ChevronUp } from '@oracle/icons';
 import { SectionStyle } from './index.style';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { ViewKeyEnum } from '@components/Sidekick/constants';
+import { cleanName } from '@utils/string';
 import { find, indexBy } from '@utils/array';
 import { getStreamAndStreamsFromCatalog } from './utils';
 import { getUpstreamBlockUuids } from '@components/CodeBlock/utils';
@@ -232,6 +233,9 @@ function IntegrationPipeline({
                   }
                   if (!stream.unique_conflict_method) {
                     stream.unique_conflict_method = UniqueConflictMethodEnum.UPDATE;
+                  }
+                  if (!stream.destination_table) {
+                    stream.destination_table = cleanName(stream.tap_stream_id);
                   }
 
                   stream.metadata[idx] = {

--- a/mage_ai/frontend/utils/string.ts
+++ b/mage_ai/frontend/utils/string.ts
@@ -253,3 +253,7 @@ export function randomNameGenerator() {
 export function randomSimpleHashGenerator() {
   return `${randomSample(letters)}${randomSample(numbers)}`;
 }
+
+export function cleanName(name: string): string {
+  return name.toLowerCase().replace(/\W+/g, '_')
+}

--- a/mage_integrations/mage_integrations/destinations/base.py
+++ b/mage_integrations/mage_integrations/destinations/base.py
@@ -270,11 +270,15 @@ class Destination():
                 raise Exception(message)
 
             stream = row.get(KEY_STREAM)
+            if TYPE_STATE == row_type:
+                stream = list(row['value']['bookmarks'].keys())[0]
+
             schema = self.schemas.get(stream)
+
             if stream:
                 tags.update(stream=stream)
 
-            if not batches_by_stream.get(stream):
+            if stream and not batches_by_stream.get(stream):
                 batches_by_stream[stream] = dict(
                     record_data=[],
                     state_data=[],
@@ -314,12 +318,14 @@ class Destination():
 
         for stream, batches in batches_by_stream.items():
             record_data = batches['record_data']
+
             if len(record_data) >= 1:
                 self.process_record_data(record_data, stream)
 
-            states = batches['state_data']
-            for state in states:
-                self.process_state(**state)
+                states = batches['state_data']
+
+                for state in states:
+                    self.process_state(**state)
 
     def _emit_state(self, state):
         if state:

--- a/mage_integrations/mage_integrations/sources/base.py
+++ b/mage_integrations/mage_integrations/sources/base.py
@@ -347,10 +347,16 @@ class Source:
 
         if bookmark_properties and not self.is_sorted:
             if max_bookmark:
-                write_state({
-                    stream.tap_stream_id:
-                    {col: max_bookmark[idx] for idx, col in enumerate(bookmark_properties)},
-                })
+                state = {}
+
+                for idx, col in enumerate(bookmark_properties):
+                    singer.write_bookmark(state,
+                        stream.tap_stream_id,
+                        col,
+                        max_bookmark[idx],
+                    )
+
+                write_state(state)
 
         return record_count
 
@@ -381,9 +387,16 @@ class Source:
 
             if REPLICATION_METHOD_INCREMENTAL == stream.replication_method and bookmark_properties:
                 if self.is_sorted:
-                    write_state({
-                        stream.tap_stream_id: {col: row.get(col) for col in bookmark_properties},
-                    })
+                    state = {}
+
+                    for idx, col in enumerate(bookmark_properties):
+                        singer.write_bookmark(state,
+                            stream.tap_stream_id,
+                            col,
+                            row.get(col),
+                        )
+
+                    write_state(state)
                 else:
                     # If data unsorted, save max value until end of writes
                     max_bookmark = max(

--- a/mage_integrations/mage_integrations/sources/sql/base.py
+++ b/mage_integrations/mage_integrations/sources/sql/base.py
@@ -126,12 +126,16 @@ class Source(BaseSource):
 
         while rows_temp is None or len(rows_temp) >= 1:
             order_by_columns = set()
-            if key_properties:
-                order_by_columns.update(key_properties)
-            if unique_constraints:
-                order_by_columns.update(unique_constraints)
+
             if bookmark_properties:
                 order_by_columns.update(bookmark_properties)
+
+            if key_properties:
+                order_by_columns.update(key_properties)
+
+            if unique_constraints:
+                order_by_columns.update(unique_constraints)
+
             order_by_columns = list(order_by_columns)
 
             if order_by_columns:

--- a/mage_integrations/mage_integrations/sources/sql/utils.py
+++ b/mage_integrations/mage_integrations/sources/sql/utils.py
@@ -26,7 +26,7 @@ def column_type_mapping(column_type: str) -> str:
     if COLUMN_TYPE_BOOLEAN == column_type:
         return 'BOOL'
     elif COLUMN_TYPE_INTEGER == column_type:
-        return 'UNSIGNED INTEGER'
+        return 'BIGINT'
     elif COLUMN_TYPE_NUMBER == column_type:
         return 'DECIMAL'
     elif COLUMN_TYPE_OBJECT == column_type:

--- a/mage_integrations/mage_integrations/sources/utils.py
+++ b/mage_integrations/mage_integrations/sources/utils.py
@@ -131,10 +131,10 @@ def update_source_state_from_destination_state(
             f.write('')
 
     with open(absolute_path_to_source_state, 'w') as f:
-        line = '{}'
+        line = json.dumps(dict(bookmarks={}))
         if destination_state and len(destination_state) >= 1:
             line = destination_state[len(destination_state) - 1]
-        f.write(json.dumps(dict(bookmarks=json.loads(line))))
+        f.write(line)
 
 
 def parse_args(required_config_keys):


### PR DESCRIPTION
# Summary
- Use `singer.write_bookmark` to nest bookmarks in a bookmark key
- Then pass that to `write_state`; now state messages contain top level bookmark key in the dictionary
- Support bookmarks for multiple streams
- Always write state for successfully saved streams even if error from another stream

# Tests
<!-- How did you test your change? -->

cc:
<!-- Optionally mention someone to let them know about this pull request -->
