### PR TITLE
[jk] Disable setting toggles when no stream selected

### DIFF
--- a/mage_ai/frontend/components/IntegrationPipeline/index.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/index.tsx
@@ -351,6 +351,10 @@ function IntegrationPipeline({
   const updateAllStreams = useCallback((
     streamDataTransformer: (stream: StreamType) => StreamType,
   ) => {
+    if (!catalog?.streams) {
+      return;
+    }
+
     onChangeCodeBlock(dataLoaderBlock.uuid, stringify({
       ...dataLoaderBlockContent,
       catalog: {
@@ -974,6 +978,7 @@ function IntegrationPipeline({
 
                   <ToggleSwitch
                     checked={!!autoAddNewFields}
+                    disabled={!catalog?.streams}
                     onCheck={() => updateAllStreams((stream: StreamType) => ({
                       ...stream,
                       auto_add_new_fields: !autoAddNewFields,
@@ -1001,6 +1006,7 @@ function IntegrationPipeline({
 
                   <ToggleSwitch
                     checked={!!disableColumnTypeCheck}
+                    disabled={!catalog?.streams}
                     onCheck={() => updateAllStreams((stream: StreamType) => ({
                       ...stream,
                       disable_column_type_check: !disableColumnTypeCheck,


### PR DESCRIPTION
# Summary
- Resolves frontend error when user toggles "automatically add new fields" or "disable column type check" setting for integration pipeline when no streams have been selected.

# Tests
- Local. Toggles are disabled when no stream selected.
![image](https://user-images.githubusercontent.com/78053898/207953003-5fcbee5d-1998-45bf-b445-654fa5305b64.png)
