### PR TITLE
[jk] Indicate number of columns displayed in code block output footer

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
@@ -187,7 +187,7 @@ function CodeOutput({
         const borderTop = idx >= 1;
 
         if (typeof data === 'string' && data.match(INTERNAL_OUTPUT_REGEX)) {
-          const parts = data.split('[__internal_output__]')
+          const parts = data.split('[__internal_output__]');
           let rawString = parts[parts.length - 1];
 
           // Sometimes the FloatProgress is appended to the end of the table data
@@ -243,7 +243,7 @@ function CodeOutput({
                 <Text
                   // @ts-ignore
                   dangerouslySetInnerHTML={{
-                    __html: data
+                    __html: data,
                   }}
                   monospace
                 />
@@ -278,11 +278,14 @@ function CodeOutput({
 
     if (isInProgress && pipeline?.type === PipelineTypeEnum.PYSPARK) {
       arrContent.unshift([
-        <OutputRowStyle contained>
+        <OutputRowStyle
+          contained
+          key="progress_bar"
+        >
           <Spacing mt={1}>
             {progressBar}
           </Spacing>
-        </OutputRowStyle>
+        </OutputRowStyle>,
       ]);
     }
 
@@ -295,6 +298,11 @@ function CodeOutput({
     progressBar,
     selected,
   ]);
+
+  const columnCount = dataFrameShape?.[1] || 0;
+  const columnsPreviewMessage = columnCount > 30
+    ? ` (30 out of ${columnCount} columns displayed)`
+    : '';
 
   return (
     <>
@@ -342,7 +350,7 @@ function CodeOutput({
                       {dataFrameShape && (
                         <Spacing ml={2}>
                           <Text>
-                            {`${dataFrameShape[0]} rows x ${dataFrameShape[1]} columns`}
+                            {`${dataFrameShape[0]} rows x ${dataFrameShape[1]} columns${columnsPreviewMessage}`}
                           </Text>
                         </Spacing>
                       )}

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -146,7 +146,7 @@ function Sidekick({
     columnTypes,
     statistics,
   });
-  const hasData = sampleData && insights && Object.keys(statistics).length > 0;
+  const hasData = !!sampleData;
   const isIntegration = useMemo(() => PipelineTypeEnum.INTEGRATION === pipeline?.type, [pipeline]);
 
   const renderColumnHeader = useCallback(buildRenderColumnHeader({


### PR DESCRIPTION
# Summary
- The number of columns in the code block output preview is limited to 30, so this adds a note to the footer. User can see row number for number of rows displayed.

# Tests
![image](https://user-images.githubusercontent.com/78053898/207782500-255340ee-6909-4a2a-91ae-a9d9d9cdffcf.png)

No note for less than 31 columns:
![image](https://user-images.githubusercontent.com/78053898/207782779-36dbf57b-45ff-4eab-9575-2cd23995ea82.png)

