### PR TITLE
[td] Fix MongoDB type and overflow errors

### DIFF
--- a/mage_ai/data_preparation/models/utils.py
+++ b/mage_ai/data_preparation/models/utils.py
@@ -9,21 +9,26 @@ JSON_SERIALIZABLE_COLUMN_TYPES = [
     dict.__name__,
     list.__name__,
 ]
+STRING_SERIALIZABLE_COLUMN_TYPES = [
+    'ObjectId',
+]
 
 
 def serialize_columns(row: pd.Series, column_types: Dict) -> pd.Series:
     for column, column_type in column_types.items():
-        if column_type not in JSON_SERIALIZABLE_COLUMN_TYPES:
-            continue
-
-        val = row[column]
-        if val is not None:
-            row[column] = simplejson.dumps(
-                val,
-                default=encode_complex,
-                ignore_nan=True,
-                use_decimal=True,
-            )
+        if column_type in JSON_SERIALIZABLE_COLUMN_TYPES:
+            val = row[column]
+            if val is not None:
+                row[column] = simplejson.dumps(
+                    val,
+                    default=encode_complex,
+                    ignore_nan=True,
+                    use_decimal=True,
+                )
+        elif column_type in STRING_SERIALIZABLE_COLUMN_TYPES:
+            val = row[column]
+            if val is not None:
+                row[column] = str(val)
 
     return row
 

--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -156,7 +156,7 @@ def __custom_output():
     ):
         _sample = _internal_output_return.iloc[:{DATAFRAME_SAMPLE_COUNT_PREVIEW}]
         _columns = _sample.columns.tolist()[:{DATAFRAME_ANALYSIS_MAX_COLUMNS}]
-        _rows = json.loads(_sample[_columns].to_json(orient='split'))['data']
+        _rows = json.loads(_sample[_columns].to_json(default_handler=str, orient='split'))['data']
         _shape = _internal_output_return.shape
         _index = _sample.index.tolist()
 


### PR DESCRIPTION
# Summary
- Fixes `OverflowError: Overlong 2 byte UTF-8 sequence detected when encoding string`
- Fixes `ObjectId` not being serializable