### PR TITLE
[jl] Update default query limit in docs

### DIFF
--- a/docs/design/data-loading.mdx
+++ b/docs/design/data-loading.mdx
@@ -217,12 +217,12 @@ Exports a Pandas data frame to a Redshift cluster under the specified table. The
 
 Loads data from the results of a query into a Pandas data frame. This will fail if the query returns no data from the database.
 
-This function will load at maximum 100,000 rows of data (this limit is configurable). To operate on more data, consider performing data transformations in warehouse using `execute`.
+This function will load at maximum 10,000,000 rows of data (this limit is configurable). To operate on more data, consider performing data transformations in warehouse using `execute`.
 
 -   **Args**:
 
     -   `query_string (str)`: Query to fetch a table or subset of a table.
-    -   `limit (int, Optional)`: The number of rows to limit the loaded data frame to. Defaults to 100,000.
+    -   `limit (int, Optional)`: The number of rows to limit the loaded data frame to. Defaults to 10,000,000.
     -   `*args, **kwargs`: Additional parameters to send to query, including parameters
         for use with format strings. See [`redshift-connector` docs](https://github.com/aws/amazon-redshift-python-driver#configuring-cursor-paramstyle) for configuring query parameters.
 
@@ -243,7 +243,7 @@ Sample data from a table in the selected database in the Redshift cluster. Sampl
 -   **Args**:
 
     -   `schema (str)`: The schema to select the table from.
-    -   `size (int)`: The number of rows to sample. Defaults to 100,000.
+    -   `size (int)`: The number of rows to sample. Defaults to 10,000,000.
     -   `table (str)`: The table to sample from in the connected database.
 
 -   **Returns**: (`DataFrame`) Sampled data from the table.
@@ -318,14 +318,14 @@ If the format is HDF5, the default key under which the data frame is stored is t
 
 **_load_** - `load(bucket_name: str, object_key: str, format: FileFormat | str = None, limit: int = QUERY_ROW_LIMIT **kwargs) -> DataFrame`
 
-Loads data from object in S3 bucket into a Pandas data frame. This function will load at maximum 100,000 rows of data from the specified file (this limit is configurable).
+Loads data from object in S3 bucket into a Pandas data frame. This function will load at maximum 10,000,000 rows of data from the specified file (this limit is configurable).
 
 -   **Args**:
 
     -   `bucket_name (str)`: Name of the bucket to load data from.
     -   `object_key (str)`: Key of the object in S3 bucket to load data from.
     -   `format (FileFormat | str, Optional)`: Format of the file to load data frame from. Defaults to None, in which case the format is inferred.
-    -   `limit (int, optional)`: The number of rows to limit the loaded data frame to. Defaults to 100,000.
+    -   `limit (int, optional)`: The number of rows to limit the loaded data frame to. Defaults to 10,000,000.
     -   `**kwargs` - Additional keyword arguments to pass to the file writer. See possible arguments by file formats at:
 
         | Format  | Pandas Reader                                                                                         |
@@ -381,13 +381,13 @@ If the format is HDF5, the default key under which the data frame is stored is t
 
 **_load_** - `load(filepath: os.PathLike, format: FileFormat | str = None, limit: int = QUERY_ROW_LIMIT **kwargs) -> DataFrame`
 
-Loads the data frame from the filepath specified. This function will load at maximum 100,000 rows of data from the specified file (this limit is configurable).
+Loads the data frame from the filepath specified. This function will load at maximum 10,000,000 rows of data from the specified file (this limit is configurable).
 
 -   **Args**:
 
     -   `filepath (os.PathLike)`: Filepath to load data frame from.
     -   `format (FileFormat | str, Optional)`: Format of the file to load data frame from. Defaults to None, in which case the format is inferred.
-    -   `limit (int, optional)`: The number of rows to limit the loaded data frame to. Defaults to 100,000.
+    -   `limit (int, optional)`: The number of rows to limit the loaded data frame to. Defaults to 10,000,000.
     -   `**kwargs` - Additional keyword arguments to pass to the file writer. See possible arguments by file formats at:
 
         | Format  | Pandas Reader                                                                                         |
@@ -489,11 +489,11 @@ Exports a data frame to a Google BigQuery warehouse. If table doesn't exist, the
 
 Loads data from the results of a query into a Pandas data frame. This will fail if the query returns no data from the database.
 
-When a select query is provided, this function will load at maximum 100,000 rows of data (this limit is configurable). To operate on more data, consider performing data transformations in warehouse.
+When a select query is provided, this function will load at maximum 10,000,000 rows of data (this limit is configurable). To operate on more data, consider performing data transformations in warehouse.
 
 -   **Args**:
     -   `query_string (str)`: Query to fetch a table or subset of a table.
-    -   `limit (int, Optional)`: The number of rows to limit the loaded data frame to. Defaults to 100,000.
+    -   `limit (int, Optional)`: The number of rows to limit the loaded data frame to. Defaults to 10,000,000.
     -   `**kwargs`: Additional parameters to pass to the query. See [Google BigQuery Python client](https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.client.Client.html?highlight=client#google.cloud.bigquery.client.Client.query) docs for additional arguments.
 
 **_sample_** - `sample(schema: str, table: str, size: int, **kwargs) -> DataFrame`
@@ -503,7 +503,7 @@ Sample data from a table in the BigQuery warehouse. Sample is not guaranteed to 
 -   **Args**:
 
     -   `schema (str)`: The schema to select the table from.
-    -   `size (int)`: The number of rows to sample. Defaults to 100,000
+    -   `size (int)`: The number of rows to sample. Defaults to 10,000,000.
     -   `table (str)`: The table to sample from in the connected database.
 
 -   **Returns**: (`DataFrame`) Sampled data from the table.
@@ -597,11 +597,11 @@ Any changes made to the database will not be saved unless `commit()` is called a
 
 Loads data from the results of a query into a Pandas data frame. This will fail if the query returns no data from the database.
 
-This function will load at maximum 100,000 rows of data (this limit is configurable). To operate on more data, consider performing data transformations in warehouse.
+This function will load at maximum 10,000,000 rows of data (this limit is configurable). To operate on more data, consider performing data transformations in warehouse.
 
 -   **Args**:
     -   `query_string (str)`: Query to fetch a table or subset of a table.
-    -   `limit (int, Optional)`: The number of rows to limit the loaded data frame to. Defaults to 100,000.
+    -   `limit (int, Optional)`: The number of rows to limit the loaded data frame to. Defaults to 10,000,000.
     -   `**kwargs`: Additional parameters to pass to the query. See [`psycopg2` docs](https://www.psycopg.org/docs/usage.html#query-parameters) for configuring query parameters.
 -   **Returns**: (`DataFrame`) Data frame containing the queried data.
 
@@ -620,7 +620,7 @@ Sample data from a table in the PostgreSQL database. Sample is not guaranteed to
 -   **Args**:
 
     -   `schema (str)`: The schema to select the table from.
-    -   `size (int)`: The number of rows to sample. Defaults to 100,000.
+    -   `size (int)`: The number of rows to sample. Defaults to 10,000,000.
     -   `table (str)`: The table to sample from in the connected database.
 
 -   **Returns**: (`DataFrame`) Sampled data from the table.
@@ -720,11 +720,11 @@ Any changes made to the database will not be saved unless `commit()` is called a
 
 Loads data from Snowflake into a Pandas data frame based on the query given. This will fail unless a `SELECT` query is provided.
 
-This function will load at maximum 100,000 rows of data (this limit is configurable). To operate on more data, consider performing data transformations in warehouse using `execute`.
+This function will load at maximum 10,000,000 rows of data (this limit is configurable). To operate on more data, consider performing data transformations in warehouse using `execute`.
 
 -   **Args**:
     -   `query_string (str)`: Query to fetch a table or subset of a table.
-    -   `limit (int, Optional)`: The number of rows to limit the loaded data frame to. Defaults to 100,000.
+    -   `limit (int, Optional)`: The number of rows to limit the loaded data frame to. Defaults to 10,000,000.
     -   `*args, **kwargs`: Additional parameters to pass to the query. See [Snowflake Connector Docs](https://docs.snowflake.com/en/user-guide/python-connector-api.html#execute) for additional parameters.
 -   **Returns**: (`DataFrame`) Data frame containing the queried data
 
@@ -743,7 +743,7 @@ Sample data from a table in the Snowflake warehouse. Sample is not guaranteed to
 -   **Args**:
 
     -   `schema (str)`: The schema to select the table from.
-    -   `size (int)`: The number of rows to sample. Defaults to 100,000
+    -   `size (int)`: The number of rows to sample. Defaults to 10,000,000.
     -   `table (str)`: The table to sample from in the connected database.
 
 -   **Returns**: (`DataFrame`) Sampled data from the data frame.

--- a/mage_ai/io/azure_blob_storage.py
+++ b/mage_ai/io/azure_blob_storage.py
@@ -55,7 +55,7 @@ class AzureBlobStorage(BaseFile):
     ) -> DataFrame:
         """
         Loads data from Azure Blob Storage into a Pandas data frame. This function will load at
-        maximum 100,000 rows of data from the specified file.
+        maximum 10,000,000 rows of data from the specified file.
 
         Returns:
             DataFrame: The data frame constructed from the file in the Azure Blob Storage container.

--- a/mage_ai/io/base.py
+++ b/mage_ai/io/base.py
@@ -243,7 +243,7 @@ class BaseSQLDatabase(BaseIO):
 
         Args:
             schema (str): The schema to select the table from.
-            size (int): The number of rows to sample. Defaults to 100,000
+            size (int): The number of rows to sample. Defaults to 10,000,000.
             table (str): The table to sample from in the connected database.
 
         Returns:

--- a/mage_ai/io/bigquery.py
+++ b/mage_ai/io/bigquery.py
@@ -121,14 +121,14 @@ WHERE TABLE_NAME = '{table_name}'
         """
         Loads data from BigQuery into a Pandas data frame based on the query given.
         This will fail if the query returns no data from the database. When a select query
-        is provided, this function will load at maximum 100,000 rows of data. To operate on more data,
+        is provided, this function will load at maximum 10,000,000 rows of data. To operate on more data,
         consider performing data transformations in warehouse.
 
 
 
         Args:
             query_string (str): Query to fetch a table or subset of a table.
-            limit (int, Optional): The number of rows to limit the loaded dataframe to. Defaults to 100000.
+            limit (int, Optional): The number of rows to limit the loaded dataframe to. Defaults to 10,000,000.
             **kwargs: Additional arguments to pass to query, such as query configurations
 
         Returns:

--- a/mage_ai/io/google_cloud_storage.py
+++ b/mage_ai/io/google_cloud_storage.py
@@ -72,12 +72,12 @@ class GoogleCloudStorage(BaseFile):
     ) -> DataFrame:
         """
         Loads data from Google Cloud Storage into a Pandas data frame. This function will load at
-        maximum 100,000 rows of data from the specified file.
+        maximum 10,000,000 rows of data from the specified file.
 
         Args:
             import_config (Mapping, optional): Configuration settings for importing file from
             Google Cloud Storage. Defaults to None.
-            limit (int, Optional): The number of rows to limit the loaded dataframe to. Defaults to 100000.
+            limit (int, Optional): The number of rows to limit the loaded dataframe to. Defaults to 10,000,000.
             read_config (Mapping, optional): Configuration settings for reading file into data
             frame. Defaults to None.
 

--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -83,12 +83,12 @@ class Postgres(BaseSQLConnection):
         """
         Loads data from the connected database into a Pandas data frame based on the query given.
         This will fail if the query returns no data from the database. This function will load at
-        maximum 100,000 rows of data. To operate on more data, consider performing data
+        maximum 10,000,000 rows of data. To operate on more data, consider performing data
         transformations in warehouse.
 
         Args:
             query_string (str): Query to execute on the database.
-            limit (int, Optional): The number of rows to limit the loaded dataframe to. Defaults to 100000.
+            limit (int, Optional): The number of rows to limit the loaded dataframe to. Defaults to 10,000,000.
             **kwargs: Additional query parameters.
 
         Returns:

--- a/mage_ai/io/redshift.py
+++ b/mage_ai/io/redshift.py
@@ -54,13 +54,13 @@ class Redshift(BaseSQLConnection):
         """
         Uses query to load data from Redshift cluster into a Pandas data frame.
         This will fail if the query returns no data from the database. When a
-        select query is provided, this function will load at maximum 100,000 rows of data.
+        select query is provided, this function will load at maximum 10,000,000 rows of data.
         To operate on more data, consider performing data transformations in warehouse.
 
 
         Args:
             query_string (str): Query to fetch a table or subset of a table.
-            limit (int, Optional): The number of rows to limit the loaded dataframe to. Defaults to 100000.
+            limit (int, Optional): The number of rows to limit the loaded dataframe to. Defaults to 10,000,000.
             *args, **kwargs: Additional parameters to send to query, including parameters
             for use with format strings. See `redshift-connector` docs for more options.
 

--- a/mage_ai/io/s3.py
+++ b/mage_ai/io/s3.py
@@ -48,12 +48,12 @@ class S3(BaseFile):
     ) -> DataFrame:
         """
         Loads data from S3 into a Pandas data frame. This function will load at
-        maximum 100,000 rows of data from the specified file.
+        maximum 10,000,000 rows of data from the specified file.
 
         Args:
             import_config (Mapping, optional): Configuration settings for importing file from
             S3. Defaults to None.
-            limit (int, Optional): The number of rows to limit the loaded dataframe to. Defaults to 100000.
+            limit (int, Optional): The number of rows to limit the loaded dataframe to. Defaults to 10,000,000.
             read_config (Mapping, optional): Configuration settings for reading file into data
             frame. Defaults to None.
 

--- a/mage_ai/io/snowflake.py
+++ b/mage_ai/io/snowflake.py
@@ -68,13 +68,12 @@ class Snowflake(BaseSQLConnection):
         """
         Loads data from Snowflake into a Pandas data frame based on the query given.
         This will fail unless a `SELECT` query is provided. This function will load at
-        maximum 100,000 rows of data. To operate on more data, consider performing data
+        maximum 10,000,000 rows of data. To operate on more data, consider performing data
         transformations in warehouse.
-
 
         Args:
             query_string (str): Query to fetch a table or subset of a table.
-            limit (int, Optional): The number of rows to limit the loaded dataframe to. Defaults to 100000.
+            limit (int, Optional): The number of rows to limit the loaded dataframe to. Defaults to 10,000,000.
             *args, **kwargs: Additional parameters to provide to the query
 
         Returns:


### PR DESCRIPTION
# Summary
Update the documentation for the **default row limit when loading data**. Increased it from 100,000 to 10,000,000 due to changes in #779.

