### PR TITLE
[jk] Migrate additional resources when pipeline renamed

### DIFF
--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -507,6 +507,11 @@ class Pipeline:
             old_uuid = self.uuid
             new_name = data['name']
             new_uuid = clean_name(new_name)
+
+            all_pipelines = self.get_all_pipelines(self.repo_path)
+            if new_uuid in all_pipelines:
+                raise Exception(f'Pipeline {new_uuid} already exists. Choose a different name.')
+
             old_pipeline_path = self.dir_path
             self.name = new_name
             self.uuid = new_uuid

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -16,6 +16,7 @@ from mage_ai.data_preparation.models.widget import Widget
 from mage_ai.data_preparation.repo_manager import RepoConfig, get_repo_config, get_repo_path
 from mage_ai.data_preparation.templates.utils import copy_template_directory
 from mage_ai.data_preparation.variable_manager import VariableManager
+from mage_ai.orchestration.db import db_connection
 from mage_ai.shared.hash import extract, merge_dict
 from mage_ai.shared.io import safe_write, safe_write_async
 from mage_ai.shared.strings import format_enum
@@ -499,9 +500,11 @@ class Pipeline:
 
     async def update(self, data, update_content=False):
         if 'name' in data and data['name'] != self.name:
+            from mage_ai.orchestration.db.models import Backfill, PipelineRun, PipelineSchedule
             """
             Rename pipeline folder
             """
+            old_uuid = self.uuid
             new_name = data['name']
             new_uuid = clean_name(new_name)
             old_pipeline_path = self.dir_path
@@ -510,6 +513,20 @@ class Pipeline:
             new_pipeline_path = self.dir_path
             os.rename(old_pipeline_path, new_pipeline_path)
             self.save()
+
+            # Migrate pipeline schedules
+            PipelineSchedule.query.filter(PipelineSchedule.pipeline_uuid == old_uuid).update({
+                PipelineSchedule.pipeline_uuid: new_uuid
+            }, synchronize_session=False)
+            # Migrate pipeline runs (block runs have foreign key ref to PipelineRun id)
+            PipelineRun.query.filter(PipelineRun.pipeline_uuid == old_uuid).update({
+                PipelineRun.pipeline_uuid: new_uuid
+            }, synchronize_session=False)
+            # Migrate backfills
+            Backfill.query.filter(Backfill.pipeline_uuid == old_uuid).update({
+                Backfill.pipeline_uuid: new_uuid
+            }, synchronize_session=False)
+            db_connection.session.commit()
 
         if 'type' in data and data['type'] != self.type:
             """

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -16,7 +16,7 @@ from mage_ai.data_preparation.models.widget import Widget
 from mage_ai.data_preparation.repo_manager import RepoConfig, get_repo_config, get_repo_path
 from mage_ai.data_preparation.templates.utils import copy_template_directory
 from mage_ai.data_preparation.variable_manager import VariableManager
-from mage_ai.orchestration.db import db_connection
+from mage_ai.orchestration.db import db_connection, safe_db_query
 from mage_ai.shared.hash import extract, merge_dict
 from mage_ai.shared.io import safe_write, safe_write_async
 from mage_ai.shared.strings import format_enum
@@ -498,9 +498,26 @@ class Pipeline:
             widgets=widgets_data,
         ))
 
+    @safe_db_query
+    def __transfer_related_models(self, old_uuid, new_uuid):
+        from mage_ai.orchestration.db.models import Backfill, PipelineRun, PipelineSchedule
+
+        # Migrate pipeline schedules
+        PipelineSchedule.query.filter(PipelineSchedule.pipeline_uuid == old_uuid).update({
+            PipelineSchedule.pipeline_uuid: new_uuid
+        }, synchronize_session=False)
+        # Migrate pipeline runs (block runs have foreign key ref to PipelineRun id)
+        PipelineRun.query.filter(PipelineRun.pipeline_uuid == old_uuid).update({
+            PipelineRun.pipeline_uuid: new_uuid
+        }, synchronize_session=False)
+        # Migrate backfills
+        Backfill.query.filter(Backfill.pipeline_uuid == old_uuid).update({
+            Backfill.pipeline_uuid: new_uuid
+        }, synchronize_session=False)
+        db_connection.session.commit()
+
     async def update(self, data, update_content=False):
         if 'name' in data and data['name'] != self.name:
-            from mage_ai.orchestration.db.models import Backfill, PipelineRun, PipelineSchedule
             """
             Rename pipeline folder
             """
@@ -518,20 +535,7 @@ class Pipeline:
             new_pipeline_path = self.dir_path
             os.rename(old_pipeline_path, new_pipeline_path)
             self.save()
-
-            # Migrate pipeline schedules
-            PipelineSchedule.query.filter(PipelineSchedule.pipeline_uuid == old_uuid).update({
-                PipelineSchedule.pipeline_uuid: new_uuid
-            }, synchronize_session=False)
-            # Migrate pipeline runs (block runs have foreign key ref to PipelineRun id)
-            PipelineRun.query.filter(PipelineRun.pipeline_uuid == old_uuid).update({
-                PipelineRun.pipeline_uuid: new_uuid
-            }, synchronize_session=False)
-            # Migrate backfills
-            Backfill.query.filter(Backfill.pipeline_uuid == old_uuid).update({
-                Backfill.pipeline_uuid: new_uuid
-            }, synchronize_session=False)
-            db_connection.session.commit()
+            self.__transfer_related_models(old_uuid, new_uuid)
 
         if 'type' in data and data['type'] != self.type:
             """


### PR DESCRIPTION
# Summary
- When renaming a pipeline, transfer existing triggers, backfills, pipeline runs, and block runs (blocks already transferred currently).
- Prevent users from renaming pipeline to a name already in use by another pipeline.

# Tests
- Added unit tests.
- Renaming a pipeline with an existing pipeline name:
![pipeline name taken](https://user-images.githubusercontent.com/78053898/223574648-04fa5405-db32-4e99-97be-732aac87490a.gif)
- Renaming pipeline:
![renaming pipeline](https://user-images.githubusercontent.com/78053898/223577341-109925d9-cdaf-4348-b96b-b11499aae959.gif)
