### PR TITLE
[jk] Align Header flyout menu right

### DIFF
--- a/mage_ai/frontend/components/shared/Header/index.tsx
+++ b/mage_ai/frontend/components/shared/Header/index.tsx
@@ -322,6 +322,7 @@ function Header({
                       onClickCallback={() => setHighlightedMenuIndex(null)}
                       open={highlightedMenuIndex === 0}
                       parentRef={menuRef}
+                      rightOffset={0}
                       setConfirmationAction={setConfirmationAction}
                       setConfirmationDialogueOpen={setConfirmationDialogueOpen}
                       uuid="PipelineDetail/Header/menu"


### PR DESCRIPTION
# Summary
- The header flyout menu was cutoff when aligned left, so this aligns it in the other direction.

# Tests
![image](https://user-images.githubusercontent.com/78053898/218207850-70372fa4-d48b-4edb-9b74-1f7896bb9930.png)
