### PR TITLE
[xy] Filter order_by_columns by column types.

### DIFF
--- a/mage_integrations/mage_integrations/sources/sql/base.py
+++ b/mage_integrations/mage_integrations/sources/sql/base.py
@@ -21,7 +21,10 @@ from mage_integrations.sources.sql.utils import (
 )
 from mage_integrations.sources.utils import get_standard_metadata
 from mage_integrations.utils.dictionary import group_by
-from mage_integrations.utils.schema_helpers import extract_selected_columns
+from mage_integrations.utils.schema_helpers import (
+    extract_selected_columns,
+    filter_columns,
+)
 from singer.schema import Schema
 from time import sleep
 from typing import Any, Dict, Generator, List, Tuple
@@ -280,7 +283,16 @@ WHERE table_schema = '{schema}'
         clean_columns = self.update_column_names(columns)
 
         if not order_by_columns:
-            order_by_columns = columns
+            order_by_columns = filter_columns(
+                columns,
+                stream.schema.to_dict()['properties'],
+                [
+                    COLUMN_TYPE_BOOLEAN,
+                    COLUMN_TYPE_INTEGER,
+                    COLUMN_TYPE_NUMBER,
+                    COLUMN_TYPE_STRING,
+                ],
+            )
         order_by_columns = self.update_column_names(order_by_columns)
 
         if order_by_columns and not count_records:

--- a/mage_integrations/mage_integrations/transformers/utils.py
+++ b/mage_integrations/mage_integrations/transformers/utils.py
@@ -9,6 +9,7 @@ INVALID_DATA_TYPES = [
     'mixed',
 ]
 
+
 def write_parquet_file(file_path: str, df: pd.DataFrame) -> None:
     df_output = df.copy()
     # Clean up data types since parquet doesn't support mixed data types

--- a/mage_integrations/mage_integrations/utils/schema_helpers.py
+++ b/mage_integrations/mage_integrations/utils/schema_helpers.py
@@ -4,7 +4,7 @@ from mage_integrations.sources.constants import (
     METADATA_KEY_INCLUSION,
     METADATA_KEY_SELECTED,
 )
-from typing import List
+from typing import Dict, List
 
 
 def extract_selected_columns(metadata_array: List[dict]) -> List[str]:
@@ -27,3 +27,14 @@ def extract_selected_columns(metadata_array: List[dict]) -> List[str]:
                 columns.append(column)
 
     return columns
+
+
+def filter_columns(columns: List[str], properties: Dict, column_types: List[str]):
+    filtered_columns = []
+    for col in columns:
+        if col not in properties:
+            continue
+        types = properties[col]['type']
+        if any(t in column_types for t in types):
+            filtered_columns.append(col)
+    return filtered_columns


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Filter order_by_columns by column types. Some column types can't be used as order by columns.
```
Error while executing query: 400 ORDER BY does not support expressions of type ARRAY<STRUCT<type STRING, id INT64, role STRING>> at [11:80]
```

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
