### PR TITLE
[jk] Add SQL block from MySQL to pipeline

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -32,6 +32,7 @@ import CodeEditor, {
 import CodeOutput from './CodeOutput';
 import CommandButtons, { CommandButtonsSharedProps } from './CommandButtons';
 import DataProviderType, {
+  DataProviderEnum,
   EXPORT_WRITE_POLICIES,
   ExportWritePolicyEnum,
 } from '@interfaces/DataProviderType';
@@ -1176,44 +1177,48 @@ function CodeBlockProps({
 
                       <Spacing mr={1} />
 
-                      <Tooltip
-                        block
-                        description={
-                          <Text default inline>
-                            Schema that is used when creating a table and inserting values.
-                            <br />
-                            This field is required.
-                          </Text>
-                        }
-                        size={null}
-                        widthFitContent
-                      >
-                        <FlexContainer alignItems="center">
-                          <TextInput
-                            compact
-                            monospace
-                            onBlur={() => setTimeout(() => {
-                              setAnyInputFocused(false);
-                            }, 300)}
-                            onChange={(e) => {
-                              // @ts-ignore
-                              updateDataProviderConfig({
-                                [CONFIG_KEY_DATA_PROVIDER_SCHEMA]: e.target.value,
-                              });
-                              e.preventDefault();
-                            }}
-                            onFocus={() => {
-                              setAnyInputFocused(true);
-                            }}
-                            label="Schema"
-                            small
-                            value={dataProviderConfig[CONFIG_KEY_DATA_PROVIDER_SCHEMA]}
-                            width={10 * UNIT}
-                          />
-                        </FlexContainer>
-                      </Tooltip>
+                      {dataProviderConfig[CONFIG_KEY_DATA_PROVIDER] !== DataProviderEnum.MYSQL &&
+                        <>
+                          <Tooltip
+                            block
+                            description={
+                              <Text default inline>
+                                Schema that is used when creating a table and inserting values.
+                                <br />
+                                This field is required.
+                              </Text>
+                            }
+                            size={null}
+                            widthFitContent
+                          >
+                            <FlexContainer alignItems="center">
+                              <TextInput
+                                compact
+                                monospace
+                                onBlur={() => setTimeout(() => {
+                                  setAnyInputFocused(false);
+                                }, 300)}
+                                onChange={(e) => {
+                                  // @ts-ignore
+                                  updateDataProviderConfig({
+                                    [CONFIG_KEY_DATA_PROVIDER_SCHEMA]: e.target.value,
+                                  });
+                                  e.preventDefault();
+                                }}
+                                onFocus={() => {
+                                  setAnyInputFocused(true);
+                                }}
+                                label="Schema"
+                                small
+                                value={dataProviderConfig[CONFIG_KEY_DATA_PROVIDER_SCHEMA]}
+                                width={10 * UNIT}
+                              />
+                            </FlexContainer>
+                          </Tooltip>
 
-                      <Spacing mr={1} />
+                          <Spacing mr={1} />
+                        </>
+                      }
 
                       <Tooltip
                         block

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -97,7 +97,7 @@ import {
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { SINGLE_LINE_HEIGHT } from '@components/CodeEditor/index.style';
 import { ViewKeyEnum } from '@components/Sidekick/constants';
-import { addScratchpadNote } from '@components/PipelineDetail/AddNewBlocks/utils';
+import { addScratchpadNote, addSqlBlockNote } from '@components/PipelineDetail/AddNewBlocks/utils';
 import { buildConvertBlockMenuItems, getUpstreamBlockUuids } from './utils';
 import { capitalize, pluralize } from '@utils/string';
 import { executeCode } from '@components/CodeEditor/keyboard_shortcuts/shortcuts';
@@ -1481,6 +1481,7 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')`;
                   content = addScratchpadNote(newBlock, content);
 
                   if (BlockLanguageEnum.SQL === block.language) {
+                    content = addSqlBlockNote(content);
                     configuration = {
                       ...selectKeys(block.configuration, [
                         CONFIG_KEY_DATA_PROVIDER,

--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/utils.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/utils.tsx
@@ -209,6 +209,11 @@ export const createColorMenuItems = (
     uuid: `${language}_${color}`,
   }));
 
+export const addSqlBlockNote = (content: string) => (
+  `-- Docs: https://docs.mage.ai/guides/sql-blocks
+` + (content || '')
+);
+
 export function addScratchpadNote(
   block: BlockType,
   content?: string,

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -57,7 +57,7 @@ import {
 } from '@utils/hooks/keyboardShortcuts/constants';
 import { PADDING_UNITS } from '@oracle/styles/units/spacing';
 import { ViewKeyEnum } from '@components/Sidekick/constants';
-import { addScratchpadNote } from '@components/PipelineDetail/AddNewBlocks/utils';
+import { addScratchpadNote, addSqlBlockNote } from '@components/PipelineDetail/AddNewBlocks/utils';
 import { addUnderscores, randomNameGenerator } from '@utils/string';
 import { getUpstreamBlockUuids } from '@components/CodeBlock/utils';
 import { onlyKeysPresent } from '@utils/hooks/keyboardShortcuts/utils';
@@ -535,6 +535,10 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
               ...configuration,
             };
           }
+        }
+
+        if (BlockLanguageEnum.SQL === newBlock.language) {
+          content = addSqlBlockNote(content);
         }
         content = addScratchpadNote(newBlock, content);
 

--- a/mage_ai/frontend/interfaces/DataProviderType.ts
+++ b/mage_ai/frontend/interfaces/DataProviderType.ts
@@ -10,8 +10,16 @@ export const EXPORT_WRITE_POLICIES = [
   ExportWritePolicyEnum.REPLACE,
 ];
 
+export enum DataProviderEnum {
+  BIGQUERY = 'bigquery',
+  MYSQL = 'mysql',
+  POSTGRES = 'postgres',
+  REDSHIFT = 'redshift',
+  SNOWFLAKE = 'snowflake',
+}
+
 export default interface DataProviderType {
   id: string;
   profiles: string[];
-  value: string;
+  value: DataProviderEnum;
 }

--- a/mage_ai/server/api/data_providers.py
+++ b/mage_ai/server/api/data_providers.py
@@ -7,6 +7,7 @@ import yaml
 
 DATA_PROVIDERS = [
     DataSource.BIGQUERY,
+    DataSource.MYSQL,
     DataSource.POSTGRES,
     DataSource.REDSHIFT,
     DataSource.SNOWFLAKE,


### PR DESCRIPTION
# Summary
- User can choose MySQL as a connection for the SQL block in their pipeline.
- Hide `schema` input in code block if MySQL is selected since it is not necessary for MySQL connections (but required for other SQL connections).
- Add reference to [docs](https://docs.mage.ai/guides/sql-blocks) in comment.

# Tests
![run mysql block](https://user-images.githubusercontent.com/78053898/218244303-235e9ec4-071c-4f8c-b123-66a27bdaa230.gif)


cc:
@tommydangerous 
