### PR TITLE
[xy] Fix N+1 query in facebook ads source adsets stream.

### DIFF
--- a/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/__init__.py
+++ b/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/__init__.py
@@ -403,7 +403,7 @@ class AdSets(IncrementalStream):
         # Added retry_pattern to handle AttributeError raised from ad_set.api_get() below
         @retry_pattern(backoff.expo, (FacebookRequestError, AttributeError), max_tries=5, factor=5)
         def prepare_record(ad_set):
-            return ad_set.api_get(fields=self.fields()).export_all_data()
+            return ad_set.export_all_data()
 
         if CONFIG.get('include_deleted', 'false').lower() == 'true':
             ad_sets = do_request_multiple()


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Fix N+1 query in facebook ads source adsets stream.

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
