### PR TITLE
[jk] Disable other keyboard shortcuts 

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -61,6 +61,7 @@ import { addScratchpadNote } from '@components/PipelineDetail/AddNewBlocks/utils
 import { addUnderscores, randomNameGenerator } from '@utils/string';
 import { getUpstreamBlockUuids } from '@components/CodeBlock/utils';
 import { onlyKeysPresent } from '@utils/hooks/keyboardShortcuts/utils';
+import { pauseEvent } from '@utils/events';
 import { selectKeys } from '@utils/hash';
 import { useKeyboardContext } from '@context/Keyboard';
 
@@ -204,6 +205,7 @@ function PipelineDetail({
 
   const uuidKeyboard = 'PipelineDetail/index';
   const {
+    disableGlobalKeyboardShortcuts,
     registerOnKeyDown,
     unregisterOnKeyDown,
   } = useKeyboardContext();
@@ -215,6 +217,11 @@ function PipelineDetail({
   registerOnKeyDown(
     uuidKeyboard,
     (event, keyMapping, keyHistory) => {
+      if (disableGlobalKeyboardShortcuts) {
+        pauseEvent(event);
+        return;
+      }
+
       if (pipelineContentTouched && onlyKeysPresent([KEY_CODE_META, KEY_CODE_R], keyMapping)) {
         event.preventDefault();
         const warning = 'You have changes that are unsaved. Click cancel and save your changes before reloading page.';

--- a/mage_ai/frontend/components/Terminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/index.tsx
@@ -113,6 +113,7 @@ function Terminal({
 
   const {
     registerOnKeyDown,
+    setDisableGlobalKeyboardShortcuts,
     unregisterOnKeyDown,
   } = useKeyboardContext();
 
@@ -257,9 +258,11 @@ preference in "about:config" to "true" and clicking "Paste" in the context menu 
         onClick={() => {
           onFocus?.();
           setFocus(true);
+          setDisableGlobalKeyboardShortcuts(true);
         }}
         onClickOutside={() => {
           setFocus(false);
+          setDisableGlobalKeyboardShortcuts(false);
         }}
         style={{
           minHeight: '100%',

--- a/mage_ai/frontend/context/Keyboard/index.tsx
+++ b/mage_ai/frontend/context/Keyboard/index.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 
 type KeyboardContextType = {
+  disableGlobalKeyboardShortcuts?: boolean;
   registerOnKeyDown: (
     uuid: string,
     onKeyDown: (
@@ -26,13 +27,18 @@ type KeyboardContextType = {
     ) => void,
     dependencies: any[],
   ) => void;
+  setDisableGlobalKeyboardShortcuts?: (
+    disableGlobalKeyboardShortcuts: boolean)
+   => void;
   unregisterOnKeyDown: (uuid: string) => void;
   unregisterOnKeyUp: (uuid: string) => void;
 };
 
 const KeyboardContext = React.createContext<KeyboardContextType>({
+  disableGlobalKeyboardShortcuts: false,
   registerOnKeyDown: null,
   registerOnKeyUp: null,
+  setDisableGlobalKeyboardShortcuts: () => {},
   unregisterOnKeyDown: null,
   unregisterOnKeyUp: null,
 });

--- a/mage_ai/frontend/pages/_app.tsx
+++ b/mage_ai/frontend/pages/_app.tsx
@@ -84,19 +84,25 @@ function MyApp(props: MyAppProps & AppProps) {
   ]);
 
   const {
+    disableGlobalKeyboardShortcuts,
     registerOnKeyDown,
     registerOnKeyUp,
+    setDisableGlobalKeyboardShortcuts,
     unregisterOnKeyDown,
     unregisterOnKeyUp,
   } = useGlobalKeyboardShortcuts(keyMapping, keyHistory);
   const keyboardContextValue = useMemo(() => ({
+    disableGlobalKeyboardShortcuts,
     registerOnKeyDown,
     registerOnKeyUp,
+    setDisableGlobalKeyboardShortcuts,
     unregisterOnKeyDown,
     unregisterOnKeyUp,
   }), [
+    disableGlobalKeyboardShortcuts,
     registerOnKeyDown,
     registerOnKeyUp,
+    setDisableGlobalKeyboardShortcuts,
     unregisterOnKeyDown,
     unregisterOnKeyUp,
   ]);

--- a/mage_ai/frontend/utils/hooks/keyboardShortcuts/useGlobalKeyboardShortcuts.tsx
+++ b/mage_ai/frontend/utils/hooks/keyboardShortcuts/useGlobalKeyboardShortcuts.tsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from 'react';
 
 import { KEY_CODE_METAS } from './constants';
@@ -10,6 +11,7 @@ import { isEmptyObject } from '@utils/hash';
 import { logRender } from '@utils/environment';
 
 export default function useGlobalKeyboardShortcuts(keyMapping, keyHistory) {
+  const [disableGlobalKeyboardShortcuts, setDisableGlobalKeyboardShortcuts] = useState<boolean>(false);
   const timeout = useRef(null);
 
   const onKeyDownDependencies = useMemo(() => ({}), []);
@@ -172,8 +174,10 @@ export default function useGlobalKeyboardShortcuts(keyMapping, keyHistory) {
   ]);
 
   return {
+    disableGlobalKeyboardShortcuts,
     registerOnKeyDown,
     registerOnKeyUp,
+    setDisableGlobalKeyboardShortcuts,
     unregisterOnKeyDown,
     unregisterOnKeyUp,
   };


### PR DESCRIPTION
# Summary
- Add properties to the keyboard context so that we can customize which keyboard shortcuts are available when focused on a specific component.
- When focused on the Terminal, disable keyboard shortcuts from the PipelineDetail page (i.e. `cmd+s` or `ctrl+s` to save).

# Tests
![disable other keyboard shortcuts](https://user-images.githubusercontent.com/78053898/218219677-8fa5e099-972b-447f-bffa-1e1d7d18cc01.gif)


cc:
@tommydangerous 
