### PR TITLE
[jk] Disable keyboard shortcuts while focused in Sidekick inputs

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -220,7 +220,6 @@ function PipelineDetail({
     uuidKeyboard,
     (event, keyMapping, keyHistory) => {
       if (disableGlobalKeyboardShortcuts) {
-        pauseEvent(event);
         return;
       }
 

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -81,6 +81,7 @@ type PipelineDetailProps = {
   blocks: BlockType[];
   dataProviders: DataProviderType[];
   deleteBlock: (block: BlockType) => Promise<any>;
+  disableShortcuts: boolean;
   fetchFileTree: () => void;
   fetchPipeline: () => void;
   fetchSampleData: () => void;
@@ -140,6 +141,7 @@ function PipelineDetail({
   blocks = [],
   dataProviders,
   deleteBlock,
+  disableShortcuts,
   fetchFileTree,
   fetchPipeline,
   fetchSampleData,
@@ -219,7 +221,7 @@ function PipelineDetail({
   registerOnKeyDown(
     uuidKeyboard,
     (event, keyMapping, keyHistory) => {
-      if (disableGlobalKeyboardShortcuts) {
+      if (disableShortcuts || disableGlobalKeyboardShortcuts) {
         return;
       }
 

--- a/mage_ai/frontend/components/Sidekick/GlobalVariables/Secrets.tsx
+++ b/mage_ai/frontend/components/Sidekick/GlobalVariables/Secrets.tsx
@@ -115,7 +115,7 @@ function Secrets({
     from mage_ai.data_preparation.shared.secrets import get_secret_value
 
     get_secret_value('<secret_name>')
-  `
+  `;
 
   return (
     <Spacing p={PADDING_UNITS}>
@@ -185,8 +185,8 @@ function Secrets({
               <Col md={4}>
                 <CellStyle>
                   <TextInput
-                    compact
                     borderless
+                    compact
                     fullWidth
                     monospace
                     onChange={(e) => {
@@ -204,8 +204,8 @@ function Secrets({
               <Col md={7}>
                 <CellStyle>
                   <TextInput
-                    compact
                     borderless
+                    compact
                     fullWidth
                     monospace
                     onChange={(e) => {
@@ -227,11 +227,12 @@ function Secrets({
               deleteVariable={() => deleteSecret(secret.name)}
               fetchVariables={fetchSecrets}
               hideEdit
+              key={secret.name}
               obfuscate
               pipelineUUID={pipelineUUID}
               variable={{
                 uuid: secret.name,
-                value: secret.value
+                value: secret.value,
               } as VariableType}
             />
           ))}

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -81,6 +81,7 @@ export type SidekickProps = {
   sampleData: SampleDataType;
   secrets: SecretType[];
   selectedBlock: BlockType;
+  setDisableShortcuts: (disableShortcuts: boolean) => void;
   setErrors: (opts: {
     errors: any;
     response: any;
@@ -119,6 +120,7 @@ function Sidekick({
   secrets,
   selectedBlock,
   setAnyInputFocused,
+  setDisableShortcuts,
   setEditingBlock,
   setErrors,
   setSelectedBlock,
@@ -261,8 +263,8 @@ function Sidekick({
       <SidekickContainerStyle
         fullWidth={FULL_WIDTH_VIEWS.includes(activeView)}
         heightOffset={ViewKeyEnum.TERMINAL === activeView ? 0 : SCROLLBAR_WIDTH}
-        onBlur={() => setDisableGlobalKeyboardShortcuts(false)}
-        onFocus={() => setDisableGlobalKeyboardShortcuts(true)}
+        onBlur={() => setDisableShortcuts(false)}
+        onFocus={() => setDisableShortcuts(true)}
       >
         {activeView === ViewKeyEnum.TREE &&
           <>

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -46,7 +46,6 @@ import { buildRenderColumnHeader } from '@components/datasets/overview/utils';
 import { createMetricsSample, createStatisticsSample } from './utils';
 import { indexBy } from '@utils/array';
 import { isEmptyObject } from '@utils/hash';
-import { useKeyboardContext } from '@context/Keyboard';
 import { useWindowSize } from '@utils/sizes';
 
 const MAX_COLUMNS = 100;
@@ -131,9 +130,6 @@ function Sidekick({
   widgets,
 }: SidekickProps) {
   const {
-    setDisableGlobalKeyboardShortcuts,
-  } = useKeyboardContext();
-  const {
     height: heightWindow,
   } = useWindowSize();
   const heightOffset = ALL_HEADERS_HEIGHT;
@@ -217,21 +213,6 @@ function Sidekick({
     pipeline,
     secrets,
   ]);
-
-  const dataTableMemo = useMemo(() => (
-    <DataTable
-      columnHeaderHeight={TABLE_COLUMN_HEADER_HEIGHT}
-      columns={columns}
-      height={heightWindow - heightOffset - ASIDE_SUBHEADER_HEIGHT}
-      noBorderBottom
-      noBorderLeft
-      noBorderRight
-      noBorderTop
-      renderColumnHeader={renderColumnHeader}
-      rows={rows}
-      width={afterWidth}
-    />
-  ), [columns, rows]);
 
   return (
     <>

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -46,6 +46,7 @@ import { buildRenderColumnHeader } from '@components/datasets/overview/utils';
 import { createMetricsSample, createStatisticsSample } from './utils';
 import { indexBy } from '@utils/array';
 import { isEmptyObject } from '@utils/hash';
+import { useKeyboardContext } from '@context/Keyboard';
 import { useWindowSize } from '@utils/sizes';
 
 const MAX_COLUMNS = 100;
@@ -127,6 +128,9 @@ function Sidekick({
   updateWidget,
   widgets,
 }: SidekickProps) {
+  const {
+    setDisableGlobalKeyboardShortcuts,
+  } = useKeyboardContext();
   const {
     height: heightWindow,
   } = useWindowSize();
@@ -257,6 +261,8 @@ function Sidekick({
       <SidekickContainerStyle
         fullWidth={FULL_WIDTH_VIEWS.includes(activeView)}
         heightOffset={ViewKeyEnum.TERMINAL === activeView ? 0 : SCROLLBAR_WIDTH}
+        onBlur={() => setDisableGlobalKeyboardShortcuts(false)}
+        onFocus={() => setDisableGlobalKeyboardShortcuts(true)}
       >
         {activeView === ViewKeyEnum.TREE &&
           <>

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -111,6 +111,7 @@ function PipelineDetailPage({
   }>({});
   const [textareaFocused, setTextareaFocused] = useState<boolean>(false);
   const [anyInputFocused, setAnyInputFocused] = useState<boolean>(false);
+  const [disableShortcuts, setDisableShortcuts] = useState<boolean>(false);
 
   const mainContainerRef = useRef(null);
 
@@ -1481,6 +1482,7 @@ function PipelineDetailPage({
       secrets={secrets}
       selectedBlock={selectedBlock}
       setAnyInputFocused={setAnyInputFocused}
+      setDisableShortcuts={setDisableShortcuts}
       setEditingBlock={setEditingBlock}
       setErrors={setErrors}
       setSelectedBlock={setSelectedBlock}
@@ -1556,6 +1558,7 @@ function PipelineDetailPage({
       blocks={blocks}
       dataProviders={dataProviders}
       deleteBlock={deleteBlock}
+      disableShortcuts={disableShortcuts}
       fetchFileTree={fetchFileTree}
       fetchPipeline={fetchPipeline}
       fetchSampleData={fetchSampleData}


### PR DESCRIPTION
# Summary
- See title.

# Tests
Before - shortcuts NOT disabled:
![before - shortcuts not disabled](https://user-images.githubusercontent.com/78053898/222313916-9a754d88-bff3-4a71-a16e-c1d9901dde8f.gif)

After - shortcuts disabled on input focus:
![after - shortcuts disabled](https://user-images.githubusercontent.com/78053898/222313965-95368fdf-99cd-4659-aaf2-e969fc6920b0.gif)
