### PR TITLE
[xy] Batch update block run status to improve perf.

### DIFF
--- a/mage_ai/orchestration/db/models.py
+++ b/mage_ai/orchestration/db/models.py
@@ -367,6 +367,17 @@ class BlockRun(BaseModel):
         ).get_logs()
 
     @classmethod
+    def batch_update_status(self, block_run_ids: List[int], status):
+        BlockRun.query.filter(BlockRun.id.in_(block_run_ids)).update({
+            BlockRun.status: status
+        }, synchronize_session=False)
+        try:
+            db_connection.session.commit()
+        except Exception as e:
+            db_connection.rollback()
+            raise e
+
+    @classmethod
     def get(self, pipeline_run_id: int = None, block_uuid: str = None) -> 'BlockRun':
         block_runs = self.query.filter(
             BlockRun.pipeline_run_id == pipeline_run_id,

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -65,13 +65,18 @@ class PipelineScheduler:
         self.pipeline_run.update(status=PipelineRun.PipelineRunStatus.CANCELLED)
 
         # Cancel all the block runs
+        block_runs_to_cancel = []
         for b in self.pipeline_run.block_runs:
             if b.status in [
                 BlockRun.BlockRunStatus.INITIAL,
                 BlockRun.BlockRunStatus.QUEUED,
                 BlockRun.BlockRunStatus.RUNNING,
             ]:
-                b.update(status=BlockRun.BlockRunStatus.CANCELLED)
+                block_runs_to_cancel.append(b)
+        BlockRun.batch_update_status(
+            [b.id for b in block_runs_to_cancel],
+            BlockRun.BlockRunStatus.CANCELLED,
+        )
 
         if PipelineType.INTEGRATION == self.pipeline.type:
             execution_process_manager.terminate_pipeline_process(self.pipeline_run.id)

--- a/mage_ai/server/api/orchestration.py
+++ b/mage_ai/server/api/orchestration.py
@@ -234,6 +234,11 @@ class ApiPipelineRunDetailHandler(BaseDetailHandler):
                             pipeline_run.block_runs
                         )
                     )
+                # Update block run status to INITIAL
+                BlockRun.batch_update_status(
+                    [b.id for b in incomplete_block_runs],
+                    BlockRun.BlockRunStatus.INITIAL,
+                )
 
                 from mage_ai.orchestration.execution_process_manager import execution_process_manager
                 if PipelineType.STREAMING != pipeline.type:
@@ -269,8 +274,10 @@ class ApiPipelineRunListHandler(BaseHandler):
 
         if PipelineSchedule.ScheduleType.API == pipeline_schedule.schedule_type and \
             pipeline_schedule.token and \
-            pipeline_schedule.token != token:
-            raise UnauthenticatedRequestException(f'Invalid token for pipeline schedule ID {pipeline_schedule_id}.')
+                pipeline_schedule.token != token:
+            raise UnauthenticatedRequestException(
+                f'Invalid token for pipeline schedule ID {pipeline_schedule_id}.',
+            )
 
         pipeline = Pipeline.get(pipeline_schedule.pipeline_uuid)
 

--- a/mage_ai/server/api/orchestration.py
+++ b/mage_ai/server/api/orchestration.py
@@ -248,11 +248,7 @@ class ApiPipelineRunDetailHandler(BaseDetailHandler):
                         for br in incomplete_block_runs:
                             execution_process_manager.terminate_block_process(pipeline_run.id, br.id)
 
-                from mage_ai.orchestration.pipeline_scheduler import PipelineScheduler
-                pipeline_scheduler = PipelineScheduler(pipeline_run)
-
                 pipeline_run.update(status=PipelineRun.PipelineRunStatus.RUNNING)
-                pipeline_scheduler.schedule(incomplete_block_runs)
         elif payload.get('status') == PipelineRun.PipelineRunStatus.CANCELLED:
             from mage_ai.orchestration.pipeline_scheduler import PipelineScheduler
             PipelineScheduler(pipeline_run).stop()


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
* Batch update block run status to improve perf.
  * Batch update block run status to CANCELLED when cancelling pipeline run
  * Batch update block run status to INITIAL when retrying pipeline run
* Not run scheduler for same pipeline run twice. API server and Scheduler don't share the same execution_process_manager. They could run the pipeline run at the same time. Thus, don't schedule pipeline run in API server.

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
