### PR TITLE
Update type hints of IO modules

### DIFF
--- a/mage_ai/io/azure_blob_storage.py
+++ b/mage_ai/io/azure_blob_storage.py
@@ -5,6 +5,7 @@ from mage_ai.io.base import BaseFile, FileFormat, QUERY_ROW_LIMIT
 from mage_ai.io.config import BaseConfigLoader, ConfigKey
 from mage_ai.shared.hash import extract, merge_dict
 from pandas import DataFrame
+from typing import Union
 
 
 class AzureBlobStorage(BaseFile):
@@ -23,7 +24,7 @@ class AzureBlobStorage(BaseFile):
 
     def __init__(
         self,
-        verbose=False,
+        verbose: bool = False,
         **kwargs,
     ) -> None:
         """
@@ -49,7 +50,7 @@ class AzureBlobStorage(BaseFile):
         self,
         container_name: str,
         blob_path: str,
-        format: FileFormat = None,
+        format: Union[FileFormat, str, None] = None,
         limit: int = QUERY_ROW_LIMIT,
         **kwargs,
     ) -> DataFrame:
@@ -80,7 +81,7 @@ class AzureBlobStorage(BaseFile):
         df: DataFrame,
         container_name: str,
         blob_path: str,
-        format: FileFormat = None,
+        format: Union[FileFormat, str, None] = None,
         **kwargs,
     ) -> None:
         """

--- a/mage_ai/io/base.py
+++ b/mage_ai/io/base.py
@@ -97,10 +97,10 @@ class BaseFile(BaseIO):
         """
         pass
 
-    def _get_file_format(self, filepath):
+    def _get_file_format(self, filepath: Union[os.PathLike, str]) -> str:
         return os.path.splitext(os.path.basename(filepath))[-1][1:]
 
-    def __get_reader(self, format: Union[FileFormat, str]) -> Callable:
+    def __get_reader(self, format: Union[FileFormat, str, None]) -> Callable:
         """
         Gets data frame reader based on file format
 
@@ -126,8 +126,8 @@ class BaseFile(BaseIO):
 
     def _read(
         self,
-        input: Union[IO, os.PathLike],
-        format: Union[FileFormat, str],
+        input: Union[IO, os.PathLike, str],
+        format: Union[FileFormat, str, None],
         limit: int = QUERY_ROW_LIMIT,
         **kwargs,
     ) -> DataFrame:
@@ -162,8 +162,8 @@ class BaseFile(BaseIO):
     def _write(
         self,
         df: DataFrame,
-        format: Union[FileFormat, str],
-        output: Union[IO, os.PathLike],
+        format: Union[FileFormat, str, None],
+        output: Union[IO, os.PathLike, str],
         **kwargs,
     ) -> None:
         """
@@ -192,7 +192,7 @@ class BaseFile(BaseIO):
     def __get_writer(
         self,
         df: DataFrame,
-        format: Union[FileFormat, str],
+        format: Union[FileFormat, str, None],
     ) -> Callable:
         """
         Fetches the appropriate file writer based on format
@@ -277,7 +277,7 @@ class BaseSQLConnection(BaseSQLDatabase):
     manager when connecting to external data sources.
     """
 
-    def __init__(self, verbose=False, **kwargs) -> None:
+    def __init__(self, verbose: bool = False, **kwargs) -> None:
         """
         Initializes the connection with the settings given as keyword arguments.
         Specific data connectors will have access to different settings.

--- a/mage_ai/io/bigquery.py
+++ b/mage_ai/io/bigquery.py
@@ -8,7 +8,7 @@ from mage_ai.shared.utils import (
     convert_python_type_to_bigquery_type,
 )
 from pandas import DataFrame
-from typing import Mapping
+from typing import Mapping, Union
 
 
 class BigQuery(BaseSQLDatabase):
@@ -59,7 +59,7 @@ class BigQuery(BaseSQLDatabase):
         self,
         df: DataFrame,
         table_id: str,
-        database: str = None,
+        database: Union[str, None] = None,
         verbose: bool = True,
     ):
         def __process(database):
@@ -114,7 +114,7 @@ WHERE TABLE_NAME = '{table_name}'
         self,
         query_string: str,
         limit: int = QUERY_ROW_LIMIT,
-        display_query: str = None,
+        display_query: Union[str, None] = None,
         verbose: bool = True,
         **kwargs,
     ) -> DataFrame:
@@ -156,9 +156,9 @@ WHERE TABLE_NAME = '{table_name}'
         self,
         df: DataFrame,
         table_id: str,
-        database: str = None,
+        database: Union[str, None] = None,
         if_exists: str = 'replace',
-        query_string: str = None,
+        query_string: Union[str, None] = None,
         verbose: bool = True,
         **configuration_params,
     ) -> None:
@@ -181,7 +181,7 @@ WHERE TABLE_NAME = '{table_name}'
             **configuration_params: Configuration parameters for export job
         """
 
-        def __process(database):
+        def __process(database: Union[str, None]):
             if query_string:
                 parts = table_id.split('.')
                 if len(parts) == 2:

--- a/mage_ai/io/config.py
+++ b/mage_ai/io/config.py
@@ -102,7 +102,10 @@ class AWSSecretLoader(BaseConfigLoader):
         self.client = boto3.client('secretsmanager', **kwargs)
 
     def contains(
-        self, secret_id: Union[ConfigKey, str], version_id=None, version_stage_label=None
+        self,
+        secret_id: Union[ConfigKey, str],
+        version_id: Union[str, None] = None,
+        version_stage_label: Union[str, None] = None,
     ) -> bool:
         """
         Check if there is a secret with ID `secret_id` contained. Can also specify the version of the
@@ -121,7 +124,10 @@ class AWSSecretLoader(BaseConfigLoader):
         return self.__get_secret(secret_id, version_id, version_stage_label) is not None
 
     def get(
-        self, secret_id: Union[ConfigKey, str], version_id=None, version_stage_label=None
+        self,
+        secret_id: Union[ConfigKey, str],
+        version_id: Union[str, None] = None,
+        version_stage_label: Union[str, None] = None,
     ) -> Union[bytes, str]:
         """
         Loads the secret stored under `secret_id`. Can also specify the version of the
@@ -147,8 +153,11 @@ class AWSSecretLoader(BaseConfigLoader):
             return response['SecretString']
 
     def __get_secret(
-        self, secret_id: Union[ConfigKey, str], version_id=None, version_stage_label=None
-    ) -> Dict:
+        self,
+        secret_id: Union[ConfigKey, str],
+        version_id: Union[str, None] = None,
+        version_stage_label: Union[str, None] = None,
+    ) -> Union[Dict, None]:
         """
         Get secret with ID `secret_id`. Can also specify the version of the secret to get.
         If
@@ -273,9 +282,9 @@ class ConfigFileLoader(BaseConfigLoader):
 
     def __init__(
         self,
-        filepath: os.PathLike = None,
-        profile='default',
-        config: Dict = None,
+        filepath: Union[os.PathLike, None] = None,
+        profile: str = 'default',
+        config: Union[Dict, None] = None,
     ) -> None:
         """
         Initializes IO Configuration loader. Input configuration file can have two formats:

--- a/mage_ai/io/export_utils.py
+++ b/mage_ai/io/export_utils.py
@@ -57,7 +57,9 @@ def infer_dtypes(df: DataFrame) -> Dict[str, str]:
 
 
 def clean_df_for_export(
-    df: DataFrame, column_mapper: Callable[[Series, str], str], dtypes: Mapping[str, str]
+    df: DataFrame,
+    column_mapper: Callable[[Series, str], Series],
+    dtypes: Mapping[str, str],
 ) -> DataFrame:
     """
     Cleans data frame with the appropriate steps to prepare loading the data frame

--- a/mage_ai/io/file.py
+++ b/mage_ai/io/file.py
@@ -11,8 +11,8 @@ class FileIO(BaseFile):
 
     def load(
         self,
-        filepath: str,
-        format: FileFormat = None,
+        filepath: Union[str, os.PathLike],
+        format: Union[FileFormat, str, None] = None,
         **kwargs,
     ) -> DataFrame:
         """
@@ -32,7 +32,11 @@ class FileIO(BaseFile):
             return self._read(filepath, format, **kwargs)
 
     def export(
-        self, df: DataFrame, filepath: str, format: Union[FileFormat, str] = None, **kwargs
+        self,
+        df: DataFrame,
+        filepath: Union[str, os.PathLike],
+        format: Union[FileFormat, str, None] = None,
+        **kwargs,
     ) -> None:
         """
         Exports the input dataframe to the file specified.
@@ -49,6 +53,7 @@ class FileIO(BaseFile):
             self._write(df, format, filepath, **kwargs)
 
     def exists(
-        self, filepath: str
+        self,
+        filepath: Union[os.PathLike, str],
     ) -> bool:
         return os.path.exists(filepath)

--- a/mage_ai/io/google_cloud_storage.py
+++ b/mage_ai/io/google_cloud_storage.py
@@ -4,6 +4,7 @@ from google.oauth2 import service_account
 from mage_ai.io.base import BaseFile, FileFormat, QUERY_ROW_LIMIT
 from mage_ai.io.config import BaseConfigLoader, ConfigKey
 from pandas import DataFrame
+from typing import Union
 
 
 class GoogleCloudStorage(BaseFile):
@@ -21,7 +22,7 @@ class GoogleCloudStorage(BaseFile):
 
     def __init__(
         self,
-        verbose=False,
+        verbose: bool = False,
         **kwargs,
     ) -> None:
         """
@@ -66,7 +67,7 @@ class GoogleCloudStorage(BaseFile):
         self,
         bucket_name: str,
         object_key: str,
-        format: FileFormat = None,
+        format: Union[FileFormat, str, None] = None,
         limit: int = QUERY_ROW_LIMIT,
         **kwargs,
     ) -> DataFrame:
@@ -97,7 +98,12 @@ class GoogleCloudStorage(BaseFile):
             return self._read(buffer, format, limit, **kwargs)
 
     def export(
-        self, df: DataFrame, bucket_name: str, object_key: str, format: FileFormat = None, **kwargs
+        self,
+        df: DataFrame,
+        bucket_name: str,
+        object_key: str,
+        format: Union[FileFormat, str, None] = None,
+        **kwargs,
     ) -> None:
         """
         Exports data frame to a Google Cloud Storage bucket.

--- a/mage_ai/io/io_config.py
+++ b/mage_ai/io/io_config.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Mapping
+from typing import Any, Mapping, Union
 import pathlib
 import os
 import yaml
@@ -20,7 +20,10 @@ class IOConfig:
     Wrapper around IO configuration file.
     """
 
-    def __init__(self, filepath: os.PathLike = './default_repo/io_config.yaml') -> None:
+    def __init__(
+        self,
+        filepath: Union[os.PathLike, str] = './default_repo/io_config.yaml'
+    ) -> None:
         """
         Initializes IO Configuration loader
 

--- a/mage_ai/io/mysql.py
+++ b/mage_ai/io/mysql.py
@@ -3,8 +3,10 @@ from mage_ai.io.export_utils import BadConversionError, PandasTypes
 from mage_ai.io.sql import BaseSQL
 from mage_ai.shared.utils import clean_name
 from mysql.connector import connect
+from mysql.connector.cursor import MySQLCursor
 from pandas import DataFrame, Series
 import numpy as np
+from typing import IO, Mapping, Union
 
 
 class MySQL(BaseSQL):
@@ -38,7 +40,12 @@ class MySQL(BaseSQL):
             user=config[ConfigKey.MYSQL_USER],
         )
 
-    def build_create_table_command(self, dtypes, schema_name: str, table_name: str) -> str:
+    def build_create_table_command(
+        self,
+        dtypes: Mapping[str, str],
+        schema_name: str,
+        table_name: str
+    ) -> str:
         query = []
         for cname in dtypes:
             query.append(f'`{clean_name(cname)}` {dtypes[cname]}')
@@ -59,7 +66,13 @@ class MySQL(BaseSQL):
             ]))
             return len(cur.fetchall()) >= 1
 
-    def upload_dataframe(self, cursor, df: DataFrame, full_table_name: str, buffer = None) -> None:
+    def upload_dataframe(
+        self,
+        cursor: MySQLCursor,
+        df: DataFrame,
+        full_table_name: str,
+        buffer: Union[IO, None] = None
+    ) -> None:
         values_placeholder = ', '.join(["%s" for i in range(len(df.columns))])
         values = []
         for i, row in df.iterrows():
@@ -115,4 +128,3 @@ class MySQL(BaseSQL):
             return 'BIGINT'
         else:
             raise ValueError(f'Invalid datatype provided: {dtype}')
-

--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -2,9 +2,10 @@ from mage_ai.io.config import BaseConfigLoader, ConfigKey
 from mage_ai.io.export_utils import BadConversionError, PandasTypes
 from mage_ai.io.sql import BaseSQL
 from pandas import DataFrame, Series
-from psycopg2 import connect
+from psycopg2 import connect, _psycopg
 from sshtunnel import SSHTunnelForwarder
 import numpy as np
+from typing import Union, IO
 
 
 class Postgres(BaseSQL):
@@ -17,13 +18,13 @@ class Postgres(BaseSQL):
         user: str,
         password: str,
         host: str,
-        port: str = None,
+        port: Union[str, None] = None,
         connection_method: str = 'direct',
-        ssh_host: str = None,
-        ssh_port: str = None,
-        ssh_username: str = None,
-        ssh_password: str = None,
-        ssh_pkey: str = None,
+        ssh_host: Union[str, None] = None,
+        ssh_port: Union[str, None] = None,
+        ssh_username: Union[str, None] = None,
+        ssh_password: Union[str, None] = None,
+        ssh_pkey: Union[str, None] = None,
         verbose=True,
         **kwargs,
     ) -> None:
@@ -178,7 +179,13 @@ class Postgres(BaseSQL):
         else:
             raise ValueError(f'Invalid datatype provided: {dtype}')
 
-    def upload_dataframe(self, cursor, df: DataFrame, full_table_name: str, buffer = None) -> None:
+    def upload_dataframe(
+        self,
+        cursor: _psycopg.cursor,
+        df: DataFrame,
+        full_table_name: str,
+        buffer: Union[IO, None] = None
+    ) -> None:
         df.to_csv(buffer, index=False, header=False)
         buffer.seek(0)
         cursor.copy_expert(

--- a/mage_ai/io/redshift.py
+++ b/mage_ai/io/redshift.py
@@ -7,6 +7,7 @@ from mage_ai.shared.utils import (
 from pandas import DataFrame
 from redshift_connector import connect
 import json
+from typing import Union
 
 
 class Redshift(BaseSQLConnection):
@@ -46,11 +47,11 @@ class Redshift(BaseSQLConnection):
         self,
         query_string: str,
         limit: int = QUERY_ROW_LIMIT,
-        display_query: str = None,
+        display_query: Union[str, None] = None,
         verbose: bool = True,
         *args,
         **kwargs,
-    ) -> DataFrame:
+    ) -> Union[DataFrame, None]:
         """
         Uses query to load data from Redshift cluster into a Pandas data frame.
         This will fail if the query returns no data from the database. When a
@@ -101,8 +102,8 @@ class Redshift(BaseSQLConnection):
         df: DataFrame,
         table_name: str,
         if_exists: str = 'append',
-        query_string: str = None,
-        schema: str = None,
+        query_string: Union[str, None] = None,
+        schema: Union[str, None] = None,
         verbose: bool = True,
     ) -> None:
         """

--- a/mage_ai/io/s3.py
+++ b/mage_ai/io/s3.py
@@ -6,6 +6,7 @@ from pandas import DataFrame
 from pathlib import Path
 import boto3
 import os
+from typing import Union
 
 
 class S3(BaseFile):
@@ -24,7 +25,7 @@ class S3(BaseFile):
 
     def __init__(
         self,
-        verbose=False,
+        verbose: bool = False,
         **kwargs,
     ) -> None:
         """
@@ -42,7 +43,7 @@ class S3(BaseFile):
         self,
         bucket_name: str,
         object_key: str,
-        format: FileFormat = None,
+        format: Union[FileFormat, str, None] = None,
         limit: int = QUERY_ROW_LIMIT,
         **kwargs,
     ) -> DataFrame:
@@ -78,7 +79,12 @@ class S3(BaseFile):
             return self._read(buffer, format, limit, **kwargs)
 
     def export(
-        self, df: DataFrame, bucket_name: str, object_key: str, format: FileFormat = None, **kwargs
+        self,
+        df: DataFrame,
+        bucket_name: str,
+        object_key: str,
+        format: Union[FileFormat, str, None] = None,
+        **kwargs,
     ) -> None:
         """
         Exports data frame to an S3 bucket.

--- a/mage_ai/io/snowflake.py
+++ b/mage_ai/io/snowflake.py
@@ -3,6 +3,7 @@ from mage_ai.io.config import BaseConfigLoader, ConfigKey
 from pandas import DataFrame
 from snowflake.connector import connect
 from snowflake.connector.pandas_tools import write_pandas
+from typing import Union
 
 DEFAULT_LOGIN_TIMEOUT = 20
 # NOTE: if credentials are wrong, it’ll take this many seconds for the user to be shown an error.
@@ -60,7 +61,7 @@ class Snowflake(BaseSQLConnection):
         self,
         query_string: str,
         limit: int = QUERY_ROW_LIMIT,
-        display_query: str = None,
+        display_query: Union[str, None] = None,
         verbose: bool = True,
         *args,
         **kwargs,
@@ -105,7 +106,7 @@ class Snowflake(BaseSQLConnection):
         database: str,
         schema: str,
         if_exists: str = 'append',
-        query_string: str = None,
+        query_string: Union[str, None] = None,
         verbose: bool = True,
         **kwargs,
     ) -> None:

--- a/mage_ai/io/sql.py
+++ b/mage_ai/io/sql.py
@@ -9,6 +9,7 @@ from mage_ai.io.export_utils import (
     PandasTypes,
 )
 from pandas import DataFrame, read_sql, Series
+from typing import IO, Mapping, Union
 
 
 class BaseSQL(BaseSQLConnection):
@@ -38,7 +39,12 @@ class BaseSQL(BaseSQLConnection):
         """
         raise Exception('Subclasses must override this method.')
 
-    def build_create_table_command(self, dtypes, schema_name: str, table_name: str) -> str:
+    def build_create_table_command(
+        self,
+        dtypes: Mapping[str, str],
+        schema_name: str,
+        table_name: str
+    ) -> str:
         return gen_table_creation_query(dtypes, schema_name, table_name)
 
     def open(self) -> None:
@@ -60,7 +66,13 @@ class BaseSQL(BaseSQLConnection):
         """
         raise Exception('Subclasses must override this method.')
 
-    def upload_dataframe(self, cursor, df: DataFrame, full_table_name: str, buffer = None) -> None:
+    def upload_dataframe(
+        self,
+        cursor,
+        df: DataFrame,
+        full_table_name: str,
+        buffer: Union[IO, None] = None
+    ) -> None:
         raise Exception('Subclasses must override this method.')
 
     def execute(self, query_string: str, **query_vars) -> None:
@@ -80,7 +92,7 @@ class BaseSQL(BaseSQLConnection):
         self,
         query_string: str,
         limit: int = QUERY_ROW_LIMIT,
-        display_query: str = None,
+        display_query: Union[str, None] = None,
         verbose: bool = True,
         **kwargs,
     ) -> DataFrame:
@@ -121,7 +133,7 @@ class BaseSQL(BaseSQLConnection):
         if_exists: ExportWritePolicy = ExportWritePolicy.REPLACE,
         index: bool = False,
         verbose: bool = True,
-        query_string: str = None,
+        query_string: Union[str, None] = None,
         drop_table_on_replace: bool = False,
         cascade_on_drop: bool = False,
     ) -> None:


### PR DESCRIPTION
# Summary
Updates type annotations of IO modules. Specifically targetted arguments that:
1. Had no type annotation (e.g. `def foo(a): ...`)
2. Had a default value that was not included in the list of expected types (e.g. `def bar(a: str = None): ...`)

# Tests
Tested locally following the contribution guideline.
