### PR TITLE
[jk] Update once trigger with completed run to inactive

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -65,7 +65,7 @@ function PipelineSchedules({
   const {
     data: dataPipelineSchedules,
     mutate: fetchPipelineSchedules,
-  } = api.pipeline_schedules.pipelines.list(pipelineUUID);
+  } = api.pipeline_schedules.pipelines.list(pipelineUUID, {}, { refreshInterval: 7500 });
   const pipelinesSchedules: PipelineScheduleType[] =
     useMemo(() => dataPipelineSchedules?.pipeline_schedules || [], [dataPipelineSchedules]);
 

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -95,13 +95,13 @@ class PipelineScheduler:
                     )
 
                 pipeline_schedule = PipelineSchedule.query.get(self.pipeline_run.pipeline_schedule_id)
-                if (pipeline_schedule is not None):
-                    if (pipeline_schedule.status == PipelineSchedule.ScheduleStatus.ACTIVE \
-                        and pipeline_schedule.schedule_type == PipelineSchedule.ScheduleType.TIME \
-                        and pipeline_schedule.schedule_interval == PipelineSchedule.ScheduleInterval.ONCE):
-                        pipeline_schedule.update(
-                            status=PipelineSchedule.ScheduleStatus.INACTIVE,
-                        )
+                if pipeline_schedule is not None and \
+                        pipeline_schedule.status == PipelineSchedule.ScheduleStatus.ACTIVE and \
+                        pipeline_schedule.schedule_type == PipelineSchedule.ScheduleType.TIME and \
+                        pipeline_schedule.schedule_interval == PipelineSchedule.ScheduleInterval.ONCE:
+                    pipeline_schedule.update(
+                        status=PipelineSchedule.ScheduleStatus.INACTIVE,
+                    )
                 self.pipeline_run.update(
                     status=PipelineRun.PipelineRunStatus.COMPLETED,
                     completed_at=datetime.now(),

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -94,6 +94,14 @@ class PipelineScheduler:
                         tags=merge_dict(tags, dict(metrics=self.pipeline_run.metrics)),
                     )
 
+                pipeline_schedule = PipelineSchedule.query.get(self.pipeline_run.pipeline_schedule_id)
+                if (pipeline_schedule is not None):
+                    if (pipeline_schedule.status == PipelineSchedule.ScheduleStatus.ACTIVE \
+                        and pipeline_schedule.schedule_type == PipelineSchedule.ScheduleType.TIME \
+                        and pipeline_schedule.schedule_interval == PipelineSchedule.ScheduleInterval.ONCE):
+                        pipeline_schedule.update(
+                            status=PipelineSchedule.ScheduleStatus.INACTIVE,
+                        )
                 self.pipeline_run.update(
                     status=PipelineRun.PipelineRunStatus.COMPLETED,
                     completed_at=datetime.now(),


### PR DESCRIPTION
# Summary
- Updates pipeline schedule pertaining to a pipeline run to `inactive` status if the trigger was scheduled to run only once and was `active` status. Changes made on the backend.
- Added refresh interval to Triggers list page so it periodically checks for updates to the trigger and latest run statuses.

# Tests
![2022-12-02 18 04 02](https://user-images.githubusercontent.com/78053898/205417476-0cb9da03-5e70-46f8-9afe-d449ffd8c884.gif)
