### PR TITLE
[jk] Bump to v0.7.101

### DIFF
--- a/mage_ai/server/constants.py
+++ b/mage_ai/server/constants.py
@@ -12,4 +12,4 @@ DATAFRAME_OUTPUT_SAMPLE_COUNT = 10
 # Dockerfile depends on it because it runs ./scripts/install_mage.sh and uses
 # the last line to determine the version to install.
 VERSION = \
-'0.7.100'
+'0.7.101'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     name='mage-ai',
     # NOTE: when you change this, change the value of VERSION in the following file:
     # mage_ai/server/constants.py
-    version='0.7.100',
+    version='0.7.101',
     author='Mage',
     author_email='eng@mage.ai',
     description='Mage is a tool for building and deploying data pipelines.',


### PR DESCRIPTION
# Summary
- Bump to version 0.7.101
- https://github.com/mage-ai/mage-ai/pull/2015
- https://github.com/mage-ai/mage-ai/pull/2018
- https://github.com/mage-ai/mage-ai/pull/2022

# Tests
N/A
