### PR TITLE
[jk] Show block output for non-table output data.

### DIFF
--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -449,7 +449,7 @@ function Table({
     >
       {renderRow}
     </VariableSizeList>
-  ), [listHeight, refListOuter, renderRow, rows])
+  ), [listHeight, refListOuter, renderRow, rows]);
 
   return (
     <div
@@ -571,7 +571,7 @@ function DataTable({
       columnHeaderHeight={columnHeaderHeight}
       disableScrolling={disableScrolling}
       height={height}
-      maxHeight={maxHeight + 37}    // Add 37px so horizontal scrollbar is visible
+      maxHeight={(maxHeight || 0) + 37}    // Add 37px so horizontal scrollbar is visible
       noBorderBottom={noBorderBottom}
       noBorderLeft={noBorderLeft}
       noBorderRight={noBorderRight}

--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/buildTableSidekick.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/buildTableSidekick.tsx
@@ -120,7 +120,7 @@ export default function({
               </Spacing>
             )}
             {(!loadingData && dataType === DataTypeEnum.TABLE) && blockOutputTable}
-            {(!loadingData && dataType === DataTypeEnum.TEXT) && blockOutputText}
+            {(!loadingData && dataType !== DataTypeEnum.TABLE) && blockOutputText}
           </div>
         </>
       )}

--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/buildTableSidekick.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/buildTableSidekick.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 import BlockRunType from '@interfaces/BlockRunType';
 import DataTable from '@components/DataTable';
 import DependencyGraph from '@components/DependencyGraph';
@@ -9,12 +7,15 @@ import PipelineType from '@interfaces/PipelineType';
 import Spacing from '@oracle/elements/Spacing';
 import Spinner from '@oracle/components/Spinner';
 import Text from '@oracle/elements/Text';
+import { DataTypeEnum } from '@interfaces/KernelOutputType';
 import { TABLE_COLUMN_HEADER_HEIGHT } from '@components/Sidekick/index.style';
 import { createBlockStatus } from '@components/Triggers/utils';
 
+// eslint-disable-next-line import/no-anonymous-default-export
 export default function({
   blockRuns,
   columns,
+  dataType,
   height,
   heightOffset,
   loadingData,
@@ -22,10 +23,12 @@ export default function({
   renderColumnHeader,
   rows,
   selectedRun,
+  textData,
   ...props
 }: {
   blockRuns: BlockRunType[];
   columns: string[],
+  dataType: DataTypeEnum,
   height: number;
   heightOffset?: number;
   loadingData?: boolean;
@@ -35,32 +38,44 @@ export default function({
   }) => any;
   rows: string[][] | number[][];
   selectedRun?: BlockRunType;
+  textData?: string;
 }) {
 
   const updatedProps = { ...props };
   updatedProps['blockStatus'] = createBlockStatus(blockRuns);
 
-  const blockOutputTable = (
-    <>
-      {rows && rows.length > 0 ? (
-        <DataTable
-          columnHeaderHeight={renderColumnHeader ? TABLE_COLUMN_HEADER_HEIGHT : 0}
-          columns={columns}
-          height={height - heightOffset - 90}
-          noBorderBottom
-          noBorderLeft
-          noBorderRight
-          renderColumnHeader={renderColumnHeader}
-          rows={rows}
-        />
-      ) : (
-        <Spacing ml={2}>
-          <Text>
-            This block run has no output
-          </Text>
-        </Spacing>
-      )}
-    </>
+  const emptyOutputMessageEl = (
+    <Spacing ml={2}>
+      <Text>
+        This block run has no output.
+      </Text>
+    </Spacing>
+  );
+
+  const blockOutputTable = (rows && rows.length > 0
+    ? (
+      <DataTable
+        columnHeaderHeight={renderColumnHeader ? TABLE_COLUMN_HEADER_HEIGHT : 0}
+        columns={columns}
+        height={height - heightOffset - 90}
+        noBorderBottom
+        noBorderLeft
+        noBorderRight
+        renderColumnHeader={renderColumnHeader}
+        rows={rows}
+      />
+    ) : emptyOutputMessageEl
+  );
+
+  const blockOutputText = (!!textData
+    ? (
+      <Spacing ml={2}>
+        <Text monospace>
+          {textData}
+        </Text>
+      </Spacing>
+    )
+    : emptyOutputMessageEl
   );
 
   return (
@@ -98,7 +113,8 @@ export default function({
                 </FlexContainer>
               </Spacing>
             )}
-            {!loadingData && blockOutputTable}
+            {(!loadingData && dataType === DataTypeEnum.TABLE) && blockOutputTable}
+            {(!loadingData && dataType === DataTypeEnum.TEXT) && blockOutputText}
           </div>
         </>
       )}

--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/buildTableSidekick.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/buildTableSidekick.tsx
@@ -10,6 +10,7 @@ import Text from '@oracle/elements/Text';
 import { DataTypeEnum } from '@interfaces/KernelOutputType';
 import { TABLE_COLUMN_HEADER_HEIGHT } from '@components/Sidekick/index.style';
 import { createBlockStatus } from '@components/Triggers/utils';
+import { isJsonString } from '@utils/string';
 
 // eslint-disable-next-line import/no-anonymous-default-export
 export default function({
@@ -67,11 +68,16 @@ export default function({
     ) : emptyOutputMessageEl
   );
 
+  const parsedText = isJsonString(textData)
+    ? JSON.stringify(JSON.parse(textData), null, 2)
+    : textData;
   const blockOutputText = (!!textData
     ? (
       <Spacing ml={2}>
         <Text monospace>
-          {textData}
+          <pre>
+            {parsedText}
+          </pre>
         </Text>
       </Spacing>
     )

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
@@ -12,6 +12,7 @@ import PipelineType from '@interfaces/PipelineType';
 import Spacing from '@oracle/elements/Spacing';
 import api from '@api';
 import buildTableSidekick from '@components/PipelineDetail/BlockRuns/buildTableSidekick';
+import { OutputType } from '@interfaces/BlockType';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
 import { PADDING_UNITS } from '@oracle/styles/units/spacing';
 import { onSuccess } from '@api/utils/response';
@@ -83,10 +84,13 @@ function PipelineBlockRuns({
     loading: loadingOutput,
     mutate: fetchOutput,
   } = api.outputs.block_runs.list(selectedRun?.id);
+  console.log('dataOutput:', dataOutput);
 
   const {
-    sample_data: blockSampleData
-  } = dataOutput?.outputs?.[0] || {};
+    sample_data: blockSampleData,
+    text_data: textData,
+    type: dataType,
+  }: OutputType = dataOutput?.outputs?.[0] || {};
 
   const blockRuns = useMemo(() => pipelineRun?.block_runs, [pipelineRun]);
 
@@ -112,14 +116,6 @@ function PipelineBlockRuns({
 
   return (
     <PipelineDetailPage
-      buildSidekick={props => buildTableSidekick({
-        ...props,
-        blockRuns,
-        columns,
-        loadingData: loadingOutput,
-        rows,
-        selectedRun,
-      })}
       breadcrumbs={[
         {
           label: () => 'Runs',
@@ -132,6 +128,16 @@ function PipelineBlockRuns({
           label: () => pipelineRun?.execution_date,
         },
       ]}
+      buildSidekick={props => buildTableSidekick({
+        ...props,
+        blockRuns,
+        columns,
+        dataType,
+        loadingData: loadingOutput,
+        rows,
+        selectedRun,
+        textData,
+      })}
       pageName={PageNameEnum.RUNS}
       pipeline={pipeline}
       subheader={pipelineRun?.status && pipelineRun.status !== RunStatus.COMPLETED && (


### PR DESCRIPTION
# Summary
- Block output was not appearing in certain scenarios, so this PR parses and displays text data (in addition to existing table data).

# Tests
![text block output](https://user-images.githubusercontent.com/78053898/210461376-14f512c2-a34c-429a-8412-ac1eb222ac6c.gif)
