### PR TITLE
[jk] Show Pipeline Editor main content header on Firefox

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/FileTabs/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/FileTabs/index.tsx
@@ -35,7 +35,7 @@ function FileTabs({
   useMemo(() => filePaths.map(path => decodeURIComponent(path)), [filePaths]);
 
   return (
-    <PipelineHeaderStyle secondary>
+    <PipelineHeaderStyle relativePosition secondary>
       <FlexContainer
         alignItems="center"
         justifyContent="flex-start"

--- a/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
@@ -363,7 +363,7 @@ function KernelStatus({
   ]);
 
   return (
-    <PipelineHeaderStyle>
+    <PipelineHeaderStyle relativePosition>
       <FlexContainer
         alignItems="center"
         fullHeight

--- a/mage_ai/frontend/components/PipelineDetail/index.style.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.style.tsx
@@ -34,6 +34,7 @@ export const OverlayStyle = styled.div`
 `;
 
 export const PipelineHeaderStyle = styled.div<{
+  relativePosition?: boolean;
   secondary?: boolean;
 }>`
   height: ${ASIDE_HEADER_HEIGHT}px;
@@ -47,9 +48,13 @@ export const PipelineHeaderStyle = styled.div<{
     border-bottom: 1px solid ${(props.theme.borders || dark.borders).medium};
   `}
 
+  ${props => props.relativePosition && `
+    position: relative;
+  `}
+
   ${props => props.secondary && `
     height: ${TABS_HEADER_HEIGHT}px;
-    top: ${ASIDE_HEADER_HEIGHT * 2}px;
+    top: ${ASIDE_HEADER_HEIGHT}px;
     overflow-x: auto;
     z-index: 3;
   `}


### PR DESCRIPTION
# Summary
- The header for the Pipeline Editor main content was hidden for Firefox browsers specifically (which prevented users from being able to change their pipeline names on Firefox), so this PR fixes that. 

# Tests
Firefox:
![firefox](https://user-images.githubusercontent.com/78053898/220802649-86a3d90b-a591-4525-b152-1e179cacc1e6.png)

Chrome:
![chrome](https://user-images.githubusercontent.com/78053898/220802679-68cfb878-36f0-45dc-bdc8-cc4494f6172f.png)

Safari:
![safari](https://user-images.githubusercontent.com/78053898/220802701-5c38224c-655c-4ad4-9397-363d5ba6af0e.png)
