### PR TITLE
[jk] Fix AddNewBlocks dropdown from being blocked by following block header

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -654,7 +654,7 @@ function CodeBlockProps({
   return (
     <div ref={ref} style={{
       position: 'relative',
-      zIndex: blockIdx === addNewBlockMenuOpenIdx ? 11 : null,
+      zIndex: blockIdx === addNewBlockMenuOpenIdx ? 12 : null,
     }}>
       <BlockHeaderStyle {...borderColorShareProps}>
         <FlexContainer


### PR DESCRIPTION
# Summary
- When the following block was selected, its header would block the AddNewBlocks dropdown so this PR fixes that issue.

# Tests
Before:
![blocked dropdown](https://user-images.githubusercontent.com/78053898/209448065-bdbfab3b-b803-4262-a4ad-29ac99b5b563.png)

After:
![fixed dropdown](https://user-images.githubusercontent.com/78053898/209448071-b6073924-b57d-44d5-bec2-b78585e03a48.png)


cc:
@tommydangerous 
