### PR TITLE
[jk] Fix partially covered AddNewBlocks buttons between code blocks

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/index.style.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.style.tsx
@@ -155,7 +155,9 @@ export const CodeContainerStyle = styled.div<{
   }
 `;
 
-export const BlockDivider = styled.div`
+export const BlockDivider = styled.div<{
+  additionalZIndex?: number;
+}>`
   align-items: center;
   display: flex;
   height: ${UNIT * 2}px;
@@ -165,6 +167,10 @@ export const BlockDivider = styled.div`
   bottom: ${UNIT * 0.5}px;
 
   &:hover {
+    ${props => props.additionalZIndex > 0 && `
+      z-index: ${8 + props.additionalZIndex};
+    `}
+
     .block-divider-inner {
       ${props => `
         background-color: ${(props.theme.text || dark.text).fileBrowser};

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -717,12 +717,12 @@ function CodeBlockProps({
   return (
     <div ref={ref} style={{
       position: 'relative',
-      zIndex: blockIdx === addNewBlockMenuOpenIdx ? (blocksLength + 6) : null,
+      zIndex: blockIdx === addNewBlockMenuOpenIdx ? (blocksLength + 9) : null,
     }}>
       <BlockHeaderStyle
         {...borderColorShareProps}
         onClick={() => onClickSelectBlock()}
-        zIndex={blocksLength - (blockIdx || 0)}
+        zIndex={blocksLength + 1 - (blockIdx || 0)}
       >
         <FlexContainer
           alignItems="center"
@@ -1343,6 +1343,7 @@ function CodeBlockProps({
 
       {!noDivider && (
         <BlockDivider
+          additionalZIndex={blocksLength - blockIdx}
           onMouseEnter={() => setAddNewBlocksVisible(true)}
           onMouseLeave={() => {
             setAddNewBlocksVisible(false);


### PR DESCRIPTION
# Summary
- Fix z-index issues with code block dropdowns and dividers.

# Tests
Before:
![before z-index fix](https://user-images.githubusercontent.com/78053898/213327086-14c9d7a3-0bc4-4e6b-b2d9-6e108b3a08e2.gif)

After:
![after z-index fix](https://user-images.githubusercontent.com/78053898/213327108-dc53b8c0-b5e5-427d-bd14-f52bd620419a.gif)
