### PR TITLE
[jk] Bugfixes: Streams tabs overflow and Summary table sticky first column

### DIFF
--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/index.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/index.tsx
@@ -97,6 +97,7 @@ function SchemaSettings({
               </Text>
             ));
           })}
+          stickyFirstColumn
           stickyHeader
           wrapColumns
         />

--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/index.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/index.tsx
@@ -107,6 +107,8 @@ function SchemaSettings({
   return (
     <>
       <ButtonTabs
+        allowScroll
+        noPadding
         onClickTab={(tab) => {
           setSelectedTab(tab);
           setSelectedStream(tab.uuid);

--- a/mage_ai/frontend/components/shared/Table/index.style.tsx
+++ b/mage_ai/frontend/components/shared/Table/index.style.tsx
@@ -85,6 +85,11 @@ export const TableHeadStyle = styled.th<SHARED_TABLE_PROPS & {
     z-index: 1;
     position: sticky;
     top: 0;
+
+    &:first-child {
+      left: 0;
+      z-index: 2;
+    }
   `}
 `;
 
@@ -104,11 +109,10 @@ export const TableDataStyle = styled.td<SHARED_TABLE_PROPS & {
   `}
 
   ${props => props.stickyFirstColumn && `
-    background-color: ${(props.theme || dark).background.rowHoverBackground};
+    background-color: ${(props.theme || dark).background.panel};
     z-index: 1;
     position: sticky;
     left: 0;
-    top: ${ROW_HEIGHT}px;
   `}
 
   ${props => props.selected && `

--- a/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.style.ts
+++ b/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.style.ts
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
+import { hideScrollBar } from '@oracle/styles/scrollbars';
+
+export const TabsContainerStyle = styled.div<{
+  allowScroll?: boolean;
+  noPadding?: boolean;
+}>`
+  padding-left: ${PADDING_UNITS * UNIT}px;
+  padding-right: ${PADDING_UNITS * UNIT}px;
+
+  ${props => props.noPadding && `
+    padding: 0;
+  `}
+
+  ${props => props.allowScroll && `
+    overflow: auto;
+
+    ${hideScrollBar()}
+  `}
+`;

--- a/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.tsx
+++ b/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.tsx
@@ -5,7 +5,8 @@ import FlexContainer from '@oracle/components/FlexContainer';
 import GradientButton from '@oracle/elements/Button/GradientButton';
 import Spacing from '@oracle/elements/Spacing';
 import { PURPLE_BLUE } from '@oracle/styles/colors/gradients';
-import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
+import { TabsContainerStyle } from './index.style';
+import { UNIT } from '@oracle/styles/units/spacing';
 
 export type TabType = {
   Icon?: any;
@@ -15,14 +16,18 @@ export type TabType = {
 };
 
 type ButtonTabsProps = {
+  allowScroll?: boolean;
   contained?: boolean;
+  noPadding?: boolean;
   onClickTab: (tab: TabType) => void;
   selectedTabUUID?: string;
   tabs: TabType[];
 };
 
 function ButtonTabs({
+  allowScroll,
   contained,
+  noPadding,
   onClickTab,
   selectedTabUUID,
   tabs,
@@ -62,7 +67,7 @@ function ButtonTabs({
           <div
             key={`spacing-${uuid}`}
             style={{ marginLeft: 1.5 * UNIT }}
-          />
+          />,
         );
       }
 
@@ -79,7 +84,7 @@ function ButtonTabs({
             paddingUnitsVertical={1.25}
           >
             {el}
-          </GradientButton>
+          </GradientButton>,
         );
       } else {
         arr.push(
@@ -93,7 +98,7 @@ function ButtonTabs({
             >
               {el}
             </Button>
-          </div>
+          </div>,
         );
       }
     });
@@ -116,14 +121,12 @@ function ButtonTabs({
   }
 
   return (
-    <div
-      style={{
-        paddingLeft: PADDING_UNITS * UNIT,
-        paddingRight: PADDING_UNITS * UNIT,
-      }}
+    <TabsContainerStyle
+      allowScroll={allowScroll}
+      noPadding={noPadding}
     >
       {el}
-    </div>
+    </TabsContainerStyle>
   );
 }
 

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -249,7 +249,7 @@ function PipelineSchedules({
             appearBefore
             default
             fullSize
-            label="Creates an @once trigger and runs it immediately"
+            label="Creates an @once trigger and runs pipeline immediately"
             widthFitContent
           >
             <Button


### PR DESCRIPTION
# Summary
- Make streams tabs scrollable so it doesn't overflow container.
- Make first column of summary table sticky for better UX.

# Tests
![2022-11-18 17 00 51](https://user-images.githubusercontent.com/78053898/202826194-7d8cb25f-c79b-471f-ade6-b6a662541827.gif)
