### PR TITLE
[jk] Include priority when adding all blocks

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -328,7 +328,7 @@ class Block:
                 upstream_block_uuids += [b.uuid for b in arr]
                 priority_final = priority if len(upstream_block_uuids) == 0 else None
             else:
-                priority_final = priority if len(upstream_block_uuids) > 0 else None
+                priority_final = priority
 
             pipeline.add_block(
                 block,

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1398,7 +1398,7 @@ function PipelineDetailPage({
         ? addNewBlockAtIndex
         : (block, idx, onCreateCallback, name) => new Promise((resolve, reject) => {
             if (BlockTypeEnum.DBT === block?.type) {
-              addNewBlockAtIndex(block, idx, onCreateCallback, name)
+              addNewBlockAtIndex(block, idx, onCreateCallback, name);
             } else {
               // @ts-ignore
               showModal(block, idx, onCreateCallback, name);


### PR DESCRIPTION
# Summary
- Scratchpad blocks were not being positioned immediately after the block where it was added due to the priority being excluded, so this PR includes the priority even for scratchpad blocks. 

# Tests
![scratchpad block positioning](https://user-images.githubusercontent.com/78053898/213272960-eb74f59c-f01d-47fe-bd63-98d3582e630d.gif)
