### PR TITLE
[jk] Hide column header analysis output

### DIFF
--- a/mage_ai/frontend/components/PipelineRun/shared/buildTableSidekick.tsx
+++ b/mage_ai/frontend/components/PipelineRun/shared/buildTableSidekick.tsx
@@ -1,7 +1,6 @@
 import ButtonTabs, { TabType } from '@oracle/components/Tabs/ButtonTabs';
 import CodeBlock from '@oracle/components/CodeBlock';
 import DependencyGraph from '@components/DependencyGraph';
-import Headline from '@oracle/elements/Headline';
 import PipelineType from '@interfaces/PipelineType';
 import PipelineRunType from '@interfaces/PipelineRunType';
 import Spacing from '@oracle/elements/Spacing';
@@ -9,7 +8,6 @@ import Text from '@oracle/elements/Text';
 import Table from '@components/shared/Table';
 import {
   PADDING_UNITS,
-  UNITS_BETWEEN_SECTIONS,
 } from '@oracle/styles/units/spacing';
 import { createBlockStatus } from '@components/Triggers/utils';
 

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -45,6 +45,7 @@ import { SCROLLBAR_WIDTH } from '@oracle/styles/scrollbars';
 import { buildRenderColumnHeader } from '@components/datasets/overview/utils';
 import { createMetricsSample, createStatisticsSample } from './utils';
 import { indexBy } from '@utils/array';
+import { isEmptyObject } from '@utils/hash';
 import { useWindowSize } from '@utils/sizes';
 
 const MAX_COLUMNS = 100;
@@ -286,7 +287,13 @@ function Sidekick({
         }
         {activeView === ViewKeyEnum.DATA && columns.length > 0 && (
           <DataTable
-            columnHeaderHeight={TABLE_COLUMN_HEADER_HEIGHT}
+            columnHeaderHeight={
+              (isEmptyObject(columnTypes)
+                && isEmptyObject(insightsByFeatureUUID)
+                && isEmptyObject(insightsOverview))
+              ? 0
+              : TABLE_COLUMN_HEADER_HEIGHT
+            }
             columns={columns}
             height={heightWindow - heightOffset - ASIDE_SUBHEADER_HEIGHT}
             noBorderBottom


### PR DESCRIPTION
# Summary
- Hide blank area in code block output column headers if block analysis is not available.

# Tests
![hide column header analysis area](https://user-images.githubusercontent.com/78053898/219576757-7d0ece67-0964-48fb-b8a0-05ac799d7110.gif)
