### PR TITLE
[jk] Fix error when refreshing Pipeline Runs page

### DIFF
--- a/mage_ai/frontend/pages/pipeline-runs/index.tsx
+++ b/mage_ai/frontend/pages/pipeline-runs/index.tsx
@@ -119,4 +119,6 @@ function RunListPage() {
   );
 }
 
+RunListPage.getInitialProps = async () => ({});
+
 export default PrivateRoute(RunListPage);


### PR DESCRIPTION
# Summary
- Fix "circular structure in getInitialProps" error on pipeline runs page.

# Tests
- Confirmed no error upon refreshing pipeline runs page.
