### PR TITLE
[jk] Hide delete confirm dialogue after confirming deletion of trigger

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -420,7 +420,10 @@ function PipelineSchedules({
                 <PopupMenu
                   danger
                   onCancel={() => setDeleteConfirmationOpenIdx(null)}
-                  onClick={() => deletePipelineTrigger(id)}
+                  onClick={() => {
+                    setDeleteConfirmationOpenIdx(null);
+                    deletePipelineTrigger(id);
+                  }}
                   right={UNIT * 2}
                   title={`Are you sure you want to delete the trigger ${name}?`}
                   top={(windowHeight / 2) - (UNIT * 16)}


### PR DESCRIPTION
# Summary
- This PR fixes a bug where the trigger delete confirm dialogue appears after pressing "Sync run now" button if the most recent trigger has just been deleted.

# Tests
- Locally
