### PR TITLE
[dy] Add backticks for bigquery

### DIFF
--- a/mage_integrations/mage_integrations/destinations/bigquery/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/bigquery/__init__.py
@@ -80,6 +80,7 @@ class BigQuery(Destination):
                 # BigQuery doesn't support unique constraints
                 unique_constraints=None,
                 create_temporary_table=create_temporary_table,
+                column_identifier='`',
             )
 
         stream_partition_keys = self.partition_keys.get(stream, [])
@@ -88,7 +89,7 @@ class BigQuery(Destination):
             create_table_command = f'''
 {create_table_command}
 PARTITION BY
-  DATE({partition_col})
+  DATE(`{partition_col}`)
             '''
 
         return [
@@ -274,6 +275,7 @@ WHERE table_id = '{table_name}'
             string_parse_func=convert_json_or_string,
             stringify_values=False,
             convert_column_types=True,
+            column_identifier='`',
         )
         insert_columns = ', '.join(insert_columns)
 

--- a/mage_integrations/mage_integrations/destinations/sql/utils.py
+++ b/mage_integrations/mage_integrations/destinations/sql/utils.py
@@ -19,10 +19,12 @@ def build_create_table_command(
     full_table_name: str,
     unique_constraints: List[str] = None,
     create_temporary_table: bool = False,
+    column_identifier: str = '',
 ) -> str:
     columns_and_types = [
-        f"{clean_column_name(col)} {column_type_mapping[col]['type_converted']}" for col
-        in columns
+        f"{column_identifier}{clean_column_name(col)}{column_identifier}" + \
+            f" {column_type_mapping[col]['type_converted']}"
+        for col in columns
     ]
 
     if unique_constraints:
@@ -153,6 +155,7 @@ def build_insert_command(
     string_parse_func: Callable = None,
     stringify_values: bool = True,
     convert_column_types: bool = True,
+    column_identifier: str = '',
 ) -> List[str]:
     values = []
     for row in records:
@@ -196,6 +199,6 @@ def build_insert_command(
         values.append(vals)
 
     return [
-        [clean_column_name(col) for col in columns],
+        [f'{column_identifier}{clean_column_name(col)}{column_identifier}' for col in columns],
         values,
     ]


### PR DESCRIPTION
# Summary

Column names can contain reserved keywords, and it causes the bigquery queries to fail. Adding backticks to the column name fixes that issue.
<!-- Brief summary of what your code does -->

# Tests

tested locally
<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
