### PR TITLE
[jk] Revert "Show specific pipeline or block run logs" PR

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -193,14 +193,14 @@ function BlockRuns({
           }
           evals.push(query['block_type[]'].includes(blocksByUUID[blockUUID]?.type));
         }
-        if (query[PIPELINE_RUN_ID_PARAM]) {
-          const pipelineRunId = data?.pipeline_run_id;
-          evals.push(query[PIPELINE_RUN_ID_PARAM].includes(String(pipelineRunId)));
-        }
-        if (query[BLOCK_RUN_ID_PARAM]) {
-          const blockRunId = data?.block_run_id;
-          evals.push(query[BLOCK_RUN_ID_PARAM].includes(String(blockRunId)));
-        }
+        // if (query[PIPELINE_RUN_ID_PARAM]) {
+        //   const pipelineRunId = data?.pipeline_run_id;
+        //   evals.push(query[PIPELINE_RUN_ID_PARAM].includes(String(pipelineRunId)));
+        // }
+        // if (query[BLOCK_RUN_ID_PARAM]) {
+        //   const blockRunId = data?.block_run_id;
+        //   evals.push(query[BLOCK_RUN_ID_PARAM].includes(String(blockRunId)));
+        // }
 
         return evals.every(v => v);
       }), [


### PR DESCRIPTION
# Summary
- Commenting out code from https://github.com/mage-ai/mage-ai/pull/1530 since it was filtering out certain logs when viewing by individual pipeline or block run.

# Tests
- N/A

cc:
@wangxiaoyou1993 