### PR TITLE
Migrate CLI to Typer

### DIFF
--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -51,21 +51,44 @@ def start(
     set_repo_path(project_path)
 
     start_server(host, port, project_path, manage_instance, dbt_docs_instance)
-    print(f'Mage is running at http://{host or "localhost"}:{port} and serving project {project_path}')
+    print(
+        f'Mage is running at http://{host or "localhost"}:{port}'
+        f' and serving project {project_path}'''
+    )
 
 
 @app.command()
 def run(
-    project_path: str = typer.Argument(..., help="path of the Mage project that contains the pipeline."),
-    pipeline_uuid: str = typer.Argument(..., help="uuid of the pipeline to be run."),
-    test: bool = typer.Option(False, help="specify if tests should be run."),
-    block_uuid: Union[str, None] = typer.Option(None, help="uuid of the block to be run."),
-    execution_partition: Union[str, None] = typer.Option(None, help=""),
-    executor_type: Union[str, None] = typer.Option(None, help=""),
-    callback_url: Union[str, None] = typer.Option(None, help=""),
-    block_run_id: Union[int, None] = typer.Option(None, help=""),
-    runtime_vars: Union[List[str], None] = typer.Option(None, help="specify runtime variables. These will overwrite the pipeline global variables."),
-    skip_sensors: bool = typer.Option(False, help="specify if the sensors should be skipped."),
+    project_path: str = typer.Argument(
+        ..., help="path of the Mage project that contains the pipeline."
+    ),
+    pipeline_uuid: str = typer.Argument(
+        ..., help="uuid of the pipeline to be run."
+    ),
+    test: bool = typer.Option(
+        False, help="specify if tests should be run."
+    ),
+    block_uuid: Union[str, None] = typer.Option(
+        None, help="uuid of the block to be run."
+    ),
+    execution_partition: Union[str, None] = typer.Option(
+        None, help=""
+    ),
+    executor_type: Union[str, None] = typer.Option(
+        None, help=""
+    ),
+    callback_url: Union[str, None] = typer.Option(
+        None, help=""
+    ),
+    block_run_id: Union[int, None] = typer.Option(
+        None, help=""
+    ),
+    runtime_vars: Union[List[str], None] = typer.Option(
+        None, help="specify runtime variables. These will overwrite the pipeline global variables."
+    ),
+    skip_sensors: bool = typer.Option(
+        False, help="specify if the sensors should be skipped."
+    ),
 ):
     """
     Run pipeline.
@@ -116,7 +139,9 @@ def run(
 
 @app.command()
 def create_spark_cluster(
-    project_path: str = typer.Argument(..., help=" path of the Mage project that contains the EMR config."),
+    project_path: str = typer.Argument(
+        ..., help=" path of the Mage project that contains the EMR config."
+    ),
 ):
     """
     Create EMR cluster for Mage project.

--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -1,13 +1,11 @@
-import os
-import sys
-from typing import List, Union
-
-import typer
 from click import Context
-from rich import print
-from typer.core import TyperGroup
-
 from mage_ai.cli.utils import parse_runtime_variables
+import os
+from rich import print
+import sys
+import typer
+from typer.core import TyperGroup
+from typing import List, Union
 
 
 class OrderCommands(TyperGroup):

--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -1,11 +1,11 @@
 from click import Context
 from mage_ai.cli.utils import parse_runtime_variables
-import os
 from rich import print
-import sys
-import typer
 from typer.core import TyperGroup
 from typing import List, Union
+import os
+import sys
+import typer
 
 
 class OrderCommands(TyperGroup):

--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -21,7 +21,7 @@ app = typer.Typer(
 
 @app.command()
 def init(
-    project_path: str = typer.Argument(..., help="path of the Mage project to be created.")
+    project_path: str = typer.Argument(..., help='path of the Mage project to be created.')
 ):
     """
     Initialize Mage project.
@@ -30,16 +30,16 @@ def init(
 
     repo_path = os.path.join(os.getcwd(), project_path)
     init_repo(repo_path)
-    print(f"Initialized Mage project at {repo_path}")
+    print(f'Initialized Mage project at {repo_path}')
 
 
 @app.command()
 def start(
-    project_path: str = typer.Argument(os.getcwd(), help="path of the Mage project to be loaded."),
-    host: str = typer.Option("localhost", help="specify the host."),
-    port: str = typer.Option("6789", help="specify the port."),
-    manage_instance: bool = typer.Option(False, help=""),
-    dbt_docs_instance: bool = typer.Option(False, help=""),
+    project_path: str = typer.Argument(os.getcwd(), help='path of the Mage project to be loaded.'),
+    host: str = typer.Option('localhost', help='specify the host.'),
+    port: str = typer.Option('6789', help='specify the port.'),
+    manage_instance: bool = typer.Option(False, help=''),
+    dbt_docs_instance: bool = typer.Option(False, help=''),
 ):
     """
     Start Mage server and UI.
@@ -59,41 +59,41 @@ def start(
     )
     print(
         f'Mage is running at http://{host or "localhost"}:{port}'
-        f' and serving project {project_path}'''
+        f' and serving project {project_path}'
     )
 
 
 @app.command()
 def run(
     project_path: str = typer.Argument(
-        ..., help="path of the Mage project that contains the pipeline."
+        ..., help='path of the Mage project that contains the pipeline.'
     ),
     pipeline_uuid: str = typer.Argument(
-        ..., help="uuid of the pipeline to be run."
+        ..., help='uuid of the pipeline to be run.'
     ),
     test: bool = typer.Option(
-        False, help="specify if tests should be run."
+        False, help='specify if tests should be run.'
     ),
     block_uuid: Union[str, None] = typer.Option(
-        None, help="uuid of the block to be run."
+        None, help='uuid of the block to be run.'
     ),
     execution_partition: Union[str, None] = typer.Option(
-        None, help=""
+        None, help=''
     ),
     executor_type: Union[str, None] = typer.Option(
-        None, help=""
+        None, help=''
     ),
     callback_url: Union[str, None] = typer.Option(
-        None, help=""
+        None, help=''
     ),
     block_run_id: Union[int, None] = typer.Option(
-        None, help=""
+        None, help=''
     ),
     runtime_vars: Union[List[str], None] = typer.Option(
-        None, help="specify runtime variables. These will overwrite the pipeline global variables."
+        None, help='specify runtime variables. These will overwrite the pipeline global variables.'
     ),
     skip_sensors: bool = typer.Option(
-        False, help="specify if the sensors should be skipped."
+        False, help='specify if the sensors should be skipped.'
     ),
 ):
     """
@@ -140,13 +140,13 @@ def run(
             global_vars=global_vars,
             update_status=False,
         )
-    print("Pipeline run completed.")
+    print('Pipeline run completed.')
 
 
 @app.command()
 def create_spark_cluster(
     project_path: str = typer.Argument(
-        ..., help=" path of the Mage project that contains the EMR config."
+        ..., help='path of the Mage project that contains the EMR config.'
     ),
 ):
     """
@@ -158,5 +158,5 @@ def create_spark_cluster(
     create_cluster(project_path)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     app()

--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -38,8 +38,8 @@ def start(
     project_path: str = typer.Argument(os.getcwd(), help='path of the Mage project to be loaded.'),
     host: str = typer.Option('localhost', help='specify the host.'),
     port: str = typer.Option('6789', help='specify the port.'),
-    manage_instance: bool = typer.Option(False, help=''),
-    dbt_docs_instance: bool = typer.Option(False, help=''),
+    manage_instance: str = typer.Option('0', help=''),
+    dbt_docs_instance: str = typer.Option('0', help=''),
 ):
     """
     Start Mage server and UI.
@@ -54,8 +54,8 @@ def start(
         host=host,
         port=port,
         project=project_path,
-        manage=manage_instance,
-        dbt_docs=dbt_docs_instance,
+        manage=manage_instance == "1",
+        dbt_docs=dbt_docs_instance == "1",
     )
     print(
         f'Mage is running at http://{host or "localhost"}:{port}'

--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -1,6 +1,7 @@
-from mage_ai.cli.utils import parse_runtime_variables
 import argparse
 import os
+
+from mage_ai.cli.utils import parse_runtime_variables
 
 
 def main():
@@ -9,10 +10,11 @@ def main():
     try:
         command = sys.argv[1]
     except IndexError:
-        command = 'help'
+        command = "help"
 
-    if command == 'help':
-        print("""Usage:
+    if command == "help":
+        print(
+            """Usage:
     mage <command> 
 
 Commands:
@@ -44,24 +46,25 @@ Commands:
     create_spark_cluster <project_path>
       args:
         project_path                    path of the Mage project that contains the EMR config.
-        """)
-    elif command == 'init':
+        """
+        )
+    elif command == "init":
         from mage_ai.data_preparation.repo_manager import init_repo
 
         repo_path = os.path.join(os.getcwd(), sys.argv[2])
         init_repo(repo_path)
-    elif command == 'start':
+    elif command == "start":
         parser = argparse.ArgumentParser()
-        parser.add_argument('repo_path', metavar='project_path', type=str)
-        parser.add_argument('--host', nargs='?', type=str)
-        parser.add_argument('--port', nargs='?', type=int)
-        parser.add_argument('--manage-instance', nargs='?', type=str)
-        parser.add_argument('--dbt-docs-instance', nargs='?', type=str)
+        parser.add_argument("repo_path", metavar="project_path", type=str)
+        parser.add_argument("--host", nargs="?", type=str)
+        parser.add_argument("--port", nargs="?", type=int)
+        parser.add_argument("--manage-instance", nargs="?", type=str)
+        parser.add_argument("--dbt-docs-instance", nargs="?", type=str)
 
         args = dict()
         if len(sys.argv) >= 3:
             args = vars(parser.parse_args(sys.argv[2:]))
-            project_path = args['repo_path']
+            project_path = args["repo_path"]
         else:
             project_path = os.getcwd()
         project_path = os.path.abspath(project_path)
@@ -73,36 +76,36 @@ Commands:
         from mage_ai.server.server import start_server
 
         start_server(
-            host=args.get('host'),
-            dbt_docs=args.get('dbt_docs_instance') == '1',
-            manage=args.get('manage_instance') == '1',
-            port=args.get('port'),
+            host=args.get("host"),
+            dbt_docs=args.get("dbt_docs_instance") == "1",
+            manage=args.get("manage_instance") == "1",
+            port=args.get("port"),
             project=project_path,
         )
-    elif command == 'run' or command == 'test':
+    elif command == "run" or command == "test":
         from mage_ai.data_preparation.repo_manager import set_repo_path
         from mage_ai.shared.hash import merge_dict
 
-        parser = argparse.ArgumentParser(description='Run pipeline.')
-        parser.add_argument('repo_path', metavar='project_path', type=str)
-        parser.add_argument('pipeline_uuid', type=str)
-        parser.add_argument('--block_uuid', nargs='?', type=str)
-        parser.add_argument('--execution_partition', nargs='?', type=str)
-        parser.add_argument('--executor_type', nargs='?', type=str)
-        parser.add_argument('--callback_url', nargs='?', type=str)
-        parser.add_argument('--block_run_id', nargs='?', type=int)
-        parser.add_argument('--runtime-vars', nargs="+")
-        parser.add_argument('--skip-sensors', type=bool)
+        parser = argparse.ArgumentParser(description="Run pipeline.")
+        parser.add_argument("repo_path", metavar="project_path", type=str)
+        parser.add_argument("pipeline_uuid", type=str)
+        parser.add_argument("--block_uuid", nargs="?", type=str)
+        parser.add_argument("--execution_partition", nargs="?", type=str)
+        parser.add_argument("--executor_type", nargs="?", type=str)
+        parser.add_argument("--callback_url", nargs="?", type=str)
+        parser.add_argument("--block_run_id", nargs="?", type=int)
+        parser.add_argument("--runtime-vars", nargs="+")
+        parser.add_argument("--skip-sensors", type=bool)
 
         args = vars(parser.parse_args(sys.argv[2:]))
-        project_path = args['repo_path']
-        pipeline_uuid = args['pipeline_uuid']
-        block_uuid = args.get('block_uuid')
-        execution_partition = args.get('execution_partition')
-        executor_type = args.get('executor_type')
-        callback_url = args.get('callback_url')
-        runtime_vars = args.get('runtime_vars')
-        skip_sensors = args.get('skip_sensors', False)
+        project_path = args["repo_path"]
+        pipeline_uuid = args["pipeline_uuid"]
+        block_uuid = args.get("block_uuid")
+        execution_partition = args.get("execution_partition")
+        executor_type = args.get("executor_type")
+        callback_url = args.get("callback_url")
+        runtime_vars = args.get("runtime_vars")
+        skip_sensors = args.get("skip_sensors", False)
 
         runtime_variables = dict()
         if runtime_vars is not None:
@@ -122,6 +125,7 @@ Commands:
         global_vars = merge_dict(default_variables, runtime_variables)
 
         from mage_ai.orchestration.db import db_connection
+
         db_connection.start_session()
 
         if block_uuid is None:
@@ -129,7 +133,7 @@ Commands:
                 analyze_outputs=False,
                 global_vars=global_vars,
                 run_sensors=not skip_sensors,
-                run_tests=command == 'test',
+                run_tests=command == "test",
                 update_status=False,
             )
         else:
@@ -145,13 +149,15 @@ Commands:
                 update_status=False,
             )
 
-    elif command == 'create_spark_cluster':
+    elif command == "create_spark_cluster":
         from mage_ai.services.aws.emr.launcher import create_cluster
 
         project_path = os.path.abspath(sys.argv[2])
         create_cluster(project_path)
     else:
-        print(f'Unknown command "{command}". Type "mage help" to see what commands are available.')
+        print(
+            f'Unknown command "{command}". Type "mage help" to see what commands are available.'
+        )
 
 
 if __name__ == "__main__":

--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -4,6 +4,7 @@ from typing import List, Union
 
 import typer
 from click import Context
+from rich import print
 from typer.core import TyperGroup
 
 from mage_ai.cli.utils import parse_runtime_variables
@@ -31,13 +32,14 @@ def init(
 
     repo_path = os.path.join(os.getcwd(), project_path)
     init_repo(repo_path)
+    print(f"Initialized Mage project at {repo_path}")
 
 
 @app.command()
 def start(
     project_path: str = typer.Argument(os.getcwd(), help="path of the Mage project to be loaded."),
-    host: str = typer.Option("localhost", help="specify the host, defaults to localhost."),
-    port: str = typer.Option("6789", help="specify the port, defaults to 6789."),
+    host: str = typer.Option("localhost", help="specify the host."),
+    port: str = typer.Option("6789", help="specify the port."),
     manage_instance: bool = typer.Option(False, help=""),
     dbt_docs_instance: bool = typer.Option(False, help=""),
 ):
@@ -51,6 +53,7 @@ def start(
     set_repo_path(project_path)
 
     start_server(host, port, project_path, manage_instance, dbt_docs_instance)
+    print(f'Mage is running at http://{host or "localhost"}:{port} and serving project {project_path}')
 
 
 @app.command()
@@ -110,6 +113,7 @@ def run(
             global_vars=global_vars,
             update_status=False,
         )
+    print("Pipeline run completed.")
 
 
 @app.command()
@@ -124,3 +128,6 @@ def create_spark_cluster(
     project_path = os.path.abspath(project_path)
     create_cluster(project_path)
 
+
+if __name__ == "__main__":
+    app()

--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -50,7 +50,13 @@ def start(
     project_path = os.path.abspath(project_path)
     set_repo_path(project_path)
 
-    start_server(host, port, project_path, manage_instance, dbt_docs_instance)
+    start_server(
+        host=host,
+        port=port,
+        project=project_path,
+        manage=manage_instance,
+        dbt_docs=dbt_docs_instance,
+    )
     print(
         f'Mage is running at http://{host or "localhost"}:{port}'
         f' and serving project {project_path}'''

--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -1,164 +1,126 @@
-import argparse
 import os
+import sys
+from typing import List, Union
+
+import typer
+from click import Context
+from typer.core import TyperGroup
 
 from mage_ai.cli.utils import parse_runtime_variables
 
 
-def main():
-    import sys
+class OrderCommands(TyperGroup):
+    def list_commands(self, ctx: Context):
+        """Return list of commands in the order they appear."""
+        return list(self.commands)
 
-    try:
-        command = sys.argv[1]
-    except IndexError:
-        command = "help"
 
-    if command == "help":
-        print(
-            """Usage:
-    mage <command> 
+app = typer.Typer(
+    cls=OrderCommands,
+)
 
-Commands:
-    init <project_path>                 Initialize Mage project.
-      args:
-        project_path                    path of the Mage project to be created.
 
-    start <project_path>                Start Mage server and UI.
-      args:
-        project_path                    path of the Mage project to be loaded.
-      options:
-        --host <host>                   specify the host, defaults to localhost
-        --port <port>                   specify the port, defaults to 6789
+@app.command()
+def init(
+    project_path: str = typer.Argument(..., help="path of the Mage project to be created.")
+):
+    """
+    Initialize Mage project.
+    """
+    from mage_ai.data_preparation.repo_manager import init_repo
 
-    run <project_path> <pipeline_uuid>  Run pipeline.
-      args:
-        project_path                    path of the Mage project that contains the pipeline.
-        pipeline_uuid                   uuid of the pipeline to be run.
-      options:
-        --runtime-vars [key value]...   specify runtime variables. These will overwrite the pipeline global variables.   
+    repo_path = os.path.join(os.getcwd(), project_path)
+    init_repo(repo_path)
 
-    test <project_path> <pipeline_uuid> Run pipeline and output tests.
-      args:
-        project_path                    path of the Mage project that contains the pipeline.
-        pipeline_uuid                   uuid of the pipeline to be run and tested.
-      options:
-        --runtime-vars [key value]...   specify runtime variables. These will overwrite the pipeline global variables.
 
-    create_spark_cluster <project_path>
-      args:
-        project_path                    path of the Mage project that contains the EMR config.
-        """
+@app.command()
+def start(
+    project_path: str = typer.Argument(os.getcwd(), help="path of the Mage project to be loaded."),
+    host: str = typer.Option("localhost", help="specify the host, defaults to localhost."),
+    port: str = typer.Option("6789", help="specify the port, defaults to 6789."),
+    manage_instance: bool = typer.Option(False, help=""),
+    dbt_docs_instance: bool = typer.Option(False, help=""),
+):
+    """
+    Start Mage server and UI.
+    """
+    from mage_ai.data_preparation.repo_manager import set_repo_path
+    from mage_ai.server.server import start_server
+
+    project_path = os.path.abspath(project_path)
+    set_repo_path(project_path)
+
+    start_server(host, port, project_path, manage_instance, dbt_docs_instance)
+
+
+@app.command()
+def run(
+    project_path: str = typer.Argument(..., help="path of the Mage project that contains the pipeline."),
+    pipeline_uuid: str = typer.Argument(..., help="uuid of the pipeline to be run."),
+    test: bool = typer.Option(False, help="specify if tests should be run."),
+    block_uuid: Union[str, None] = typer.Option(None, help="uuid of the block to be run."),
+    execution_partition: Union[str, None] = typer.Option(None, help=""),
+    executor_type: Union[str, None] = typer.Option(None, help=""),
+    callback_url: Union[str, None] = typer.Option(None, help=""),
+    block_run_id: Union[int, None] = typer.Option(None, help=""),
+    runtime_vars: Union[List[str], None] = typer.Option(None, help="specify runtime variables. These will overwrite the pipeline global variables."),
+    skip_sensors: bool = typer.Option(False, help="specify if the sensors should be skipped."),
+):
+    """
+    Run pipeline.
+    """
+    from mage_ai.data_preparation.executors.executor_factory import ExecutorFactory
+    from mage_ai.data_preparation.models.pipeline import Pipeline
+    from mage_ai.data_preparation.repo_manager import set_repo_path
+    from mage_ai.data_preparation.variable_manager import get_global_variables
+    from mage_ai.orchestration.db import db_connection
+    from mage_ai.shared.hash import merge_dict
+
+    runtime_variables = dict()
+    if runtime_vars is not None:
+        runtime_variables = parse_runtime_variables(runtime_vars)
+
+    project_path = os.path.abspath(project_path)
+    set_repo_path(project_path)
+    sys.path.append(os.path.dirname(project_path))
+    pipeline = Pipeline(pipeline_uuid, repo_path=project_path)
+
+    default_variables = get_global_variables(pipeline_uuid)
+    global_vars = merge_dict(default_variables, runtime_variables)
+
+    db_connection.start_session()
+
+    if block_uuid is None:
+        ExecutorFactory.get_pipeline_executor(pipeline).execute(
+            analyze_outputs=False,
+            global_vars=global_vars,
+            run_sensors=not skip_sensors,
+            run_tests=test,
+            update_status=False,
         )
-    elif command == "init":
-        from mage_ai.data_preparation.repo_manager import init_repo
-
-        repo_path = os.path.join(os.getcwd(), sys.argv[2])
-        init_repo(repo_path)
-    elif command == "start":
-        parser = argparse.ArgumentParser()
-        parser.add_argument("repo_path", metavar="project_path", type=str)
-        parser.add_argument("--host", nargs="?", type=str)
-        parser.add_argument("--port", nargs="?", type=int)
-        parser.add_argument("--manage-instance", nargs="?", type=str)
-        parser.add_argument("--dbt-docs-instance", nargs="?", type=str)
-
-        args = dict()
-        if len(sys.argv) >= 3:
-            args = vars(parser.parse_args(sys.argv[2:]))
-            project_path = args["repo_path"]
-        else:
-            project_path = os.getcwd()
-        project_path = os.path.abspath(project_path)
-
-        from mage_ai.data_preparation.repo_manager import set_repo_path
-
-        set_repo_path(project_path)
-
-        from mage_ai.server.server import start_server
-
-        start_server(
-            host=args.get("host"),
-            dbt_docs=args.get("dbt_docs_instance") == "1",
-            manage=args.get("manage_instance") == "1",
-            port=args.get("port"),
-            project=project_path,
-        )
-    elif command == "run" or command == "test":
-        from mage_ai.data_preparation.repo_manager import set_repo_path
-        from mage_ai.shared.hash import merge_dict
-
-        parser = argparse.ArgumentParser(description="Run pipeline.")
-        parser.add_argument("repo_path", metavar="project_path", type=str)
-        parser.add_argument("pipeline_uuid", type=str)
-        parser.add_argument("--block_uuid", nargs="?", type=str)
-        parser.add_argument("--execution_partition", nargs="?", type=str)
-        parser.add_argument("--executor_type", nargs="?", type=str)
-        parser.add_argument("--callback_url", nargs="?", type=str)
-        parser.add_argument("--block_run_id", nargs="?", type=int)
-        parser.add_argument("--runtime-vars", nargs="+")
-        parser.add_argument("--skip-sensors", type=bool)
-
-        args = vars(parser.parse_args(sys.argv[2:]))
-        project_path = args["repo_path"]
-        pipeline_uuid = args["pipeline_uuid"]
-        block_uuid = args.get("block_uuid")
-        execution_partition = args.get("execution_partition")
-        executor_type = args.get("executor_type")
-        callback_url = args.get("callback_url")
-        runtime_vars = args.get("runtime_vars")
-        skip_sensors = args.get("skip_sensors", False)
-
-        runtime_variables = dict()
-        if runtime_vars is not None:
-            runtime_variables = parse_runtime_variables(runtime_vars)
-
-        project_path = os.path.abspath(project_path)
-        set_repo_path(project_path)
-
-        from mage_ai.data_preparation.executors.executor_factory import ExecutorFactory
-        from mage_ai.data_preparation.models.pipeline import Pipeline
-        from mage_ai.data_preparation.variable_manager import get_global_variables
-
-        sys.path.append(os.path.dirname(project_path))
-        pipeline = Pipeline(pipeline_uuid, repo_path=project_path)
-
-        default_variables = get_global_variables(pipeline_uuid)
-        global_vars = merge_dict(default_variables, runtime_variables)
-
-        from mage_ai.orchestration.db import db_connection
-
-        db_connection.start_session()
-
-        if block_uuid is None:
-            ExecutorFactory.get_pipeline_executor(pipeline).execute(
-                analyze_outputs=False,
-                global_vars=global_vars,
-                run_sensors=not skip_sensors,
-                run_tests=command == "test",
-                update_status=False,
-            )
-        else:
-            ExecutorFactory.get_block_executor(
-                pipeline,
-                block_uuid,
-                execution_partition=execution_partition,
-                executor_type=executor_type,
-            ).execute(
-                analyze_outputs=False,
-                callback_url=callback_url,
-                global_vars=global_vars,
-                update_status=False,
-            )
-
-    elif command == "create_spark_cluster":
-        from mage_ai.services.aws.emr.launcher import create_cluster
-
-        project_path = os.path.abspath(sys.argv[2])
-        create_cluster(project_path)
     else:
-        print(
-            f'Unknown command "{command}". Type "mage help" to see what commands are available.'
+        ExecutorFactory.get_block_executor(
+            pipeline,
+            block_uuid,
+            execution_partition=execution_partition,
+            executor_type=executor_type,
+        ).execute(
+            analyze_outputs=False,
+            callback_url=callback_url,
+            global_vars=global_vars,
+            update_status=False,
         )
 
 
-if __name__ == "__main__":
-    main()
+@app.command()
+def create_spark_cluster(
+    project_path: str = typer.Argument(..., help=" path of the Mage project that contains the EMR config."),
+):
+    """
+    Create EMR cluster for Mage project.
+    """
+    from mage_ai.services.aws.emr.launcher import create_cluster
+
+    project_path = os.path.abspath(project_path)
+    create_cluster(project_path)
+

--- a/mage_ai/cli/utils.py
+++ b/mage_ai/cli/utils.py
@@ -1,8 +1,11 @@
-from typing import Dict, List
 import json
+from typing import Any, Dict, List, Union
 
 
-def parse_runtime_variables(variables: List[str]) -> Dict[str, any]:
+def parse_runtime_variables(variables: List[str]) -> Dict[str, Any]:
+    """
+    Returns a dictionary of variable to parsed values.
+    """
     vars_parsed = dict()
 
     if variables is None:
@@ -10,14 +13,20 @@ def parse_runtime_variables(variables: List[str]) -> Dict[str, any]:
     for i in range(0, len(variables), 2):
         key = variables[i]
         try:
-            value = variables[i+1]
+            value = variables[i + 1]
         except IndexError:
             value = None
         vars_parsed[key] = get_value(value)
     return vars_parsed
 
 
-def get_value(value: str) -> any:
+def get_value(value: Union[str, None]) -> Any:
+    """
+    Returns parsed value.
+
+    If the string is a valid JSON object, deserializes it to a Python object.
+    Otherwise, passes the original value.
+    """
     if value is not None:
         try:
             return json.loads(value)

--- a/mage_ai/cli/utils.py
+++ b/mage_ai/cli/utils.py
@@ -1,5 +1,5 @@
-import json
 from typing import Any, Dict, List, Union
+import json
 
 
 def parse_runtime_variables(variables: List[str]) -> Dict[str, Any]:

--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -1,13 +1,15 @@
-from mage_ai.data_preparation.models.block.dbt.utils import run_dbt_tests
-from mage_ai.data_preparation.models.constants import BlockType, PipelineType
+import json
+import traceback
+from typing import Callable, Dict, List, Union
+
+import requests
+
 from mage_ai.data_preparation.logging.logger import DictLogger
 from mage_ai.data_preparation.logging.logger_manager_factory import LoggerManagerFactory
+from mage_ai.data_preparation.models.block.dbt.utils import run_dbt_tests
+from mage_ai.data_preparation.models.constants import BlockType, PipelineType
 from mage_ai.shared.hash import merge_dict
 from mage_ai.shared.utils import clean_name
-from typing import Callable, Dict, List
-import json
-import requests
-import traceback
 
 
 class BlockExecutor:
@@ -32,19 +34,19 @@ class BlockExecutor:
     def execute(
         self,
         analyze_outputs: bool = False,
-        callback_url: str = None,
-        global_vars: Dict = None,
+        callback_url: Union[str, None] = None,
+        global_vars: Union[Dict, None] = None,
         update_status: bool = False,
-        on_complete: Callable[[str], None] = None,
-        on_failure: Callable[[str, Dict], None] = None,
-        on_start: Callable[[str], None] = None,
-        input_from_output: Dict = None,
+        on_complete: Union[Callable[[str], None], None] = None,
+        on_failure: Union[Callable[[str, Dict], None], None] = None,
+        on_start: Union[Callable[[str], None], None] = None,
+        input_from_output: Union[Dict, None] = None,
         verify_output: bool = True,
-        runtime_arguments: Dict = None,
-        template_runtime_configuration: Dict = None,
-        dynamic_block_index: int = None,
-        dynamic_block_uuid: str = None,
-        dynamic_upstream_block_uuids: List[str] = None,
+        runtime_arguments: Union[Dict, None] = None,
+        template_runtime_configuration: Union[Dict, None] = None,
+        dynamic_block_index: Union[int, None] = None,
+        dynamic_block_uuid: Union[str, None] = None,
+        dynamic_upstream_block_uuids: Union[List[str], None] = None,
         **kwargs,
     ) -> Dict:
         if template_runtime_configuration:
@@ -102,16 +104,16 @@ class BlockExecutor:
     def _execute(
         self,
         analyze_outputs: bool = False,
-        callback_url: str = None,
-        global_vars: Dict = None,
+        callback_url: Union[str, None] = None,
+        global_vars: Union[Dict, None] = None,
         update_status: bool = False,
-        input_from_output: Dict = None,
+        input_from_output: Union[Dict, None] = None,
         logging_tags: Dict = dict(),
         verify_output: bool = True,
-        runtime_arguments: Dict = None,
-        dynamic_block_index: int = None,
-        dynamic_block_uuid: str = None,
-        dynamic_upstream_block_uuids: List[str] = None,
+        runtime_arguments: Union[Dict, None] = None,
+        dynamic_block_index: Union[int, None] = None,
+        dynamic_block_uuid: Union[str, None] = None,
+        dynamic_upstream_block_uuids: Union[List[str], None] = None,
         **kwargs,
     ) -> Dict:
         result = self.block.execute_sync(
@@ -149,7 +151,7 @@ class BlockExecutor:
 
         return result
 
-    def __update_block_run_status(self, callback_url: str, status: str, tags: dict):
+    def __update_block_run_status(self, callback_url: str, status: str, tags: Dict):
         """Update the status of block run by edither updating the BlockRun db object or making API call
 
         Args:

--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -1,15 +1,13 @@
 import json
-import traceback
-from typing import Callable, Dict, List, Union
-
-import requests
-
 from mage_ai.data_preparation.logging.logger import DictLogger
 from mage_ai.data_preparation.logging.logger_manager_factory import LoggerManagerFactory
 from mage_ai.data_preparation.models.block.dbt.utils import run_dbt_tests
 from mage_ai.data_preparation.models.constants import BlockType, PipelineType
 from mage_ai.shared.hash import merge_dict
 from mage_ai.shared.utils import clean_name
+import requests
+import traceback
+from typing import Callable, Dict, List, Union
 
 
 class BlockExecutor:

--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -1,13 +1,13 @@
-import json
 from mage_ai.data_preparation.logging.logger import DictLogger
 from mage_ai.data_preparation.logging.logger_manager_factory import LoggerManagerFactory
 from mage_ai.data_preparation.models.block.dbt.utils import run_dbt_tests
 from mage_ai.data_preparation.models.constants import BlockType, PipelineType
 from mage_ai.shared.hash import merge_dict
 from mage_ai.shared.utils import clean_name
+from typing import Callable, Dict, List, Union
+import json
 import requests
 import traceback
-from typing import Callable, Dict, List, Union
 
 
 class BlockExecutor:

--- a/mage_ai/data_preparation/executors/executor_factory.py
+++ b/mage_ai/data_preparation/executors/executor_factory.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from mage_ai.data_preparation.executors.block_executor import BlockExecutor
 from mage_ai.data_preparation.executors.pipeline_executor import PipelineExecutor
 from mage_ai.data_preparation.models.constants import (
@@ -14,15 +16,17 @@ class ExecutorFactory:
     def get_pipeline_executor(
         self,
         pipeline: Pipeline,
-        execution_partition: str = None,
+        execution_partition: Union[str, None] = None,
     ) -> PipelineExecutor:
         if pipeline.type == PipelineType.PYSPARK:
-            from mage_ai.data_preparation.executors.pyspark_pipeline_executor \
-                import PySparkPipelineExecutor
+            from mage_ai.data_preparation.executors.pyspark_pipeline_executor import (
+                PySparkPipelineExecutor,
+            )
             return PySparkPipelineExecutor(pipeline)
         elif pipeline.type == PipelineType.STREAMING:
-            from mage_ai.data_preparation.executors.streaming_pipeline_executor \
-                import StreamingPipelineExecutor
+            from mage_ai.data_preparation.executors.streaming_pipeline_executor import (
+                StreamingPipelineExecutor,
+            )
             return StreamingPipelineExecutor(pipeline, execution_partition=execution_partition)
         else:
             return PipelineExecutor(pipeline)
@@ -32,8 +36,8 @@ class ExecutorFactory:
         self,
         pipeline: Pipeline,
         block_uuid: str,
-        execution_partition: str = None,
-        executor_type: ExecutorType = None,
+        execution_partition: Union[str, None] = None,
+        executor_type: Union[ExecutorType, str, None] = None,
     ) -> BlockExecutor:
         executor_kwargs = dict(
             pipeline=pipeline,
@@ -49,20 +53,24 @@ class ExecutorFactory:
             else:
                 executor_type = block.executor_type
         if executor_type == ExecutorType.PYSPARK:
-            from mage_ai.data_preparation.executors.pyspark_block_executor \
-                import PySparkBlockExecutor
+            from mage_ai.data_preparation.executors.pyspark_block_executor import (
+                PySparkBlockExecutor,
+            )
             return PySparkBlockExecutor(**executor_kwargs)
         elif executor_type == ExecutorType.ECS:
-            from mage_ai.data_preparation.executors.ecs_block_executor \
-                import EcsBlockExecutor
+            from mage_ai.data_preparation.executors.ecs_block_executor import (
+                EcsBlockExecutor,
+            )
             return EcsBlockExecutor(**executor_kwargs)
         elif executor_type == ExecutorType.GCP_CLOUD_RUN:
-            from mage_ai.data_preparation.executors.gcp_cloud_run_block_executor \
-                import GcpCloudRunBlockExecutor
+            from mage_ai.data_preparation.executors.gcp_cloud_run_block_executor import (
+                GcpCloudRunBlockExecutor,
+            )
             return GcpCloudRunBlockExecutor(**executor_kwargs)
         elif executor_type == ExecutorType.K8S:
-            from mage_ai.data_preparation.executors.k8s_block_executor \
-                import K8sBlockExecutor
+            from mage_ai.data_preparation.executors.k8s_block_executor import (
+                K8sBlockExecutor,
+            )
             return K8sBlockExecutor(**executor_kwargs)
         else:
             return BlockExecutor(**executor_kwargs)

--- a/mage_ai/data_preparation/executors/executor_factory.py
+++ b/mage_ai/data_preparation/executors/executor_factory.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from mage_ai.data_preparation.executors.block_executor import BlockExecutor
 from mage_ai.data_preparation.executors.pipeline_executor import PipelineExecutor
 from mage_ai.data_preparation.models.constants import (
@@ -9,6 +7,7 @@ from mage_ai.data_preparation.models.constants import (
 )
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.shared.code import is_pyspark_code
+from typing import Union
 
 
 class ExecutorFactory:

--- a/mage_ai/data_preparation/repo_manager.py
+++ b/mage_ai/data_preparation/repo_manager.py
@@ -99,7 +99,7 @@ def init_repo(repo_path: str) -> None:
     Initialize a repository under the current path.
     """
     if os.path.exists(repo_path):
-        return
+        raise FileExistsError(f'Repository {repo_path} already exists')
 
     os.makedirs(os.getenv(MAGE_DATA_DIR_ENV_VAR, DEFAULT_MAGE_DATA_DIR), exist_ok=True)
     copy_template_directory('repo', repo_path)

--- a/mage_ai/data_preparation/repo_manager.py
+++ b/mage_ai/data_preparation/repo_manager.py
@@ -2,10 +2,10 @@ from jinja2 import Template
 from mage_ai.data_preparation.shared.constants import REPO_PATH_ENV_VAR
 from mage_ai.shared.environments import is_test
 from mage_ai.data_preparation.templates.utils import copy_template_directory
+from typing import Dict
 import os
 import sys
 import traceback
-from typing import Dict
 import yaml
 
 MAGE_DATA_DIR_ENV_VAR = 'MAGE_DATA_DIR'

--- a/mage_ai/data_preparation/repo_manager.py
+++ b/mage_ai/data_preparation/repo_manager.py
@@ -1,11 +1,11 @@
+from jinja2 import Template
 from mage_ai.data_preparation.shared.constants import REPO_PATH_ENV_VAR
 from mage_ai.shared.environments import is_test
 from mage_ai.data_preparation.templates.utils import copy_template_directory
-from jinja2 import Template
-from typing import Dict
 import os
 import sys
 import traceback
+from typing import Dict
 import yaml
 
 MAGE_DATA_DIR_ENV_VAR = 'MAGE_DATA_DIR'

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -98,8 +98,8 @@ import os
 import socket
 import tornado.ioloop
 import tornado.web
-import urllib.parse
 from typing import Union
+import urllib.parse
 
 
 class MainPageHandler(tornado.web.RequestHandler):

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -91,6 +91,7 @@ from sqlalchemy.orm import aliased
 from tornado import autoreload
 from tornado.ioloop import PeriodicCallback
 from tornado.log import enable_pretty_logging
+from typing import Union
 import argparse
 import asyncio
 import json
@@ -98,7 +99,6 @@ import os
 import socket
 import tornado.ioloop
 import tornado.web
-from typing import Union
 import urllib.parse
 
 

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -99,6 +99,7 @@ import socket
 import tornado.ioloop
 import tornado.web
 import urllib.parse
+from typing import Union
 
 
 class MainPageHandler(tornado.web.RequestHandler):
@@ -596,9 +597,8 @@ def make_app():
 
 
 async def main(
-    host: str = None,
-    port: str = None,
-    project: str = None,
+    host: Union[str, None] = None,
+    port: Union[str, None] = None,
 ):
     switch_active_kernel(DEFAULT_KERNEL_NAME)
 
@@ -622,9 +622,6 @@ async def main(
         port,
         address=host,
     )
-
-    print(f'Mage is running at http://{host or "localhost"}:{port} and serving project {project}')
-
     db_connection.start_session(force=True)
 
     # Check scheduler status periodically
@@ -650,7 +647,6 @@ def start_server(
     manage: bool = False,
     dbt_docs: bool = False,
 ):
-
     host = host if host else None
     port = port if port else DATA_PREP_SERVER_PORT
     project = project if project else None
@@ -681,7 +677,6 @@ def start_server(
             main(
                 host=host,
                 port=port,
-                project=project,
             )
         )
 

--- a/mage_ai/tests/cli/test_init.py
+++ b/mage_ai/tests/cli/test_init.py
@@ -1,0 +1,30 @@
+from typer.testing import CliRunner
+
+from mage_ai.cli.main import app
+from mage_ai.tests.base_test import TestCase
+from unittest import mock
+
+runner = CliRunner()
+
+
+class InitTests(TestCase):
+    @mock.patch("mage_ai.data_preparation.repo_manager.init_repo")
+    @mock.patch("mage_ai.cli.main.os.getcwd")
+    def test_init_project_with_path(self, mock_getcwd, mock_init_repo):
+        mock_getcwd.return_value = "home"
+        result = runner.invoke(app, ["init", "my_mage_project"])
+        mock_init_repo.assert_called_once_with("home/my_mage_project")
+        assert result.exit_code == 0
+        assert "Initialized Mage project" in result.output
+
+    def test_init_project_without_path(self):
+        result = runner.invoke(app, ["init"])
+        assert result.exit_code == 2
+        assert "Initialized Mage project" not in result.output
+
+    @mock.patch("mage_ai.data_preparation.repo_manager.init_repo")
+    def test_init_project_with_existing_path(self, mock_init_repo):
+        mock_init_repo.side_effect = FileExistsError()
+        result = runner.invoke(app, ["init", "my_mage_project"])
+        mock_init_repo.assert_called_once()
+        assert "Initialized Mage project" not in result.output

--- a/mage_ai/tests/cli/test_init.py
+++ b/mage_ai/tests/cli/test_init.py
@@ -7,23 +7,23 @@ runner = CliRunner()
 
 
 class InitTests(TestCase):
-    @mock.patch("mage_ai.data_preparation.repo_manager.init_repo")
-    @mock.patch("mage_ai.cli.main.os.getcwd")
+    @mock.patch('mage_ai.data_preparation.repo_manager.init_repo')
+    @mock.patch('mage_ai.cli.main.os.getcwd')
     def test_init_project_with_path(self, mock_getcwd, mock_init_repo):
-        mock_getcwd.return_value = "home"
-        result = runner.invoke(app, ["init", "my_mage_project"])
-        mock_init_repo.assert_called_once_with("home/my_mage_project")
+        mock_getcwd.return_value = 'home'
+        result = runner.invoke(app, ['init', 'my_mage_project'])
+        mock_init_repo.assert_called_once_with('home/my_mage_project')
         assert result.exit_code == 0
-        assert "Initialized Mage project" in result.output
+        assert 'Initialized Mage project' in result.output
 
     def test_init_project_without_path(self):
-        result = runner.invoke(app, ["init"])
+        result = runner.invoke(app, ['init'])
         assert result.exit_code == 2
-        assert "Initialized Mage project" not in result.output
+        assert 'Initialized Mage project' not in result.output
 
-    @mock.patch("mage_ai.data_preparation.repo_manager.init_repo")
+    @mock.patch('mage_ai.data_preparation.repo_manager.init_repo')
     def test_init_project_with_existing_path(self, mock_init_repo):
         mock_init_repo.side_effect = FileExistsError()
-        result = runner.invoke(app, ["init", "my_mage_project"])
+        result = runner.invoke(app, ['init', 'my_mage_project'])
         mock_init_repo.assert_called_once()
-        assert "Initialized Mage project" not in result.output
+        assert 'Initialized Mage project' not in result.output

--- a/mage_ai/tests/cli/test_init.py
+++ b/mage_ai/tests/cli/test_init.py
@@ -1,7 +1,6 @@
-from typer.testing import CliRunner
-
 from mage_ai.cli.main import app
 from mage_ai.tests.base_test import TestCase
+from typer.testing import CliRunner
 from unittest import mock
 
 runner = CliRunner()

--- a/mage_ai/tests/cli/test_run.py
+++ b/mage_ai/tests/cli/test_run.py
@@ -1,10 +1,7 @@
-
-from unittest import mock
-
-from typer.testing import CliRunner
-
 from mage_ai.cli.main import app
 from mage_ai.tests.base_test import TestCase
+from typer.testing import CliRunner
+from unittest import mock
 
 runner = CliRunner()
 

--- a/mage_ai/tests/cli/test_run.py
+++ b/mage_ai/tests/cli/test_run.py
@@ -1,0 +1,39 @@
+
+from unittest import mock
+
+from typer.testing import CliRunner
+
+from mage_ai.cli.main import app
+from mage_ai.tests.base_test import TestCase
+
+runner = CliRunner()
+
+
+class RunTests(TestCase):
+    def test_run_with_no_arguments(self):
+        result = runner.invoke(app, ["run"])
+        assert result.exit_code == 2
+
+    @mock.patch("mage_ai.data_preparation.models.pipeline.Pipeline")
+    @mock.patch("mage_ai.data_preparation.executors.executor_factory.ExecutorFactory")
+    def test_run_with_arguments(self, mock_executor_factory, mock_pipeline):
+        result = runner.invoke(app, ["run", "my_mage_project", "load_titanic"])
+        mock_pipeline.assert_called_once()
+        mock_executor_factory.get_pipeline_executor.return_value.execute.assert_called_once()
+        assert result.exit_code == 0
+        assert "Pipeline run completed." in result.output
+
+    @mock.patch("mage_ai.data_preparation.models.pipeline.Pipeline")
+    @mock.patch("mage_ai.data_preparation.executors.executor_factory.ExecutorFactory")
+    def test_run_with_tests(self, mock_executor_factory, mock_pipeline):
+        result = runner.invoke(app, ["run", "my_mage_project", "load_titanic", "--test"])
+        mock_pipeline.assert_called_once()
+        mock_executor_factory.get_pipeline_executor.return_value.execute.assert_called_once_with(
+            analyze_outputs=mock.ANY,
+            global_vars=mock.ANY,
+            run_sensors=mock.ANY,
+            run_tests=True,
+            update_status=mock.ANY,
+        )
+        assert result.exit_code == 0
+        assert "Pipeline run completed." in result.output

--- a/mage_ai/tests/cli/test_run.py
+++ b/mage_ai/tests/cli/test_run.py
@@ -8,22 +8,22 @@ runner = CliRunner()
 
 class RunTests(TestCase):
     def test_run_with_no_arguments(self):
-        result = runner.invoke(app, ["run"])
+        result = runner.invoke(app, ['run'])
         assert result.exit_code == 2
 
-    @mock.patch("mage_ai.data_preparation.models.pipeline.Pipeline")
-    @mock.patch("mage_ai.data_preparation.executors.executor_factory.ExecutorFactory")
+    @mock.patch('mage_ai.data_preparation.models.pipeline.Pipeline')
+    @mock.patch('mage_ai.data_preparation.executors.executor_factory.ExecutorFactory')
     def test_run_with_arguments(self, mock_executor_factory, mock_pipeline):
-        result = runner.invoke(app, ["run", "my_mage_project", "load_titanic"])
+        result = runner.invoke(app, ['run', 'my_mage_project', 'load_titanic'])
         mock_pipeline.assert_called_once()
         mock_executor_factory.get_pipeline_executor.return_value.execute.assert_called_once()
         assert result.exit_code == 0
-        assert "Pipeline run completed." in result.output
+        assert 'Pipeline run completed.' in result.output
 
-    @mock.patch("mage_ai.data_preparation.models.pipeline.Pipeline")
-    @mock.patch("mage_ai.data_preparation.executors.executor_factory.ExecutorFactory")
+    @mock.patch('mage_ai.data_preparation.models.pipeline.Pipeline')
+    @mock.patch('mage_ai.data_preparation.executors.executor_factory.ExecutorFactory')
     def test_run_with_tests(self, mock_executor_factory, mock_pipeline):
-        result = runner.invoke(app, ["run", "my_mage_project", "load_titanic", "--test"])
+        result = runner.invoke(app, ['run', 'my_mage_project', 'load_titanic', '--test'])
         mock_pipeline.assert_called_once()
         mock_executor_factory.get_pipeline_executor.return_value.execute.assert_called_once_with(
             analyze_outputs=mock.ANY,
@@ -33,4 +33,4 @@ class RunTests(TestCase):
             update_status=mock.ANY,
         )
         assert result.exit_code == 0
-        assert "Pipeline run completed." in result.output
+        assert 'Pipeline run completed.' in result.output

--- a/mage_ai/tests/cli/test_start.py
+++ b/mage_ai/tests/cli/test_start.py
@@ -12,23 +12,23 @@ class StartTests(TestCase):
     def tests_start_with_no_arguments(self, mock_start_sever):
         result = runner.invoke(app, ['start'])
         mock_start_sever.assert_called_once_with(
-            'localhost',
-            '6789',
-            os.getcwd(),
-            False,
-            False
+            host='localhost',
+            port='6789',
+            project=os.getcwd(),
+            manage=False,
+            dbt_docs=False
         )
         assert result.exit_code == 0
         assert 'Mage is running at http://' in result.output
 
-    def test_with_host(self, mock_start_sever):
+    def test_start_with_host(self, mock_start_sever):
         result = runner.invoke(app, ['start', '--host', '127.0.0.1'])
         mock_start_sever.assert_called_once_with(
-            '127.0.0.1',
-            '6789',
-            os.getcwd(),
-            False,
-            False
+            host='127.0.0.1',
+            port='6789',
+            project=os.getcwd(),
+            manage=False,
+            dbt_docs=False
         )
         assert result.exit_code == 0
         assert 'Mage is running at http://127.0.0.1:6789' in result.output
@@ -36,11 +36,11 @@ class StartTests(TestCase):
     def test_start_with_port(self, mock_start_sever):
         result = runner.invoke(app, ['start', '--port', '8000'])
         mock_start_sever.assert_called_once_with(
-            'localhost',
-            '8000',
-            os.getcwd(),
-            False,
-            False
+            host='localhost',
+            port='8000',
+            project=os.getcwd(),
+            manage=False,
+            dbt_docs=False
         )
         assert result.exit_code == 0
         assert 'Mage is running at http://localhost:8000' in result.output
@@ -50,11 +50,11 @@ class StartTests(TestCase):
         mock_abspath.side_effect = lambda x: x
         result = runner.invoke(app, ['start', 'my_mage_project'])
         mock_start_sever.assert_called_once_with(
-            'localhost',
-            '6789',
-            'my_mage_project',
-            False,
-            False
+            host='localhost',
+            port='6789',
+            project='my_mage_project',
+            manage=False,
+            dbt_docs=False
         )
         assert result.exit_code == 0
         assert ('Mage is running at http://localhost:6789'

--- a/mage_ai/tests/cli/test_start.py
+++ b/mage_ai/tests/cli/test_start.py
@@ -1,0 +1,64 @@
+
+import os
+from unittest import mock
+
+from typer.testing import CliRunner
+
+from mage_ai.cli.main import app
+from mage_ai.tests.base_test import TestCase
+
+runner = CliRunner()
+
+
+@mock.patch("mage_ai.server.server.start_server")
+class StartTests(TestCase):
+    def tests_start_with_no_arguments(self, mock_start_sever):
+        result = runner.invoke(app, ["start"])
+        mock_start_sever.assert_called_once_with(
+            "localhost",
+            "6789",
+            os.getcwd(),
+            False,
+            False
+        )
+        assert result.exit_code == 0
+        assert "Mage is running at http://" in result.output
+
+    def test_with_host(self, mock_start_sever):
+        result = runner.invoke(app, ["start", "--host", "127.0.0.1"])
+        mock_start_sever.assert_called_once_with(
+            "127.0.0.1",
+            "6789",
+            os.getcwd(),
+            False,
+            False
+        )
+        assert result.exit_code == 0
+        assert "Mage is running at http://127.0.0.1:6789" in result.output
+
+    def test_start_with_port(self, mock_start_sever):
+        result = runner.invoke(app, ["start", "--port", "8000"])
+        mock_start_sever.assert_called_once_with(
+            "localhost",
+            "8000",
+            os.getcwd(),
+            False,
+            False
+        )
+        assert result.exit_code == 0
+        assert "Mage is running at http://localhost:8000" in result.output
+
+    @mock.patch("mage_ai.cli.main.os.path.abspath")
+    def test_start_with_project_path(self, mock_abspath, mock_start_sever):
+        mock_abspath.side_effect = lambda x: x
+        result = runner.invoke(app, ["start", "my_mage_project"])
+        mock_start_sever.assert_called_once_with(
+            "localhost",
+            "6789",
+            "my_mage_project",
+            False,
+            False
+        )
+        assert result.exit_code == 0
+        assert ("Mage is running at http://localhost:6789"
+                " and serving project my_mage_project") in result.output

--- a/mage_ai/tests/cli/test_start.py
+++ b/mage_ai/tests/cli/test_start.py
@@ -1,8 +1,8 @@
 from mage_ai.cli.main import app
 from mage_ai.tests.base_test import TestCase
-import os
 from typer.testing import CliRunner
 from unittest import mock
+import os
 
 runner = CliRunner()
 

--- a/mage_ai/tests/cli/test_start.py
+++ b/mage_ai/tests/cli/test_start.py
@@ -1,11 +1,8 @@
-
-import os
-from unittest import mock
-
-from typer.testing import CliRunner
-
 from mage_ai.cli.main import app
 from mage_ai.tests.base_test import TestCase
+import os
+from typer.testing import CliRunner
+from unittest import mock
 
 runner = CliRunner()
 

--- a/mage_ai/tests/cli/test_start.py
+++ b/mage_ai/tests/cli/test_start.py
@@ -7,55 +7,55 @@ from unittest import mock
 runner = CliRunner()
 
 
-@mock.patch("mage_ai.server.server.start_server")
+@mock.patch('mage_ai.server.server.start_server')
 class StartTests(TestCase):
     def tests_start_with_no_arguments(self, mock_start_sever):
-        result = runner.invoke(app, ["start"])
+        result = runner.invoke(app, ['start'])
         mock_start_sever.assert_called_once_with(
-            "localhost",
-            "6789",
+            'localhost',
+            '6789',
             os.getcwd(),
             False,
             False
         )
         assert result.exit_code == 0
-        assert "Mage is running at http://" in result.output
+        assert 'Mage is running at http://' in result.output
 
     def test_with_host(self, mock_start_sever):
-        result = runner.invoke(app, ["start", "--host", "127.0.0.1"])
+        result = runner.invoke(app, ['start', '--host', '127.0.0.1'])
         mock_start_sever.assert_called_once_with(
-            "127.0.0.1",
-            "6789",
+            '127.0.0.1',
+            '6789',
             os.getcwd(),
             False,
             False
         )
         assert result.exit_code == 0
-        assert "Mage is running at http://127.0.0.1:6789" in result.output
+        assert 'Mage is running at http://127.0.0.1:6789' in result.output
 
     def test_start_with_port(self, mock_start_sever):
-        result = runner.invoke(app, ["start", "--port", "8000"])
+        result = runner.invoke(app, ['start', '--port', '8000'])
         mock_start_sever.assert_called_once_with(
-            "localhost",
-            "8000",
+            'localhost',
+            '8000',
             os.getcwd(),
             False,
             False
         )
         assert result.exit_code == 0
-        assert "Mage is running at http://localhost:8000" in result.output
+        assert 'Mage is running at http://localhost:8000' in result.output
 
-    @mock.patch("mage_ai.cli.main.os.path.abspath")
+    @mock.patch('mage_ai.cli.main.os.path.abspath')
     def test_start_with_project_path(self, mock_abspath, mock_start_sever):
         mock_abspath.side_effect = lambda x: x
-        result = runner.invoke(app, ["start", "my_mage_project"])
+        result = runner.invoke(app, ['start', 'my_mage_project'])
         mock_start_sever.assert_called_once_with(
-            "localhost",
-            "6789",
-            "my_mage_project",
+            'localhost',
+            '6789',
+            'my_mage_project',
             False,
             False
         )
         assert result.exit_code == 0
-        assert ("Mage is running at http://localhost:6789"
-                " and serving project my_mage_project") in result.output
+        assert ('Mage is running at http://localhost:6789'
+                ' and serving project my_mage_project') in result.output

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ six>=1.15.0
 sqlalchemy>=1.4.20
 tornado==6.1
 aiofiles==22.1.0
+typer[all]==0.7.0
 
 
 # extras

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
     python_requires='>=3.6',
     entry_points={
         'console_scripts': [
-            'mage=mage_ai.cli.main:main',
+            'mage=mage_ai.cli.main:app',
         ],
     },
     extras_require={


### PR DESCRIPTION
## Summary
Migrate the CLI to [Typer](https://github.com/tiangolo/typer) in order to:
1. Make future development of the CLI easier
2. Allow growth in complexity
3. Improve user interaction via better formatting

## Tests
I'll write them in future commits if the idea is approved

## Output examples
![image](https://user-images.githubusercontent.com/43001823/214992313-c9b91022-4f8a-4b15-802d-be4f0e5c578c.png)

![image](https://user-images.githubusercontent.com/43001823/214992392-2f58df6d-82a9-4971-b863-7abfb3ff272f.png)

@tommydangerous is this in line with the company's goals? 