### PR TITLE
[dy] Add initial datadog logging library

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -308,7 +308,13 @@
       "group": "Observability",
       "pages": [
         "production/observability/logging",
-        "production/observability/monitoring",
+        {
+          "group": "Monitoring",
+          "pages": [
+            "production/observability/monitoring",
+            "production/observability/datadog"
+          ]
+        },
         {
           "group": "Alerting",
           "pages": [

--- a/docs/production/observability/datadog.mdx
+++ b/docs/production/observability/datadog.mdx
@@ -1,0 +1,23 @@
+---
+title: "Writing metrics to Datadog"
+sidebarTitle: "Datadog"
+---
+
+## Provide your Datadog credentials
+
+You will need to add the following environment variables in order to use
+Datadog in mage:
+* DD_API_KEY: your datadog api key
+* DD_APP_KEY: your datadog app key
+
+## Using Datadog in Mage
+
+You can now call Datadog helper functions in your Mage blocks to create or update metrics.
+You can see the existing helper functions [here](https://github.com/mage-ai/mage-ai/blob/master/mage_ai/services/datadog/__init__.py).
+
+Example:
+```python
+from mage_ai.services import datadog as dd
+
+dd.increment('<your metric here>', tags=dict(pipeline='<pipeline_uuid>'))
+```

--- a/mage_ai/services/datadog/__init__.py
+++ b/mage_ai/services/datadog/__init__.py
@@ -1,0 +1,123 @@
+from datadog import initialize, api, statsd
+from datetime import datetime
+import os
+import time
+
+options = {
+    'api_key': os.getenv('DD_API_KEY'),
+    'app_key': os.getenv('DD_APP_KEY'),
+}
+
+initialize(**options)
+
+
+def create_event(title, text, tags={}):
+    return api.Event.create(
+        title=title,
+        text=text,
+        tags=tags,
+    )
+
+
+def gauge(metric, value, host='mage', tags={}):
+    return api.Metric.send(
+        host=host,
+        metric=metric,
+        points=[
+            (datetime.utcnow().timestamp(), value),
+        ],
+        tags=tags,
+        type='gauge',
+    )
+
+
+def increment(metric, tags={}, value=1):
+    return create_metrics([
+        (metric, value, tags),
+    ])
+
+
+def create_metrics(metrics, host='mage', metric_type='count'):
+    # Format of argument
+    # metrics = [
+    #     ('metric', 'value', 'tags'),
+    # ]
+    arr = [{
+        'host': host,
+        'metric': t[0],
+        'points': t[1],
+        'tags': t[2] if len(t) == 3 else {},
+        'type': metric_type,
+    } for t in metrics]
+    return api.Metric.send(metrics=arr)
+
+
+def create_metric(metric, value, host='mage', tags={}):
+    return api.Metric.send(
+        host=host,
+        metric=metric,
+        points=[
+            (datetime.utcnow().timestamp(), value),
+        ],
+        tags=tags,
+        type='count',
+    )
+
+
+def histogram(metric, value, host='mage', tags={}):
+    return api.Metric.send(
+        host=host,
+        metric=metric,
+        points=[
+            (datetime.utcnow().timestamp(), value),
+        ],
+        tags=tags,
+        type='histogram',
+    )
+
+
+def timing(metric, value, host='mage', tags={}):
+    return api.Metric.send(
+        host=host,
+        metric=metric,
+        points=[
+            (datetime.utcnow().timestamp(), value),
+        ],
+        tags=tags,
+        type='timer',
+    )
+
+
+class timed_decorator(object):
+    """
+    @timed_decorator('metric.metric', tags={ 'key': 'value' })
+    """
+    def __init__(self, metric, tags={}):
+        self.metric = metric
+        self.tags = tags
+
+    def __call__(self, f):
+        def wrapped_f(*args):
+            with statsd.timed(self.metric, tags=self.tags):
+                return f(*args)
+        return wrapped_f
+
+
+class timer(object):
+    """
+    with timer('metric.metric', tags={ 'key': 'value' }):
+        function()
+    """
+    def __init__(self, metric, tags={}):
+        self.metric = metric
+        self.start = None
+        self.tags = tags
+
+    def __enter__(self):
+        self.start = time.time()
+
+    def __exit__(self, type, value, traceback):
+        # Must convert to milliseconds, see details in
+        # https://statsd.readthedocs.io/en/v3.1/timing.html
+        dt = int((time.time() - self.start) * 1000)
+        return timing(self.metric, dt, tags=self.tags)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ bcrypt==4.0.1
 croniter==1.3.7
 cryptography==36.0.2
 dask>=2022.2.0
+datadog==0.44.0
 freezegun==1.2.2
 httpx==0.23.1
 inflection==0.5.1


### PR DESCRIPTION
# Summary

Add some basic datadog logging methods. Not entirely sure what the difference is between using the api and the `statsd` library.
<!-- Brief summary of what your code does -->

# Tests

tested locally
![Screenshot 2023-02-23 at 12 17 56 PM](https://user-images.githubusercontent.com/14357209/221020569-dd208cad-4946-4cbf-afe0-a7f835457af5.png)

<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
