### PR TITLE
[xy] Speed up more API endpoints

### DIFF
--- a/mage_ai/data_preparation/logging/logger_manager.py
+++ b/mage_ai/data_preparation/logging/logger_manager.py
@@ -102,3 +102,7 @@ class LoggerManager:
     def get_logs(self):
         file = File.from_path(self.get_log_filepath())
         return file.to_dict(include_content=True)
+
+    async def get_logs_async(self):
+        file = File.from_path(self.get_log_filepath())
+        return await file.to_dict_async(include_content=True)

--- a/mage_ai/data_preparation/logging/s3_logger_manager.py
+++ b/mage_ai/data_preparation/logging/s3_logger_manager.py
@@ -52,3 +52,9 @@ class S3LoggerManager(LoggerManager):
             path=s3_object_key,
             content=s3_object,
         )
+
+    async def get_logs_async(self):
+        """
+        TODO: Implement this method
+        """
+        return self.get_logs()

--- a/mage_ai/data_preparation/models/file.py
+++ b/mage_ai/data_preparation/models/file.py
@@ -83,6 +83,12 @@ class File:
             data['content'] = self.content()
         return data
 
+    async def to_dict_async(self, include_content=False):
+        data = dict(name=self.filename, path=os.path.join(self.dir_path, self.filename))
+        if include_content:
+            data['content'] = await self.content_async()
+        return data
+
 
 def traverse(name: str, is_dir: str, path: str, disabled=False, depth=1) -> Dict:
     tree_entry = dict(name=name)

--- a/mage_ai/orchestration/db/models.py
+++ b/mage_ai/orchestration/db/models.py
@@ -289,6 +289,13 @@ class PipelineRun(BaseModel):
             repo_config=self.pipeline.repo_config,
         ).get_logs()
 
+    async def logs_async(self):
+        return await LoggerManagerFactory.get_logger_manager(
+            pipeline_uuid=self.pipeline_uuid,
+            partition=self.execution_partition,
+            repo_config=self.pipeline.repo_config,
+        ).get_logs_async()
+
     @property
     def pipeline_schedule_name(self):
         return self.pipeline_schedule.name
@@ -365,6 +372,15 @@ class BlockRun(BaseModel):
             partition=self.pipeline_run.execution_partition,
             repo_config=pipeline.repo_config,
         ).get_logs()
+
+    async def logs_async(self):
+        pipeline = await Pipeline.get_async(self.pipeline_run.pipeline_uuid)
+        return await LoggerManagerFactory.get_logger_manager(
+            pipeline_uuid=pipeline.uuid,
+            block_uuid=clean_name(self.block_uuid),
+            partition=self.pipeline_run.execution_partition,
+            repo_config=pipeline.repo_config,
+        ).get_logs_async()
 
     @classmethod
     def batch_update_status(self, block_run_ids: List[int], status):

--- a/mage_ai/server/api/logs.py
+++ b/mage_ai/server/api/logs.py
@@ -9,20 +9,20 @@ MAX_LOG_FILES = 20
 
 
 class ApiPipelineLogListHandler(BaseHandler):
-    @safe_db_query
-    def get(self, pipeline_uuid):
+    async def get(self, pipeline_uuid):
         start_timestamp = self.get_argument('start_timestamp', None)
         end_timestamp = self.get_argument('end_timestamp', None)
+
         if start_timestamp:
             try:
                 start_timestamp = datetime.fromtimestamp(int(start_timestamp))
             except (ValueError, OverflowError):
-                raise Exception(f'Value is invalid for start_timestamp')
+                raise Exception('Value is invalid for start_timestamp')
         if end_timestamp:
             try:
                 end_timestamp = datetime.fromtimestamp(int(end_timestamp))
             except (ValueError, OverflowError):
-                raise Exception(f'Value is invalid for end_timestamp')
+                raise Exception('Value is invalid for end_timestamp')
 
         pipeline_schedule_ids = self.get_argument('pipeline_schedule_id[]', None)
         if pipeline_schedule_ids:
@@ -50,6 +50,7 @@ class ApiPipelineLogListHandler(BaseHandler):
 
         a = aliased(PipelineRun, name='a')
         b = aliased(PipelineSchedule, name='b')
+        c = aliased(BlockRun, name='c')
 
         columns = [
             a.execution_date,
@@ -58,114 +59,135 @@ class ApiPipelineLogListHandler(BaseHandler):
             a.pipeline_uuid,
         ]
 
-        query = (
-            PipelineRun.
-            select(*columns).
-            join(b, a.pipeline_schedule_id == b.id).
-            filter(b.pipeline_uuid == pipeline_uuid).
-            order_by(a.created_at.desc())
-        )
-
-        if len(pipeline_schedule_ids):
-            query = (
-                query.
-                filter(a.pipeline_schedule_id.in_(pipeline_schedule_ids))
-            )
-
-        if len(pipeline_run_ids):
-            query = (
-                query.
-                filter(a.id.in_(pipeline_run_ids))
-            )
-
-        if start_timestamp:
-            query = (
-                query.
-                filter(a.execution_date >= start_timestamp)
-            )
-
-        if end_timestamp:
-            query = (
-                query.
-                filter(a.execution_date <= end_timestamp)
-            )
-
         total_pipeline_run_log_count = 0
         pipeline_run_logs = []
-        if not len(block_uuids) and not len(block_run_ids):
+
+        @safe_db_query
+        def get_pipeline_runs():
+            query = (
+                PipelineRun.
+                select(*columns).
+                join(b, a.pipeline_schedule_id == b.id).
+                filter(b.pipeline_uuid == pipeline_uuid).
+                order_by(a.created_at.desc())
+            )
+
+            if len(pipeline_schedule_ids):
+                query = (
+                    query.
+                    filter(a.pipeline_schedule_id.in_(pipeline_schedule_ids))
+                )
+
+            if len(pipeline_run_ids):
+                query = (
+                    query.
+                    filter(a.id.in_(pipeline_run_ids))
+                )
+
+            if start_timestamp:
+                query = (
+                    query.
+                    filter(a.execution_date >= start_timestamp)
+                )
+
+            if end_timestamp:
+                query = (
+                    query.
+                    filter(a.execution_date <= end_timestamp)
+                )
             total_pipeline_run_log_count = query.count()
             if self.get_argument(META_KEY_LIMIT, None) is not None:
                 rows = self.limit(query)
             else:
                 rows = query.all()
+            return dict(
+                total_pipeline_run_log_count=total_pipeline_run_log_count,
+                rows=rows,
+            )
+
+        if not len(block_uuids) and not len(block_run_ids):
+            pipeline_run_results = get_pipeline_runs()
+            total_pipeline_run_log_count = pipeline_run_results['total_pipeline_run_log_count']
+            pipeline_run_rows = pipeline_run_results['rows']
 
             processed_pipeline_run_log_files = set()
-            for row in rows:
+            for row in pipeline_run_rows:
                 model = PipelineRun()
                 model.execution_date = row.execution_date
                 model.pipeline_schedule_id = row.pipeline_schedule_id
                 model.pipeline_uuid = row.pipeline_uuid
-                pipeline_log_file_path = model.logs.get('path')
+                logs = await model.logs_async()
+                pipeline_log_file_path = logs.get('path')
                 if pipeline_log_file_path not in processed_pipeline_run_log_files:
-                    pipeline_run_logs.append(model.logs)
+                    pipeline_run_logs.append(logs)
                     processed_pipeline_run_log_files.add(pipeline_log_file_path)
                 if len(pipeline_run_logs) >= MAX_LOG_FILES:
                     break
 
-        c = aliased(BlockRun, name='c')
-        query = (
-            BlockRun.
-            select(*(columns + [
-                c.block_uuid,
-            ])).
-            join(a, a.id == c.pipeline_run_id).
-            join(b, a.pipeline_schedule_id == b.id).
-            filter(b.pipeline_uuid == pipeline_uuid).
-            order_by(c.started_at.desc())
-        )
-
-        if len(block_uuids):
+        @safe_db_query
+        def get_block_runs():
             query = (
-                query.
-                filter(c.block_uuid.in_(block_uuids))
+                BlockRun.
+                select(*(columns + [
+                    c.block_uuid,
+                ])).
+                join(a, a.id == c.pipeline_run_id).
+                join(b, a.pipeline_schedule_id == b.id).
+                filter(b.pipeline_uuid == pipeline_uuid).
+                order_by(c.started_at.desc())
             )
 
-        if len(block_run_ids):
-            query = (
-                query.
-                filter(c.id.in_(block_run_ids))
+            if len(block_uuids):
+                query = (
+                    query.
+                    filter(c.block_uuid.in_(block_uuids))
+                )
+
+            if len(block_run_ids):
+                query = (
+                    query.
+                    filter(c.id.in_(block_run_ids))
+                )
+
+            if len(pipeline_schedule_ids):
+                query = (
+                    query.
+                    filter(a.pipeline_schedule_id.in_(pipeline_schedule_ids))
+                )
+
+            if len(pipeline_run_ids):
+                query = (
+                    query.
+                    filter(a.id.in_(pipeline_run_ids))
+                )
+
+            if start_timestamp:
+                query = (
+                    query.
+                    filter(a.execution_date >= start_timestamp)
+                )
+
+            if end_timestamp:
+                query = (
+                    query.
+                    filter(a.execution_date <= end_timestamp)
+                )
+
+            if self.get_argument(META_KEY_LIMIT, None) is not None:
+                rows = self.limit(query)
+            else:
+                rows = query.all()
+
+            total_block_run_log_count = query.count()
+            return dict(
+                total_block_run_log_count=total_block_run_log_count,
+                rows=rows,
             )
 
-        if len(pipeline_schedule_ids):
-            query = (
-                query.
-                filter(a.pipeline_schedule_id.in_(pipeline_schedule_ids))
-            )
+        block_run_results = get_block_runs()
+        total_block_run_log_count = block_run_results['total_block_run_log_count']
+        rows = block_run_results['rows']
 
-        if len(pipeline_run_ids):
-            query = (
-                query.
-                filter(a.id.in_(pipeline_run_ids))
-            )
-
-        if start_timestamp:
-            query = (
-                query.
-                filter(a.execution_date >= start_timestamp)
-            )
-
-        if end_timestamp:
-            query = (
-                query.
-                filter(a.execution_date <= end_timestamp)
-            )
-
-        if self.get_argument(META_KEY_LIMIT, None) is not None:
-            rows = self.limit(query)
-        else:
-            rows = query.all()
-
-        total_block_run_log_count = query.count()
         block_run_logs = []
 
         processed_block_run_log_files = set()
@@ -179,9 +201,10 @@ class ApiPipelineLogListHandler(BaseHandler):
             model2.block_uuid = row.block_uuid
             model2.pipeline_run = model
 
-            block_log_file_path = model2.logs.get('path')
+            logs = await model2.logs_async()
+            block_log_file_path = logs.get('path')
             if block_log_file_path not in processed_block_run_log_files:
-                block_run_logs.append(model2.logs)
+                block_run_logs.append(logs)
                 processed_block_run_log_files.add(block_log_file_path)
 
             if len(block_run_logs) >= MAX_LOG_FILES:

--- a/mage_ai/server/api/orchestration.py
+++ b/mage_ai/server/api/orchestration.py
@@ -18,7 +18,7 @@ from mage_ai.orchestration.db.models import (
 from mage_ai.orchestration.pipeline_scheduler import get_variables
 from mage_ai.server.api.errors import UnauthenticatedRequestException
 from mage_ai.shared.hash import merge_dict
-from sqlalchemy.orm import aliased, joinedload
+from sqlalchemy.orm import aliased, selectinload
 import json
 
 
@@ -133,8 +133,8 @@ def process_pipeline_runs(
     results = (
         PipelineRun.
         query.
-        options(joinedload(PipelineRun.block_runs)).
-        options(joinedload(PipelineRun.pipeline_schedule))
+        options(selectinload(PipelineRun.block_runs)).
+        options(selectinload(PipelineRun.pipeline_schedule))
     )
     if pipeline_schedule_id is not None:
         results = results.filter(PipelineRun.pipeline_schedule_id == pipeline_schedule_id)
@@ -183,7 +183,10 @@ def process_pipeline_runs(
         collection = \
             list(filter(lambda x: x['execution_date'] not in filter_dates, collection)) + addons
 
-    handler.write(dict(pipeline_runs=collection, total_count=initial_results.count()))
+    handler.write(dict(
+        pipeline_runs=collection,
+        total_count=initial_results.count(),
+    ))
     handler.finish()
 
 
@@ -411,8 +414,8 @@ class ApiPipelineScheduleListHandler(BaseHandler):
                 results = (
                     PipelineSchedule.
                     query.
-                    options(joinedload(PipelineSchedule.event_matchers)).
-                    options(joinedload(PipelineSchedule.pipeline_runs)).
+                    options(selectinload(PipelineSchedule.event_matchers)).
+                    options(selectinload(PipelineSchedule.pipeline_runs)).
                     filter(PipelineSchedule.pipeline_uuid == pipeline.uuid).
                     order_by(PipelineSchedule.start_time.desc(), PipelineSchedule.id.desc())
                 )


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
* Speed up `/api/pipeline_runs` endpoint by using `selectinload` instead of `joinedload` (reduce time by 30%~50%)
* Speed up `/api/logs` endpoint

# Tests
<!-- How did you test your change? -->
tested locally

Before updating the logs endpoint
<img width="1350" alt="image" src="https://user-images.githubusercontent.com/80284865/211690339-3db99e48-3ba4-48a9-b4ac-1bdcfe61c322.png">

After updating the logs endpoint
<img width="1304" alt="image" src="https://user-images.githubusercontent.com/80284865/211690773-00c89f00-798c-4cf6-8b21-a4b816cebe69.png">



cc:
<!-- Optionally mention someone to let them know about this pull request -->
