### PR TITLE
[jk] Create trigger 1 day ago to avoid timezone issues

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -262,7 +262,10 @@ function PipelineSchedules({
                     name: randomNameGenerator(),
                     schedule_interval: ScheduleIntervalEnum.ONCE,
                     schedule_type: ScheduleTypeEnum.TIME,
-                    start_time: dateFormatLong(new Date().toISOString(), { utcFormat: true }),
+                    start_time: dateFormatLong(
+                      new Date().toISOString(),
+                      { dayAgo: true, utcFormat: true },
+                    ),
                     status: ScheduleStatusEnum.ACTIVE,
                   },
                 });

--- a/mage_ai/frontend/utils/date.ts
+++ b/mage_ai/frontend/utils/date.ts
@@ -13,13 +13,17 @@ export function dateFormatShort(text) {
 }
 
 export function dateFormatLong(text, opts?) {
-  const { utcFormat } = opts;
+  const { utcFormat, dayAgo } = opts;
+  let momentObj = moment(text);
 
   if (utcFormat) {
-    return moment(text).utc().format(DATE_FORMAT_LONG_NO_SEC);
+    momentObj = momentObj.utc();
+  }
+  if (dayAgo) {
+    momentObj = momentObj.subtract(1, 'days');
   }
 
-  return moment(text).format(DATE_FORMAT_LONG_NO_SEC);
+  return momentObj.format(DATE_FORMAT_LONG_NO_SEC);
 }
 
 export function dateFormatLongFromUnixTimestamp(text) {


### PR DESCRIPTION
# Summary
- "Running pipeline once" would start in the future in certain situations (e.g. sometimes with local Postgres sources), so timezone should not affect the pipeline running immediately with the trigger date set in the past 1 day.

# Tests
![run pipeline once](https://user-images.githubusercontent.com/78053898/208793514-8db92f48-5a03-4ed3-a1d8-540d8d47d435.gif)
