### PR TITLE
[xy] Fix monitor stats for deleted pipeline schedule.

### DIFF
--- a/mage_ai/orchestration/monitor/monitor_stats.py
+++ b/mage_ai/orchestration/monitor/monitor_stats.py
@@ -61,6 +61,8 @@ class MonitorStats:
         pipeline_runs = pipeline_runs.all()
         stats_by_schedule_id = dict()
         for p in pipeline_runs:
+            if p.pipeline_schedule is None:
+                continue
             if p.pipeline_schedule_id not in stats_by_schedule_id:
                 stats_by_schedule_id[p.pipeline_schedule_id] = dict(
                     name=p.pipeline_schedule_name,


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Fix monitor stats for deleted pipeline schedule.

```
Traceback (most recent call last):
  File \"/usr/local/lib/python3.10/site-packages/tornado/web.py\", line 1702, in _execute
    result = method(*self.path_args, **self.path_kwargs)
  File \"/usr/local/lib/python3.10/site-packages/mage_ai/server/api/monitor.py\", line 11, in get
    stats = MonitorStats().get_stats(
  File \"/usr/local/lib/python3.10/site-packages/mage_ai/orchestration/monitor/monitor_stats.py\", line 40, in get_stats
    return self.get_pipeline_run_count(**new_kwargs)
  File \"/usr/local/lib/python3.10/site-packages/mage_ai/orchestration/monitor/monitor_stats.py\", line 66, in get_pipeline_run_count
    name=p.pipeline_schedule_name,
  File \"/usr/local/lib/python3.10/site-packages/mage_ai/orchestration/db/models.py\", line 284, in pipeline_schedule_name
    return self.pipeline_schedule.name
AttributeError: 'NoneType' object has no attribute 'name'
```

# Tests
<!-- How did you test your change? -->

cc:
<!-- Optionally mention someone to let them know about this pull request -->
