### PR TITLE
[jk] Overwrite runtime variables when "running pipeline now"

### DIFF
--- a/mage_ai/frontend/components/Sidekick/utils.ts
+++ b/mage_ai/frontend/components/Sidekick/utils.ts
@@ -132,8 +132,8 @@ export function getFormattedVariables(variables, filterBlock) {
       return {
         ...variable,
         value: getFormattedVariable(variableValue),
-      }
-    })
+      };
+    });
 }
 
 export function addTriggerVariables(variablesArr, scheduleType) {

--- a/mage_ai/frontend/components/Triggers/RunPipelinePopup/index.style.ts
+++ b/mage_ai/frontend/components/Triggers/RunPipelinePopup/index.style.ts
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+import dark from '@oracle/styles/themes/dark';
+import { BORDER_RADIUS } from '@oracle/styles/units/borders';
+import { UNIT } from '@oracle/styles/units/spacing';
+
+export const ToggleStyle = styled.div`
+  padding: ${UNIT * 1.5}px ${UNIT * 2}px;
+  border-radius: ${BORDER_RADIUS}px;
+
+  ${props => `
+    border: 1px solid ${(props.theme || dark).borders.light};
+    background-color: ${(props.theme || dark).background.popup};
+  `}
+`;

--- a/mage_ai/frontend/components/Triggers/RunPipelinePopup/index.tsx
+++ b/mage_ai/frontend/components/Triggers/RunPipelinePopup/index.tsx
@@ -70,6 +70,7 @@ function RunPipelinePopup({
       return (
         <TextArea
           {...sharedValueElProps}
+          rows={1}
           value={value}
         />
       );

--- a/mage_ai/frontend/components/Triggers/RunPipelinePopup/index.tsx
+++ b/mage_ai/frontend/components/Triggers/RunPipelinePopup/index.tsx
@@ -135,6 +135,7 @@ function RunPipelinePopup({
           Run pipeline now
         </Headline>
       }
+      maxHeight="90vh"
       minWidth={UNIT * 85}
       subtitle="Creates a new trigger and immediately runs the current pipeline once."
     >

--- a/mage_ai/frontend/components/Triggers/RunPipelinePopup/index.tsx
+++ b/mage_ai/frontend/components/Triggers/RunPipelinePopup/index.tsx
@@ -1,0 +1,169 @@
+import { useMemo, useState } from 'react';
+
+import Button from '@oracle/elements/Button';
+import FlexContainer from '@oracle/components/FlexContainer';
+import Headline from '@oracle/elements/Headline';
+import Panel from '@oracle/components/Panel';
+import PipelineScheduleType from '@interfaces/PipelineScheduleType';
+import Spacing from '@oracle/elements/Spacing';
+import Table from '@components/shared/Table';
+import Text from '@oracle/elements/Text';
+import TextArea from '@oracle/elements/Inputs/TextArea';
+import TextInput from '@oracle/elements/Inputs/TextInput';
+import ToggleSwitch from '@oracle/elements/Inputs/ToggleSwitch';
+import dark from '@oracle/styles/themes/dark';
+import { ToggleStyle } from './index.style';
+import { UNIT } from '@oracle/styles/units/spacing';
+import { isJsonString } from '@utils/string';
+import { parseVariables } from '@components/Sidekick/utils';
+
+type RunPipelinePopupProps = {
+  initialPipelineSchedulePayload: PipelineScheduleType,
+  onCancel: () => void;
+  onSuccess: (
+    payload: { pipeline_schedule: PipelineScheduleType },
+  ) => void;
+  variables?: { [keyof: string]: string };
+};
+
+const BUTTON_PADDING = `${UNIT}px ${UNIT * 3}px`;
+
+function RunPipelinePopup({
+  initialPipelineSchedulePayload,
+  onCancel,
+  onSuccess,
+  variables,
+}: RunPipelinePopupProps) {
+  const [overwriteVariables, setOverwriteVariables] = useState<boolean>(false);
+  const [runtimeVariables, setRuntimeVariables] = useState<{
+    [keyof: string]: string,
+  }>(variables || {});
+
+  const finalPipelineSchedulePayload = useMemo(() => ({
+    ...initialPipelineSchedulePayload,
+    variables: overwriteVariables ? parseVariables(runtimeVariables) : null,
+  }), [
+    initialPipelineSchedulePayload,
+    overwriteVariables,
+    runtimeVariables,
+  ]);
+
+  const buildValueRowEl = useMemo(() => (uuid: string, value: string) => {
+    const sharedValueElProps = {
+      borderless: true,
+      key: `variable_uuid_input_${uuid}`,
+      monospace: true,
+      onChange: (e) => {
+        e.preventDefault();
+        setRuntimeVariables(vars => ({
+          ...vars,
+          [uuid]: e.target.value,
+        }));
+      },
+      paddingHorizontal: 0,
+      placeholder: 'Variable value',
+      value,
+    };
+
+    if (isJsonString(value)
+      && typeof JSON.parse(value) === 'object'
+      && !Array.isArray(JSON.parse(value))
+      && JSON.parse(value) !== null
+    ) {
+      return (
+        <TextArea
+          {...sharedValueElProps}
+          value={JSON.stringify(JSON.parse(value), null, 2)}
+        />
+      );
+    }
+
+    return (
+      <TextInput {...sharedValueElProps} />
+    );
+  }, []);
+
+  return (
+    <Panel
+      footer={
+        <FlexContainer
+          alignItems="center"
+          fullWidth
+          justifyContent="flex-end"
+        >
+          <Button
+            onClick={() => {
+              onSuccess({
+                pipeline_schedule: finalPipelineSchedulePayload,
+              });
+              onCancel();
+            }}
+            padding={BUTTON_PADDING}
+            primaryAlternate
+          >
+            Run now
+          </Button>
+          <Spacing mr={1} />
+          <Button
+            borderColor={dark.background.page}
+            onClick={onCancel}
+            padding={BUTTON_PADDING}
+            secondary
+          >
+            Cancel
+          </Button>
+        </FlexContainer>
+      }
+      header={
+        <Headline level={5}>
+          Run pipeline now
+        </Headline>
+      }
+      minWidth={UNIT * 85}
+      subtitle="Creates a new trigger and immediately runs the current pipeline once."
+    >
+      <ToggleStyle>
+        <FlexContainer alignItems="center">
+          <Spacing mr={2}>
+            <ToggleSwitch
+              checked={overwriteVariables}
+              onCheck={setOverwriteVariables}
+            />
+          </Spacing>
+          <Text bold large>
+            Overwrite runtime variables
+          </Text>
+        </FlexContainer>
+      </ToggleStyle>
+
+      {overwriteVariables && runtimeVariables
+        && Object.entries(runtimeVariables).length > 0 && (
+        <Spacing mt={2}>
+          <Table
+            columnFlex={[null, 1]}
+            columns={[
+              {
+                uuid: 'Variable',
+              },
+              {
+                uuid: 'Value',
+              },
+            ]}
+            rows={Object.entries(runtimeVariables).map(([uuid, value]) => [
+              <Text
+                default
+                key={`variable_${uuid}`}
+                monospace
+              >
+                {uuid}
+              </Text>,
+              buildValueRowEl(uuid, value),
+            ])}
+          />
+        </Spacing>
+      )}
+    </Panel>
+  );
+}
+
+export default RunPipelinePopup;

--- a/mage_ai/frontend/oracle/components/Panel/index.tsx
+++ b/mage_ai/frontend/oracle/components/Panel/index.tsx
@@ -21,6 +21,7 @@ const PanelStyle = styled.div<{
   borderless?: boolean;
   fullHeight?: boolean;
   overflowVisible?: boolean;
+  minWidth?: number;
 }>`
   border-radius: ${BORDER_RADIUS}px;
   overflow: hidden;
@@ -33,6 +34,14 @@ const PanelStyle = styled.div<{
 
   ${props => !props.fullHeight && `
     height: fit-content;
+  `}
+
+  ${props => props.minWidth && `
+    min-width: ${props.minWidth}px;
+
+    @media (max-width: ${props.minWidth}px) {
+      min-width: 0;
+    }
   `}
 
   ${props => props.borderless && `
@@ -97,7 +106,8 @@ export type PanelProps = {
   fullHeight?: boolean;
   noPadding?: boolean;
   overflowVisible?: boolean;
-  subtitle?: JSX.Element;
+  subtitle?: string;
+  minWidth?: number;
 };
 
 function Panel({
@@ -114,11 +124,13 @@ function Panel({
   noPadding,
   overflowVisible,
   subtitle,
+  minWidth,
 }: PanelProps) {
   return (
     <PanelStyle
       borderless={borderless}
       fullHeight={fullHeight}
+      minWidth={minWidth}
       overflowVisible={overflowVisible}
       ref={containerRef}
     >
@@ -137,28 +149,27 @@ function Panel({
               </FlexContainer>
             </FlexContainer>
           }
-          { subtitle &&
-          <>
-            <Spacing mb={2}/>
-            <FlexContainer alignItems="right">
-              {subtitle}
-            </FlexContainer>
-          </>
-          }
         </HeaderStyle>
       }
+
       <ContentStyle
         noPadding={noPadding}
         overflowVisible={overflowVisible}
         ref={contentContainerRef}
       >
+        {subtitle &&
+          <Spacing mb={2}>
+            <Text default>
+              {subtitle}
+            </Text>
+          </Spacing>
+        }
         {children}
       </ContentStyle>
+
       {footer &&
         <FooterStyle>
-          <FlexContainer alignItems="center" justifyContent="center">
-            {footer}
-          </FlexContainer>
+          {footer}
         </FooterStyle>
       }
     </PanelStyle>

--- a/mage_ai/frontend/oracle/components/Panel/index.tsx
+++ b/mage_ai/frontend/oracle/components/Panel/index.tsx
@@ -3,10 +3,11 @@ import styled, { css } from 'styled-components';
 import FlexContainer from '@oracle/components/FlexContainer';
 import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
-import { UNIT } from '@oracle/styles/units/spacing';
-
 import light from '@oracle/styles/themes/light';
+
 import { BORDER_RADIUS, BORDER_STYLE, BORDER_WIDTH } from '@oracle/styles/units/borders';
+import { ScrollbarStyledCss } from '@oracle/styles/scrollbars';
+import { UNIT } from '@oracle/styles/units/spacing';
 
 const HEADER_PADDING_Y_UNITS = 1.5;
 const PADDING_UNITS = 1.75;
@@ -20,8 +21,9 @@ const HEADER_STYLES = css`
 const PanelStyle = styled.div<{
   borderless?: boolean;
   fullHeight?: boolean;
-  overflowVisible?: boolean;
+  maxHeight?: string;
   minWidth?: number;
+  overflowVisible?: boolean;
 }>`
   border-radius: ${BORDER_RADIUS}px;
   overflow: hidden;
@@ -34,6 +36,10 @@ const PanelStyle = styled.div<{
 
   ${props => !props.fullHeight && `
     height: fit-content;
+  `}
+
+  ${props => props.maxHeight && `
+    max-height: ${props.maxHeight};
   `}
 
   ${props => props.minWidth && `
@@ -73,9 +79,14 @@ const ContentStyle = styled.div<any>`
   overflow-y: auto;
   padding: ${PADDING_UNITS * UNIT}px;
   height: 100%;
+  ${ScrollbarStyledCss}
 
   ${props => props.height && `
     height: ${props.height}px;
+  `}
+
+  ${props => props.maxHeight && `
+    max-height: calc(${props.maxHeight} - ${UNIT * 15}px);
   `}
 
   ${props => props.noPadding && `
@@ -102,6 +113,7 @@ export type PanelProps = {
   headerHeight?: number;
   headerIcon?: JSX.Element;
   headerTitle?: string;
+  maxHeight?: string;
   footer?: JSX.Element;
   fullHeight?: boolean;
   noPadding?: boolean;
@@ -121,6 +133,7 @@ function Panel({
   headerHeight,
   headerIcon,
   headerTitle,
+  maxHeight,
   noPadding,
   overflowVisible,
   subtitle,
@@ -130,6 +143,7 @@ function Panel({
     <PanelStyle
       borderless={borderless}
       fullHeight={fullHeight}
+      maxHeight={maxHeight}
       minWidth={minWidth}
       overflowVisible={overflowVisible}
       ref={containerRef}
@@ -153,6 +167,7 @@ function Panel({
       }
 
       <ContentStyle
+        maxHeight={maxHeight}
         noPadding={noPadding}
         overflowVisible={overflowVisible}
         ref={contentContainerRef}

--- a/mage_ai/frontend/oracle/elements/Button/index.tsx
+++ b/mage_ai/frontend/oracle/elements/Button/index.tsx
@@ -67,6 +67,7 @@ export type ButtonProps = {
   pill?: boolean;
   pointerEventsEnabled?: boolean;
   primary?: boolean;
+  primaryAlternate?: boolean;
   primaryGradient?: boolean;
   sameColorAsText?: boolean;
   secondary?: boolean;
@@ -111,10 +112,6 @@ const SHARED_STYLES = css<{
 
   ${props => props.default && `
     color: ${(props.theme.content || dark.content).default};
-  `}
-
-  ${props => props.borderColor && `
-    border-color: ${props.borderColor};
   `}
 
   ${props => !props.noBackground && `
@@ -273,6 +270,14 @@ const SHARED_STYLES = css<{
       background-color: ${(props.theme.interactive || dark.interactive).linkPrimaryHover} !important;
       border-color: ${(props.theme.interactive || dark.interactive).linkPrimary} !important;
     }
+  `}
+
+  ${props => props.primaryAlternate && `
+    background-color: ${(props.theme.brand || dark.brand).wind400};
+  `}
+
+  ${props => props.borderColor && `
+    border-color: ${props.borderColor};
   `}
 
   ${props => props.secondaryGradient && `

--- a/mage_ai/frontend/oracle/elements/Inputs/TextArea.tsx
+++ b/mage_ai/frontend/oracle/elements/Inputs/TextArea.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import InputWrapper, { InputWrapperProps, SHARED_INPUT_STYLES } from './InputWrapper';
+
+export type TextAreaProps = {
+  rows?: number;
+} & InputWrapperProps;
+
+const TextInputStyle = styled.textarea<TextAreaProps>`
+  ${SHARED_INPUT_STYLES}
+`;
+
+const TextInput = ({ rows = 3, ...props }: TextAreaProps, ref) => {
+  return (
+    <InputWrapper
+      {...props}
+      input={<TextInputStyle rows={rows} {...props} />}
+      ref={ref}
+    />
+  );
+};
+
+export default React.forwardRef(TextInput);


### PR DESCRIPTION
# Summary
- Add modal for overwriting runtime variables when clicking "Run pipeline now" button.
- If no global variables exist, the modal will not appear and the pipeline will be run immediately after clicking the "Run pipeline now" button.

# Tests
Run pipeline immediately (no modal appears since no runtime variables):
![Run pipeline immediately (no vars)](https://user-images.githubusercontent.com/78053898/217393954-4164342e-0392-4e18-87b2-51207295cd02.gif)

Overwrite variables:
![Overwrite variables](https://user-images.githubusercontent.com/78053898/217394091-e50ee7b5-01b6-4762-8578-929268fabbe8.gif)
