### PR TITLE
[jk] Only show spinner for runs with triggers that exist

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -111,7 +111,7 @@ function RetryButton({
         borderRadius={BORDER_RADIUS_XXXLARGE}
         danger={RunStatus.FAILED === status}
         default={RunStatus.INITIAL === status}
-        loading={!pipelineSchedule}
+        loading={!!pipelineScheduleId && !pipelineSchedule}
         onClick={() => setShowConfirmation(true)}
         padding="6px"
         primary={RunStatus.RUNNING === status && !isLoadingCancelPipeline}


### PR DESCRIPTION
# Summary
- Pipeline runs page was showing an infinite spinner if the trigger (pipeline schedule) had been deleted, so this PR checks if the trigger exists.

# Tests
- Local

cc:
@tommydangerous 
