### PR TITLE
[dy] Add secret var

### DIFF
--- a/mage_ai/data_integrations/utils/config.py
+++ b/mage_ai/data_integrations/utils/config.py
@@ -129,7 +129,7 @@ def interpolate_string(text: str, variables: Dict) -> str:
         env_var=os.getenv,
         variables=lambda x: variables.get(x),
         n_days_ago=n_days_ago,
-        secret_var=get_secret,
+        aws_secret_var=get_secret,
     )
 
 

--- a/mage_ai/data_integrations/utils/config.py
+++ b/mage_ai/data_integrations/utils/config.py
@@ -1,5 +1,6 @@
 from jinja2 import Template
 from mage_ai.data_integrations.utils.parsers import NoDatesSafeLoader
+from mage_ai.services.aws.secrets_manager.secrets_manager import get_secret
 from mage_ai.shared.dates import n_days_ago
 from mage_ai.shared.hash import merge_dict
 from mage_ai.shared.parsers import encode_complex
@@ -128,6 +129,7 @@ def interpolate_string(text: str, variables: Dict) -> str:
         env_var=os.getenv,
         variables=lambda x: variables.get(x),
         n_days_ago=n_days_ago,
+        secret_var=get_secret,
     )
 
 

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -436,15 +436,19 @@ class ApiStatusHandler(BaseHandler):
             GCP_PROJECT_ID,
             KUBE_NAMESPACE,
         )
-        from mage_ai.cluster_manager.kubernetes.workload_manager import WorkloadManager
 
         instance_type = None
         if os.getenv(ECS_CLUSTER_NAME):
             instance_type = ClusterType.ECS
-        elif WorkloadManager.load_config() or os.getenv(KUBE_NAMESPACE):
-            instance_type = ClusterType.K8S
         elif os.getenv(GCP_PROJECT_ID):
             instance_type = ClusterType.CLOUD_RUN
+        else:
+            try:
+                from mage_ai.cluster_manager.kubernetes.workload_manager import WorkloadManager
+                if WorkloadManager.load_config() or os.getenv(KUBE_NAMESPACE):
+                    instance_type = ClusterType.K8S
+            except ModuleNotFoundError:
+                pass
 
         status = {
             'is_instance_manager': os.getenv(MANAGE_ENV_VAR) == '1',

--- a/mage_ai/services/aws/secrets_manager/secrets_manager.py
+++ b/mage_ai/services/aws/secrets_manager/secrets_manager.py
@@ -1,0 +1,29 @@
+from aws_secretsmanager_caching import SecretCache, SecretCacheConfig 
+from botocore.config import Config
+import boto3
+import os
+
+
+region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
+config = Config(region_name=region_name)
+client = boto3.client('secretsmanager', config=config)
+cache_config = SecretCacheConfig()
+cache = SecretCache(config=cache_config, client=client)
+
+
+def get_secret(secret_id: str, cached=True) -> str:
+    if cached:
+        return cache.get_secret_string(secret_id)
+    else:
+        return get_secret_force(secret_id)
+
+
+def get_secret_force(secret_id: str) -> str:
+    region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
+    config = Config(region_name=region_name)
+    client = boto3.client('secretsmanager', config=config)
+
+    return client.get_secret_value(
+        SecretId=secret_id,
+    ).get('SecretString')
+

--- a/mage_ai/services/aws/secrets_manager/secrets_manager.py
+++ b/mage_ai/services/aws/secrets_manager/secrets_manager.py
@@ -1,24 +1,32 @@
-from aws_secretsmanager_caching import SecretCache, SecretCacheConfig 
-from botocore.config import Config
-import boto3
 import os
 
 
-region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
-config = Config(region_name=region_name)
-client = boto3.client('secretsmanager', config=config)
-cache_config = SecretCacheConfig()
-cache = SecretCache(config=cache_config, client=client)
+class SecretsManager:
+    def __init__(self):
+        from aws_secretsmanager_caching import SecretCache, SecretCacheConfig 
+        from botocore.config import Config
+        import boto3
+
+        region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
+        config = Config(region_name=region_name)
+        client = boto3.client('secretsmanager', config=config)
+        cache_config = SecretCacheConfig()
+        self.cache = SecretCache(config=cache_config, client=client)
+
+secrets_manager = SecretsManager()
 
 
 def get_secret(secret_id: str, cached=True) -> str:
     if cached:
-        return cache.get_secret_string(secret_id)
+        return secrets_manager.cache.get_secret_string(secret_id)
     else:
         return get_secret_force(secret_id)
 
 
 def get_secret_force(secret_id: str) -> str:
+    from botocore.config import Config
+    import boto3
+    
     region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
     config = Config(region_name=region_name)
     client = boto3.client('secretsmanager', config=config)

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ aiofiles==22.1.0
 
 
 # extras
+aws-secretsmanager-caching==1.1.1.5
 botocore==1.27.19
 boto3==1.24.19
 db-dtypes==1.0.5

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setuptools.setup(
             'requests_aws4auth',
         ],
         'all': [
+            'aws-secretsmanager-caching==1.1.1.5',
             'azure-identity',
             'azure-keyvault-secrets',
             'azure-keyvault-certificates',


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

Add `secret_var` variable. Syntax is `"secret_var('secret_id', True/False)"`. Right now it will only check AWS secret manager. I was wondering if we should name the variable like `aws_secret_var` to specify AWS because there may be other secret managers in the future.

I also added caching because every request to the API costs money, but you can fetch directly from AWS with by setting the second argument as `False`. 


# Tests

<img width="929" alt="Screenshot 2023-01-17 at 3 51 36 PM" src="https://user-images.githubusercontent.com/14357209/213037496-20dd9a78-9006-4143-a3a5-836d1ab195bb.png">

<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
