### PR TITLE
[Frontend][Bug] Fix selecting block file

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -985,6 +985,10 @@ function PipelineDetailPage({
         const blockRef = blockRefs.current[`${block.type}s/${block.uuid}.py`];
         blockRef?.current?.scrollIntoView();
       }
+      goToWithQuery({
+        file_path: null,
+        'file_paths[]': [],
+      });
     } else if (blockType === BlockTypeEnum.CHART) {
       const chart = widgets.find(({ uuid }) => uuid === blockUUID);
       if (chart) {


### PR DESCRIPTION
# Summary
In the editor, if you click on a block file after opening a regular file, the block file doesn't load. Instead, it scrolls down in the regular file.

This PR removes the open regular files so that clicking the block file shows the file and scrolls to the appropriate place.

# Tests
| Before | After |
| - | - |
| <video src="https://user-images.githubusercontent.com/3804139/208254235-9a889d3d-6a57-46cc-9fa7-ffb76820339d.mov"> | <video src="https://user-images.githubusercontent.com/3804139/208254241-fb7db0a2-d239-4cc8-b1fb-03da854c5a8c.mov"> |