### PR TITLE
[jk] Apply bookmark property only to relevant streams

### DIFF
--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
@@ -399,8 +399,17 @@ function SchemaTable({
                     format: columnFormat || null,
                     type: columnTypes,
                   };
+                  const currStreamMetadata = find(
+                    stream?.metadata || [],
+                    ({ breadcrumb }) => breadcrumb.length === 0,
+                  )?.metadata;
+                  const currStreamReplicationKeys = currStreamMetadata[MetadataKeyEnum.REPLICATION_KEYS] || [];
+                  const currStreamKeyProperties = currStreamMetadata[MetadataKeyEnum.KEY_PROPERTIES] || [];
 
-                  if (uniqueConstraints?.includes(columnName) && !stream?.unique_constraints?.includes(columnName)) {
+                  if (uniqueConstraints?.includes(columnName)
+                    && !stream?.unique_constraints?.includes(columnName)
+                    && currStreamKeyProperties.includes(columnName)
+                  ) {
                     stream.unique_constraints = [columnName].concat(stream.unique_constraints || []);
                   } else if (!uniqueConstraints?.includes(columnName)
                     && stream?.unique_constraints?.includes(columnName)
@@ -408,15 +417,11 @@ function SchemaTable({
                     stream.unique_constraints = remove(stream.unique_constraints, col => columnName === col);
                   }
 
-                  if (bookmarkProperties?.includes(columnName) && !stream?.bookmark_properties?.includes(columnName)) {
-                    const currStreamMetadata = find(
-                      stream?.metadata || [],
-                      ({ breadcrumb }) => breadcrumb.length === 0,
-                    )?.metadata;
-                    const currStreamReplicationKeys = currStreamMetadata[MetadataKeyEnum.REPLICATION_KEYS] || [];
-                    if (currStreamReplicationKeys.includes(columnName)) {
-                      stream.bookmark_properties = [columnName].concat(stream.bookmark_properties || []);
-                    }
+                  if (bookmarkProperties?.includes(columnName)
+                    && !stream?.bookmark_properties?.includes(columnName)
+                    && currStreamReplicationKeys.includes(columnName)
+                  ) {
+                    stream.bookmark_properties = [columnName].concat(stream.bookmark_properties || []);
                   } else if (!bookmarkProperties?.includes(columnName)
                     && stream?.bookmark_properties?.includes(columnName)
                   ) {

--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
@@ -505,7 +505,9 @@ function SchemaTable({
       columnFlex.push(null);
       columns.push({
         tooltipMessage: 'This will apply this individual feature\'s schema \
-          settings to all selected streams that have the same feature.',
+          settings to all selected streams that have the same feature. \
+          Unique features must be valid key properties in other streams. \
+          Bookmark features must be valid replication keys in other streams.',
         uuid: 'All streams',
       });
     }

--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
@@ -646,16 +646,20 @@ function SchemaTable({
               <Spacing ml={TOOLTIP_LEFT_SPACING} />
               <Tooltip
                 label={(
-                  <Text>
+                  <Text wordBreak>
                     If a new record has the same value as an existing record in
-                    the {pluralize('column', uniqueConstraints?.length)} {uniqueConstraints?.sort().map((col: string, idx: number) => (
+                    the {pluralize('column', uniqueConstraints?.length)}
+                    {uniqueConstraints?.length > 0 && <>&nbsp;</>}
+                    {uniqueConstraints?.sort().map((col: string, idx: number) => (
                       <Text
                         bold
                         inline
                         key={col}
                         monospace
                       >
-                        {idx >= 1 && <>,&nbsp;</>}
+                        {uniqueConstraints?.length !== 1 && idx === uniqueConstraints?.length - 1
+                          ? <Text inline key={col}> and </Text>
+                          : (idx >= 1 && <>,&nbsp;</>)}
                         {col}
                       </Text>
                     ))}, how do you want to resolve the conflict?

--- a/mage_ai/frontend/interfaces/IntegrationSourceType.ts
+++ b/mage_ai/frontend/interfaces/IntegrationSourceType.ts
@@ -71,11 +71,18 @@ interface SchemaType {
   type: ColumnTypeEnum;
 }
 
+export enum MetadataKeyEnum {
+  FORCED_REPLICATION_METHOD = 'forced-replication-method',
+  KEY_PROPERTIES = 'table-key-properties',
+  REPLICATION_KEYS = 'valid-replication-keys',
+  SCHEMA_NAME = 'schema-name',
+}
+
 export interface PropertyMetadataType {
-  'forced-replication-method'?: ReplicationMethodEnum,
-  'schema-name'?: string;
-  'table-key-properties'?: string[];
-  'valid-replication-keys'?: string[];
+  [MetadataKeyEnum.FORCED_REPLICATION_METHOD]?: ReplicationMethodEnum,
+  [MetadataKeyEnum.KEY_PROPERTIES]?: string[];
+  [MetadataKeyEnum.REPLICATION_KEYS]?: string[];
+  [MetadataKeyEnum.SCHEMA_NAME]?: string;
   inclusion?: InclusionEnum;
   selected: boolean;
 }


### PR DESCRIPTION
# Summary
- When clicking "Apply (to all streams)" for a column's bookmark property in the data integration schema table, only apply it to other streams if that stream's bookmark column is a valid replication key.
- When clicking "Apply (to all streams)" for a column's unique property in the data integration schema table, only apply it to other streams if that stream's unique column is a valid key property.
- Fix formatting in "Unique conflict method" tooltip when several columns are selected.

# Tests
Unique and bookmark prop APPLIED to other streams:
![Unique and bookmark prop APPLIED to other streams](https://user-images.githubusercontent.com/78053898/215595584-b6ecace3-a9b6-4654-9828-80fe1b83c4b4.gif)

Unique and bookmark prop NOT APPLIED to other streams:
![Unique and bookmark prop NOT APPLIED to other streams](https://user-images.githubusercontent.com/78053898/215595616-b2324f47-d628-43bb-b42d-b0e263486c54.gif)
