### PR TITLE
[xy] Restrict sqlalchemy version.

### DIFF
--- a/mage_ai/tests/base_test.py
+++ b/mage_ai/tests/base_test.py
@@ -1,3 +1,4 @@
+from mage_ai.data_preparation.repo_manager import set_repo_path
 from mage_ai.orchestration.db import TEST_DB, db_connection
 from mage_ai.orchestration.db.database_manager import database_manager
 from mage_ai.shared.logger import LoggingLevel
@@ -17,6 +18,7 @@ class DBTestCase(unittest.TestCase):
     def setUpClass(self):
         super().setUpClass()
         self.repo_path = os.getcwd() + '/test'
+        set_repo_path(self.repo_path)
         if not os.path.exists(self.repo_path):
             os.mkdir(self.repo_path)
         database_manager.run_migrations(log_level=LoggingLevel.ERROR)

--- a/mage_ai/tests/orchestration/db/test_models.py
+++ b/mage_ai/tests/orchestration/db/test_models.py
@@ -136,7 +136,7 @@ class PipelineRunTests(DBTestCase):
             'pipelines/test_pipeline/.logs',
             f'{pipeline_run.pipeline_schedule_id}/{execution_date_str}/pipeline.log',
         )
-        self.assertEquals(pipeline_run.logs.get('path'), expected_file_path)
+        self.assertEqual(pipeline_run.logs.get('path'), expected_file_path)
 
     def test_active_runs(self):
         create_pipeline_with_blocks(

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ requests==2.27.1
 scikit-learn>=1.0
 simplejson
 six>=1.15.0
-sqlalchemy>=1.4.20
+sqlalchemy>=1.4.20, <2.0.0
 tornado==6.1
 aiofiles==22.1.0
 


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Restrict sqlalchemy version. SQLAlchemy 2.0.0 was released 2 hours ago, which broke our unit tests. Thus, add one more constraint to not upgrade SQLAlchemy to above 2.0.0.

# Tests
<!-- How did you test your change? -->
unit tests

cc:
<!-- Optionally mention someone to let them know about this pull request -->
