### PR TITLE
[dy] Add option to run integration streams in parallel

### DIFF
--- a/mage_ai/data_integrations/utils/scheduler.py
+++ b/mage_ai/data_integrations/utils/scheduler.py
@@ -1,19 +1,29 @@
+import json
+import math
+import os
+import shutil
+from typing import Dict, List
+
 from mage_ai.data_integrations.sources.constants import SQL_SOURCES
 from mage_ai.data_preparation.logging.logger import DictLogger
-from mage_ai.data_preparation.models.pipelines.integration_pipeline import IntegrationPipeline
+from mage_ai.data_preparation.models.pipelines.integration_pipeline import (
+    IntegrationPipeline,
+)
 from mage_ai.orchestration.db import db_connection
 from mage_ai.orchestration.db.models.schedules import BlockRun, PipelineRun
 from mage_ai.orchestration.metrics.pipeline_run import calculate_metrics
 from mage_ai.shared.array import find
 from mage_ai.shared.hash import index_by, merge_dict
-from typing import Dict, List
-import json
-import math
-import os
-import shutil
-
 
 SQL_SOURCES_UUID = [d.get('uuid', d['name'].lower()) for d in SQL_SOURCES]
+
+
+def get_extra_variables(pipeline: IntegrationPipeline) -> Dict:
+    return {
+        'pipeline.name': pipeline.name,
+        'pipeline.uuid': pipeline.uuid,
+        'pipeline_uuid': pipeline.uuid,
+    }
 
 
 def clear_source_output_files(
@@ -164,7 +174,9 @@ def create_block_runs(pipeline_run: PipelineRun, logger: DictLogger) -> List[Blo
 
 
 def update_stream_states(pipeline_run: PipelineRun, logger: DictLogger, variables: Dict) -> None:
-    from mage_integrations.sources.utils import update_source_state_from_destination_state
+    from mage_integrations.sources.utils import (
+        update_source_state_from_destination_state,
+    )
 
     integration_pipeline = IntegrationPipeline.get(pipeline_run.pipeline_uuid)
 

--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
@@ -104,6 +104,7 @@ function SchemaTable({
     metadata,
     partition_keys: partitionKeys,
     replication_method: replicationMethod,
+    run_in_parallel: runInParallel,
     schema: {
       properties,
     },
@@ -830,6 +831,78 @@ function SchemaTable({
           Settings
         </Headline>
 
+<<<<<<< HEAD
+=======
+        <Spacing mb={SPACING_BOTTOM_UNITS}>
+          <Spacing mb={1}>
+            <FlexContainer alignItems="center" flexWrap="wrap">
+              <Text bold large>
+                Run stream in parallel
+              </Text>
+              <Spacing ml={1} />
+              <Checkbox
+                checked={runInParallel}
+                key={`${streamUUID}/run_in_parallel`}
+                onClick={() => updateStream(streamUUID, (stream: StreamType) => {
+                  stream.run_in_parallel = !runInParallel;
+                  return stream;
+                })}
+              />
+            </FlexContainer>
+            <Text default>
+              Parallel streams will be run at the same time, so make sure there are no dependencies between them.
+            </Text>
+          </Spacing>
+        </Spacing>
+
+        <Spacing mb={SPACING_BOTTOM_UNITS}>
+          <Spacing mb={1}>
+            <Text bold large>
+              Replication method
+            </Text>
+            <Text default>
+              Do you want to synchronize the entire stream (<Text bold inline monospace>
+                {ReplicationMethodEnum.FULL_TABLE}
+              </Text>)
+              on each integration pipeline run or
+              only new records (<Text bold inline monospace>
+                {ReplicationMethodEnum.INCREMENTAL}
+              </Text>)?
+              {source === IntegrationSourceEnum.POSTGRESQL &&
+                <Text default>
+                  Log-based incremental replication (<Text bold inline monospace>
+                    {ReplicationMethodEnum.LOG_BASED}
+                  </Text>)
+                  is also available for PostgreSQL sources.
+                </Text>
+              }
+            </Text>
+          </Spacing>
+
+          <Select
+            onChange={(e) => {
+              updateStream(streamUUID, (stream: StreamType) => ({
+                ...stream,
+                replication_method: e.target.value,
+              }));
+            }}
+            primary
+            value={replicationMethod}
+          >
+            <option value="" />
+            {Object.values(ReplicationMethodEnum)
+              .filter(method => (source === IntegrationSourceEnum.POSTGRESQL
+                ? true
+                : method !== ReplicationMethodEnum.LOG_BASED))
+              .map(method => (
+                <option key={method} value={method}>
+                  {method}
+                </option>
+            ))}
+          </Select>
+        </Spacing>
+
+>>>>>>> cf2110040 ([dy] Run streams in parallel)
         {ReplicationMethodEnum.INCREMENTAL === replicationMethod && (
           <Spacing mb={SPACING_BOTTOM_UNITS}>
             <Spacing mb={1}>

--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
@@ -146,7 +146,12 @@ function SchemaTable({
         [streamUUID]: bookmarkValuesInit,
       }));
     }
-  }, [bookmarkProperties?.length, bookmarkValuesInit, streamUUID]);
+  }, [
+    bookmarkProperties?.length,
+    bookmarkValues,
+    bookmarkValuesInit,
+    streamUUID,
+  ]);
 
   const metadataByColumn = useMemo(() => indexBy(metadata, ({ breadcrumb }) => breadcrumb.join('/')), [
     metadata,
@@ -575,6 +580,7 @@ function SchemaTable({
     metadataByColumn,
     partitionKeys,
     properties,
+    removeBookmarkPropertyFromState,
     showPartitionKey,
     streamUUID,
     uniqueConstraints,
@@ -833,23 +839,21 @@ function SchemaTable({
 
         <Spacing mb={SPACING_BOTTOM_UNITS}>
           <Spacing mb={1}>
-            <FlexContainer alignItems="center" flexWrap="wrap">
-              <Text bold large>
-                Run stream in parallel
-              </Text>
-              <Spacing ml={1} />
-              <Checkbox
-                checked={runInParallel}
-                key={`${streamUUID}/run_in_parallel`}
-                onClick={() => updateStream(streamUUID, (stream: StreamType) => {
-                  stream.run_in_parallel = !runInParallel;
-                  return stream;
-                })}
-              />
-            </FlexContainer>
+            <Text bold large>
+              Run stream in parallel
+            </Text>
             <Text default>
               Parallel streams will be run at the same time, so make sure there are no dependencies between them.
             </Text>
+            <Spacing mb={1} />
+            <ToggleSwitch
+              checked={runInParallel}
+              key={`${streamUUID}/run_in_parallel`}
+              onCheck={() => updateStream(streamUUID, (stream: StreamType) => {
+                stream.run_in_parallel = !runInParallel;
+                return stream;
+              })}
+            />
           </Spacing>
         </Spacing>
 

--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
@@ -831,8 +831,6 @@ function SchemaTable({
           Settings
         </Headline>
 
-<<<<<<< HEAD
-=======
         <Spacing mb={SPACING_BOTTOM_UNITS}>
           <Spacing mb={1}>
             <FlexContainer alignItems="center" flexWrap="wrap">
@@ -855,54 +853,6 @@ function SchemaTable({
           </Spacing>
         </Spacing>
 
-        <Spacing mb={SPACING_BOTTOM_UNITS}>
-          <Spacing mb={1}>
-            <Text bold large>
-              Replication method
-            </Text>
-            <Text default>
-              Do you want to synchronize the entire stream (<Text bold inline monospace>
-                {ReplicationMethodEnum.FULL_TABLE}
-              </Text>)
-              on each integration pipeline run or
-              only new records (<Text bold inline monospace>
-                {ReplicationMethodEnum.INCREMENTAL}
-              </Text>)?
-              {source === IntegrationSourceEnum.POSTGRESQL &&
-                <Text default>
-                  Log-based incremental replication (<Text bold inline monospace>
-                    {ReplicationMethodEnum.LOG_BASED}
-                  </Text>)
-                  is also available for PostgreSQL sources.
-                </Text>
-              }
-            </Text>
-          </Spacing>
-
-          <Select
-            onChange={(e) => {
-              updateStream(streamUUID, (stream: StreamType) => ({
-                ...stream,
-                replication_method: e.target.value,
-              }));
-            }}
-            primary
-            value={replicationMethod}
-          >
-            <option value="" />
-            {Object.values(ReplicationMethodEnum)
-              .filter(method => (source === IntegrationSourceEnum.POSTGRESQL
-                ? true
-                : method !== ReplicationMethodEnum.LOG_BASED))
-              .map(method => (
-                <option key={method} value={method}>
-                  {method}
-                </option>
-            ))}
-          </Select>
-        </Spacing>
-
->>>>>>> cf2110040 ([dy] Run streams in parallel)
         {ReplicationMethodEnum.INCREMENTAL === replicationMethod && (
           <Spacing mb={SPACING_BOTTOM_UNITS}>
             <Spacing mb={1}>

--- a/mage_ai/frontend/interfaces/IntegrationSourceType.ts
+++ b/mage_ai/frontend/interfaces/IntegrationSourceType.ts
@@ -102,6 +102,7 @@ export interface StreamType {
   partition_keys: string[];
   replication_key: string;
   replication_method: ReplicationMethodEnum;
+  run_in_parallel?: boolean;
   schema: SchemaType;
   stream: string;
   tap_stream_id: string;

--- a/mage_ai/frontend/oracle/elements/Inputs/ToggleSwitch.tsx
+++ b/mage_ai/frontend/oracle/elements/Inputs/ToggleSwitch.tsx
@@ -15,7 +15,7 @@ type ToggleSwitchProps = {
 } & InputWrapperProps;
 
 const ToggleSwitchStyle = styled.label<
-  InputWrapperProps & {monotone?: boolean }
+  InputWrapperProps & { monotone?: boolean }
 >`
   ${SHARED_INPUT_STYLES}
 

--- a/mage_ai/orchestration/job_manager.py
+++ b/mage_ai/orchestration/job_manager.py
@@ -7,6 +7,7 @@ from mage_ai.orchestration.queue.queue_factory import QueueFactory
 class JobType(str, Enum):
     BLOCK_RUN = 'block_run'
     PIPELINE_RUN = 'pipeline_run'
+    INTEGRATION_STREAM = 'integration_stream'
 
 
 class JobManager:
@@ -36,6 +37,10 @@ class JobManager:
         job_id = self.__job_id(JobType.PIPELINE_RUN, pipeline_run_id)
         return self.queue.has_job(job_id)
 
+    def has_integration_stream_job(self, pipeline_run_id, stream):
+        job_id = self.__job_id(JobType.PIPELINE_RUN, f'{pipeline_run_id}_{stream}')
+        return self.queue.has_job(job_id)
+
     def kill_block_run_job(self, block_run_id):
         print(f'Kill block run id: {block_run_id}')
         job_id = self.__job_id(JobType.BLOCK_RUN, block_run_id)
@@ -44,6 +49,12 @@ class JobManager:
     def kill_pipeline_run_job(self, pipeline_run_id):
         print(f'Kill pipeline run id: {pipeline_run_id}')
         job_id = self.__job_id(JobType.PIPELINE_RUN, pipeline_run_id)
+        return self.queue.kill_job(job_id)
+
+    def kill_integration_stream_job(self, pipeline_run_id, stream):
+        id = f'{pipeline_run_id}_{stream}'
+        print(f'Kill integration stream id: {id}')
+        job_id = self.__job_id(JobType.INTEGRATION_STREAM, id)
         return self.queue.kill_job(job_id)
 
     def __job_id(self, job_type: JobType, uid: Union[str, int]):

--- a/mage_integrations/mage_integrations/sources/catalog.py
+++ b/mage_integrations/mage_integrations/sources/catalog.py
@@ -13,6 +13,7 @@ class CatalogEntry(catalog.CatalogEntry):
         disable_column_type_check: bool = None,
         bookmark_properties: List[str] = None,
         partition_keys: List[str] = None,
+        run_in_parallel: bool = False,
         unique_conflict_method: str = None,
         unique_constraints: List[str] = None,
         **kwargs,
@@ -22,6 +23,7 @@ class CatalogEntry(catalog.CatalogEntry):
         self.bookmark_properties = bookmark_properties
         self.disable_column_type_check = disable_column_type_check
         self.partition_keys = partition_keys
+        self.run_in_parallel = run_in_parallel
         self.unique_conflict_method = unique_conflict_method
         self.unique_constraints = unique_constraints
 
@@ -36,6 +38,8 @@ class CatalogEntry(catalog.CatalogEntry):
             result['disable_column_type_check'] = self.disable_column_type_check
         if self.partition_keys:
             result['partition_keys'] = self.partition_keys
+        if self.run_in_parallel:
+            result['run_in_parallel'] = self.run_in_parallel
         if self.unique_conflict_method:
             result['unique_conflict_method'] = self.unique_conflict_method
         if self.unique_constraints:
@@ -93,6 +97,7 @@ class Catalog(catalog.Catalog):
             entry.partition_keys = stream.get('partition_keys')
             entry.replication_key = stream.get('replication_key')
             entry.replication_method = stream.get('replication_method')
+            entry.run_in_parallel = stream.get('run_in_parallel')
             entry.schema = catalog.Schema.from_dict(stream.get('schema'))
             entry.stream = stream.get('stream')
             entry.stream_alias = stream.get('stream_alias')


### PR DESCRIPTION
# Summary

Run streams in parallel if they are marked as parallel. I added the `run_in_parallel` config to the stream catalog entry.

I updated the `run_integration_pipeline` method in `pipeline_scheduler` to queue a job for each parallel stream and another job for all non-parallel streams. The code that is run for each stream should be unchanged, but the structure of an integration pipeline run is different.


![Screenshot 2023-07-12 at 6 05 58 PM](https://github.com/mage-ai/mage-ai/assets/14357209/f72cea1b-63e8-46f6-901c-f0f3719eb294)

<!-- Brief summary of what your code does -->

# Tests

tested locally
<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
