### PR TITLE
[jk] Disable deleting dependency on non-pipeline-editor page

### DIFF
--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -550,7 +550,7 @@ function DependencyGraph({
                   });
                   setEdgeSelections([]);
                 }}
-                removable={!editingBlock?.upstreamBlocks}
+                removable={enablePorts && !editingBlock?.upstreamBlocks}
                 style={{
                   stroke: getColorsForBlockType(block?.type, { theme: themeContext })?.accent,
                 }}


### PR DESCRIPTION
# Summary
- Only allow deletion of edges (dependencies between nodes in dependency graph) in the Pipeline Editor page.

# Tests
- Local
