### PR TITLE
[jk] Add mage integrations unit tests to GitHub Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -21,6 +21,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r mage_integrations/requirements.txt
+          pip install "git+https://github.com/mage-ai/singer-python.git#egg=singer-python"
       - name: Run unit tests
         run: |
           python3 -m unittest discover -s mage_ai --failfast

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Run unit tests
         run: |
           python3 -m unittest discover -s mage_ai --failfast
+      - name: Run mage integrations unit tests
+        run: |
+          cd mage_integrations && python3 -m unittest discover mage_integrations.tests
   build_frontend:
     runs-on: ubuntu-latest
     steps:

--- a/mage_integrations/mage_integrations/connections/utils/google.py
+++ b/mage_integrations/mage_integrations/connections/utils/google.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing_extensions import TypedDict
 
 
 class CredentialsInfoType(TypedDict):

--- a/mage_integrations/mage_integrations/connections/utils/google.py
+++ b/mage_integrations/mage_integrations/connections/utils/google.py
@@ -1,4 +1,4 @@
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 
 class CredentialsInfoType(TypedDict):

--- a/mage_integrations/mage_integrations/tests/sources/bigquery/test_bigquery.py
+++ b/mage_integrations/mage_integrations/tests/sources/bigquery/test_bigquery.py
@@ -108,6 +108,8 @@ def build_sample_bigquery_rows():
     ]
 
 class BigQuerySourceTests(unittest.TestCase):
+    maxDiff = None
+
     def test_discover(self):
         source = BigQuery(config=dict(project_id="mage_test_project"))
         bigquery_connection = MagicMock()
@@ -151,7 +153,7 @@ class BigQuerySourceTests(unittest.TestCase):
                                         'metadata': {
                                             'table-key-properties': [],
                                             'forced-replication-method': 'FULL_TABLE',
-                                            'valid-replication-keys': [],
+                                            'valid-replication-keys': ['date_joined'],
                                             'inclusion': 'available',
                                             'schema-name': 'demo_users',
                                         },
@@ -182,7 +184,7 @@ class BigQuerySourceTests(unittest.TestCase):
                                     },
                                     {
                                         'breadcrumb': ('properties', 'date_joined'),
-                                        'metadata': {'inclusion': 'available'},
+                                        'metadata': {'inclusion': 'automatic'},
                                     },
                                 ],
                                 'auto_add_new_fields': False,

--- a/mage_integrations/mage_integrations/tests/sources/mysql/test_mysql.py
+++ b/mage_integrations/mage_integrations/tests/sources/mysql/test_mysql.py
@@ -23,6 +23,8 @@ def build_sample_mysql_rows():
     ]
 
 class MySQLSourceTests(unittest.TestCase):
+    maxDiff = None
+
     def test_discover(self):
         source = MySQL(config=dict(database="demo_db"))
         mysql_connection = MagicMock()
@@ -64,7 +66,7 @@ class MySQLSourceTests(unittest.TestCase):
                                         'metadata': {
                                             'table-key-properties': ['id'],
                                             'forced-replication-method': 'FULL_TABLE',
-                                            'valid-replication-keys': ['id'],
+                                            'valid-replication-keys': ['id', 'date_joined'],
                                             'inclusion': 'available',
                                             'schema-name': 'demo_users',
                                         },
@@ -95,7 +97,7 @@ class MySQLSourceTests(unittest.TestCase):
                                     },
                                     {
                                         'breadcrumb': ('properties', 'date_joined'),
-                                        'metadata': {'inclusion': 'available'},
+                                        'metadata': {'inclusion': 'automatic'},
                                     },
                                     {
                                         'breadcrumb': ('properties', 'power_level'),

--- a/mage_integrations/mage_integrations/tests/sources/sql/test_base.py
+++ b/mage_integrations/mage_integrations/tests/sources/sql/test_base.py
@@ -24,6 +24,8 @@ def build_log_based_sample_catalog_entry():
     )
 
 class BaseSQLSourceTests(unittest.TestCase):
+    maxDiff = None
+
     def test_discover(self):
         source = Source()
         build_connection_result = MagicMock()
@@ -68,7 +70,7 @@ class BaseSQLSourceTests(unittest.TestCase):
                                             'metadata': {
                                                 'table-key-properties': [],
                                                 'forced-replication-method': 'FULL_TABLE',
-                                                'valid-replication-keys': [],
+                                                'valid-replication-keys': ['createddate'],
                                                 'inclusion': 'available',
                                                 'schema-name': 'demo_actions',
                                             },
@@ -83,7 +85,7 @@ class BaseSQLSourceTests(unittest.TestCase):
                                         },
                                         {
                                             'breadcrumb': ('properties', 'createddate'),
-                                            'metadata': {'inclusion': 'available'},
+                                            'metadata': {'inclusion': 'automatic'},
                                         },
                                         {
                                             'breadcrumb': ('properties', 'type'),

--- a/mage_integrations/mage_integrations/tests/sources/test_base.py
+++ b/mage_integrations/mage_integrations/tests/sources/test_base.py
@@ -44,6 +44,9 @@ def build_sample_streams_catalog():
     )
 
 class BaseSourceTests(unittest.TestCase):
+    # Shows full diff if any unit tests fail
+    maxDiff = None
+
     def test_templates(self):
         # Template folders exist in the different integration source folders.
         source = PostgreSQL()
@@ -370,7 +373,7 @@ class BaseSourceTests(unittest.TestCase):
         source = Stripe()
         schemas = source.load_schemas_from_folder()
         self.assertEqual(
-            list(schemas),
+            list(schemas).sort(),
             [
                 'balance_transactions',
                 'charges',
@@ -389,5 +392,5 @@ class BaseSourceTests(unittest.TestCase):
                 'subscription_items',
                 'subscriptions',
                 'transfers',
-            ],
+            ].sort(),
         )

--- a/mage_integrations/mage_integrations/tests/sources/test_base.py
+++ b/mage_integrations/mage_integrations/tests/sources/test_base.py
@@ -4,7 +4,7 @@ from mage_integrations.sources.intercom import Intercom
 from mage_integrations.sources.postgresql import PostgreSQL
 from mage_integrations.sources.stripe import Stripe
 from singer.schema import Schema
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 import os
 import unittest
 import json
@@ -162,28 +162,25 @@ class BaseSourceTests(unittest.TestCase):
 
     def test_process_count_records_mode(self):
         catalog = build_sample_streams_catalog()
+        catalog.get_selected_streams = MagicMock()
+        catalog.get_selected_streams.return_value = build_sample_streams_catalog_entries()
         source = Source(
             catalog=catalog,
             count_records=True,
             selected_streams=['demo_table', 'demo_users'],
         )
         with patch.object(source, 'count_records') as mock_count_records:
-            with patch.object(
-                catalog,
-                'get_selected_streams',
-                return_value=build_sample_streams_catalog_entries(),
-            ):
-                with patch.object(json, 'dump'):
-                    with patch.object(source, 'discover_streams') as mock_discover_streams:
-                        with patch.object(source, 'discover') as mock_discover:
-                            with patch.object(source, 'load_data') as mock_load_data:
-                                with patch.object(source, 'sync') as mock_sync:
-                                    source.process()
-                                    self.assertEqual(mock_count_records.call_count, 2)
-                                    mock_discover_streams.assert_not_called()
-                                    mock_discover.assert_not_called()
-                                    mock_load_data.assert_not_called()
-                                    mock_sync.assert_not_called()
+            with patch.object(json, 'dump'):
+                with patch.object(source, 'discover_streams') as mock_discover_streams:
+                    with patch.object(source, 'discover') as mock_discover:
+                        with patch.object(source, 'load_data') as mock_load_data:
+                            with patch.object(source, 'sync') as mock_sync:
+                                source.process()
+                                self.assertEqual(mock_count_records.call_count, 2)
+                                mock_discover_streams.assert_not_called()
+                                mock_discover.assert_not_called()
+                                mock_load_data.assert_not_called()
+                                mock_sync.assert_not_called()
 
     def test_process_no_catalog(self):
         source = Source()
@@ -288,17 +285,14 @@ class BaseSourceTests(unittest.TestCase):
 
     def test_sync(self):
         catalog = build_sample_streams_catalog()
+        catalog.get_selected_streams = MagicMock()
+        catalog.get_selected_streams.return_value = build_sample_streams_catalog_entries()
         source = Source()
         with patch.object(source, 'process_stream', return_value=None) as mock_process_stream:
             with patch.object(source, 'sync_stream') as mock_sync_stream:
-                with patch.object(
-                    catalog,
-                    'get_selected_streams',
-                    return_value=build_sample_streams_catalog_entries(),
-                ):
-                    source.sync(catalog)
-                    self.assertEqual(mock_process_stream.call_count, 2)
-                    self.assertEqual(mock_sync_stream.call_count, 2)
+                source.sync(catalog)
+                self.assertEqual(mock_process_stream.call_count, 2)
+                self.assertEqual(mock_sync_stream.call_count, 2)
 
     def test_build_catalog_entry(self):
         source = Source()

--- a/mage_integrations/requirements.txt
+++ b/mage_integrations/requirements.txt
@@ -21,12 +21,10 @@ redshift-connector==2.0.909
 requests==2.27.1
 requests_mock==1.10.0
 simplejson==3.11.1
-singer-python==5.13.0
 snowflake-connector-python==2.9.0
 sshtunnel==0.4.0
 stripe==4.2.0
 trino==0.321.0
-typing-extensions==4.4.0
 tzlocal==4.2
 xmltodict==0.13.0
 zenpy==2.0.25

--- a/mage_integrations/requirements.txt
+++ b/mage_integrations/requirements.txt
@@ -21,10 +21,12 @@ redshift-connector==2.0.909
 requests==2.27.1
 requests_mock==1.10.0
 simplejson==3.11.1
+singer-python==5.13.0
 snowflake-connector-python==2.9.0
 sshtunnel==0.4.0
 stripe==4.2.0
 trino==0.321.0
+typing-extensions==4.4.0
 tzlocal==4.2
 xmltodict==0.13.0
 zenpy==2.0.25


### PR DESCRIPTION
# Summary
- Include mage integrations unit tests as part of GitHub Actions
- Runs unit tests in `mage-ai/mage_integrations/mage_integrations/tests` directory.

# Tests
- [x] Confirmed github actions successfully ran in branch.
