### PR TITLE
[jk] Link to docs in sql comment when adding new dbt model

### DIFF
--- a/mage_ai/frontend/components/FileEditor/index.tsx
+++ b/mage_ai/frontend/components/FileEditor/index.tsx
@@ -32,6 +32,7 @@ type FileEditorProps = {
   fetchPipeline: () => void;
   filePath: string;
   pipeline: PipelineType;
+  selectedFilePath: string;
   setFilesTouched: (data: {
     [path: string]: boolean;
   }) => void;
@@ -44,6 +45,7 @@ function FileEditor({
   fetchPipeline,
   filePath,
   pipeline,
+  selectedFilePath,
   setFilesTouched,
   setSelectedBlock,
 }: FileEditorProps) {
@@ -60,8 +62,10 @@ function FileEditor({
   const [touched, setTouched] = useState<boolean>(false);
 
   useEffect(() => {
-    containerRef?.current?.scrollIntoView();
-  }, [containerRef?.current]);
+    if (selectedFilePath) {
+      containerRef?.current?.scrollIntoView();
+    }
+  }, [selectedFilePath]);
 
   const [updateFile] = useMutation(
     api.file_contents.useUpdate(file?.path),

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -109,7 +109,7 @@ type PipelineDetailProps = {
   setPipelineContentTouched: (value: boolean) => void;
   setRecsWindowOpenBlockIdx: (idx: number) => void;
   setRunningBlocks: (blocks: BlockType[]) => void;
-  setSampleDataVariable: (variable: string) => void; 
+  setSampleDataVariable: (variable: string) => void;
   setSelectedBlock: (block: BlockType) => void;
   setSelectedOutputBlock: (block: BlockType) => void;
   setTextareaFocused: (value: boolean) => void;
@@ -575,7 +575,7 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
                 const finalFilePath = creatingNewDBTModel
                   ? `${filePath}/${addUnderscores(dbtModelName || randomNameGenerator())}.${FileExtensionEnum.SQL}`
                   : filePath;
-                const newBlock = {
+                const newBlock: BlockRequestPayloadType = {
                   configuration: {
                     file_path: finalFilePath,
                   },
@@ -583,6 +583,11 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
                   name: finalFilePath,
                   type: BlockTypeEnum.DBT,
                 };
+                if (creatingNewDBTModel) {
+                  newBlock.content = `--Docs: https://docs.mage.ai/docs/guides/dbt/dependencies
+`;
+                }
+
                 const isAddingFromBlock =
                   typeof lastBlockIndex === 'undefined' || lastBlockIndex === null;
                 const block = blocks[isAddingFromBlock ? blocks.length - 1 : lastBlockIndex];

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1654,6 +1654,7 @@ function PipelineDetailPage({
               fetchPipeline={fetchPipeline}
               filePath={filePath}
               pipeline={pipeline}
+              selectedFilePath={selectedFilePath}
               setFilesTouched={setFilesTouched}
               setSelectedBlock={setSelectedBlock}
             />


### PR DESCRIPTION
# Summary
- Added a comment in new dbt model block referencing docs. This also fixes the bug where new sql files would NOT be immediately created when adding a new dbt model (some content was needed in the code block for the new file to appear; otherwise, the new file would only be created after adding some content to the block and manually saving). 
- UX improvement: Automatically scroll to top when switching to file editor tab (could be confusing if user sees blank space when switching tabs).

# Tests
File immediately created when adding new dbt model:
![2022-11-15 17 46 36](https://user-images.githubusercontent.com/78053898/202063580-6a366c73-a02e-4d4a-b614-d44e92349711.gif)

Scroll file editor block into view when switching tabs:
![after](https://user-images.githubusercontent.com/78053898/202070590-d87c31f9-e898-4fa7-8894-b4752e4bbb8c.gif)


