### PR TITLE
[xy] Fix Snowflake alter table command.

### DIFF
--- a/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
@@ -146,6 +146,7 @@ WHERE TABLE_SCHEMA = '{schema_name}' AND TABLE_NAME ILIKE '%{table_name}%'
                     schema_name,
                     table_name,
                 ),
+                add_column_cmd='ADD',
                 column_identifier=self.column_identifier,
             ),
         ]

--- a/mage_integrations/mage_integrations/destinations/sql/utils.py
+++ b/mage_integrations/mage_integrations/destinations/sql/utils.py
@@ -66,13 +66,14 @@ def build_alter_table_command(
     column_type_mapping: Dict,
     columns: List[str],
     full_table_name: str,
+    add_column_cmd: str = 'ADD COLUMN',
     column_identifier: str = '',
 ) -> str:
     if not columns:
         return None
 
     columns_and_types = [
-        f"ADD COLUMN {column_identifier}{clean_column_name(col)}{column_identifier}" +
+        f"{add_column_cmd} {column_identifier}{clean_column_name(col)}{column_identifier}" +
         f" {column_type_mapping[col]['type_converted']}" for col
         in columns
     ]


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Fix Snowflake alter table command.
Fix error:
```
syntax error line 1 at position 69 unexpected 'COLUMN'.
```

https://stephenallwright.com/snowflake-add-multiple-columns/


# Tests
<!-- How did you test your change? -->
to be tested

cc:
<!-- Optionally mention someone to let them know about this pull request -->
