### PR TITLE
[xy] Support multi streams in s3 source.

### DIFF
--- a/mage_integrations/mage_integrations/sources/amazon_s3/README.md
+++ b/mage_integrations/mage_integrations/sources/amazon_s3/README.md
@@ -18,5 +18,6 @@ You must enter the following credentials when configuring this source:
 | `prefix` | The path of the location where you have files. Don’t include the `s3`, the bucket name, or the table name in this path value.  | `users/ds/20221225` |
 | `search_pattern` | Search files with the regular expression syntax. | `test_table\\/.*\\.csv` |
 | `single_stream_in_prefix` | If `true`, then this source will treat all files in the prefix as part of the same stream. | `false` (default value) |
+| `table_configs` | A list of table configs to configure multiple streams. Each table config must have three keys: `prefix`, `search_pattern` and `table_name`| `[{"prefix": "users/", "search_pattern": "test_table\\/.*\\.csv", "table_name": "test_table"}]` |
 
 <br />


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Multi stream configs are stored in key `table_configs`
Example table configs
```
  "table_configs": [
    {
      "prefix": "test/",
      "search_pattern": ".*?/.*?test_table\\.csv$",
      "table_name": "table_1"
    },
    {
      "prefix": "test/",
      "search_pattern": ".*?/.*?test_table\\.csv$",
      "table_name": "table_2"
    }
  ]
```


# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
