### PR TITLE
[jk] Add return value to mock

### DIFF
--- a/mage_integrations/mage_integrations/tests/sources/test_base.py
+++ b/mage_integrations/mage_integrations/tests/sources/test_base.py
@@ -292,7 +292,7 @@ class BaseSourceTests(unittest.TestCase):
         catalog.get_selected_streams.return_value = build_sample_streams_catalog_entries()
         source = Source()
         with patch.object(source, 'process_stream', return_value=None) as mock_process_stream:
-            with patch.object(source, 'sync_stream') as mock_sync_stream:
+            with patch.object(source, 'sync_stream', return_value=dict()) as mock_sync_stream:
                 source.sync(catalog)
                 self.assertEqual(mock_process_stream.call_count, 2)
                 self.assertEqual(mock_sync_stream.call_count, 2)

--- a/mage_integrations/mage_integrations/tests/sources/test_base.py
+++ b/mage_integrations/mage_integrations/tests/sources/test_base.py
@@ -292,7 +292,7 @@ class BaseSourceTests(unittest.TestCase):
         catalog.get_selected_streams.return_value = build_sample_streams_catalog_entries()
         source = Source()
         with patch.object(source, 'process_stream', return_value=None) as mock_process_stream:
-            with patch.object(source, 'sync_stream', return_value=dict()) as mock_sync_stream:
+            with patch.object(source, 'sync_stream', return_value=1) as mock_sync_stream:
                 source.sync(catalog)
                 self.assertEqual(mock_process_stream.call_count, 2)
                 self.assertEqual(mock_sync_stream.call_count, 2)


### PR DESCRIPTION
# Summary
- Fix unit test that was inconsistently throwing an error (though passed most of the time).

# Tests
- Reran `test_sync` unit test many times in order for the error to appear. Reran test many times after updating it, and the error stopped appearing.

cc:
@wangxiaoyou1993 
