### PR TITLE
[xy] Increase pool size for postgres.

### DIFF
--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -24,6 +24,9 @@ if not db_connection_url:
         db_connection_url = f'sqlite:///{get_variables_dir()}/mage-ai.db'
     db_kwargs['connect_args'] = {'check_same_thread': False}
 
+if db_connection_url.startswith('postgresql'):
+    db_kwargs['pool_size'] = 50
+
 engine = create_engine(
     db_connection_url,
     **db_kwargs,


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Got error below when running multiple schedules at the same time on GCP.
```
psycopg2.OperationalError: connection to server on socket "...." failed: FATAL: remaining connection slots are reserved for non-replication superuser connections
```

Increase pool size for postgres. Default value is 5.
https://docs.sqlalchemy.org/en/14/core/pooling.html

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
