### PR TITLE
Fix bug when installing Mage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setuptools.setup(
             'mysql-connector-python==8.0.31',
         ],
         'postgres': [
-            'psycopg2-binary==2.9.3'
+            'psycopg2-binary==2.9.3',
             'sshtunnel==0.4.0',
         ],
         'redshift': ['boto3==1.24.19', 'redshift-connector==2.0.909'],


### PR DESCRIPTION
## Summary
Added a missing comma that would beak the installation of Mage.

After #1814, installing Mage with `pip` would fail due to a missing comma in the list of `postgres` extra requirements.

## How to reproduce
1. Uninstall Mage from your environment
2. Install it from the latest GitHub distribution `pip install git+https://github.com/mage-ai/mage-ai`

## Tests
Installed it from source. The installation ran smoothly.
