### PR TITLE
[xy] Fix encode emoji.

### DIFF
--- a/mage_integrations/mage_integrations/destinations/bigquery/utils.py
+++ b/mage_integrations/mage_integrations/destinations/bigquery/utils.py
@@ -120,7 +120,7 @@ def convert_converted_type_to_parameter_type(converted_type):
 
 
 def convert_json_or_string(value, column_type_dict):
-    value = value.replace('\n', '\\n')
+    value = value.replace('\n', '\\n').encode('utf-16', 'surrogatepass').decode('utf-16')
 
     column_type = column_type_dict['type']
     if COLUMN_TYPE_OBJECT == column_type:

--- a/mage_integrations/mage_integrations/destinations/bigquery/utils.py
+++ b/mage_integrations/mage_integrations/destinations/bigquery/utils.py
@@ -9,11 +9,14 @@ from mage_integrations.destinations.sql.utils import convert_column_type as conv
 from typing import Dict, List
 import dateutil.parser
 import json
+import re
 
 
 def replace_single_quotes_with_double(v: str) -> str:
     if type(v) is dict:
         v = json.dumps(v)
+    # Remove emoji code
+    v = re.sub(r'(\\ud83d\\ude[0-4][0-f])|(\\ud83c\\udf[0-f][0-f])|(\\ud83d\\u[0-d][-d][0-f][0-f]])|(\\ud83d\\ude[8-f][0-f])|(\\ud83c\\udd[e-f][0-f])', '', v)
     return v.replace("'", '"')
 
 
@@ -120,7 +123,7 @@ def convert_converted_type_to_parameter_type(converted_type):
 
 
 def convert_json_or_string(value, column_type_dict):
-    value = value.replace('\n', '\\n').encode('utf-16', 'surrogatepass').decode('utf-16')
+    value = value.replace('\n', '\\n')
 
     column_type = column_type_dict['type']
     if COLUMN_TYPE_OBJECT == column_type:


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Fix error
```
GigQuery process failed with error 400 Syntax error: Illegal escape sequence:
Unicode value \ud83d is invalid at [1:180360]
```
Remove emoji code in bigquery quey.
Reference: https://stackoverflow.com/questions/33404752/removing-emojis-from-a-string-in-python

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
