### PR TITLE
[jk] Add button for installing  packages from requirements.txt file

### DIFF
--- a/mage_ai/frontend/components/FileEditor/index.tsx
+++ b/mage_ai/frontend/components/FileEditor/index.tsx
@@ -273,6 +273,10 @@ function FileEditor({
             uuid: DEFAULT_TERMINAL_UUID,
           }));
         }}
+        title={!repoPath
+          ? 'Please use right panel terminal to install packages.'
+          : 'Pip install packages from your saved requirements.txt file (⌘+S to save).'
+        }
         uuid="FileEditor/InstallPackages"
       >
         Install packages

--- a/mage_ai/frontend/components/FileEditor/index.tsx
+++ b/mage_ai/frontend/components/FileEditor/index.tsx
@@ -265,7 +265,7 @@ function FileEditor({
         onClick={() => {
           openSidekickView(ViewKeyEnum.TERMINAL);
           sendMessage(JSON.stringify({
-            code: `!pip install -r ~/../home/src/${projectName}/requirements.txt`,
+            install_packages: true,
             uuid: DEFAULT_TERMINAL_UUID,
           }));
         }}

--- a/mage_ai/frontend/components/FileEditor/index.tsx
+++ b/mage_ai/frontend/components/FileEditor/index.tsx
@@ -66,6 +66,9 @@ function FileEditor({
   const [file, setFile] = useState<FileType>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const containerRef = useRef(null);
+
+  const { data: serverStatus } = api.status.list();
+  const repoPath = serverStatus?.status?.repo_path;
   const { data } = api.file_contents.detail(filePath);
   useEffect(() => {
     if (data?.file_content) {
@@ -260,12 +263,13 @@ function FileEditor({
   const installPackagesButtonEl = (
     <Spacing m={2}>
       <KeyboardShortcutButton
+        disabled={!repoPath}
         inline
         loading={loading}
         onClick={() => {
           openSidekickView(ViewKeyEnum.TERMINAL);
           sendMessage(JSON.stringify({
-            install_packages: true,
+            code: `!pip install -r ${repoPath}/requirements.txt`,
             uuid: DEFAULT_TERMINAL_UUID,
           }));
         }}

--- a/mage_ai/frontend/components/FileEditor/index.tsx
+++ b/mage_ai/frontend/components/FileEditor/index.tsx
@@ -1,3 +1,4 @@
+import useWebSocket from 'react-use-websocket';
 import {
   useEffect,
   useMemo,
@@ -8,20 +9,29 @@ import { useMutation } from 'react-query';
 
 import BlockType, { BlockRequestPayloadType, BlockTypeEnum } from '@interfaces/BlockType';
 import CodeEditor from '@components/CodeEditor';
-import FileType, { FileExtensionEnum, FILE_EXTENSION_TO_LANGUAGE_MAPPING } from '@interfaces/FileType';
+import FileType, {
+  FileExtensionEnum,
+  FILE_EXTENSION_TO_LANGUAGE_MAPPING,
+  SpecialFileEnum,
+} from '@interfaces/FileType';
+import KernelOutputType, { ExecutionStateEnum } from '@interfaces/KernelOutputType';
 import KeyboardShortcutButton from '@oracle/elements/Button/KeyboardShortcutButton';
 import PipelineType, { PipelineTypeEnum } from '@interfaces/PipelineType';
 import Spacing from '@oracle/elements/Spacing';
 import api from '@api';
+
+import { DEFAULT_TERMINAL_UUID } from '@components/Terminal';
 import {
   KEY_CODE_CONTROL,
   KEY_CODE_META,
   KEY_CODE_R,
   KEY_CODE_S,
 } from '@utils/hooks/keyboardShortcuts/constants';
+import { ViewKeyEnum } from '@components/Sidekick/constants';
 import { find } from '@utils/array';
 import { getBlockType, getBlockUUID } from './utils';
 import { getNonPythonBlockFromFile } from '@components/FileBrowser/utils';
+import { getWebSocket } from '@api/utils/url';
 import { onSuccess } from '@api/utils/response';
 import { onlyKeysPresent } from '@utils/hooks/keyboardShortcuts/utils';
 import { useKeyboardContext } from '@context/Keyboard';
@@ -31,7 +41,9 @@ type FileEditorProps = {
   addNewBlock: (b: BlockRequestPayloadType, cb: any) => void;
   fetchPipeline: () => void;
   filePath: string;
+  openSidekickView: (newView: ViewKeyEnum) => void;
   pipeline: PipelineType;
+  projectName: string;
   selectedFilePath: string;
   setFilesTouched: (data: {
     [path: string]: boolean;
@@ -44,12 +56,15 @@ function FileEditor({
   addNewBlock,
   fetchPipeline,
   filePath,
+  openSidekickView,
   pipeline,
+  projectName,
   selectedFilePath,
   setFilesTouched,
   setSelectedBlock,
 }: FileEditorProps) {
   const [file, setFile] = useState<FileType>(null);
+  const [loading, setLoading] = useState<boolean>(false);
   const containerRef = useRef(null);
   const { data } = api.file_contents.detail(filePath);
   useEffect(() => {
@@ -167,7 +182,7 @@ function FileEditor({
     || ((fileExtension === FileExtensionEnum.YAML || fileExtension === FileExtensionEnum.R)
       && getNonPythonBlockFromFile(file, file?.path))
     ) && getBlockType(file.path.split('/')) !== BlockTypeEnum.SCRATCHPAD && (
-    <Spacing p={2}>
+    <Spacing m={2}>
       <KeyboardShortcutButton
         inline
         onClick={() => {
@@ -215,6 +230,52 @@ function FileEditor({
     </Spacing>
   );
 
+  const {
+    lastJsonMessage,
+    sendMessage,
+  } = useWebSocket(getWebSocket(), {
+    shouldReconnect: () => true,
+  });
+
+  useEffect(() => {
+    if (lastJsonMessage) {
+      // @ts-ignore
+      const jsonMessage: KernelOutputType = lastJsonMessage;
+      const executionState = jsonMessage?.execution_state;
+      const messageUUID = jsonMessage?.uuid;
+
+      if (messageUUID === DEFAULT_TERMINAL_UUID) {
+        if (ExecutionStateEnum.BUSY === executionState) {
+          setLoading(true);
+        } else if (ExecutionStateEnum.IDLE === executionState) {
+          setLoading(false);
+        }
+      }
+    }
+  }, [
+    lastJsonMessage,
+    setLoading,
+  ]);
+
+  const installPackagesButtonEl = (
+    <Spacing m={2}>
+      <KeyboardShortcutButton
+        inline
+        loading={loading}
+        onClick={() => {
+          openSidekickView(ViewKeyEnum.TERMINAL);
+          sendMessage(JSON.stringify({
+            code: `!pip install -r ~/../home/src/${projectName}/requirements.txt`,
+            uuid: DEFAULT_TERMINAL_UUID,
+          }));
+        }}
+        uuid="FileEditor/InstallPackages"
+      >
+        Install packages
+      </KeyboardShortcutButton>
+    </Spacing>
+  );
+
   const uuidKeyboard = `FileEditor/${file?.path}`;
   const {
     registerOnKeyDown,
@@ -254,6 +315,7 @@ function FileEditor({
     <div ref={containerRef}>
       {codeEditorEl}
       {addToPipelineEl}
+      {filePath === SpecialFileEnum.REQS_TXT && installPackagesButtonEl}
     </div>
   );
 }

--- a/mage_ai/frontend/components/Terminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/index.tsx
@@ -37,9 +37,7 @@ import { onlyKeysPresent } from '@utils/hooks/keyboardShortcuts/utils';
 import { pauseEvent } from '@utils/events';
 import { useKeyboardContext } from '@context/Keyboard';
 
-const DEFAULT_TERMINAL_UUID = 'terminal';
-const INIT_COMMAND =
-  'echo https://github.com/mage-ai/mage-ai/blob/master/docs/guides/version_control/Git.md';
+export const DEFAULT_TERMINAL_UUID = 'terminal';
 
 type TerminalProps = {
   interruptKernel: () => void;
@@ -61,22 +59,11 @@ function Terminal({
   const [command, setCommand] = useState<string>('');
   const [commandIndex, setCommandIndex] = useState<number>(0);
   const [cursorIndex, setCursorIndex] = useState<number>(0);
-  const [commandHistory, setCommandHistory] = useState<string[]>([INIT_COMMAND]);
+  const [commandHistory, setCommandHistory] = useState<string[]>([]);
   const [focus, setFocus] = useState<boolean>(false);
   const [kernelOutputs, setKernelOutputs] = useState<(KernelOutputType & {
     command: boolean;
-  })[]>([
-    {
-      command: true,
-      data: INIT_COMMAND,
-      execution_state: null,
-      msg_id: null,
-      msg_type: null,
-      pipeline_uuid: null,
-      type: DataTypeEnum.TEXT,
-      uuid: terminalUUID,
-    },
-  ]);
+  })[]>([]);
 
   const {
     lastMessage,

--- a/mage_ai/frontend/interfaces/FileType.ts
+++ b/mage_ai/frontend/interfaces/FileType.ts
@@ -11,6 +11,7 @@ export enum FileExtensionEnum {
 
 export enum SpecialFileEnum {
   INIT_PY = '__init__.py',
+  REQS_TXT = 'requirements.txt',
 }
 
 export const CODE_BLOCK_FILE_EXTENSIONS = [

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1678,7 +1678,9 @@ function PipelineDetailPage({
               }}
               fetchPipeline={fetchPipeline}
               filePath={filePath}
+              openSidekickView={openSidekickView}
               pipeline={pipeline}
+              projectName={projectName}
               selectedFilePath={selectedFilePath}
               setFilesTouched={setFilesTouched}
               setSelectedBlock={setSelectedBlock}

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -424,6 +424,7 @@ class ApiStatusHandler(BaseHandler):
 
         status = {
             'is_instance_manager': os.getenv(MANAGE_ENV_VAR) == '1',
+            'repo_path': get_repo_path(),
             'scheduler_status': scheduler_manager.get_status(),
             'instance_type': instance_type,
         }

--- a/mage_ai/server/websocket.py
+++ b/mage_ai/server/websocket.py
@@ -183,10 +183,6 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
             # Need to use Python magic command for changing directories
             code = re.sub(r'^!%cd|^!cd', '%cd', code)
 
-            install_packages = message.get('install_packages')
-            if install_packages:
-                code = f'!pip install -r {get_repo_path()}/requirements.txt'
-
             client = self.init_kernel_client(DEFAULT_KERNEL_NAME)
             msg_id = client.execute(code)
             uuid = message.get('uuid')

--- a/mage_ai/server/websocket.py
+++ b/mage_ai/server/websocket.py
@@ -183,6 +183,10 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
             # Need to use Python magic command for changing directories
             code = re.sub(r'^!%cd|^!cd', '%cd', code)
 
+            install_packages = message.get('install_packages')
+            if install_packages:
+                code = f'!pip install -r {get_repo_path()}/requirements.txt'
+
             client = self.init_kernel_client(DEFAULT_KERNEL_NAME)
             msg_id = client.execute(code)
             uuid = message.get('uuid')


### PR DESCRIPTION
# Summary
- When user clicks on `requirements.txt` file in root project folder, they can pip install the packages saved in that file by clicking on a button (instead of having to enter a command through the Sidekick terminal). This automatically opens up the terminal to see the output from the `pip install -r requirements.txt` command.

# Tests
![pip install packages](https://user-images.githubusercontent.com/78053898/208858446-d7d7eb3b-0e1d-4287-86bd-003dcd3f08d8.gif)

cc:
@tommydangerous 
