### PR TITLE
[jk] Revert afterWidth change

### DIFF
--- a/mage_ai/frontend/components/Dashboard/index.tsx
+++ b/mage_ai/frontend/components/Dashboard/index.tsx
@@ -58,14 +58,8 @@ function Dashboard({
   const localStorageKeyBefore = `dashboard_before_width_${uuid}`;
 
   const mainContainerRef = useRef(null);
-
-  const [afterWidth, setAfterWidth] = useState(after && !afterHidden
-    ? Math.max(
-      get(localStorageKeyAfter, afterWidthProp),
-      UNIT * 13,
-    )
-    : null
-  );
+  const [afterWidth, setAfterWidth] = useState(get(localStorageKeyAfter, afterWidthProp));
+  console.log('afterWidth:', afterWidth);
   const [afterMousedownActive, setAfterMousedownActive] = useState(false);
   const [beforeWidth, setBeforeWidth] = useState(before
     ? Math.max(

--- a/mage_ai/frontend/components/Dashboard/index.tsx
+++ b/mage_ai/frontend/components/Dashboard/index.tsx
@@ -59,7 +59,6 @@ function Dashboard({
 
   const mainContainerRef = useRef(null);
   const [afterWidth, setAfterWidth] = useState(get(localStorageKeyAfter, afterWidthProp));
-  console.log('afterWidth:', afterWidth);
   const [afterMousedownActive, setAfterMousedownActive] = useState(false);
   const [beforeWidth, setBeforeWidth] = useState(before
     ? Math.max(


### PR DESCRIPTION
# Summary
- Fix issue with width of `after` element taking up whole screen.

# Tests
Bug:
![after width bug](https://user-images.githubusercontent.com/78053898/217954355-3c13cbba-428c-4948-a068-6dc8c3d56b0d.gif)

Fix:
![revert afterWidth change](https://user-images.githubusercontent.com/78053898/217954143-1017239c-9b28-46dc-8876-7e706c8b25ab.gif)

cc:
@tommydangerous 
