### PR TITLE
[jk] Allow copy/paste in Mage terminal

### DIFF
--- a/mage_ai/frontend/components/Terminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/index.tsx
@@ -192,7 +192,8 @@ function Terminal({
             setCommand('');
           } else if (onlyKeysPresent([KEY_CODE_META, KEY_CODE_C], keyMapping)) {
             navigator.clipboard.writeText(window.getSelection().toString());
-          } else if (onlyKeysPresent([KEY_CODE_META, KEY_CODE_V], keyMapping)) {
+          } else if (onlyKeysPresent([KEY_CODE_META, KEY_CODE_V], keyMapping)
+            || onlyKeysPresent([KEY_CODE_CONTROL, KEY_CODE_V], keyMapping)) {
             if (navigator?.clipboard?.readText) {
               navigator.clipboard.readText()
                 .then(clipText => {

--- a/mage_ai/frontend/components/Terminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/index.tsx
@@ -193,10 +193,36 @@ function Terminal({
           } else if (onlyKeysPresent([KEY_CODE_META, KEY_CODE_C], keyMapping)) {
             navigator.clipboard.writeText(window.getSelection().toString());
           } else if (onlyKeysPresent([KEY_CODE_META, KEY_CODE_V], keyMapping)) {
-            navigator.clipboard.readText().then(clipText => {
-              setCommand(prev => prev + clipText);
-              setCursorIndex(command.length + clipText.length);
-            });
+            if (navigator?.clipboard?.readText) {
+              navigator.clipboard.readText()
+                .then(clipText => {
+                  setCommand(prev => prev + clipText);
+                  setCursorIndex(command.length + clipText.length);
+                }).catch(err => alert(`${err}
+    For Chrome, users need to allow clipboard permissions for this site under \
+"Privacy and security" -> "Site settings".
+    For Safari, users need to allow the clipboard paste by clicking "Paste" \
+in the context menu that appears.`),
+                );
+            } else {
+              navigator.clipboard.read()
+                .then(clipboardItems => {
+                  for (const clipboardItem of clipboardItems) {
+                    for (const type of clipboardItem.types) {
+                      if (type === 'text/plain') {
+                        return clipboardItem.getType(type);
+                      }
+                    }
+                  }
+                }).then(blob => blob.text(),
+                ).then(clipText => {
+                  setCommand(prev => prev + clipText);
+                  setCursorIndex(command.length + clipText.length);
+                }).catch(err => alert(`${err}
+    For Firefox, users need to allow clipboard paste by setting the "dom.events.asyncClipboard.read" \
+preference in "about:config" to "true" and clicking "Paste" in the context menu that appears.`),
+                );
+            }
           } else if (!keyMapping[KEY_CODE_META] && !keyMapping[KEY_CODE_CONTROL] && key.length === 1) {
             setCommand(prev => prev.slice(0, cursorIndex) + key + prev.slice(cursorIndex));
             increaseCursorIndex();

--- a/mage_ai/frontend/utils/hooks/keyboardShortcuts/constants.ts
+++ b/mage_ai/frontend/utils/hooks/keyboardShortcuts/constants.ts
@@ -40,9 +40,11 @@ export const KEY_CODE_Y = 89;
 export const KEY_CODE_META = 'metaKey';
 export const KEY_CODE_META_LEFT = 91;
 export const KEY_CODE_META_RIGHT = 93;
+export const KEY_CODE_META_FIREFOX = 224;
 export const KEY_CODE_METAS = [
   KEY_CODE_META_LEFT,
   KEY_CODE_META_RIGHT,
+  KEY_CODE_META_FIREFOX,
 ];
 export const KEY_CODE_NUMBER_0 = 48;
 export const KEY_CODE_NUMBER_1 = 49;


### PR DESCRIPTION
# Summary
- Support copy/paste in Mage terminal in chrome, safari, and firefox browsers.
- Users need to allow permissions for clipboard paste in the terminal. If permissions are not granted, an alert will appear telling users how they can enable it.
- Allow paste with `ctrl+V` keyboard shortcut (in addition to `cmd+V`) so Windows users can paste. Windows users can copy selected text in the terminal by selecting "Copy" in the context menu. The `ctrl+C` keyboard shortcut is reserved for interrupting the kernel.

# Tests
Chrome:
![chrome](https://user-images.githubusercontent.com/78053898/217639695-a5805c97-0d47-4f6d-9779-2630e39ec064.gif)

Safari:
![safari](https://user-images.githubusercontent.com/78053898/217640181-c8ecc833-95ba-4d62-b623-27b8f1c70728.gif)

Firefox:
![firefox](https://user-images.githubusercontent.com/78053898/217639795-82841a42-7910-480f-815d-d46dc9007492.gif)
