### PR TITLE
[jk] Backfill preview runs

### DIFF
--- a/mage_ai/api/policies/BackfillPolicy.py
+++ b/mage_ai/api/policies/BackfillPolicy.py
@@ -60,6 +60,14 @@ BackfillPolicy.allow_write([
 ], condition=lambda policy: policy.has_at_least_editor_role())
 
 BackfillPolicy.allow_query([
+    'include_preview_runs',
+], scopes=[
+    OauthScope.CLIENT_PRIVATE,
+], on_action=[
+    constants.DETAIL,
+], condition=lambda policy: policy.has_at_least_viewer_role())
+
+BackfillPolicy.allow_query([
     'pipeline_uuid',
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,

--- a/mage_ai/api/policies/BackfillPolicy.py
+++ b/mage_ai/api/policies/BackfillPolicy.py
@@ -61,6 +61,7 @@ BackfillPolicy.allow_write([
 
 BackfillPolicy.allow_query([
     'include_preview_runs',
+    'include_run_count',
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[

--- a/mage_ai/api/presenters/BackfillPresenter.py
+++ b/mage_ai/api/presenters/BackfillPresenter.py
@@ -29,10 +29,13 @@ class BackfillPresenter(BasePresenter):
         data = self.model.to_dict()
 
         include_preview_runs = query.get('include_preview_runs', [False])
+        include_run_count = query.get('include_run_count', [False])
         if include_preview_runs:
             include_preview_runs = include_preview_runs[0]
+        if include_run_count:
+            include_run_count = include_run_count[0]
         if (
-            include_preview_runs and
+            (include_preview_runs or include_run_count) and
             self.model.start_datetime is not None and
             self.model.end_datetime is not None and
             self.model.interval_type is not None and
@@ -40,6 +43,7 @@ class BackfillPresenter(BasePresenter):
         ):
             pipeline_run_dates = preview_run_dates(self.model)
             data['total_run_count'] = len(pipeline_run_dates)
-            data['pipeline_run_dates'] = pipeline_run_dates
+            if include_preview_runs:
+                data['pipeline_run_dates'] = pipeline_run_dates
 
         return data

--- a/mage_ai/api/presenters/BackfillPresenter.py
+++ b/mage_ai/api/presenters/BackfillPresenter.py
@@ -1,4 +1,5 @@
 from mage_ai.api.presenters.BasePresenter import BasePresenter
+from mage_ai.orchestration.backfills.service import preview_run_dates
 
 
 class BackfillPresenter(BasePresenter):
@@ -23,4 +24,22 @@ class BackfillPresenter(BasePresenter):
     ]
 
     def present(self, **kwargs):
-        return self.model.to_dict()
+        query = kwargs.get('query', {})
+
+        data = self.model.to_dict()
+
+        include_preview_runs = query.get('include_preview_runs', [False])
+        if include_preview_runs:
+            include_preview_runs = include_preview_runs[0]
+        if (
+            include_preview_runs and
+            self.model.start_datetime is not None and
+            self.model.end_datetime is not None and
+            self.model.interval_type is not None and
+            self.model.interval_units is not None
+        ):
+            pipeline_run_dates = preview_run_dates(self.model)
+            data['total_run_count'] = len(pipeline_run_dates)
+            data['pipeline_run_dates'] = pipeline_run_dates
+
+        return data

--- a/mage_ai/api/resources/BackfillResource.py
+++ b/mage_ai/api/resources/BackfillResource.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from mage_ai.api.resources.DatabaseResource import DatabaseResource
 from mage_ai.orchestration.backfills.service import start_backfill, cancel_backfill
 from mage_ai.orchestration.db import safe_db_query
@@ -48,7 +49,10 @@ class BackfillResource(DatabaseResource):
         if 'status' in payload and payload['status'] != self.status:
             if Backfill.Status.INITIAL == payload['status']:
                 pipeline_runs += start_backfill(self.model)
-                return super().update(dict(status=payload['status']))
+                return super().update(dict(
+                    started_at=datetime.now(),
+                    status=payload['status'],
+                ))
             elif Backfill.Status.CANCELLED == payload['status']:
                 cancel_backfill(self.model)
                 return super().update(dict(status=payload['status']))

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -113,9 +113,19 @@ function BackfillDetail({
     },
     {
       pauseFetch: !modelID,
-    }
+    },
   );
-  const pipelineRuns = useMemo(() => dataPipelineRuns?.pipeline_runs || [], [dataPipelineRuns]);
+
+  const showPreviewRuns = !status;
+  const pipelineRuns = useMemo(() => (showPreviewRuns
+    ? pipelineRunDates
+    : (dataPipelineRuns?.pipeline_runs || [])
+    ), [
+      dataPipelineRuns,
+      pipelineRunDates,
+      showPreviewRuns,
+    ],
+  );
   const totalRuns = useMemo(() => dataPipelineRuns?.metadata?.count || [], [dataPipelineRuns]);
 
   const [selectedRun, setSelectedRun] = useState<PipelineRunType>(null);
@@ -125,6 +135,7 @@ function BackfillDetail({
     return (
       <>
         <PipelineRunsTable
+          disableRowSelect={showPreviewRuns}
           emptyMessage='No runs available. Please complete backfill configuration by clicking "Edit backfill" above.'
           fetchPipelineRuns={fetchPipelineRuns}
           onClickRow={(rowIndex: number) => setSelectedRun((prev) => {
@@ -215,7 +226,7 @@ function BackfillDetail({
           monospace
         >
           {blockUUID ? BACKFILL_TYPE_CODE : BACKFILL_TYPE_DATETIME}
-        </Text>
+        </Text>,
       ],
       [
         <FlexContainer

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -116,6 +116,7 @@ function BackfillDetail({
     },
   );
 
+  const isNotConfigured = !(startDatetime && endDatetime && intervalType && intervalUnits);
   const showPreviewRuns = !status;
   const pipelineRuns = useMemo(() => ((
     showPreviewRuns
@@ -499,6 +500,7 @@ function BackfillDetail({
                       />
                   }
                   danger={isActive}
+                  disabled={isNotConfigured}
                   loading={isLoadingUpdate}
                   onClick={(e) => {
                     pauseEvent(e);
@@ -512,7 +514,10 @@ function BackfillDetail({
                     });
                   }}
                   outline
-                  success={!isActive && !(BackfillStatusEnum.CANCELLED === status || BackfillStatusEnum.FAILED === status)}
+                  success={!isActive
+                    && !(BackfillStatusEnum.CANCELLED === status || BackfillStatusEnum.FAILED === status)
+                    && !isNotConfigured
+                  }
                 >
                   {isActive
                     ? 'Cancel backfill'

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -31,6 +31,7 @@ import buildTableSidekick, { TABS } from '@components/PipelineRun/shared/buildTa
 import {
   Backfill,
   CalendarDate,
+  NumberHash,
   MultiShare,
   Pause,
   PlayButtonFilled,
@@ -49,7 +50,6 @@ import {
   getFormattedVariable,
   getFormattedVariables,
 } from '@components/Sidekick/utils';
-import { getTimeInUTCString } from '@components/Triggers/utils';
 import { goToWithQuery } from '@utils/routing';
 import { isEmptyObject } from '@utils/hash';
 import { onSuccess } from '@api/utils/response';
@@ -79,8 +79,10 @@ function BackfillDetail({
     interval_type: intervalType,
     interval_units: intervalUnits,
     name: modelName,
+    pipeline_run_dates: pipelineRunDates,
     start_datetime: startDatetime,
     status,
+    total_run_count: totalRunCount,
     variables: modelVariablesInit = {},
   } = model || {};
   const {
@@ -312,6 +314,24 @@ function BackfillDetail({
             monospace
           >
             {intervalUnits}
+          </Text>,
+        ],
+        [
+          <FlexContainer
+            alignItems="center"
+            key="total_runs_label"
+          >
+            <NumberHash {...iconProps} />
+            <Spacing mr={1} />
+            <Text default>
+              Total runs
+            </Text>
+          </FlexContainer>,
+          <Text
+            key="total_runs"
+            monospace
+          >
+            {totalRunCount}
           </Text>,
         ],
       ]);

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -117,9 +117,11 @@ function BackfillDetail({
   );
 
   const showPreviewRuns = !status;
-  const pipelineRuns = useMemo(() => (showPreviewRuns
-    ? pipelineRunDates
-    : (dataPipelineRuns?.pipeline_runs || [])
+  const pipelineRuns = useMemo(() => ((
+    showPreviewRuns
+      ? pipelineRunDates
+      : dataPipelineRuns?.pipeline_runs)
+    || []
     ), [
       dataPipelineRuns,
       pipelineRunDates,

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -554,39 +554,41 @@ function BackfillDetail({
 
             <Spacing mr={PADDING_UNITS} />
 
-            <Select
-              compact
-              defaultColor
-              onChange={e => {
-                e.preventDefault();
-                const updatedStatus = e.target.value;
-                if (updatedStatus === 'all') {
-                  router.push(
-                    '/pipelines/[pipeline]/backfills/[...slug]',
-                    `/pipelines/${pipelineUUID}/backfills/${modelID}`,
-                  );
-                } else {
-                  goToWithQuery(
-                    {
-                      page: 0,
-                      status: e.target.value,
-                    },
-                  );
-                }
-              }}
-              paddingRight={UNIT * 4}
-              placeholder="Select run status"
-              value={q?.status || 'all'}
-            >
-              <option key="all_statuses" value="all">
-                All statuses
-              </option>
-              {Object.values(RunStatus).map(status => (
-                <option key={status} value={status}>
-                  {RUN_STATUS_TO_LABEL[status]}
+            {!showPreviewRuns &&
+              <Select
+                compact
+                defaultColor
+                onChange={e => {
+                  e.preventDefault();
+                  const updatedStatus = e.target.value;
+                  if (updatedStatus === 'all') {
+                    router.push(
+                      '/pipelines/[pipeline]/backfills/[...slug]',
+                      `/pipelines/${pipelineUUID}/backfills/${modelID}`,
+                    );
+                  } else {
+                    goToWithQuery(
+                      {
+                        page: 0,
+                        status: e.target.value,
+                      },
+                    );
+                  }
+                }}
+                paddingRight={UNIT * 4}
+                placeholder="Select run status"
+                value={q?.status || 'all'}
+              >
+                <option key="all_statuses" value="all">
+                  All statuses
                 </option>
-              ))}
-            </Select>
+                {Object.values(RunStatus).map(status => (
+                  <option key={status} value={status}>
+                    {RUN_STATUS_TO_LABEL[status]}
+                  </option>
+                ))}
+              </Select>
+            }
           </FlexContainer>
         )}
         title={() => modelName}

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -125,6 +125,7 @@ function BackfillDetail({
     return (
       <>
         <PipelineRunsTable
+          emptyMessage='No runs available. Please complete backfill configuration by clicking "Edit backfill" above.'
           fetchPipelineRuns={fetchPipelineRuns}
           onClickRow={(rowIndex: number) => setSelectedRun((prev) => {
             const run = pipelineRuns[rowIndex];

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -139,7 +139,10 @@ function BackfillDetail({
       <>
         <PipelineRunsTable
           disableRowSelect={showPreviewRuns}
-          emptyMessage='No runs available. Please complete backfill configuration by clicking "Edit backfill" above.'
+          emptyMessage={!q?.status
+            ? 'No runs available. Please complete backfill configuration by clicking "Edit backfill" above.'
+            : 'No runs available'
+          }
           fetchPipelineRuns={fetchPipelineRuns}
           onClickRow={(rowIndex: number) => setSelectedRun((prev) => {
             const run = pipelineRuns[rowIndex];
@@ -530,18 +533,24 @@ function BackfillDetail({
               </>
             )}
 
-            <Button
-              disabled={status === RunStatus.COMPLETED}
-              linkProps={{
-                as: `/pipelines/${pipelineUUID}/backfills/${modelID}/edit`,
-                href: '/pipelines/[pipeline]/backfills/[...slug]',
-              }}
-              noHoverUnderline
-              outline
-              sameColorAsText
-            >
-              {status === RunStatus.COMPLETED ? 'Backfill completed' : 'Edit backfill'}
-            </Button>
+            {status === RunStatus.COMPLETED
+              ?
+                <Text bold default large>
+                  Filter runs by status:
+                </Text>
+              :
+                <Button
+                  linkProps={{
+                    as: `/pipelines/${pipelineUUID}/backfills/${modelID}/edit`,
+                    href: '/pipelines/[pipeline]/backfills/[...slug]',
+                  }}
+                  noHoverUnderline
+                  outline
+                  sameColorAsText
+                >
+                  Edit backfill
+                </Button>
+            }
 
             <Spacing mr={PADDING_UNITS} />
 

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -531,6 +531,7 @@ function BackfillDetail({
             )}
 
             <Button
+              disabled={status === RunStatus.COMPLETED}
               linkProps={{
                 as: `/pipelines/${pipelineUUID}/backfills/${modelID}/edit`,
                 href: '/pipelines/[pipeline]/backfills/[...slug]',
@@ -539,7 +540,7 @@ function BackfillDetail({
               outline
               sameColorAsText
             >
-              Edit backfill
+              {status === RunStatus.COMPLETED ? 'Backfill completed' : 'Edit backfill'}
             </Button>
 
             <Spacing mr={PADDING_UNITS} />

--- a/mage_ai/frontend/components/Backfills/Edit/constants.ts
+++ b/mage_ai/frontend/components/Backfills/Edit/constants.ts
@@ -9,9 +9,9 @@ export const BACKFILL_TYPES = [
     description: () => 'Backfill between a date and time range.',
     uuid: BACKFILL_TYPE_DATETIME,
   },
-  {
-    label: () => 'Custom code',
-    description: () => 'Use the output of a block to generate backfills.',
-    uuid: BACKFILL_TYPE_CODE,
-  },
+  // {
+  //   label: () => 'Custom code',
+  //   description: () => 'Use the output of a block to generate backfills.',
+  //   uuid: BACKFILL_TYPE_CODE,
+  // },
 ];

--- a/mage_ai/frontend/components/Backfills/Edit/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Edit/index.tsx
@@ -4,13 +4,13 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { toast } from 'react-toastify';
 import { useMutation } from 'react-query';
 import { useRouter } from 'next/router';
 
 import BackfillType, {
   BACKFILL_TYPE_CODE,
   BACKFILL_TYPE_DATETIME,
+  IntervalTypeEnum,
   INTERVAL_TYPES,
 } from '@interfaces/BackfillType';
 import Button from '@oracle/elements/Button';
@@ -21,8 +21,6 @@ import ErrorPopup from '@components/ErrorPopup';
 import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
 import Headline from '@oracle/elements/Headline';
-import Link from '@oracle/elements/Link';
-import List from '@oracle/elements/List';
 import PipelineDetailPage from '@components/PipelineDetailPage';
 import PipelineType from '@interfaces/PipelineType';
 import PipelineVariableType from '@interfaces/PipelineVariableType';
@@ -33,12 +31,9 @@ import Text from '@oracle/elements/Text';
 import TextInput from '@oracle/elements/Inputs/TextInput';
 import api from '@api';
 import {
-  Add,
   Alphabet,
   CalendarDate,
-  Code,
   Schedule,
-  Trash,
 } from '@oracle/icons';
 import { BACKFILL_TYPES } from './constants';
 import { CardStyle } from '../../Triggers/Edit/index.style';
@@ -46,12 +41,11 @@ import { PageNameEnum } from '@components/PipelineDetailPage/constants';
 import {
   PADDING_UNITS,
   UNIT,
-  UNITS_BETWEEN_ITEMS_IN_SECTIONS,
 } from '@oracle/styles/units/spacing';
 import { capitalize } from '@utils/string';
-import { getFormattedVariables, parseVariables } from '@components/Sidekick/utils';
 import { getTimeInUTC } from '../../Triggers/utils';
 import { onSuccess } from '@api/utils/response';
+import { parseVariables } from '@components/Sidekick/utils';
 import { selectKeys } from '@utils/hash';
 
 type BackfillEditProps = {
@@ -300,7 +294,7 @@ function BackfillEdit({
               }));
             }}
             placeholder={intervalType
-              ? `Number of ${intervalType} between each backfill`
+              ? `Number of ${intervalType}${intervalType !== IntervalTypeEnum.CUSTOM ? 's' : ''} between each backfill`
               : 'Interval type is required'
             }
             type="number"

--- a/mage_ai/frontend/components/Backfills/Edit/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Edit/index.tsx
@@ -490,7 +490,7 @@ function BackfillEdit({
                   noBorder
                   noPadding
                   onClick={() => {
-                    setSetupType(uuid)
+                    setSetupType(uuid);
                   }}
                 >
                   <CardStyle selected={selected}>

--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -9,6 +9,7 @@ import Link from '@oracle/elements/Link';
 import Table, { ColumnType } from '@components/shared/Table';
 import Text from '@oracle/elements/Text';
 import { Edit } from '@oracle/icons';
+import { RunStatus } from '@interfaces/PipelineRunType';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { getTimeInUTCString } from '@components/Triggers/utils';
 
@@ -108,6 +109,7 @@ function BackfillsTable({
           </Text>,
           <Button
             default
+            disabled={status === RunStatus.COMPLETED}
             iconOnly
             key={`${idx}_edit_button`}
             linkProps={{

--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -72,7 +72,8 @@ function BackfillsTable({
         start_datetime: startDatetime,
         started_at: startedAt,
         status,
-      }) => {
+        total_run_count: totalRunCount,
+      }, idx) => {
         const arr = [
           <Text default key="status" monospace>{status || 'inactive'}</Text>,
           <NextLink
@@ -88,7 +89,7 @@ function BackfillsTable({
           <Text default key="type" monospace>
             {blockUUID ? BACKFILL_TYPE_CODE : BACKFILL_TYPE_DATETIME}
           </Text>,
-          <Text default key="runs" monospace>{0}</Text>,
+          <Text default key="runs" monospace>{totalRunCount || 0}</Text>,
           <Text default key="backfill" monospace>
             {startDatetime && endDatetime && (
               <>
@@ -108,11 +109,12 @@ function BackfillsTable({
           <Button
             default
             iconOnly
-            noBackground
+            key={`${idx}_edit_button`}
             linkProps={{
               as: `/pipelines/${pipelineUUID}/backfills/${id}/edit`,
               href: '/pipelines/[pipeline]/backfills/[...slug]',
             }}
+            noBackground
             title="Edit"
           >
             <Edit default size={2 * UNIT} />

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -204,6 +204,7 @@ function RetryButton({
 }
 
 type PipelineRunsTableProps = {
+  emptyMessage?: string;
   fetchPipelineRuns: () => void;
   onClickRow?: (rowIndex: number) => void;
   pipelineRuns: PipelineRunType[];
@@ -211,6 +212,7 @@ type PipelineRunsTableProps = {
 };
 
 function PipelineRunsTable({
+  emptyMessage = 'No runs available',
   fetchPipelineRuns,
   onClickRow,
   pipelineRuns,
@@ -291,7 +293,7 @@ function PipelineRunsTable({
         ?
           <Spacing px ={3} py={1}>
             <Text bold default monospace muted>
-              No runs available
+              {emptyMessage}
             </Text>
           </Spacing>
         :

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -26,6 +26,7 @@ import { onSuccess } from '@api/utils/response';
 
 function RetryButton({
   cancelingRunId,
+  disabled,
   isLoadingCancelPipeline,
   onCancel,
   onSuccess: onSuccessProp,
@@ -35,6 +36,7 @@ function RetryButton({
   showConfirmationId,
 }: {
   cancelingRunId: number;
+  disabled?: boolean;
   isLoadingCancelPipeline: boolean;
   onCancel: (run: PipelineRunType) => void;
   onSuccess: () => void;
@@ -133,15 +135,19 @@ function RetryButton({
         borderRadius={BORDER_RADIUS_XXXLARGE}
         danger={RunStatus.FAILED === status}
         default={RunStatus.INITIAL === status}
+        disabled={disabled}
         loading={!pipelineRun}
         onClick={() => setShowConfirmationId(pipelineRunId)}
         padding="6px"
         primary={RunStatus.RUNNING === status && !isCancelingPipeline}
         warning={RunStatus.CANCELLED === status}
       >
-        {isCancelingPipeline
+        {disabled
+        ? 'Ready'
+        : (isCancelingPipeline
           ? 'Canceling'
-          : RUN_STATUS_TO_LABEL[status]}
+          : RUN_STATUS_TO_LABEL[status])
+        }
       </Button>
       <ClickOutside
         onClickOutside={() => setShowConfirmationId(null)}
@@ -204,6 +210,7 @@ function RetryButton({
 }
 
 type PipelineRunsTableProps = {
+  disableRowSelect?: boolean;
   emptyMessage?: string;
   fetchPipelineRuns: () => void;
   onClickRow?: (rowIndex: number) => void;
@@ -212,6 +219,7 @@ type PipelineRunsTableProps = {
 };
 
 function PipelineRunsTable({
+  disableRowSelect,
   emptyMessage = 'No runs available',
   fetchPipelineRuns,
   onClickRow,
@@ -276,7 +284,7 @@ function PipelineRunsTable({
     },
   ];
 
-  if (onClickRow) {
+  if (!disableRowSelect && onClickRow) {
     columnFlex.push(null);
     columns.push({
       label: () => '',
@@ -289,7 +297,7 @@ function PipelineRunsTable({
       minHeight={UNIT * 30}
       overflowVisible={!!showConfirmationId}
     >
-      {pipelineRuns.length === 0
+      {pipelineRuns?.length === 0
         ?
           <Spacing px ={3} py={1}>
             <Text bold default monospace muted>
@@ -300,10 +308,13 @@ function PipelineRunsTable({
           <Table
             columnFlex={columnFlex}
             columns={columns}
-            isSelectedRow={(rowIndex: number) => pipelineRuns[rowIndex].id === selectedRun?.id}
-            onClickRow={onClickRow}
+            isSelectedRow={(rowIndex: number) => disableRowSelect
+              ? false
+              : pipelineRuns[rowIndex].id === selectedRun?.id
+            }
+            onClickRow={disableRowSelect ? null : onClickRow}
             rowVerticalPadding={6}
-            rows={pipelineRuns.map((pipelineRun, index) => {
+            rows={pipelineRuns?.map((pipelineRun, index) => {
               const {
                 block_runs_count: blockRunsCount,
                 completed_at: completedAt,
@@ -314,6 +325,7 @@ function PipelineRunsTable({
                 pipeline_uuid: pipelineUUID,
                 status,
               } = pipelineRun;
+              const disabled = !id && !status;
 
               const isRetry =
                 index > 0
@@ -376,6 +388,7 @@ function PipelineRunsTable({
                 arr = [
                   <RetryButton
                     cancelingRunId={cancelingRunId}
+                    disabled={disabled}
                     isLoadingCancelPipeline={isLoadingCancelPipeline}
                     key="row_retry_button"
                     onCancel={updatePipelineRun}
@@ -407,8 +420,12 @@ function PipelineRunsTable({
                     key="row_block_runs"
                     passHref
                   >
-                    <Link bold sameColorAsText>
-                      {`See block runs (${blockRunsCount})`}
+                    <Link
+                      bold
+                      disabled={disabled}
+                      sameColorAsText
+                    >
+                      {disabled ? '' : `See block runs (${blockRunsCount})`}
                     </Link>
                   </NextLink>,
                   <Text default key="row_completed" monospace>
@@ -416,6 +433,7 @@ function PipelineRunsTable({
                   </Text>,
                   <Button
                     default
+                    disabled={disabled}
                     iconOnly
                     key="row_item_13"
                     noBackground
@@ -428,7 +446,7 @@ function PipelineRunsTable({
                 ];
               }
 
-              if (onClickRow) {
+              if (!disableRowSelect && onClickRow) {
                 arr.push(
                   <Flex flex={1} justifyContent="flex-end">
                     <ChevronRight default size={2 * UNIT} />

--- a/mage_ai/frontend/interfaces/BackfillType.ts
+++ b/mage_ai/frontend/interfaces/BackfillType.ts
@@ -27,6 +27,12 @@ export const INTERVAL_TYPES = [
   IntervalTypeEnum.CUSTOM,
 ];
 
+type PipelineRunDateType = {
+  ds: string;
+  execution_date: string;
+  hr: string;
+};
+
 export default interface BackfillType {
   block_uuid?: string;
   completed_at?: string;
@@ -40,11 +46,13 @@ export default interface BackfillType {
     [key: string]: number | string;
   };
   name: string;
+  pipeline_run_dates?: PipelineRunDateType[];
   pipeline_schedule_id?: number;
   pipeline_uuid: string;
   start_datetime?: string;
   started_at?: string;
   status?: RunStatus;
+  total_run_count?: number;
   updated_at?: string;
   variables?: {
     [key: string]: number | string;

--- a/mage_ai/frontend/oracle/elements/Button/index.tsx
+++ b/mage_ai/frontend/oracle/elements/Button/index.tsx
@@ -318,12 +318,16 @@ const SHARED_STYLES = css<{
 `;
 
 const ButtonStyle = styled.button`
-  ${SHARED_STYLES};
+  ${SHARED_STYLES}
 `;
 
 const AnchorStyle = styled.a`
-  ${SHARED_STYLES};
+  ${SHARED_STYLES}
   ${SHARED_LINK_STYLES}
+
+  ${props => props.disabled && `
+    pointer-events: none;
+  `}
 `;
 
 const Button = ({

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/backfills/[...slug].tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/backfills/[...slug].tsx
@@ -32,7 +32,7 @@ function BackfillDetailPage({
     uuid: pipelineUUID,
   }), [dataPipeline, pipelineUUID]);
 
-  const { data, mutate } = api.backfills.detail(modelID);
+  const { data, mutate } = api.backfills.detail(modelID, { include_preview_runs: true });
   const model = useMemo(() => data?.backfill, [data]);
 
   if ('edit' === subpath) {

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/backfills/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/backfills/index.tsx
@@ -41,6 +41,7 @@ function PipelineBackfills({
   } = api.backfills.list({
     _limit: 20,
     _offset: 0,
+    include_run_count: true,
     pipeline_uuid: pipelineUUID,
   }, {
     refreshInterval: 60000,

--- a/mage_ai/orchestration/backfills/service.py
+++ b/mage_ai/orchestration/backfills/service.py
@@ -44,6 +44,12 @@ def start_backfill(backfill: Backfill) -> List[PipelineRun]:
     return pipeline_runs
 
 
+def preview_run_dates(backfill: Backfill) -> List[Dict]:
+    variables_list = __build_variables_list(backfill)
+
+    return variables_list
+
+
 def cancel_backfill(backfill: Backfill) -> None:
     for pipeline_run in PipelineRun.query.filter(
         PipelineRun.backfill_id == backfill.id,

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -137,7 +137,10 @@ class PipelineScheduler:
                         backfill = backfills[0]
                         if all([PipelineRun.PipelineRunStatus.COMPLETED == pr.status
                                 for pr in backfill.pipeline_runs]):
-                            backfill.update(status=Backfill.Status.COMPLETED)
+                            backfill.update(
+                                completed_at=datetime.now(),
+                                status=Backfill.Status.COMPLETED,
+                            )
                             schedule.update(
                                 status=PipelineSchedule.ScheduleStatus.INACTIVE,
                             )


### PR DESCRIPTION
# Summary
- Show preview of total pipeline runs created and timestamps of pipeline runs that will be created before starting backfill.
- Misc UX improvements with the backfills pages (e.g. disabling or hiding irrelevant items depending on backfill status, updating backfill table columns that previously weren't updating as needed)

# Tests
Preview runs:
![preview backfill runs](https://user-images.githubusercontent.com/78053898/221328187-1972d249-21d8-4f75-96bd-cf19a7768533.gif)

Update columns in backfill table:
![Update columns in backfill table](https://user-images.githubusercontent.com/78053898/221344713-ba1c7d03-ad0c-4965-a782-6f9b0b3f33d8.gif)

