### PR TITLE
[dy] Add partition keys to schema for Bigquery

### DIFF
--- a/mage_integrations/mage_integrations/destinations/base.py
+++ b/mage_integrations/mage_integrations/destinations/base.py
@@ -2,6 +2,7 @@ from jsonschema.validators import Draft4Validator
 from mage_integrations.destinations.constants import (
     KEY_BOOKMARK_PROPERTIES,
     KEY_KEY_PROPERTIES,
+    KEY_PARTITION_KEYS,
     KEY_RECORD,
     KEY_REPLICATION_METHOD,
     KEY_SCHEMA,
@@ -79,12 +80,13 @@ class Destination():
 
         self.config = config
         self.settings = settings
+        self.batch_processing = batch_processing
         self.bookmark_properties = None
         self.config_file_path = config_file_path
         self.debug = debug
         self.key_properties = None
         self.logger = Logger(caller=self, log_to_stdout=log_to_stdout, logger=logger)
-        self.batch_processing = batch_processing
+        self.partition_keys = None
         self.replication_methods = None
         self.schemas = None
         self.settings_file_path = settings_file_path
@@ -202,6 +204,7 @@ class Destination():
 
         self.bookmark_properties[stream] = row.get(KEY_BOOKMARK_PROPERTIES)
         self.key_properties[stream] = row.get(KEY_KEY_PROPERTIES)
+        self.partition_keys[stream] = row.get(KEY_PARTITION_KEYS)
         self.replication_methods[stream] = row.get(KEY_REPLICATION_METHOD)
         self.schemas[stream] = schema
         self.unique_conflict_methods[stream] = row.get(KEY_UNIQUE_CONFLICT_METHOD)
@@ -236,6 +239,7 @@ class Destination():
     def _process(self, input_buffer) -> None:
         self.bookmark_properties = {}
         self.key_properties = {}
+        self.partition_keys = {}
         self.replication_methods = {}
         self.schemas = {}
         self.unique_conflict_methods = {}

--- a/mage_integrations/mage_integrations/destinations/base.py
+++ b/mage_integrations/mage_integrations/destinations/base.py
@@ -204,7 +204,7 @@ class Destination():
 
         self.bookmark_properties[stream] = row.get(KEY_BOOKMARK_PROPERTIES)
         self.key_properties[stream] = row.get(KEY_KEY_PROPERTIES)
-        self.partition_keys[stream] = row.get(KEY_PARTITION_KEYS)
+        self.partition_keys[stream] = row.get(KEY_PARTITION_KEYS, [])
         self.replication_methods[stream] = row.get(KEY_REPLICATION_METHOD)
         self.schemas[stream] = schema
         self.unique_conflict_methods[stream] = row.get(KEY_UNIQUE_CONFLICT_METHOD)

--- a/mage_integrations/mage_integrations/destinations/bigquery/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/bigquery/__init__.py
@@ -35,7 +35,7 @@ class BigQuery(Destination):
         database_name: str = None,
         unique_constraints: List[str] = None,
     ) -> List[str]:
-        return [
+        create_table_command = \
             build_create_table_command(
                 column_type_mapping=column_type_mapping(
                     schema,
@@ -48,7 +48,17 @@ class BigQuery(Destination):
                 full_table_name=f'{schema_name}.{table_name}',
                 # BigQuery doesn't support unique constraints
                 unique_constraints=None,
-            ),
+            )
+
+        if self.partition_keys:
+            create_table_command = f'''
+{create_table_command}
+PARTITION BY
+  {self.partition_keys[0]}
+            '''
+
+        return [
+            create_table_command,
         ]
 
     def build_alter_table_commands(

--- a/mage_integrations/mage_integrations/destinations/bigquery/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/bigquery/__init__.py
@@ -35,26 +35,30 @@ class BigQuery(Destination):
         database_name: str = None,
         unique_constraints: List[str] = None,
     ) -> List[str]:
+        type_mapping = column_type_mapping(
+            schema,
+            convert_column_type,
+            lambda item_type_converted: 'ARRAY',
+            number_type='FLOAT64',
+            string_type='STRING',
+        )
+
         create_table_command = \
             build_create_table_command(
-                column_type_mapping=column_type_mapping(
-                    schema,
-                    convert_column_type,
-                    lambda item_type_converted: 'ARRAY',
-                    number_type='FLOAT64',
-                    string_type='STRING',
-                ),
+                column_type_mapping=type_mapping,
                 columns=schema['properties'].keys(),
                 full_table_name=f'{schema_name}.{table_name}',
                 # BigQuery doesn't support unique constraints
                 unique_constraints=None,
             )
 
-        if self.partition_keys:
+        stream_partition_keys = self.partition_keys.get(stream, [])
+        if len(stream_partition_keys) > 0:
+            partition_col = stream_partition_keys[0]
             create_table_command = f'''
 {create_table_command}
 PARTITION BY
-  {self.partition_keys[0]}
+  DATE({partition_col})
             '''
 
         return [

--- a/mage_integrations/mage_integrations/destinations/bigquery/utils.py
+++ b/mage_integrations/mage_integrations/destinations/bigquery/utils.py
@@ -1,4 +1,8 @@
-from mage_integrations.destinations.constants import COLUMN_TYPE_OBJECT
+from mage_integrations.destinations.constants import (
+    COLUMN_FORMAT_DATETIME,
+    COLUMN_TYPE_OBJECT,
+    COLUMN_TYPE_STRING,
+)
 from mage_integrations.destinations.sql.utils import convert_column_type as convert_column_type_orig
 from typing import Dict
 
@@ -10,6 +14,10 @@ def convert_column_type(
 ) -> str:
     if COLUMN_TYPE_OBJECT == column_type:
         return 'JSON'
+    elif COLUMN_TYPE_STRING == column_type \
+        and COLUMN_FORMAT_DATETIME == column_settings.get('format'):
+        
+        return 'DATETIME'
 
     return convert_column_type_orig(column_type, column_settings, **kwargs)
 
@@ -17,3 +25,4 @@ def convert_column_type(
 def convert_column_to_type(value, column_type) -> str:
     value = value.replace("'", "\\'")
     return f"CAST('{value}' AS {column_type})"
+

--- a/mage_integrations/mage_integrations/destinations/constants.py
+++ b/mage_integrations/mage_integrations/destinations/constants.py
@@ -9,6 +9,7 @@ COLUMN_TYPE_STRING = 'string'
 
 KEY_BOOKMARK_PROPERTIES = 'bookmark_properties'
 KEY_KEY_PROPERTIES = 'key_properties'
+KEY_PARTITION_KEYS = 'partition_keys'
 KEY_RECORD = 'record'
 KEY_REPLICATION_METHOD = 'replication_method'
 KEY_SCHEMA = 'schema'

--- a/mage_integrations/mage_integrations/sources/base.py
+++ b/mage_integrations/mage_integrations/sources/base.py
@@ -303,6 +303,7 @@ class Source:
         write_schema(
             bookmark_properties=self._get_bookmark_properties_for_stream(stream),
             key_properties=stream.key_properties,
+            partition_keys=stream.partition_keys,
             replication_method=stream.replication_method,
             schema=schema_dict,
             stream_name=stream.tap_stream_id,

--- a/mage_integrations/mage_integrations/sources/catalog.py
+++ b/mage_integrations/mage_integrations/sources/catalog.py
@@ -11,6 +11,7 @@ class CatalogEntry(catalog.CatalogEntry):
         self,
         auto_add_new_fields: bool = False,
         bookmark_properties: List[str] = None,
+        partition_keys: List[str] = None,
         unique_conflict_method: str = None,
         unique_constraints: List[str] = None,
         **kwargs,
@@ -18,6 +19,7 @@ class CatalogEntry(catalog.CatalogEntry):
         super().__init__(**kwargs)
         self.auto_add_new_fields = False
         self.bookmark_properties = bookmark_properties
+        self.partition_keys = partition_keys
         self.unique_conflict_method = unique_conflict_method
         self.unique_constraints = unique_constraints
 
@@ -28,6 +30,8 @@ class CatalogEntry(catalog.CatalogEntry):
             result['auto_add_new_fields'] = self.auto_add_new_fields
         if self.bookmark_properties:
             result['bookmark_properties'] = self.bookmark_properties
+        if self.partition_keys:
+            result['partition_keys'] = self.partition_keys
         if self.unique_conflict_method:
             result['unique_conflict_method'] = self.unique_conflict_method
         if self.unique_constraints:
@@ -79,6 +83,7 @@ class Catalog(catalog.Catalog):
             entry.is_view = stream.get('is_view')
             entry.key_properties = stream.get('key_properties')
             entry.metadata = stream.get('metadata')
+            entry.partition_keys = stream.get('partition_keys')
             entry.replication_key = stream.get('replication_key')
             entry.replication_method = stream.get('replication_method')
             entry.schema = catalog.Schema.from_dict(stream.get('schema'))

--- a/mage_integrations/mage_integrations/sources/messages.py
+++ b/mage_integrations/mage_integrations/sources/messages.py
@@ -12,12 +12,14 @@ import sys
 class SchemaMessage(SchemaMessageOriginal):
     def __init__(
         self,
+        partition_keys: List[str] = None,
         replication_method: str = None,
         unique_conflict_method: str = None,
         unique_constraints: List[str] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
+        self.partition_keys = partition_keys
         self.replication_method = replication_method
         self.unique_conflict_method = unique_conflict_method
         self.unique_constraints = unique_constraints
@@ -25,6 +27,8 @@ class SchemaMessage(SchemaMessageOriginal):
     def asdict(self):
         result = super().asdict()
 
+        if self.partition_keys:
+            result['partition_keys'] = self.partition_keys
         if self.replication_method:
             result['replication_method'] = self.replication_method
         if self.unique_conflict_method:
@@ -54,6 +58,7 @@ def write_schema(
     schema,
     key_properties: List[str],
     bookmark_properties: List[str] = None,
+    partition_keys: List[str] = None,
     replication_method: str = None,
     stream_alias: str = None,
     unique_conflict_method: str = None,
@@ -75,6 +80,7 @@ def write_schema(
         SchemaMessage(
             bookmark_properties=bookmark_properties,
             key_properties=key_properties,
+            partition_keys=partition_keys,
             replication_method=replication_method,
             schema=schema,
             stream=(stream_alias or stream_name),


### PR DESCRIPTION
# Summary

Support partition keys for big query. Bigquery only supports one partition key field, but other destinations can support more, so the `partition_keys` field is an array. This adds the `partition_keys` field to the schema field in the data loader yaml.
<!-- Brief summary of what your code does -->

# Tests

tested locally

<img width="428" alt="Screenshot 2022-11-10 at 9 31 17 PM" src="https://user-images.githubusercontent.com/14357209/201270411-af6dc236-a78e-4cdf-b46d-4d9bcd671278.png">


<img width="1117" alt="Screenshot 2022-11-10 at 9 27 23 PM" src="https://user-images.githubusercontent.com/14357209/201270015-bdb264df-044f-467f-857c-012dd4e4da67.png">

<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
