### PR TITLE
[jk] Improve UX for newly added code blocks

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -305,7 +305,7 @@ class Block:
             pipeline.add_block(
                 block,
                 upstream_block_uuids,
-                priority=priority if len(upstream_block_uuids) == 0 else None,
+                priority=priority if len(upstream_block_uuids) > 0 else None,
                 widget=widget,
             )
 

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -670,7 +670,10 @@ function CodeBlockProps({
       position: 'relative',
       zIndex: blockIdx === addNewBlockMenuOpenIdx ? 12 : null,
     }}>
-      <BlockHeaderStyle {...borderColorShareProps}>
+      <BlockHeaderStyle
+        {...borderColorShareProps}
+        onClick={() => onClickSelectBlock()}
+      >
         <FlexContainer
           alignItems="center"
           justifyContent="space-between"

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -592,7 +592,7 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
                   type: BlockTypeEnum.DBT,
                 };
                 if (creatingNewDBTModel) {
-                  newBlock.content = `--Docs: https://docs.mage.ai/docs/guides/dbt/dependencies
+                  newBlock.content = `--Docs: https://docs.mage.ai/dbt/sources
 `;
                 }
 

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1016,7 +1016,7 @@ function PipelineDetailPage({
           chartRef?.current?.scrollIntoView();
         }
       }
-    } else {
+    } else if (filePath) {
       openFile(filePath);
     }
   }, [
@@ -1029,10 +1029,14 @@ function PipelineDetailPage({
       if (block) {
         onSelectBlockFile(block.uuid, block.type, null);
       }
+    } else if (blocksPrevious?.length !== blocks?.length && selectedBlock) {
+      onSelectBlockFile(selectedBlock.uuid, selectedBlock.type, null);
     }
   }, [
     blockUUIDFromUrl,
+    blocksPrevious?.length,
     blocks,
+    onSelectBlockFile,
     selectedBlock,
   ]);
 


### PR DESCRIPTION
# Summary
- Position new code blocks directly after block where it was added instead of always at the bottom.
- Scroll newly added code block into view (including code blocks added from existing files).
- Clicking on code block header will select that block (previously had to click on the body to select the block).

# Tests
![improve newly added code blocks](https://user-images.githubusercontent.com/78053898/210691308-e4ad49c2-89f9-4d1d-b7a7-9903024e1516.gif)
