### PR TITLE
[dy] Add env var to disable edit access

### DIFF
--- a/mage_ai/api/policies/BackfillPolicy.py
+++ b/mage_ai/api/policies/BackfillPolicy.py
@@ -20,7 +20,7 @@ BackfillPolicy.allow_actions([
     constants.UPDATE,
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 BackfillPolicy.allow_read([
     'pipeline_run_dates',
@@ -37,7 +37,7 @@ BackfillPolicy.allow_read([] + BackfillPresenter.default_attributes, scopes=[
 ], on_action=[
     constants.CREATE,
     constants.UPDATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 BackfillPolicy.allow_write([
     'name',
@@ -45,7 +45,7 @@ BackfillPolicy.allow_write([
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.CREATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 BackfillPolicy.allow_write([
     'block_uuid',
@@ -60,7 +60,7 @@ BackfillPolicy.allow_write([
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.UPDATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 BackfillPolicy.allow_query([
     'include_preview_runs',

--- a/mage_ai/api/policies/BasePolicy.py
+++ b/mage_ai/api/policies/BasePolicy.py
@@ -5,10 +5,12 @@ from mage_ai.api.oauth_scope import OauthScope
 from mage_ai.api.utils import (
     has_at_least_admin_role,
     has_at_least_editor_role,
+    has_at_least_editor_role_and_edit_access,
     has_at_least_viewer_role,
     is_owner,
 )
 from mage_ai.services.tracking.metrics import increment
+from mage_ai.settings import DISABLE_EDIT_ACCESS
 from mage_ai.shared.hash import extract
 import importlib
 import inflection
@@ -130,13 +132,13 @@ class BasePolicy():
     def has_at_least_editor_role(self) -> bool:
         return has_at_least_editor_role(self.current_user)
 
+    def has_at_least_editor_role_and_edit_access(self) -> bool:
+        return has_at_least_editor_role_and_edit_access(self.current_user)
+
     def has_at_least_viewer_role(self) -> bool:
         return has_at_least_viewer_role(self.current_user)
 
     def authorize_action(self, action):
-        if self.is_owner():
-            return True
-
         config = self.__class__.action_rule(action)
         if config:
             self.__validate_scopes(action, config.keys())
@@ -234,7 +236,7 @@ class BasePolicy():
         return self.parent_resource_attr
 
     def __current_scope(self):
-        if self.current_user:
+        if self.current_user or DISABLE_EDIT_ACCESS:
             return OauthScope.CLIENT_PRIVATE
         else:
             return OauthScope.CLIENT_PUBLIC
@@ -265,6 +267,8 @@ class BasePolicy():
 
     def __validate_scopes(self, val, scopes):
         error = ApiError.UNAUTHORIZED_ACCESS
+        if self.is_owner():
+            return
         if OauthScope.CLIENT_ALL in scopes:
             return
         elif not self.current_user and OauthScope.CLIENT_PUBLIC not in scopes:

--- a/mage_ai/api/policies/BasePolicy.py
+++ b/mage_ai/api/policies/BasePolicy.py
@@ -10,7 +10,7 @@ from mage_ai.api.utils import (
     is_owner,
 )
 from mage_ai.services.tracking.metrics import increment
-from mage_ai.settings import DISABLE_EDIT_ACCESS
+from mage_ai.settings import DISABLE_NOTEBOOK_EDIT_ACCESS
 from mage_ai.shared.hash import extract
 import importlib
 import inflection
@@ -236,7 +236,7 @@ class BasePolicy():
         return self.parent_resource_attr
 
     def __current_scope(self):
-        if self.current_user or DISABLE_EDIT_ACCESS:
+        if self.current_user or DISABLE_NOTEBOOK_EDIT_ACCESS:
             return OauthScope.CLIENT_PRIVATE
         else:
             return OauthScope.CLIENT_PUBLIC

--- a/mage_ai/api/policies/BlockPolicy.py
+++ b/mage_ai/api/policies/BlockPolicy.py
@@ -14,7 +14,7 @@ BlockPolicy.allow_actions([
     constants.UPDATE,
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 BlockPolicy.allow_actions([
     constants.DETAIL,
@@ -29,13 +29,13 @@ BlockPolicy.allow_read([
 ], on_action=[
     constants.CREATE,
     constants.UPDATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 BlockPolicy.allow_read(BlockPresenter.default_attributes + [], scopes=[
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.DELETE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 BlockPolicy.allow_read([
     'bookmarks',
@@ -65,7 +65,7 @@ BlockPolicy.allow_write([
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.CREATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 BlockPolicy.allow_write([
     'all_upstream_blocks_executed',
@@ -91,7 +91,7 @@ BlockPolicy.allow_write([
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.UPDATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 BlockPolicy.allow_query([
     'destination_table',

--- a/mage_ai/api/policies/FileContentPolicy.py
+++ b/mage_ai/api/policies/FileContentPolicy.py
@@ -18,7 +18,7 @@ FileContentPolicy.allow_actions([
     constants.UPDATE,
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 FileContentPolicy.allow_read(FileContentPresenter.default_attributes + [], scopes=[
     OauthScope.CLIENT_PRIVATE,
@@ -35,4 +35,4 @@ FileContentPolicy.allow_write([
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.UPDATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())

--- a/mage_ai/api/policies/FilePolicy.py
+++ b/mage_ai/api/policies/FilePolicy.py
@@ -20,7 +20,7 @@ FilePolicy.allow_actions([
     constants.UPDATE,
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 FilePolicy.allow_read(FilePresenter.default_attributes + [], scopes=[
     OauthScope.CLIENT_PRIVATE,
@@ -46,7 +46,7 @@ FilePolicy.allow_write([
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.CREATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 FilePolicy.allow_write([
     'dir_path',
@@ -55,4 +55,4 @@ FilePolicy.allow_write([
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.UPDATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())

--- a/mage_ai/api/policies/KernelPolicy.py
+++ b/mage_ai/api/policies/KernelPolicy.py
@@ -18,7 +18,7 @@ KernelPolicy.allow_actions([
     constants.UPDATE,
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 KernelPolicy.allow_read(KernelPresenter.default_attributes + [], scopes=[
     OauthScope.CLIENT_PRIVATE,
@@ -31,7 +31,7 @@ KernelPolicy.allow_read(KernelPresenter.default_attributes + [], scopes=[
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.UPDATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 KernelPolicy.allow_write([
   'action_type',
@@ -39,4 +39,4 @@ KernelPolicy.allow_write([
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.UPDATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())

--- a/mage_ai/api/policies/PipelinePolicy.py
+++ b/mage_ai/api/policies/PipelinePolicy.py
@@ -21,7 +21,7 @@ PipelinePolicy.allow_actions([
     constants.UPDATE,
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 PipelinePolicy.allow_read(PipelinePresenter.default_attributes + [], scopes=[
     OauthScope.CLIENT_PRIVATE,
@@ -35,7 +35,7 @@ PipelinePolicy.allow_read(PipelinePresenter.default_attributes + [], scopes=[
     constants.CREATE,
     constants.DELETE,
     constants.UPDATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 PipelinePolicy.allow_read(PipelinePresenter.default_attributes + [
     'schedules',
@@ -53,7 +53,7 @@ PipelinePolicy.allow_write([
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.CREATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 PipelinePolicy.allow_write([
     'add_upstream_for_block_uuid',
@@ -63,7 +63,7 @@ PipelinePolicy.allow_write([
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.UPDATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 PipelinePolicy.allow_query([
     'includes_block_metadata',
@@ -89,4 +89,4 @@ PipelinePolicy.allow_query([
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.UPDATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())

--- a/mage_ai/api/policies/SecretPolicy.py
+++ b/mage_ai/api/policies/SecretPolicy.py
@@ -19,7 +19,7 @@ SecretPolicy.allow_actions([
     constants.DELETE,
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 SecretPolicy.allow_read(SecretPresenter.default_attributes + [
 ], scopes=[
@@ -34,7 +34,7 @@ SecretPolicy.allow_read(SecretPresenter.default_attributes + [
 ], on_action=[
     constants.CREATE,
     constants.DELETE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 SecretPolicy.allow_write([
     'name',
@@ -43,4 +43,4 @@ SecretPolicy.allow_write([
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.CREATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())

--- a/mage_ai/api/policies/VariablePolicy.py
+++ b/mage_ai/api/policies/VariablePolicy.py
@@ -20,7 +20,7 @@ VariablePolicy.allow_actions([
     constants.UPDATE,
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 VariablePolicy.allow_read(VariablePresenter.default_attributes + [
 ], scopes=[
@@ -36,7 +36,7 @@ VariablePolicy.allow_read(VariablePresenter.default_attributes + [
     constants.CREATE,
     constants.DELETE,
     constants.UPDATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 VariablePolicy.allow_write([
     'name',
@@ -46,4 +46,4 @@ VariablePolicy.allow_write([
 ], on_action=[
     constants.CREATE,
     constants.UPDATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())

--- a/mage_ai/api/policies/WidgetPolicy.py
+++ b/mage_ai/api/policies/WidgetPolicy.py
@@ -20,7 +20,7 @@ WidgetPolicy.allow_actions([
     constants.UPDATE,
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 WidgetPolicy.allow_read(WidgetPresenter.default_attributes + [], scopes=[
     OauthScope.CLIENT_PRIVATE,
@@ -34,7 +34,7 @@ WidgetPolicy.allow_read(WidgetPresenter.default_attributes + [], scopes=[
     constants.CREATE,
     constants.DELETE,
     constants.UPDATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
 
 WidgetPolicy.allow_write([
     'config',
@@ -51,4 +51,4 @@ WidgetPolicy.allow_write([
 ], on_action=[
     constants.CREATE,
     constants.UPDATE,
-], condition=lambda policy: policy.has_at_least_editor_role())
+], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())

--- a/mage_ai/api/utils.py
+++ b/mage_ai/api/utils.py
@@ -1,6 +1,6 @@
 from mage_ai.orchestration.db.models import Oauth2AccessToken
 from mage_ai.settings import (
-    DISABLE_EDIT_ACCESS,
+    DISABLE_NOTEBOOK_EDIT_ACCESS,
     REQUIRE_USER_AUTHENTICATION,
 )
 from mage_ai.shared.environments import is_test
@@ -41,7 +41,7 @@ def has_at_least_editor_role(user) -> bool:
 
 
 def has_at_least_editor_role_and_edit_access(user) -> bool:
-    return not DISABLE_EDIT_ACCESS and has_at_least_editor_role(user)
+    return not DISABLE_NOTEBOOK_EDIT_ACCESS and has_at_least_editor_role(user)
 
 
 def has_at_least_viewer_role(user) -> bool:

--- a/mage_ai/api/utils.py
+++ b/mage_ai/api/utils.py
@@ -1,5 +1,8 @@
 from mage_ai.orchestration.db.models import Oauth2AccessToken
-from mage_ai.settings import REQUIRE_USER_AUTHENTICATION
+from mage_ai.settings import (
+    DISABLE_EDIT_ACCESS,
+    REQUIRE_USER_AUTHENTICATION,
+)
 from mage_ai.shared.environments import is_test
 from typing import Tuple
 
@@ -35,6 +38,10 @@ def has_at_least_editor_role(user) -> bool:
         is_owner(user) or \
         has_at_least_admin_role(user) or \
         (user.roles and user.roles & 2 != 0)
+
+
+def has_at_least_editor_role_and_edit_access(user) -> bool:
+    return not DISABLE_EDIT_ACCESS and has_at_least_editor_role()
 
 
 def has_at_least_viewer_role(user) -> bool:

--- a/mage_ai/api/utils.py
+++ b/mage_ai/api/utils.py
@@ -41,7 +41,7 @@ def has_at_least_editor_role(user) -> bool:
 
 
 def has_at_least_editor_role_and_edit_access(user) -> bool:
-    return not DISABLE_EDIT_ACCESS and has_at_least_editor_role()
+    return not DISABLE_EDIT_ACCESS and has_at_least_editor_role(user)
 
 
 def has_at_least_viewer_role(user) -> bool:

--- a/mage_ai/server/websocket_server.py
+++ b/mage_ai/server/websocket_server.py
@@ -1,7 +1,10 @@
 from datetime import datetime
 from distutils.file_util import copy_file
 from mage_ai.api.errors import ApiError
-from mage_ai.api.utils import authenticate_client_and_token, has_at_least_editor_role
+from mage_ai.api.utils import (
+    authenticate_client_and_token,
+    has_at_least_editor_role,
+)
 from mage_ai.data_preparation.models.constants import (
     BlockType,
     PipelineType,
@@ -34,7 +37,7 @@ from mage_ai.server.utils.output_display import (
     get_block_output_process_code,
     get_pipeline_execution_code,
 )
-from mage_ai.settings import REQUIRE_USER_AUTHENTICATION
+from mage_ai.settings import DISABLE_EDIT_ACCESS, REQUIRE_USER_AUTHENTICATION
 from mage_ai.shared.hash import merge_dict
 from mage_ai.utils.code import reload_all_repo_modules
 from jupyter_client import KernelClient
@@ -161,7 +164,7 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
         api_key = message.get('api_key')
         token = message.get('token')
 
-        if REQUIRE_USER_AUTHENTICATION:
+        if REQUIRE_USER_AUTHENTICATION or DISABLE_EDIT_ACCESS:
             valid = False
 
             if api_key and token:
@@ -175,7 +178,7 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
                         oauth_token.user and \
                         has_at_least_editor_role(oauth_token.user)
 
-            if not valid:
+            if not valid or DISABLE_EDIT_ACCESS:
                 return self.send_message(
                     dict(
                         data=ApiError.UNAUTHORIZED_ACCESS['message'],

--- a/mage_ai/server/websocket_server.py
+++ b/mage_ai/server/websocket_server.py
@@ -37,7 +37,10 @@ from mage_ai.server.utils.output_display import (
     get_block_output_process_code,
     get_pipeline_execution_code,
 )
-from mage_ai.settings import DISABLE_EDIT_ACCESS, REQUIRE_USER_AUTHENTICATION
+from mage_ai.settings import (
+    DISABLE_NOTEBOOK_EDIT_ACCESS,
+    REQUIRE_USER_AUTHENTICATION,
+)
 from mage_ai.shared.hash import merge_dict
 from mage_ai.utils.code import reload_all_repo_modules
 from jupyter_client import KernelClient
@@ -164,7 +167,7 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
         api_key = message.get('api_key')
         token = message.get('token')
 
-        if REQUIRE_USER_AUTHENTICATION or DISABLE_EDIT_ACCESS:
+        if REQUIRE_USER_AUTHENTICATION or DISABLE_NOTEBOOK_EDIT_ACCESS:
             valid = False
 
             if api_key and token:
@@ -178,7 +181,7 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
                         oauth_token.user and \
                         has_at_least_editor_role(oauth_token.user)
 
-            if not valid or DISABLE_EDIT_ACCESS:
+            if not valid or DISABLE_NOTEBOOK_EDIT_ACCESS:
                 return self.send_message(
                     dict(
                         data=ApiError.UNAUTHORIZED_ACCESS['message'],

--- a/mage_ai/settings/__init__.py
+++ b/mage_ai/settings/__init__.py
@@ -11,6 +11,6 @@ secrets.token_urlsafe()
 Make sure this value is the same in mage_ai/frontend/api/constants.ts
 """
 OAUTH2_APPLICATION_CLIENT_ID = 'zkWlN0PkIKSN0C11CfUHUj84OT5XOJ6tDZ6bDRO2'
-DISABLE_EDIT_ACCESS = os.getenv('DISABLE_NOTEBOOK_EDIT_ACCESS', False)
+DISABLE_NOTEBOOK_EDIT_ACCESS = os.getenv('DISABLE_NOTEBOOK_EDIT_ACCESS', False)
 
 REQUIRE_USER_AUTHENTICATION = os.getenv('REQUIRE_USER_AUTHENTICATION', False)

--- a/mage_ai/settings/__init__.py
+++ b/mage_ai/settings/__init__.py
@@ -11,4 +11,6 @@ secrets.token_urlsafe()
 Make sure this value is the same in mage_ai/frontend/api/constants.ts
 """
 OAUTH2_APPLICATION_CLIENT_ID = 'zkWlN0PkIKSN0C11CfUHUj84OT5XOJ6tDZ6bDRO2'
+DISABLE_EDIT_ACCESS = os.getenv('DISABLE_NOTEBOOK_EDIT_ACCESS', False)
+
 REQUIRE_USER_AUTHENTICATION = os.getenv('REQUIRE_USER_AUTHENTICATION', False)

--- a/mage_ai/tests/api/operations/test_operations.py
+++ b/mage_ai/tests/api/operations/test_operations.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 
 class OperationTests(BaseApiTestCase):
-    @patch('mage_ai.settings.DISABLE_EDIT_ACCESS', 1)
+    @patch('mage_ai.settings.DISABLE_NOTEBOOK_EDIT_ACCESS', 1)
     async def test_execute_create_with_disable_edit_access(self):
         operation = self.build_operation(
             action=constants.CREATE,
@@ -17,7 +17,7 @@ class OperationTests(BaseApiTestCase):
 
         self.assertIsNotNone(response['error'])
 
-    @patch('mage_ai.settings.DISABLE_EDIT_ACCESS', 1)
+    @patch('mage_ai.settings.DISABLE_NOTEBOOK_EDIT_ACCESS', 1)
     @patch('mage_ai.settings.REQUIRE_USER_AUTHENTICATION', 1)
     async def test_execute_create_with_disable_edit_access_and_user(self):
         operation = self.build_operation(

--- a/mage_ai/tests/api/operations/test_operations.py
+++ b/mage_ai/tests/api/operations/test_operations.py
@@ -1,0 +1,32 @@
+from mage_ai.api.operations import constants
+from mage_ai.tests.api.operations.base import BaseApiTestCase
+from unittest.mock import patch
+
+
+class OperationTests(BaseApiTestCase):
+    @patch('mage_ai.settings.DISABLE_EDIT_ACCESS', 1)
+    async def test_execute_create_with_disable_edit_access(self):
+        operation = self.build_operation(
+            action=constants.CREATE,
+            payload=dict(block=dict(
+                name='test block'
+            )),
+            resource='blocks',
+        )
+        response = await operation.execute()
+
+        self.assertIsNotNone(response['error'])
+
+    @patch('mage_ai.settings.DISABLE_EDIT_ACCESS', 1)
+    @patch('mage_ai.settings.REQUIRE_USER_AUTHENTICATION', 1)
+    async def test_execute_create_with_disable_edit_access_and_user(self):
+        operation = self.build_operation(
+            action=constants.CREATE,
+            payload=dict(block=dict(
+                name='test block'
+            )),
+            resource='blocks',
+        )
+        response = await operation.execute()
+
+        self.assertIsNotNone(response['error'])


### PR DESCRIPTION
# Summary

Support disabling edit access for endpoints related to the notebook. I had to make some changes to the authentication middleware to support the new policy condition.
<!-- Brief summary of what your code does -->

# Tests

tested locally. trying to perform an edit action will lead to an error pop up

![Screenshot 2023-03-07 at 9 58 56 AM](https://user-images.githubusercontent.com/14357209/223508920-ad55ee13-fa60-44e1-b7c2-9918d51ffb9f.png)


<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
