### PR TITLE
[jk] Show specific pipeline or block run logs

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -193,6 +193,14 @@ function BlockRuns({
           }
           evals.push(query['block_type[]'].includes(blocksByUUID[blockUUID]?.type));
         }
+        if (query[PIPELINE_RUN_ID_PARAM]) {
+          const pipelineRunId = data?.pipeline_run_id;
+          evals.push(query[PIPELINE_RUN_ID_PARAM].includes(String(pipelineRunId)));
+        }
+        if (query[BLOCK_RUN_ID_PARAM]) {
+          const blockRunId = data?.block_run_id;
+          evals.push(query[BLOCK_RUN_ID_PARAM].includes(String(blockRunId)));
+        }
 
         return evals.every(v => v);
       }), [


### PR DESCRIPTION
# Summary
- When clicking on logs for an individual pipeline run or block run, only show the relevant logs (previously showed logs for all subsequent and previous pipeline/block runs if it was re-ran).

# Tests
![2022-12-06 13 55 48](https://user-images.githubusercontent.com/78053898/206032213-19adb768-169c-44c4-8059-a4f449236be0.gif)

