### PR TITLE
[jk] Pass props when using name change modal

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
@@ -58,7 +58,7 @@ function ConfigureBlock({
     }
 
     return BLOCK_TYPE_NAME_MAPPING[blockType];
-  }, [block, isIntegrationPipeline])
+  }, [block, isIntegrationPipeline]);
 
   return (
     <Panel>

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -471,6 +471,7 @@ function PipelineDetail({
       setSelectedStream={setSelectedStream}
     />
   ), [
+    addNewBlockAtIndex,
     blocks,
     codeBlocks,
     fetchPipeline,


### PR DESCRIPTION
# Summary
- Maintain order of new blocks when using name change modal.
- Fix issue with transformer block not appearing between loader and exporter blocks in integration pipelines.

# Tests
Add blocks in batch pipeline:
![pipline blocks add](https://user-images.githubusercontent.com/78053898/213317752-aa35b10c-e57b-4151-a7eb-5ed706fccabb.gif)

Add transformer block in integration pipeline:
![integration pipeline transformer block add](https://user-images.githubusercontent.com/78053898/213317796-480fda24-48bf-4ec7-8aef-6325339d4844.gif)

cc:
@tommydangerous 
