### PR TITLE
[dy] Restart crashed block runs after app start

### DIFF
--- a/mage_ai/server/api/orchestration.py
+++ b/mage_ai/server/api/orchestration.py
@@ -215,7 +215,6 @@ class ApiPipelineRunDetailHandler(BaseDetailHandler):
             if pipeline_run.status != PipelineRun.PipelineRunStatus.COMPLETED:
                 pipeline_run.refresh()
                 pipeline = Pipeline.get(pipeline_run.pipeline_uuid)
-                print('block runs:', list(map(lambda br: dict(name=br.block_uuid, status=br.status), pipeline_run.block_runs)))
                 incomplete_block_runs = \
                     list(
                         filter(


### PR DESCRIPTION
# Summary

Restart block runs that are in the running state, but do not have a process running. This should only occur when the app is restarted after crashing. For integration pipelines, this will restart from the source block run.

One side effect of this change is that restarting the server when developing locally may create duplicate processes. I could just terminate all the active processes when they restart, but that doesn't seem ideal either. Since it would only effect local dev, I don't think it's a blocker for now.
<!-- Brief summary of what your code does -->

# Tests

tested locally
<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
