### PR TITLE
[xy] Fix 'outputs' referenced before assignment error.

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -770,7 +770,6 @@ class Block:
             self.test_functions = test_functions
 
         return outputs
-        
 
     def execute_block_function(
         self,

--- a/mage_ai/data_preparation/models/block/dbt/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/__init__.py
@@ -84,6 +84,7 @@ class DBTBlock(Block):
             dbt_command,
         ] + args
 
+        outputs = []
         if is_sql and test_execution:
             print(f'Running DBT command {dbt_command} with arguments {args}.')
             proc = subprocess.run(


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Fix 'outputs' referenced before assignment error.
<img width="735" alt="image" src="https://user-images.githubusercontent.com/80284865/205855932-355eb4cb-f488-450d-9b3e-87e9a4fe7d5d.png">


# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
