### PR TITLE
[jk] Windows keyboard shortcuts

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
@@ -27,6 +27,7 @@ import {
   PlayButtonFilled,
 } from '@oracle/icons';
 import {
+  KEY_SYMBOL_CONTROL,
   KEY_SYMBOL_ENTER,
   KEY_SYMBOL_I,
   KEY_SYMBOL_META,
@@ -35,6 +36,7 @@ import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { PipelineTypeEnum } from '@interfaces/PipelineType';
 import { buildConvertBlockMenuItems, getMoreActionsItems } from '../utils';
 import { getColorsForBlockType } from '../index.style';
+import { isMac } from '@utils/os';
 import { indexBy } from '@utils/array';
 
 export type CommandButtonsSharedProps = {
@@ -148,7 +150,10 @@ function CommandButtons({
                 &nbsp;
                 <KeyboardTextGroup
                   inline
-                  keyTextGroups={[[KEY_SYMBOL_META, KEY_SYMBOL_ENTER]]}
+                  keyTextGroups={[[
+                    isMac() ? KEY_SYMBOL_META : KEY_SYMBOL_CONTROL,
+                    KEY_SYMBOL_ENTER,
+                  ]]}
                   monospace
                   uuidForKey={uuid}
                 />

--- a/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/index.tsx
@@ -8,6 +8,7 @@ import Text from '@oracle/elements/Text';
 import {
   KEY_CODE_NUMBERS_TO_NUMBER,
   KEY_CODE_NUMBER_0,
+  KEY_SYMBOL_CONTROL,
   KEY_SYMBOL_I,
   KEY_SYMBOL_META,
   KEY_SYMBOL_S,
@@ -18,6 +19,7 @@ import {
 } from '@utils/hooks/keyboardShortcuts/constants';
 import { LinkStyle } from './index.style';
 import { PipelineTypeEnum } from '@interfaces/PipelineType';
+import { isMac } from '@utils/os';
 import { randomNameGenerator } from '@utils/string';
 import { useKeyboardContext } from '@context/Keyboard';
 
@@ -74,7 +76,10 @@ function FileHeaderMenu({
     },
     {
       label: () => 'Save pipeline',
-      keyTextGroups: [[KEY_SYMBOL_META, KEY_SYMBOL_S]],
+      keyTextGroups: [[
+        isMac() ? KEY_SYMBOL_META : KEY_SYMBOL_CONTROL,
+        KEY_SYMBOL_S,
+      ]],
       onClick: () => savePipelineContent(),
       uuid: 'save_pipeline',
     },

--- a/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
@@ -25,20 +25,23 @@ import Text from '@oracle/elements/Text';
 import Tooltip from '@oracle/components/Tooltip';
 import api from '@api';
 import dark from '@oracle/styles/themes/dark';
-import { Check, Close, FileFill } from '@oracle/icons';
+
+import { Check } from '@oracle/icons';
 import { CloudProviderSparkClusterEnum } from '@interfaces/CloudProviderType';
-import { FileTabStyle, PipelineHeaderStyle } from './index.style';
 import {
   KEY_CODE_ENTER,
   KEY_CODE_META,
+  KEY_SYMBOL_CONTROL,
   KEY_SYMBOL_META,
   KEY_SYMBOL_S,
 } from '@utils/hooks/keyboardShortcuts/constants';
-import { ThemeType } from '@oracle/styles/themes/constants';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
+import { PipelineHeaderStyle } from './index.style';
+import { ThemeType } from '@oracle/styles/themes/constants';
 import { dateFormatLongFromUnixTimestamp } from '@utils/date';
-import { find, remove } from '@utils/array';
+import { find } from '@utils/array';
 import { goToWithQuery } from '@utils/routing';
+import { isMac } from '@utils/os';
 import { onSuccess } from '@api/utils/response';
 import { useKeyboardContext } from '@context/Keyboard';
 
@@ -422,7 +425,7 @@ function KernelStatus({
                   <FlexContainer alignItems="center">
                     <Text default inline>Press</Text>&nbsp;<KeyboardText
                       inline
-                      keyText={KEY_SYMBOL_META}
+                      keyText={isMac() ? KEY_SYMBOL_META : KEY_SYMBOL_CONTROL}
                     />&nbsp;<Text default inline>+</Text>&nbsp;<KeyboardText
                       inline
                       keyText={KEY_SYMBOL_S}

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -45,6 +45,7 @@ import {
   KEY_CODE_ARROW_DOWN,
   KEY_CODE_ARROW_UP,
   KEY_CODE_B,
+  KEY_CODE_CONTROL,
   KEY_CODE_D,
   KEY_CODE_ENTER,
   KEY_CODE_ESCAPE,
@@ -220,7 +221,9 @@ function PipelineDetail({
         if (typeof window !== 'undefined' && typeof location !== 'undefined' && window.confirm(warning)) {
           location.reload();
         }
-      } else if (onlyKeysPresent([KEY_CODE_META, KEY_CODE_S], keyMapping)) {
+      } else if (onlyKeysPresent([KEY_CODE_META, KEY_CODE_S], keyMapping)
+        || onlyKeysPresent([KEY_CODE_CONTROL, KEY_CODE_S], keyMapping)
+      ) {
         event.preventDefault();
         savePipelineContent();
       } else if (textareaFocused) {

--- a/mage_ai/frontend/interfaces/OSType.ts
+++ b/mage_ai/frontend/interfaces/OSType.ts
@@ -1,0 +1,10 @@
+export enum OSEnum {
+  ANDROID = 'Android',
+  CHROME_OS = 'ChromeOS',
+  IOS = 'iOS',
+  LINUX = 'Linux',
+  MAC = 'macOS',
+  WINDOWS = 'Windows',
+}
+
+export default OSEnum;

--- a/mage_ai/frontend/utils/os.ts
+++ b/mage_ai/frontend/utils/os.ts
@@ -1,0 +1,36 @@
+import OSEnum from '@interfaces/OSType';
+
+export function getOS() {
+  const userAgent = window?.navigator?.userAgent;
+  const platform = window?.navigator?.userAgentData?.platform || window.navigator.platform;
+  const macosPlatforms = ['macOS', 'Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
+  const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
+  const iosPlatforms = ['iPhone', 'iPad', 'iPod'];
+  let os: OSEnum = OSEnum.MAC;
+
+  if (platform) {
+    if (macosPlatforms.includes(platform)) {
+      os = OSEnum.MAC;
+    } else if (windowsPlatforms.includes(platform)) {
+      os = OSEnum.WINDOWS;
+    } else if (iosPlatforms.includes(platform)) {
+      os = OSEnum.IOS;
+    }
+  } else if (userAgent) {
+    if (userAgent.includes('Macintosh')) {
+      os = OSEnum.MAC;
+    } else if (userAgent.includes('Windows')) {
+      os = OSEnum.WINDOWS;
+    } else if (userAgent.includes('Linux') && userAgent.includes('X11')) {
+      os = OSEnum.LINUX;
+    } else if (/(iPhone|iPad)/.test(userAgent)) {
+      os = OSEnum.IOS;
+    } else if (userAgent.includes('Android') && userAgent.includes('Mobi')) {
+      os = OSEnum.ANDROID;
+    } else if (userAgent.includes('CrOS')) {
+      os = OSEnum.CHROME_OS;
+    }
+  }
+
+  return os;
+}

--- a/mage_ai/frontend/utils/os.ts
+++ b/mage_ai/frontend/utils/os.ts
@@ -2,7 +2,11 @@ import OSEnum from '@interfaces/OSType';
 
 export function getOS() {
   const userAgent = window?.navigator?.userAgent;
+
+  //@ts-ignore
+  // We fall back to checking the User-Agent string if a browser does not support the properties below.
   const platform = window?.navigator?.userAgentData?.platform || window?.navigator?.platform;
+
   const macosPlatforms = ['macOS', 'Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
   const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
   const iosPlatforms = ['iPhone', 'iPad', 'iPod'];

--- a/mage_ai/frontend/utils/os.ts
+++ b/mage_ai/frontend/utils/os.ts
@@ -2,7 +2,7 @@ import OSEnum from '@interfaces/OSType';
 
 export function getOS() {
   const userAgent = window?.navigator?.userAgent;
-  const platform = window?.navigator?.userAgentData?.platform || window.navigator.platform;
+  const platform = window?.navigator?.userAgentData?.platform || window?.navigator?.platform;
   const macosPlatforms = ['macOS', 'Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
   const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
   const iosPlatforms = ['iPhone', 'iPad', 'iPod'];
@@ -33,4 +33,8 @@ export function getOS() {
   }
 
   return os;
+}
+
+export function isMac() {
+  return getOS() === OSEnum.MAC;
 }


### PR DESCRIPTION
# Summary
- Add `ctrl+s` keyboard shortcut for saving pipeline in Pipeline Editor.
- Display appropriate keyboard shortcut depending on user's OS.

# Tests
- [x] Confirmed correct keyboard shortcuts (e.g. for running a block and saving pipeline) were displayed and functional when running Mage on a Macbook.
![image](https://user-images.githubusercontent.com/78053898/216131069-5a7c4a33-ace1-4497-8ca7-4714c6cf7394.png)
![image](https://user-images.githubusercontent.com/78053898/216131079-d1c96b52-8376-4256-a6c1-7a9ef96555fd.png)
![image](https://user-images.githubusercontent.com/78053898/216131090-98a5a621-6f93-485c-a714-f7ce1947413a.png)

- [ ] Confirmed correct keyboard shortcuts (e.g. for running a block and saving pipeline) were displayed and functional when running Mage on Windows.
