### PR TITLE
[jk]  Add back run log filter

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -193,14 +193,14 @@ function BlockRuns({
           }
           evals.push(query['block_type[]'].includes(blocksByUUID[blockUUID]?.type));
         }
-        // if (query[PIPELINE_RUN_ID_PARAM]) {
-        //   const pipelineRunId = data?.pipeline_run_id;
-        //   evals.push(query[PIPELINE_RUN_ID_PARAM].includes(String(pipelineRunId)));
-        // }
-        // if (query[BLOCK_RUN_ID_PARAM]) {
-        //   const blockRunId = data?.block_run_id;
-        //   evals.push(query[BLOCK_RUN_ID_PARAM].includes(String(blockRunId)));
-        // }
+        if (query[PIPELINE_RUN_ID_PARAM]) {
+          const pipelineRunId = data?.pipeline_run_id;
+          evals.push(query[PIPELINE_RUN_ID_PARAM].includes(String(pipelineRunId)));
+        }
+        if (query[BLOCK_RUN_ID_PARAM]) {
+          const blockRunId = data?.block_run_id;
+          evals.push(query[BLOCK_RUN_ID_PARAM].includes(String(blockRunId)));
+        }
 
         return evals.every(v => v);
       }), [

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
@@ -84,7 +84,6 @@ function PipelineBlockRuns({
     loading: loadingOutput,
     mutate: fetchOutput,
   } = api.outputs.block_runs.list(selectedRun?.id);
-  console.log('dataOutput:', dataOutput);
 
   const {
     sample_data: blockSampleData,


### PR DESCRIPTION
# Summary
- Filters logs by individual pipeline runs and block runs when the same pipeline has been run (re-ran) multiple times.
- Originally added in https://github.com/mage-ai/mage-ai/pull/1530 but reverted until tags were added to additional logs in https://github.com/mage-ai/mage-ai/pull/1676.

# Tests
Only logs displayed for a particular run instead of all logs included in other re-runs:
![run log filter](https://user-images.githubusercontent.com/78053898/210504901-7f2fd00d-c358-44c5-9511-d014bed8a971.gif)
