### PR TITLE
[dy] Start db session from mage run

### DIFF
--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -80,7 +80,6 @@ Commands:
             project=project_path,
         )
     elif command == 'run' or command == 'test':
-
         from mage_ai.data_preparation.repo_manager import set_repo_path
         from mage_ai.shared.hash import merge_dict
 
@@ -121,6 +120,9 @@ Commands:
 
         default_variables = get_global_variables(pipeline_uuid)
         global_vars = merge_dict(default_variables, runtime_variables)
+
+        from mage_ai.orchestration.db import db_connection
+        db_connection.start_session()
 
         if block_uuid is None:
             ExecutorFactory.get_pipeline_executor(pipeline).execute(


### PR DESCRIPTION
# Summary

Start db_connection session from `cli/main.py` because it's possible the server isn't running already.
<!-- Brief summary of what your code does -->

# Tests

if the session already exists, the session won't be created, so should be safe.
<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
