### PR TITLE
[jk]  Require destination to edit bookmarks / Update docs

### DIFF
--- a/docs/guides/data-integration-pipeline.mdx
+++ b/docs/guides/data-integration-pipeline.mdx
@@ -94,6 +94,18 @@ Here are the steps you can optionally go through:
    - `IGNORE`: skip the new record if it’s a duplicate of an existing record.
    - `UPDATE`: update the existing record with the new record’s properties.
 
+### Editing bookmark property values
+   - You can edit the bookmark values for your next sync by editing them
+   in the `Bookmark property values` table under the
+   **Manually edit bookmark property values** setting in the **Settings** section.
+   - The **Manually edit bookmark property values** setting will not appear until
+   at least one column is selected as a bookmark field.
+   - In order to enable the toggle that displays the `Bookmark property values`
+   table, you need to select a destination first.
+   - Click the toggle and enter the new value for your bookmark property, and then
+   click `Save`. You MUST click the `Save` button in order for the bookmark value
+   to be updated.
+
 ---
 
 ## Configure destination

--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
@@ -891,19 +891,20 @@ function SchemaTable({
                         Manually edit bookmark property values
                       </Text>
                       <Text default>
-                        In order to override the bookmark values for the next sync, click the toggle
-                        to edit the values for the bookmark properties in the table below. Click the &#34;Save&#34;
-                        button to save your changes.
+                        In order to override the bookmark values for the next sync, you must first select a destination.
+                        Then click the toggle to edit the values for the bookmark properties in the table below.
+                        Click the &#34;Save&#34; button to save your changes.
                       </Text>
                     </Spacing>
 
                     <ToggleSwitch
                       checked={showBookmarkValuesTable}
+                      disabled={!destination}
                       onCheck={() => setShowBookmarkPropertyTable(prevState => !prevState)}
                     />
                   </FlexContainer>
                 </Spacing>
-                {showBookmarkValuesTable &&
+                {(showBookmarkValuesTable && !!destination) &&
                   <Panel
                     header={
                       <FlexContainer alignItems="center" justifyContent="space-between">

--- a/mage_ai/frontend/oracle/elements/Inputs/ToggleSwitch.tsx
+++ b/mage_ai/frontend/oracle/elements/Inputs/ToggleSwitch.tsx
@@ -9,6 +9,7 @@ const WIDTH = 46;
 
 type ToggleSwitchProps = {
   checked: boolean;
+  disabled?: boolean;
   onCheck: Dispatch<SetStateAction<boolean>>;
 } & InputWrapperProps;
 
@@ -68,31 +69,35 @@ const ToggleSwitchStyle = styled.label<InputWrapperProps>`
 
 const ToggleSwitch = ({
   checked,
+  disabled,
   onCheck,
   ...props
-}: ToggleSwitchProps, ref) => {
-  return (
-    <InputWrapper
-      {...props}
-      input={
-        <ToggleSwitchStyle
-          {...props}
-          noBackground
-          noBorder
-        >
-          <input
-            checked={checked}
-            type="checkbox"
-          />
-          <span
-            onClick={() => onCheck(value => !value)}
-          />
-        </ToggleSwitchStyle>
-      }
-      noBackground
-      ref={ref}
-    />
-  );
-};
+}: ToggleSwitchProps, ref) => (
+  <InputWrapper
+    {...props}
+    disabled={disabled}
+    input={
+      <ToggleSwitchStyle
+        {...props}
+        disabled={disabled}
+        noBackground
+        noBorder
+      >
+        <input
+          checked={checked}
+          type="checkbox"
+        />
+        <span
+          onClick={disabled
+            ? null
+            : () => onCheck?.(value => !value)
+          }
+        />
+      </ToggleSwitchStyle>
+    }
+    noBackground
+    ref={ref}
+  />
+);
 
 export default React.forwardRef(ToggleSwitch);


### PR DESCRIPTION
# Summary
- Fixed bug where users could edit bookmark values before selecting destination. A destination must be selected first so we have the folder path for where to save the updated bookmark values.
- Updated documentation for editing bookmark values. https://docs.mage.ai/guides/data-integration-pipeline#editing-bookmark-property-values

# Tests
- Locally
