### PR TITLE
[jk] Improve drag and drop dependencies

### DIFF
--- a/mage_ai/frontend/components/DependencyGraph/utils.ts
+++ b/mage_ai/frontend/components/DependencyGraph/utils.ts
@@ -1,4 +1,5 @@
-import BlockType, { BlockTypeEnum } from '@interfaces/BlockType';
+import BlockType from '@interfaces/BlockType';
+import { SideEnum } from './constants';
 import { roundNumber } from '@utils/string';
 
 export const getFinalLevelIndex = (
@@ -34,4 +35,19 @@ export const getRuntimeText = (runtime: number) => {
     runtimeUnit = 'm';
   }
   return `${runtimeValue}${runtimeUnit}`;
-}
+};
+
+export const isActivePort = (
+  activePort: { id: string, side: SideEnum },
+  node: { id: string },
+): boolean => {
+  const { id: portId, side: portSide } = activePort || {};
+  const nodeId = node?.id;
+  if (portSide === SideEnum.NORTH) {
+    return portId?.endsWith(`${nodeId}-to`);
+  } else if (portSide === SideEnum.SOUTH) {
+    return portId?.startsWith(nodeId);
+  }
+
+  return false;
+};

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -240,7 +240,7 @@ function Sidekick({
             <DependencyGraph
               blockRefs={blockRefs}
               editingBlock={editingBlock}
-              enablePorts
+              enablePorts={!isIntegration}
               fetchPipeline={fetchPipeline}
               height={heightWindow - heightOffset - OUTPUT_HEIGHT}
               pipeline={pipeline}


### PR DESCRIPTION
# Summary
- Disabled the drag and drop to create dependencies feature on integration pipelines since it is not necessary with only 1 loader, 1 exporter, and max 1 transformer block.
- Hide the ports on other blocks when a dependency drag is active (since there are no other ports, it should be more intuitive to simply drop the dependency line on another block).

# Tests
![drag and drop dependencies](https://user-images.githubusercontent.com/78053898/213353258-3a905bdd-1edb-4a37-abb6-e5670fdfa13c.gif)
