### PR TITLE
[jk] Limit log fetching

### DIFF
--- a/mage_ai/frontend/components/Logs/Filter/index.tsx
+++ b/mage_ai/frontend/components/Logs/Filter/index.tsx
@@ -11,6 +11,7 @@ import Text from '@oracle/elements/Text';
 import { BeforeStyle } from '@components/PipelineDetail/shared/index.style';
 import { BlockTypeEnum } from '@interfaces/BlockType';
 import { FilterRowStyle } from './index.style';
+import { LIMIT_PARAM, LOG_FILE_COUNT_INTERVAL, OFFSET_PARAM } from '../Toolbar/constants';
 import { LogLevelEnum, LOG_LEVELS } from '@interfaces/LogType';
 import { LogLevelIndicatorStyle } from '../index.style';
 import { PADDING_UNITS } from '@oracle/styles/units/spacing';
@@ -41,7 +42,10 @@ function Filter({
   query,
 }: FilterProps) {
   const themeContext = useContext(ThemeContext);
-  const goTo = useCallback((q1, { isList }) => {
+  const goTo = useCallback((
+    q1: any,
+    { isList, resetLimitParams }: { isList: boolean, resetLimitParams?: boolean },
+  ) => {
     let q2 = { ...query };
 
     if (isList) {
@@ -65,6 +69,11 @@ function Filter({
         ...q2,
         ...q1,
       };
+    }
+
+    if (resetLimitParams) {
+      q2[LIMIT_PARAM] = LOG_FILE_COUNT_INTERVAL;
+      q2[OFFSET_PARAM] = 0;
     }
 
     goToWithQuery(q2);
@@ -170,7 +179,10 @@ function Filter({
               noBackground
               noBorder
               noPadding
-              onClick={() => goTo({ block_uuid: block.uuid }, { isList: true })}
+              onClick={() => goTo(
+                { block_uuid: block.uuid },
+                { isList: true, resetLimitParams: true },
+              )}
             >
               <FilterRowStyle>
                 <FlexContainer alignItems="center">

--- a/mage_ai/frontend/components/Logs/Toolbar/constants.ts
+++ b/mage_ai/frontend/components/Logs/Toolbar/constants.ts
@@ -1,6 +1,9 @@
 import { LogRangeEnum } from '@interfaces/LogType';
 
+export const LIMIT_PARAM = '_limit';
+export const OFFSET_PARAM = '_offset';
 export const LOG_ITEMS_PER_PAGE = 100;
+export const LOG_FILE_COUNT_INTERVAL = 20;
 
 export const SPECIFIC_LOG_RANGES = [
   LogRangeEnum.LAST_HOUR,

--- a/mage_ai/frontend/components/Logs/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/Logs/Toolbar/index.tsx
@@ -40,6 +40,7 @@ enum RangeQueryEnum {
 
 type LogToolbarProps = {
   allPastLogsLoaded: boolean;
+  loadNewerLogInterval: () => void;
   loadPastLogInterval: () => void;
   selectedRange: LogRangeEnum;
   setSelectedRange: (range: LogRangeEnum) => void;
@@ -52,6 +53,7 @@ const SHARED_LOG_QUERY_PARAMS = {
 
 function LogToolbar({
   allPastLogsLoaded,
+  loadNewerLogInterval,
   loadPastLogInterval,
   selectedRange,
   setSelectedRange,
@@ -123,6 +125,20 @@ function LogToolbar({
           uuid="logs/load_older_logs"
         >
           {allPastLogsLoaded ? 'All past logs within range loaded' : 'Load older logs'}
+        </KeyboardShortcutButton>
+
+        <Spacing mr={1} />
+
+        <KeyboardShortcutButton
+          blackBorder
+          disabled={q?._offset <= 0}
+          inline
+          onClick={loadNewerLogInterval}
+          paddingBottom={UNIT * 0.75}
+          paddingTop={UNIT * 0.75}
+          uuid="logs/load_newer_logs"
+        >
+          Load newer logs
         </KeyboardShortcutButton>
 
         <Spacing mr={2} />

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -270,7 +270,7 @@ function BlockRuns({
     let newOffset = offset;
     if (limit >= LOG_FILE_COUNT_INTERVAL) {
       newLimit = Math.max(LOG_FILE_COUNT_INTERVAL, (limit - LOG_FILE_COUNT_INTERVAL));
-      if (limit >= greaterLogCount) {
+      if (limit >= greaterLogCount && (greaterLogCount % LOG_FILE_COUNT_INTERVAL !== 0)) {
         newLimit = greaterLogCount - (greaterLogCount % LOG_FILE_COUNT_INTERVAL);
       }
       newOffset = Math.max(0, (offset - LOG_FILE_COUNT_INTERVAL));

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -161,7 +161,7 @@ function BlockRuns({
   }, [
     dataLogs,
   ]);
-  const allPastLogsLoaded = q?._limit >= totalBlockRunLogCount && q?._limit >= totalPipelineRunLogCount;
+  const allPastLogsLoaded = +q?._limit >= totalBlockRunLogCount && +q?._limit >= totalPipelineRunLogCount;
   const logsAll: LogType[] = useMemo(() => sortByKey(
       blockRunLogs
         .concat(pipelineRunLogs)
@@ -468,10 +468,14 @@ function BlockRuns({
           inline
           onClick={() => {
             setScrollToBottom(true);
-            goToWithQuery({
-              _limit: LOG_FILE_COUNT_INTERVAL,
-              _offset: 0,
-            });
+            if (q?._offset === '0' && q?._limit === String(LOG_FILE_COUNT_INTERVAL)) {
+              fetchLogs(null);
+            } else {
+              goToWithQuery({
+                _limit: LOG_FILE_COUNT_INTERVAL,
+                _offset: 0,
+              });
+            }
           }}
           paddingBottom={UNIT * 0.75}
           paddingTop={UNIT * 0.75}

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -3,6 +3,7 @@ import NextLink from 'next/link';
 import { ThemeContext } from 'styled-components';
 import { parse } from 'yaml';
 import {
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -30,7 +31,12 @@ import LogToolbar from '@components/Logs/Toolbar';
 import api from '@api';
 import usePrevious from '@utils/usePrevious';
 import { ChevronRight } from '@oracle/icons';
-import { LOG_ITEMS_PER_PAGE, LOG_RANGE_SEC_INTERVAL_MAPPING } from '@components/Logs/Toolbar/constants';
+import {
+  LIMIT_PARAM,
+  OFFSET_PARAM,
+  LOG_FILE_COUNT_INTERVAL,
+  LOG_RANGE_SEC_INTERVAL_MAPPING,
+} from '@components/Logs/Toolbar/constants';
 import { LogLevelIndicatorStyle } from '@components/Logs/index.style';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
@@ -60,7 +66,6 @@ function BlockRuns({
   const bottomOfPageButtonRef = useRef(null);
   const pipelineUUID = pipelineProp.uuid;
 
-  const [offset, setOffset] = useState(LOG_ITEMS_PER_PAGE);
   const [query, setQuery] = useState<FilterQueryType>(null);
   const [selectedLog, setSelectedLog] = useState<LogType>(null);
   const [selectedRange, setSelectedRange] = useState<LogRangeEnum>(null);
@@ -128,26 +133,35 @@ function BlockRuns({
   const {
     blockRunLogs,
     pipelineRunLogs,
+    totalBlockRunLogCount,
+    totalPipelineRunLogCount,
   } = useMemo(() => {
     if (dataLogs?.logs?.[0]) {
       const {
         block_run_logs: brLogs,
         pipeline_run_logs: prLogs,
+        total_block_run_log_count: brLogCount,
+        total_pipeline_run_log_count: prLogCount,
       } = dataLogs.logs?.[0] || {};
 
       return {
         blockRunLogs: brLogs,
         pipelineRunLogs: prLogs,
+        totalBlockRunLogCount: brLogCount,
+        totalPipelineRunLogCount: prLogCount,
       };
     }
 
     return {
       blockRunLogs: [],
       pipelineRunLogs: [],
+      totalBlockRunLogCount: 0,
+      totalPipelineRunLogCount: 0,
     };
   }, [
     dataLogs,
   ]);
+  const allPastLogsLoaded = q?._limit >= totalBlockRunLogCount && q?._limit >= totalPipelineRunLogCount;
   const logsAll: LogType[] = useMemo(() => sortByKey(
       blockRunLogs
         .concat(pipelineRunLogs)
@@ -182,30 +196,25 @@ function BlockRuns({
 
         return evals.every(v => v);
       }), [
-    blocksByUUID,
-    logsAll,
-    query,
-  ]);
-  const filteredLogCount = logsFiltered.length;
-  const logs: LogType[] = useMemo(() => logsFiltered.slice(
-    Math.max(0, (filteredLogCount - offset)),
-  ), [
-      filteredLogCount,
-      logsFiltered,
-      offset,
+        blocksByUUID,
+        isIntegrationPipeline,
+        logsAll,
+        query,
     ]);
+  const filteredLogCount = logsFiltered.length;
 
   const qPrev = usePrevious(q);
   useEffect(() => {
     if (onlyLoadPastDayLogs) {
       goToWithQuery({
+        [LIMIT_PARAM]: LOG_FILE_COUNT_INTERVAL,
+        [OFFSET_PARAM]: 0,
         start_timestamp: dayAgoTimestamp,
       });
     }
   }, []);
   useEffect(() => {
     if (!isEqual(q, qPrev)) {
-      setOffset(LOG_ITEMS_PER_PAGE);
       setQuery(q);
     }
   }, [
@@ -235,6 +244,24 @@ function BlockRuns({
     scrollToBottom,
     isLoading,
   ]);
+
+  const loadPastLogInterval = useCallback(() => {
+    const { _limit, _offset } = q;
+    const limit = +(_limit || 0);
+    const offset = +(_offset || 0);
+    let newLimit = limit;
+    let newOffset = offset;
+    if (totalBlockRunLogCount > limit || totalPipelineRunLogCount > limit) {
+      const greaterLogCount = Math.max(totalBlockRunLogCount, totalPipelineRunLogCount);
+      newLimit = Math.min(greaterLogCount, (limit + LOG_FILE_COUNT_INTERVAL));
+      newOffset = Math.min((greaterLogCount - LOG_FILE_COUNT_INTERVAL), (offset + LOG_FILE_COUNT_INTERVAL));
+      goToWithQuery({
+        ...q,
+        [LIMIT_PARAM]: newLimit,
+        [OFFSET_PARAM]: newOffset,
+      });
+    }
+  }, [q, totalBlockRunLogCount, totalPipelineRunLogCount]);
 
   return (
     <PipelineDetailPage
@@ -271,12 +298,11 @@ function BlockRuns({
         <Text>
           {!isLoading && (
             <>
-              {numberWithCommas(logs.length)} logs of {numberWithCommas(filteredLogCount)} found
+              {numberWithCommas(filteredLogCount)} logs found
               <LogToolbar
-                logCount={filteredLogCount}
-                logOffset={offset}
+                allPastLogsLoaded={allPastLogsLoaded}
+                loadPastLogInterval={loadPastLogInterval}
                 selectedRange={selectedRange}
-                setLogOffset={setOffset}
                 setSelectedRange={setSelectedRange}
               />
             </>
@@ -293,7 +319,7 @@ function BlockRuns({
         </Spacing>
       )}
 
-      {!isLoading && logs.length >= 1 && (
+      {!isLoading && logsFiltered.length >= 1 && (
         <Table
           columnFlex={[null, null, 1, 9, null]}
           columnMaxWidth={(idx: number) => idx === 3 ? '100px' : null}
@@ -318,7 +344,7 @@ function BlockRuns({
           ]}
           compact
           onClickRow={(rowIndex: number) => {
-            const log = logs[rowIndex];
+            const log = logsFiltered[rowIndex];
             let logUUID = log.data?.uuid;
 
             if (query[LOG_UUID_PARAM] === logUUID) {
@@ -328,7 +354,7 @@ function BlockRuns({
             goToWithQuery({ [LOG_UUID_PARAM]: logUUID });
             setSelectedLog(logUUID ? log : null);
           }}
-          rows={logs?.map(({
+          rows={logsFiltered?.map(({
             content,
             createdAt,
             data,
@@ -442,7 +468,10 @@ function BlockRuns({
           inline
           onClick={() => {
             setScrollToBottom(true);
-            fetchLogs(null);
+            goToWithQuery({
+              _limit: LOG_FILE_COUNT_INTERVAL,
+              _offset: 0,
+            });
           }}
           paddingBottom={UNIT * 0.75}
           paddingTop={UNIT * 0.75}

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -254,9 +254,9 @@ function BlockRuns({
     let newOffset = offset;
     if (totalBlockRunLogCount > limit || totalPipelineRunLogCount > limit) {
       newLimit = Math.min(greaterLogCount, (limit + LOG_FILE_COUNT_INTERVAL));
-      newOffset = Math.max(
-        Math.min((greaterLogCount - LOG_FILE_COUNT_INTERVAL), (offset + LOG_FILE_COUNT_INTERVAL)),
-        0,
+      newOffset = Math.min(
+        (offset + LOG_FILE_COUNT_INTERVAL),
+        greaterLogCount - (greaterLogCount % LOG_FILE_COUNT_INTERVAL),
       );
       goToWithQuery({
         ...q,
@@ -269,7 +269,10 @@ function BlockRuns({
     let newLimit = limit;
     let newOffset = offset;
     if (limit >= LOG_FILE_COUNT_INTERVAL) {
-      newLimit = Math.max(0, (limit - LOG_FILE_COUNT_INTERVAL));
+      newLimit = Math.max(LOG_FILE_COUNT_INTERVAL, (limit - LOG_FILE_COUNT_INTERVAL));
+      if (limit >= greaterLogCount) {
+        newLimit = greaterLogCount - (greaterLogCount % LOG_FILE_COUNT_INTERVAL);
+      }
       newOffset = Math.max(0, (offset - LOG_FILE_COUNT_INTERVAL));
       goToWithQuery({
         ...q,

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -277,7 +277,7 @@ function BlockRuns({
         [OFFSET_PARAM]: newOffset,
       });
     }
-  }, [limit, offset, q, totalBlockRunLogCount, totalPipelineRunLogCount]);
+  }, [limit, offset, q]);
 
   return (
     <PipelineDetailPage

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -280,7 +280,7 @@ function BlockRuns({
         [OFFSET_PARAM]: newOffset,
       });
     }
-  }, [limit, offset, q]);
+  }, [greaterLogCount, limit, offset, q]);
 
   return (
     <PipelineDetailPage

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -254,7 +254,10 @@ function BlockRuns({
     if (totalBlockRunLogCount > limit || totalPipelineRunLogCount > limit) {
       const greaterLogCount = Math.max(totalBlockRunLogCount, totalPipelineRunLogCount);
       newLimit = Math.min(greaterLogCount, (limit + LOG_FILE_COUNT_INTERVAL));
-      newOffset = Math.min((greaterLogCount - LOG_FILE_COUNT_INTERVAL), (offset + LOG_FILE_COUNT_INTERVAL));
+      newOffset = Math.max(
+        Math.min((greaterLogCount - LOG_FILE_COUNT_INTERVAL), (offset + LOG_FILE_COUNT_INTERVAL)),
+        0,
+      );
       goToWithQuery({
         ...q,
         [LIMIT_PARAM]: newLimit,

--- a/mage_ai/server/api/logs.py
+++ b/mage_ai/server/api/logs.py
@@ -62,7 +62,7 @@ class ApiPipelineLogListHandler(BaseHandler):
             select(*columns).
             join(b, a.pipeline_schedule_id == b.id).
             filter(b.pipeline_uuid == pipeline_uuid).
-            order_by(a.execution_date.desc())
+            order_by(a.created_at.desc())
         )
 
         if len(pipeline_schedule_ids):

--- a/mage_ai/server/api/logs.py
+++ b/mage_ai/server/api/logs.py
@@ -88,6 +88,8 @@ class ApiPipelineLogListHandler(BaseHandler):
                 filter(a.execution_date <= end_timestamp)
             )
 
+        total_pipeline_run_log_count = query.count()
+
         pipeline_run_logs = []
         if not len(block_uuids) and not len(block_run_ids):
             if self.get_argument(META_KEY_LIMIT, None) is not None:
@@ -116,6 +118,7 @@ class ApiPipelineLogListHandler(BaseHandler):
             join(b, a.pipeline_schedule_id == b.id).
             filter(b.pipeline_uuid == pipeline_uuid)
         )
+
 
         if len(block_uuids):
             query = (
@@ -158,6 +161,7 @@ class ApiPipelineLogListHandler(BaseHandler):
         else:
             rows = query.all()
 
+        total_block_run_log_count = query.count()
         block_run_logs = []
 
         for row in rows:
@@ -180,5 +184,7 @@ class ApiPipelineLogListHandler(BaseHandler):
             dict(
                 block_run_logs=block_run_logs,
                 pipeline_run_logs=pipeline_run_logs,
+                total_block_run_log_count=total_block_run_log_count,
+                total_pipeline_run_log_count=total_pipeline_run_log_count,
             ),
         ]))

--- a/mage_ai/server/api/logs.py
+++ b/mage_ai/server/api/logs.py
@@ -61,7 +61,8 @@ class ApiPipelineLogListHandler(BaseHandler):
             PipelineRun.
             select(*columns).
             join(b, a.pipeline_schedule_id == b.id).
-            filter(b.pipeline_uuid == pipeline_uuid)
+            filter(b.pipeline_uuid == pipeline_uuid).
+            order_by(a.execution_date.desc())
         )
 
         if len(pipeline_schedule_ids):
@@ -116,7 +117,8 @@ class ApiPipelineLogListHandler(BaseHandler):
             ])).
             join(a, a.id == c.pipeline_run_id).
             join(b, a.pipeline_schedule_id == b.id).
-            filter(b.pipeline_uuid == pipeline_uuid)
+            filter(b.pipeline_uuid == pipeline_uuid).
+            order_by(c.started_at.desc())
         )
 
 

--- a/mage_ai/server/api/logs.py
+++ b/mage_ai/server/api/logs.py
@@ -89,10 +89,10 @@ class ApiPipelineLogListHandler(BaseHandler):
                 filter(a.execution_date <= end_timestamp)
             )
 
-        total_pipeline_run_log_count = query.count()
-
+        total_pipeline_run_log_count = 0
         pipeline_run_logs = []
         if not len(block_uuids) and not len(block_run_ids):
+            total_pipeline_run_log_count = query.count()
             if self.get_argument(META_KEY_LIMIT, None) is not None:
                 rows = self.limit(query)
             else:

--- a/mage_ai/server/api/logs.py
+++ b/mage_ai/server/api/logs.py
@@ -1,3 +1,4 @@
+from .base import META_KEY_LIMIT
 from datetime import datetime
 
 from mage_ai.orchestration.db.models import BlockRun, PipelineRun, PipelineSchedule
@@ -89,7 +90,11 @@ class ApiPipelineLogListHandler(BaseHandler):
 
         pipeline_run_logs = []
         if not len(block_uuids) and not len(block_run_ids):
-            rows = query.all()
+            if self.get_argument(META_KEY_LIMIT, None) is not None:
+                rows = self.limit(query)
+            else:
+                rows = query.all()
+
             for row in rows:
                 model = PipelineRun()
                 model.execution_date = row.execution_date
@@ -148,7 +153,11 @@ class ApiPipelineLogListHandler(BaseHandler):
                 filter(a.execution_date <= end_timestamp)
             )
 
-        rows = query.all()
+        if self.get_argument(META_KEY_LIMIT, None) is not None:
+            rows = self.limit(query)
+        else:
+            rows = query.all()
+
         block_run_logs = []
 
         for row in rows:


### PR DESCRIPTION
# Summary
- Fetch logs in intervals instead of all at once.
- Fixed issue where clicking on a log detail would reset the logs viewed if viewing past logs.

# Tests
![logs](https://user-images.githubusercontent.com/78053898/204894347-02182946-703a-4c0c-a6ae-15b3dc6a2583.gif)


cc:
@wangxiaoyou1993 
