### PR TITLE
[xy] Separate data and code directories.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     volumes:
       - .:/home/src
       - ~/.aws:/root/.aws
+      - ~/.mage_data:/root/.mage_data
     restart: on-failure:5
     stdin_open: true # used for interactive debugging
     tty: true # used for interactive debugging

--- a/mage_ai/data_preparation/logging/logger_manager.py
+++ b/mage_ai/data_preparation/logging/logger_manager.py
@@ -1,7 +1,7 @@
 from mage_ai.data_preparation.logging import LoggingConfig
 from mage_ai.data_preparation.models.constants import LOGS_DIR
 from mage_ai.data_preparation.models.file import File
-from mage_ai.data_preparation.repo_manager import RepoConfig, get_repo_path
+from mage_ai.data_preparation.repo_manager import RepoConfig, get_repo_config
 from mage_ai.shared.array import find
 import io
 import logging
@@ -24,7 +24,7 @@ class LoggerManager:
         self.block_uuid = block_uuid
         self.partition = partition
 
-        self.repo_config = repo_config
+        self.repo_config = repo_config or get_repo_config()
         logging_config = self.repo_config.logging_config if self.repo_config else dict()
         self.logging_config = LoggingConfig.load(config=logging_config)
 
@@ -74,8 +74,7 @@ class LoggerManager:
             os.makedirs(path)
 
     def get_log_filepath_prefix(self):
-        repo_path = self.repo_path or get_repo_path()
-        logs_dir = self.logs_dir or repo_path
+        logs_dir = self.logs_dir or self.repo_config.variables_dir
 
         return os.path.join(
             logs_dir,

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -69,6 +69,14 @@ class Pipeline:
         return self.repo_config.variables_dir
 
     @property
+    def pipeline_variables_dir(self):
+        return os.path.join(
+            self.variables_dir,
+            PIPELINES_FOLDER,
+            self.uuid,
+        )
+
+    @property
     def remote_variables_dir(self):
         return self.repo_config.remote_variables_dir
 

--- a/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
+++ b/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
@@ -46,7 +46,7 @@ class IntegrationPipeline(Pipeline):
 
     @property
     def destination_dir(self) -> str:
-        path = f'{self.pipeline_dir}/{self.destination_uuid}'
+        path = f'{self.pipeline_variables_dir}/{self.destination_uuid}'
         if not os.path.exists(path):
             os.makedirs(path)
         return path
@@ -73,7 +73,7 @@ class IntegrationPipeline(Pipeline):
 
     @property
     def source_dir(self) -> str:
-        path = f'{self.pipeline_dir}/{self.source_uuid}'
+        path = f'{self.pipeline_variables_dir}/{self.source_uuid}'
         if not os.path.exists(path):
             os.makedirs(path)
         return path
@@ -92,10 +92,6 @@ class IntegrationPipeline(Pipeline):
     def transformer_file_path(self) -> str:
         transformer_file = importlib.import_module('mage_integrations.transformers.base')
         return os.path.abspath(transformer_file.__file__)
-
-    @property
-    def pipeline_dir(self) -> str:
-        return '/'.join(self.config_path.split('/')[:-1])
 
     def destination_state_file_path(self, uuid: str) -> str:
         file_path = f'{self.destination_dir}/{clean_name(uuid)}_state'

--- a/mage_ai/data_preparation/repo_manager.py
+++ b/mage_ai/data_preparation/repo_manager.py
@@ -1,4 +1,5 @@
 from mage_ai.data_preparation.shared.constants import REPO_PATH_ENV_VAR
+from mage_ai.shared.environments import is_test
 from mage_ai.data_preparation.templates.utils import copy_template_directory
 from jinja2 import Template
 from typing import Dict
@@ -8,14 +9,17 @@ import traceback
 import yaml
 
 MAGE_DATA_DIR_ENV_VAR = 'MAGE_DATA_DIR'
-DEFAULT_MAGE_DATA_DIR = '~/.mage_data'
+if is_test():
+    DEFAULT_MAGE_DATA_DIR = './'
+else:
+    DEFAULT_MAGE_DATA_DIR = '~/.mage_data'
 
 
 class RepoConfig:
     def __init__(self, repo_path: str = None, config_dict: Dict = None):
         self.repo_path = repo_path or get_repo_path()
         self.repo_name = os.path.basename(self.repo_path)
-        self.variables_dir = os.getenv('MAGE_DATA_DIR', '~/.mage_data')
+        self.variables_dir = os.getenv('MAGE_DATA_DIR', DEFAULT_MAGE_DATA_DIR)
         try:
             if not config_dict:
                 metadata_path = os.path.join(self.repo_path, 'metadata.yaml')
@@ -32,10 +36,11 @@ class RepoConfig:
                 repo_config.get('variables_dir', self.variables_dir),
             )
             if self.variables_dir is not None and not self.variables_dir.startswith('s3'):
-                if os.path.isabs(self.variables_dir) and (
+                if os.path.isabs(self.variables_dir) and self.variables_dir != self.repo_path and (
                     not config_dict or not config_dict.get('variables_dir')
                 ):
-                    # If the variables_dir is an absolute path and from config file
+                    # If the variables_dir is an absolute path, not same as repo_path, and
+                    # from config file
                     self.variables_dir = os.path.join(self.variables_dir, self.repo_name)
                 else:
                     self.variables_dir = os.path.abspath(
@@ -83,7 +88,7 @@ def init_repo(repo_path: str) -> None:
     if os.path.exists(repo_path):
         return
 
-    os.makedirs(os.getenv('MAGE_DATA_DIR', '~/.mage_data'), exists_ok=True)
+    os.makedirs(os.getenv('MAGE_DATA_DIR', DEFAULT_MAGE_DATA_DIR), exists_ok=True)
     copy_template_directory('repo', repo_path)
 
 
@@ -98,3 +103,7 @@ def get_repo_config(repo_path=None) -> RepoConfig:
 def set_repo_path(repo_path: str) -> None:
     os.environ[REPO_PATH_ENV_VAR] = repo_path
     sys.path.append(os.path.dirname(repo_path))
+
+
+def get_variables_dir(repo_path: str = None) -> str:
+    return get_repo_config(repo_path=repo_path).variables_dir

--- a/mage_ai/data_preparation/repo_manager.py
+++ b/mage_ai/data_preparation/repo_manager.py
@@ -7,12 +7,15 @@ import sys
 import traceback
 import yaml
 
+MAGE_DATA_DIR_ENV_VAR = 'MAGE_DATA_DIR'
+DEFAULT_MAGE_DATA_DIR = '~/.mage_data'
+
 
 class RepoConfig:
     def __init__(self, repo_path: str = None, config_dict: Dict = None):
         self.repo_path = repo_path or get_repo_path()
         self.repo_name = os.path.basename(self.repo_path)
-        self.variables_dir = self.repo_path
+        self.variables_dir = os.getenv('MAGE_DATA_DIR', '~/.mage_data')
         try:
             if not config_dict:
                 metadata_path = os.path.join(self.repo_path, 'metadata.yaml')
@@ -25,11 +28,19 @@ class RepoConfig:
             else:
                 repo_config = config_dict
 
-            self.variables_dir = repo_config.get('variables_dir', self.repo_path)
+            self.variables_dir = os.path.expanduser(
+                repo_config.get('variables_dir', self.variables_dir),
+            )
             if self.variables_dir is not None and not self.variables_dir.startswith('s3'):
-                self.variables_dir = os.path.abspath(
-                    os.path.join(self.repo_path, self.variables_dir),
-                )
+                if os.path.isabs(self.variables_dir) and (
+                    not config_dict or not config_dict.get('variables_dir')
+                ):
+                    # If the variables_dir is an absolute path and from config file
+                    self.variables_dir = os.path.join(self.variables_dir, self.repo_name)
+                else:
+                    self.variables_dir = os.path.abspath(
+                        os.path.join(self.repo_path, self.variables_dir),
+                    )
             self.remote_variables_dir = repo_config.get('remote_variables_dir')
             self.ecs_config = repo_config.get('ecs_config')
             self.emr_config = repo_config.get('emr_config')
@@ -72,6 +83,7 @@ def init_repo(repo_path: str) -> None:
     if os.path.exists(repo_path):
         return
 
+    os.makedirs(os.getenv('MAGE_DATA_DIR', '~/.mage_data'), exists_ok=True)
     copy_template_directory('repo', repo_path)
 
 

--- a/mage_ai/data_preparation/repo_manager.py
+++ b/mage_ai/data_preparation/repo_manager.py
@@ -88,7 +88,7 @@ def init_repo(repo_path: str) -> None:
     if os.path.exists(repo_path):
         return
 
-    os.makedirs(os.getenv('MAGE_DATA_DIR', DEFAULT_MAGE_DATA_DIR), exists_ok=True)
+    os.makedirs(os.getenv(MAGE_DATA_DIR_ENV_VAR, DEFAULT_MAGE_DATA_DIR), exists_ok=True)
     copy_template_directory('repo', repo_path)
 
 

--- a/mage_ai/data_preparation/templates/repo/metadata.yaml
+++ b/mage_ai/data_preparation/templates/repo/metadata.yaml
@@ -1,4 +1,4 @@
-variables_dir: ./
+variables_dir: ~/.mage_data
 remote_variables_dir: s3://bucket/path_prefix
 
 emr_config:

--- a/mage_ai/data_preparation/variable_manager.py
+++ b/mage_ai/data_preparation/variable_manager.py
@@ -10,8 +10,8 @@ from mage_ai.data_preparation.models.variable import (
 from mage_ai.data_preparation.storage.local_storage import LocalStorage
 from mage_ai.data_preparation.storage.s3_storage import S3Storage
 from mage_ai.data_preparation.repo_manager import (
-    get_repo_config,
     get_repo_path,
+    get_variables_dir,
 )
 from mage_ai.shared.constants import S3_PREFIX
 from typing import Any, Dict, List
@@ -227,7 +227,7 @@ def get_variable(
     Set block intermediate variable by key.
     Block intermediate variables are stored in variables dir.
     """
-    return VariableManager(get_repo_config().variables_dir).get_variable(
+    return VariableManager(variables_dir=get_variables_dir()).get_variable(
         pipeline_uuid,
         block_uuid,
         key,

--- a/mage_ai/data_preparation/variable_manager.py
+++ b/mage_ai/data_preparation/variable_manager.py
@@ -9,7 +9,10 @@ from mage_ai.data_preparation.models.variable import (
 )
 from mage_ai.data_preparation.storage.local_storage import LocalStorage
 from mage_ai.data_preparation.storage.s3_storage import S3Storage
-from mage_ai.data_preparation.repo_manager import get_repo_path
+from mage_ai.data_preparation.repo_manager import (
+    get_repo_config,
+    get_repo_path,
+)
 from mage_ai.shared.constants import S3_PREFIX
 from typing import Any, Dict, List
 import os
@@ -188,6 +191,9 @@ def get_global_variables(
     pipeline_uuid: str,
     repo_path: str = None,
 ) -> Dict[str, Any]:
+    """
+    Get all global variables. Global variables are stored together with project's code.
+    """
     if repo_path is None:
         repo_path = get_repo_path()
     variables = VariableManager(repo_path).get_variables_by_block(pipeline_uuid, 'global')
@@ -203,6 +209,9 @@ def get_global_variable(
     key: str,
     repo_path: str = None,
 ) -> Any:
+    """
+    Get global variable by key. Global variables are stored together with project's code.
+    """
     if repo_path is None:
         repo_path = get_repo_path()
     return VariableManager(repo_path).get_variable(pipeline_uuid, 'global', key)
@@ -214,7 +223,11 @@ def get_variable(
     key: str,
     **kwargs
 ) -> Any:
-    return VariableManager(get_repo_path()).get_variable(
+    """
+    Set block intermediate variable by key.
+    Block intermediate variables are stored in variables dir.
+    """
+    return VariableManager(get_repo_config().variables_dir).get_variable(
         pipeline_uuid,
         block_uuid,
         key,
@@ -228,6 +241,9 @@ def set_global_variable(
     value: Any,
     repo_path: str = None,
 ) -> None:
+    """
+    Set global variable by key. Global variables are stored together with project's code.
+    """
     if repo_path is None:
         repo_path = get_repo_path()
     VariableManager(repo_path).add_variable(pipeline_uuid, 'global', key, value)
@@ -238,6 +254,9 @@ def delete_global_variable(
     key: str,
     repo_path: str = None,
 ) -> None:
+    """
+    Delete global variable by key. Global variables are stored together with project's code.
+    """
     if repo_path is None:
         repo_path = get_repo_path()
     VariableManager(repo_path).delete_variable(pipeline_uuid, 'global', key)

--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -1,3 +1,4 @@
+from mage_ai.data_preparation.repo_manager import get_variables_dir
 from mage_ai.orchestration.constants import DATABASE_CONNECTION_URL_ENV_VAR
 from mage_ai.shared.environments import is_test
 from sqlalchemy import create_engine
@@ -13,9 +14,14 @@ if not db_connection_url:
     if is_test():
         db_connection_url = f'sqlite:///{TEST_DB}'
     elif os.path.exists('mage_ai/orchestration/db/'):
+        # For local dev environment
         db_connection_url = 'sqlite:///mage_ai/orchestration/db/mage-ai.db'
+    elif os.path.exists('mage-ai.db'):
+        # For backward compatiblility
+        db_connection_url = f'sqlite:///{get_variables_dir()}/mage-ai.db'
     else:
-        db_connection_url = 'sqlite:///mage-ai.db'
+        # For new projects, create mage-ai.db in variables idr
+        db_connection_url = f'sqlite:///{get_variables_dir()}/mage-ai.db'
     db_kwargs['connect_args'] = {'check_same_thread': False}
 
 engine = create_engine(

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -2,7 +2,12 @@ from mage_ai.data_preparation.models.constants import DATAFRAME_SAMPLE_COUNT_PRE
 from mage_ai.data_preparation.models.file import File
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.data_preparation.models.variable import VariableType
-from mage_ai.data_preparation.repo_manager import get_repo_path, init_repo, set_repo_path
+from mage_ai.data_preparation.repo_manager import (
+    get_repo_path,
+    get_variables_dir,
+    init_repo,
+    set_repo_path,
+)
 from mage_ai.data_preparation.shared.constants import MANAGE_ENV_VAR
 from mage_ai.data_preparation.variable_manager import (
     VariableManager,
@@ -273,7 +278,8 @@ class ApiPipelineListHandler(BaseHandler):
 
 class ApiPipelineVariableListHandler(BaseHandler):
     def get(self, pipeline_uuid):
-        variable_manager = VariableManager(get_repo_path())
+        # Get global variables from project's path
+        variable_manager = VariableManager(variables_dir=get_repo_path())
 
         def get_variable_value(block_uuid, variable_uuid):
             variable = variable_manager.get_variable_object(pipeline_uuid, block_uuid, variable_uuid)
@@ -321,7 +327,10 @@ class ApiPipelineVariableListHandler(BaseHandler):
             variable_value,
         )
 
-        variables_dict = VariableManager(get_repo_path()).get_variables_by_pipeline(pipeline_uuid)
+        # Get global variables from project's path
+        variables_dict = VariableManager(
+            variables_dir=get_repo_path(),
+        ).get_variables_by_pipeline(pipeline_uuid)
         variables = [
             dict(
                 block=dict(uuid=uuid),

--- a/mage_ai/tests/data_preparation/models/test_block.py
+++ b/mage_ai/tests/data_preparation/models/test_block.py
@@ -2,6 +2,7 @@ from async_timeout import asyncio
 from mage_ai.data_cleaner.column_types.constants import ColumnType
 from mage_ai.data_preparation.models.block import Block, BlockType
 from mage_ai.data_preparation.models.pipeline import Pipeline
+from mage_ai.data_preparation.repo_manager import get_repo_config
 from mage_ai.data_preparation.variable_manager import VariableManager
 from mage_ai.tests.base_test import DBTestCase
 from pandas.util.testing import assert_frame_equal
@@ -55,7 +56,9 @@ def remove_duplicate_rows(df):
         asyncio.run(block1.execute())
         asyncio.run(block2.execute())
 
-        variable_manager = VariableManager(pipeline.repo_path)
+        variable_manager = VariableManager(
+            variables_dir=get_repo_config(self.repo_path).variables_dir,
+        )
         data = variable_manager.get_variable(
             pipeline.uuid,
             block2.uuid,
@@ -118,7 +121,9 @@ def union_datasets(df1, df2):
         asyncio.run(block2.execute())
         asyncio.run(block3.execute())
 
-        variable_manager = VariableManager(pipeline.repo_path)
+        variable_manager = VariableManager(
+            variables_dir=get_repo_config(self.repo_path).variables_dir,
+        )
         data = variable_manager.get_variable(
             pipeline.uuid,
             block3.uuid,

--- a/mage_ai/tests/data_preparation/test_variable_manager.py
+++ b/mage_ai/tests/data_preparation/test_variable_manager.py
@@ -1,7 +1,7 @@
 from mage_ai.data_preparation.models.block import Block
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.data_preparation.models.variable import VariableType
-from mage_ai.data_preparation.repo_manager import set_repo_path
+from mage_ai.data_preparation.repo_manager import get_repo_config, set_repo_path
 from mage_ai.data_preparation.variable_manager import (
     VariableManager,
     get_global_variable,
@@ -15,7 +15,9 @@ import pandas as pd
 class VariableManagerTest(DBTestCase):
     def test_add_and_get_variable(self):
         self.__create_pipeline('test pipeline 1')
-        variable_manager = VariableManager(self.repo_path)
+        variable_manager = VariableManager(
+            variables_dir=get_repo_config(self.repo_path).variables_dir,
+        )
         data1 = {'k1': 'v1', 'k2': 'v2'}
         data2 = pd.DataFrame([
             ['test1', 1],
@@ -68,7 +70,10 @@ class VariableManagerTest(DBTestCase):
 
     def test_get_variables_by_pipeline(self):
         self.__create_pipeline('test pipeline 2')
-        variable_manager = VariableManager(self.repo_path)
+        variable_manager = VariableManager(
+            repo_path=self.repo_path,
+            variables_dir=get_repo_config(self.repo_path).variables_dir,
+        )
         variable_manager.add_variable('test_pipeline_2', 'block1', 'var1', 1)
         variable_manager.add_variable('test_pipeline_2', 'block1', 'var2', 2)
         variable_manager.add_variable('test_pipeline_2', 'block2', 'var3', 3)

--- a/mage_ai/tests/orchestration/db/test_models.py
+++ b/mage_ai/tests/orchestration/db/test_models.py
@@ -3,6 +3,7 @@ from mage_ai.orchestration.db.models import (
     PipelineRun,
     PipelineSchedule,
 )
+from mage_ai.data_preparation.repo_manager import get_repo_config
 from mage_ai.tests.base_test import DBTestCase
 from mage_ai.tests.factory import (
     create_pipeline_run,
@@ -131,7 +132,7 @@ class PipelineRunTests(DBTestCase):
         )
         execution_date_str = execution_date.strftime(format='%Y%m%dT%H%M%S')
         expected_file_path = os.path.join(
-            self.__class__.repo_path,
+            get_repo_config(self.repo_path).variables_dir,
             'pipelines/test_pipeline/.logs',
             f'{pipeline_run.pipeline_schedule_id}/{execution_date_str}/pipeline.log',
         )
@@ -204,7 +205,7 @@ class BlockRunTests(DBTestCase):
         execution_date_str = execution_date.strftime(format='%Y%m%dT%H%M%S')
         for b in pipeline_run.block_runs:
             expected_file_path = os.path.join(
-                self.__class__.repo_path,
+                get_repo_config(self.repo_path).variables_dir,
                 'pipelines/test_pipeline/.logs',
                 f'{pipeline_run.pipeline_schedule_id}/{execution_date_str}/{b.block_uuid}.log',
             )


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Separate data and code directories. The default directory is `~/.mage_data`. Default directory can be provided via `MAGE_DATA_DIR` environment variable. User can override it in the project's metata.yaml via `variables_dir` field.
* Move variables to separate directory
* Move logs to separate directory.

TODOs
- [x] Move sqlite db to separate directory
- [x] Move state to separate directory

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
