### PR TITLE
[jk] Code block output spacing

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/index.style.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/index.style.tsx
@@ -10,6 +10,7 @@ import {
 } from '../index.style';
 
 export const ContainerStyle = styled.div<{
+  addBottomPadding?: boolean;
   executedAndIdle: boolean;
 } & BorderColorShareProps>`
   ${BORDER_COLOR_SHARED_STYLES}
@@ -20,7 +21,9 @@ export const ContainerStyle = styled.div<{
   border-right-width: 2px;
   overflow: hidden;
 
-  padding-bottom: ${2 * PADDING}px;
+  ${props => props.addBottomPadding && `
+    padding-bottom: ${2 * PADDING}px;
+  `}
 
   ${props => `
     background-color: ${(props.theme.background || dark.background).table};
@@ -66,7 +69,7 @@ export const HTMLOutputStyle = styled.div<any>`
     padding: 0 8px;
   }
   a {
-  
+
     ${props => `
       color: ${(props.theme.interactive || dark.interactive).linkPrimary};
     `}

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
@@ -308,6 +308,7 @@ function CodeOutput({
     <>
       {contained && (
         <ContainerStyle
+          addBottomPadding={isInProgress && pipeline?.type === PipelineTypeEnum.PYSPARK}
           blockType={blockType}
           executedAndIdle={executedAndIdle}
           hasError={hasError}

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -415,7 +415,7 @@ function Table({
       if (columnHeaderHeight) {
         val += columnHeaderHeight;
       } else {
-        val += BASE_ROW_HEIGHT;
+        val += BASE_ROW_HEIGHT - REGULAR_LINE_HEIGHT;
       }
     } else {
       val = height;
@@ -571,7 +571,7 @@ function DataTable({
       columnHeaderHeight={columnHeaderHeight}
       disableScrolling={disableScrolling}
       height={height}
-      maxHeight={maxHeight}
+      maxHeight={maxHeight + 37}    // Add 37px so horizontal scrollbar is visible
       noBorderBottom={noBorderBottom}
       noBorderLeft={noBorderLeft}
       noBorderRight={noBorderRight}


### PR DESCRIPTION
# Summary
- Horizontal scrollbar in code block output is no longer cut off.
- Trimmed excess padding in block output.

# Tests
Horizontal scrollbar not cut off:
![image](https://user-images.githubusercontent.com/78053898/208784231-3d8ebdbf-065a-456b-9481-21e4e9145997.png)

Before (with excess padding):
![image](https://user-images.githubusercontent.com/78053898/208784402-5d49a7e3-7327-44c8-822d-5e75f75abe5f.png)
After:
![image](https://user-images.githubusercontent.com/78053898/208784336-b781e52b-ff8b-4514-a276-6ba1603adcc6.png)

cc:
<!-- Optionally mention someone to let them know about this pull request -->