### PR TITLE
Remove duplicate downstream block in example pipeline

### DIFF
--- a/mage_ai/data_preparation/templates/repo/pipelines/example_pipeline/metadata.yaml
+++ b/mage_ai/data_preparation/templates/repo/pipelines/example_pipeline/metadata.yaml
@@ -11,7 +11,6 @@ blocks:
 - all_upstream_blocks_executed: true
   downstream_blocks:
   - export_titanic_clean
-  - export_titanic_clean
   name: fill_in_missing_values
   status: not_executed
   type: transformer


### PR DESCRIPTION
# Summary
The example pipeline has a duplicate entry in `downstream_blocks`. This PR removes the duplicate so there's only one `export_titanic_clean`.

# Tests
Successfully executed the pipeline.