### PR TITLE
[dy] Fix integration pipeline

### DIFF
--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -386,7 +386,7 @@ class PipelineScheduler:
         if job_manager.has_pipeline_run_job(self.pipeline_run.id):
             return
 
-        block_runs_to_schedule = self.executable_block_runs if block_runs is None else block_runs
+        block_runs_to_schedule = self.initial_block_runs if block_runs is None else block_runs
         block_runs_to_schedule = self.__fetch_crashed_block_runs() + block_runs_to_schedule
 
         if len(block_runs_to_schedule) > 0:


### PR DESCRIPTION
# Summary

Call `self.initial_block_runs` instead of `self.executable_block_runs` for integration pipelines.
<!-- Brief summary of what your code does -->

# Tests

tested locally. i'll add some unit tests for this too
<!-- How did you test your change? -->

cc:
<!-- Optionally mention someone to let them know about this pull request -->
