### PR TITLE
One hot encode added to transform

### DIFF
--- a/mage_ai/data_cleaner/transformer_actions/base.py
+++ b/mage_ai/data_cleaner/transformer_actions/base.py
@@ -43,6 +43,7 @@ FUNCTION_MAPPING = {
         ActionType.MAX: column.max,
         ActionType.MEDIAN: column.median,
         ActionType.MIN: column.min,
+        ActionType.ONE_HOT_ENCODE: column.one_hot_encode,
         ActionType.REFORMAT: column.reformat,
         ActionType.REMOVE: column.remove_column,
         ActionType.REMOVE_OUTLIERS: column.remove_outliers,

--- a/mage_ai/data_cleaner/transformer_actions/column.py
+++ b/mage_ai/data_cleaner/transformer_actions/column.py
@@ -216,7 +216,12 @@ def reformat(df, action, **kwargs):
             )
 
     return df
-
+    
+def one_hot_encode(df, action, **kwargs):
+    columns = action['action_arguments']
+    df = pd.concat([df.drop(columns,axis=1), pd.get_dummies(df[columns])], axis=1)
+    
+    return df
 
 def remove_column(df, action, **kwargs):
     cols = action['action_arguments']

--- a/mage_ai/data_cleaner/transformer_actions/constants.py
+++ b/mage_ai/data_cleaner/transformer_actions/constants.py
@@ -71,6 +71,7 @@ class ActionType(str, Enum):
     UPDATE_VALUE = 'update_value'
     NORMALIZE = 'normalize'
     STANDARDIZE = 'standardize'
+    ONE_HOT_ENCODE = 'one_hot_encode'
 
 
 class Axis(str, Enum):

--- a/mage_ai/data_preparation/templates/transformers/transformer_actions/column/one_hot_encode.py
+++ b/mage_ai/data_preparation/templates/transformers/transformer_actions/column/one_hot_encode.py
@@ -1,0 +1,18 @@
+{% extends "transformers/transformer_actions/action.jinja" %}
+{% block imports %}
+{{ super() -}}
+{% endblock %}
+{% block action %}
+    """
+    Execute Transformer Action: ActionType.ONE_HOT_ENCODE
+
+    Docs: https://github.com/mage-ai/mage-ai/blob/master/docs/actions/transformer_actions/README.md#one-hot-encode
+    """
+    action = build_transformer_action(
+        df,
+        action_type=ActionType.ONE_HOT_ENCODE,
+        arguments=[],  # Specify columns to normalize
+        axis=Axis.COLUMN,
+        
+    )
+{% endblock %}

--- a/mage_ai/frontend/interfaces/ActionPayloadType.ts
+++ b/mage_ai/frontend/interfaces/ActionPayloadType.ts
@@ -22,6 +22,7 @@ export enum ActionTypeEnum {
   MIN = 'min',
   MODE = 'mode',
   NORMALIZE = 'normalize',
+  ONE_HOT_ENCODE = 'one_hot_encode',
   REFORMAT = 'reformat',
   REMOVE = 'remove',
   REMOVE_OUTLIERS = 'remove_outliers',

--- a/mage_ai/frontend/interfaces/TransformerActionType.ts
+++ b/mage_ai/frontend/interfaces/TransformerActionType.ts
@@ -20,6 +20,7 @@ export const COLUMN_ACTIONS: ActionTypeEnum[] = [
   ActionTypeEnum.MEDIAN,
   ActionTypeEnum.MIN,
   ActionTypeEnum.NORMALIZE,
+  ActionTypeEnum.ONE_HOT_ENCODE,
   ActionTypeEnum.REFORMAT,
   ActionTypeEnum.REMOVE,
   ActionTypeEnum.REMOVE_OUTLIERS,
@@ -44,6 +45,7 @@ export enum ActionGroupingEnum {
   SHIFT_ROWS = 'Shift rows in a column',
   MISC = 'Miscellaneous',
   FEATURE_SCALING = 'Feature Scaling',
+  ENCODING = 'Encoding',
 }
 
 export const ACTION_GROUPING_MAPPING = {
@@ -81,6 +83,9 @@ export const ACTION_GROUPING_MAPPING = {
       ActionTypeEnum.NORMALIZE,
       ActionTypeEnum.STANDARDIZE,
     ],
+    [ActionGroupingEnum.ENCODING]: [
+      ActionTypeEnum.ONE_HOT_ENCODE,
+    ],
 
   },
   [AxisEnum.ROW]: {
@@ -111,6 +116,7 @@ export const ACTION_TYPE_HUMAN_READABLE_MAPPING = {
     [ActionTypeEnum.MAX]: 'Aggregate by maximum value',
     [ActionTypeEnum.MEDIAN]: 'Aggregate by median value',
     [ActionTypeEnum.MIN]: 'Aggregate by mininum value',
+    [ActionTypeEnum.ONE_HOT_ENCODE]: 'One Hot Encode Column',
     [ActionTypeEnum.REFORMAT]: 'Reformat',
     [ActionTypeEnum.REMOVE_OUTLIERS]: 'Remove outliers',
     [ActionTypeEnum.REMOVE]: 'Remove column(s)',


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
One Hot Encoding is used to convert numerical categorical variables into binary vectors. This is generally performed during the data preprocessing step.
Mage-Ai includes some common used transformations but one hot encoding is not a part of the tool right now. 

**Describe the solution you'd like**
User is able to select “One Hot Encoding” from the “Transformer” option on the tool. Once the use selects it, the transformation step is added in the pipeline and return the data including  the one hot encoded (get dummies) is performed.

**Additional context**
I intend to implement using the scikit learn library