### PR TITLE
[jk] Bump to version 0.7.73

### DIFF
--- a/mage_ai/server/constants.py
+++ b/mage_ai/server/constants.py
@@ -11,4 +11,4 @@ DATAFRAME_OUTPUT_SAMPLE_COUNT = 10
 # Dockerfile depends on it because it runs ./scripts/install_mage.sh and uses
 # the last line to determine the version to install.
 VERSION = \
-'0.7.72'
+'0.7.73'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     name='mage-ai',
     # NOTE: when you change this, change the value of VERSION in the following file:
     # mage_ai/server/constants.py
-    version='0.7.72',
+    version='0.7.73',
     author='Mage',
     author_email='eng@mage.ai',
     description='Mage is a tool for building and deploying data pipelines.',


### PR DESCRIPTION
# Summary
- Bump to version 0.7.73
- Includes https://github.com/mage-ai/mage-ai/pull/1784
