### PR TITLE
[jk] Dropdown formatting for Windows

### DIFF
--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -23,6 +23,7 @@ import FlexContainer from '@oracle/components/FlexContainer';
 import Headline from '@oracle/elements/Headline';
 import Link from '@oracle/elements/Link';
 import List from '@oracle/elements/List';
+import OSEnum, { getOS } from '@utils/os';
 import PipelineDetailPage from '@components/PipelineDetailPage';
 import PipelineScheduleType, {
   ScheduleIntervalEnum,
@@ -367,6 +368,7 @@ function Edit({
         <Select
           key="frequency_input"
           monospace
+          multiple={getOS() === OSEnum.WINDOWS}
           onChange={(e) => {
             e.preventDefault();
             const interval = e.target.value;
@@ -376,7 +378,10 @@ function Edit({
             }));
           }}
           placeholder="Choose the frequency to run"
-          value={scheduleInterval}
+          value={getOS() === OSEnum.WINDOWS
+            ? [scheduleInterval]
+            : scheduleInterval
+          }
         >
           {!scheduleInterval && <option value="" />}
           {Object.values(ScheduleIntervalEnum).map(value => (
@@ -707,7 +712,7 @@ function Edit({
   ]);
 
   const apiMemo = useMemo(() => {
-    let url = ''
+    let url = '';
     if (typeof window !== 'undefined') {
       url = `${window.origin}/api/pipeline_schedules/${pipelineSchedule?.id}/pipeline_runs`;
 

--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -23,7 +23,6 @@ import FlexContainer from '@oracle/components/FlexContainer';
 import Headline from '@oracle/elements/Headline';
 import Link from '@oracle/elements/Link';
 import List from '@oracle/elements/List';
-import OSEnum, { getOS } from '@utils/os';
 import PipelineDetailPage from '@components/PipelineDetailPage';
 import PipelineScheduleType, {
   ScheduleIntervalEnum,
@@ -368,7 +367,6 @@ function Edit({
         <Select
           key="frequency_input"
           monospace
-          multiple={getOS() === OSEnum.WINDOWS}
           onChange={(e) => {
             e.preventDefault();
             const interval = e.target.value;
@@ -378,10 +376,6 @@ function Edit({
             }));
           }}
           placeholder="Choose the frequency to run"
-          value={getOS() === OSEnum.WINDOWS
-            ? [scheduleInterval]
-            : scheduleInterval
-          }
         >
           {!scheduleInterval && <option value="" />}
           {Object.values(ScheduleIntervalEnum).map(value => (

--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -376,6 +376,7 @@ function Edit({
             }));
           }}
           placeholder="Choose the frequency to run"
+          value={scheduleInterval}
         >
           {!scheduleInterval && <option value="" />}
           {Object.values(ScheduleIntervalEnum).map(value => (

--- a/mage_ai/frontend/oracle/elements/Inputs/InputWrapper.tsx
+++ b/mage_ai/frontend/oracle/elements/Inputs/InputWrapper.tsx
@@ -275,6 +275,7 @@ export const SHARED_INPUT_STYLES = css<InputWrapperProps>`
     &:focus {
       background-color: ${(props.theme.interactive || dark.interactive).hoverBackground};
       border-color: ${(props.theme.interactive || dark.interactive).focusBorder};
+      color: ${(props.theme.content || dark.content).active};
     }
 
     &:active {

--- a/mage_ai/frontend/oracle/elements/Inputs/InputWrapper.tsx
+++ b/mage_ai/frontend/oracle/elements/Inputs/InputWrapper.tsx
@@ -91,7 +91,7 @@ export type InputWrapperProps = {
   spellCheck?: boolean;
   topPosition?: boolean;
   type?: string;
-  value?: string | number;
+  value?: string | number | string[];
   borderTheme?: boolean;
   visible?: boolean;
   warning?: boolean;

--- a/mage_ai/frontend/oracle/elements/Inputs/InputWrapper.tsx
+++ b/mage_ai/frontend/oracle/elements/Inputs/InputWrapper.tsx
@@ -273,6 +273,7 @@ export const SHARED_INPUT_STYLES = css<InputWrapperProps>`
     }
 
     &:focus {
+      background-color: ${(props.theme.interactive || dark.interactive).hoverBackground};
       border-color: ${(props.theme.interactive || dark.interactive).focusBorder};
     }
 

--- a/mage_ai/frontend/oracle/elements/Inputs/Select.tsx
+++ b/mage_ai/frontend/oracle/elements/Inputs/Select.tsx
@@ -12,6 +12,7 @@ export type SelectProps = {
   cyan?: boolean;
   children?: any;
   hasContent?: boolean;
+  multiple?: boolean;
   showPlaceholder?: boolean;
 } & InputWrapperProps;
 
@@ -58,6 +59,7 @@ const Select = ({
   beforeIcon,
   children,
   label,
+  multiple,
   placeholder,
   ...props
 }: SelectProps, ref) => (
@@ -65,7 +67,7 @@ const Select = ({
     {...props}
     beforeIcon={beforeIcon}
     input={
-      <SelectStyle {...props}>
+      <SelectStyle multiple={multiple} {...props}>
         {(label || placeholder) && (
         <option
           disabled

--- a/mage_ai/frontend/utils/os.ts
+++ b/mage_ai/frontend/utils/os.ts
@@ -1,6 +1,10 @@
 import OSEnum from '@interfaces/OSType';
 
 export function getOS() {
+  let os: OSEnum = OSEnum.MAC;
+  if (typeof window === 'undefined') {
+    return os;
+  }
   const userAgent = window?.navigator?.userAgent;
 
   //@ts-ignore
@@ -10,7 +14,6 @@ export function getOS() {
   const macosPlatforms = ['macOS', 'Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
   const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
   const iosPlatforms = ['iPhone', 'iPad', 'iPod'];
-  let os: OSEnum = OSEnum.MAC;
 
   if (platform) {
     if (macosPlatforms.includes(platform)) {
@@ -42,3 +45,5 @@ export function getOS() {
 export function isMac() {
   return getOS() === OSEnum.MAC;
 }
+
+export default OSEnum;


### PR DESCRIPTION
# Summary
- The coloring was off for the Frequency dropdown menu on the Trigger edit page for Windows users. The dropdown items had white font against a white background after an item was selected and the dropdown reopened (the items were visible initially when no item was selected). This PR fixes the coloring for Select dropdowns on Windows.

# Tests
Before (dropdown items not visible):
<img width="1400" alt="dropdown single" src="https://user-images.githubusercontent.com/78053898/217751859-676ddc0f-6499-46f0-aa23-5aad8ef8116e.png">

After:
![dropdown 1](https://user-images.githubusercontent.com/78053898/221044560-08c9def1-3858-4c06-ac8a-aa2b5a0c3dac.png)
![dropdown 2](https://user-images.githubusercontent.com/78053898/221044565-308b0d3a-17da-4fa1-baa1-c563163aef9f.png)

