### PR TITLE
[jk] Add more messaging around how to configure pasting

### DIFF
--- a/mage_ai/frontend/components/Terminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/index.tsx
@@ -242,7 +242,7 @@ function Terminal({
     For Safari, users need to allow the clipboard paste by clicking "Paste" \
 in the context menu that appears.`),
                 );
-            } else {
+            } else if (navigator?.clipboard?.read) {
               navigator.clipboard.read()
                 .then(clipboardItems => {
                   for (const clipboardItem of clipboardItems) {
@@ -258,6 +258,17 @@ in the context menu that appears.`),
     For Firefox, users need to allow clipboard paste by setting the "dom.events.asyncClipboard.read" \
 preference in "about:config" to "true" and clicking "Paste" in the context menu that appears.`),
                 );
+            } else {
+              alert(`If pasting is not working properly, you may need to adjust some settings in your browser.
+
+    For Firefox, users need to allow clipboard paste by setting both the "dom.events.asyncClipboard.clipboardItem" \
+and "dom.events.asyncClipboard.read" preferences in "about:config" to "true" and clicking "Paste" in the context \
+menu that appears.
+    For Chrome, users need to allow clipboard permissions for this site under \
+"Privacy and security" -> "Site settings".
+    For Safari, users need to allow the clipboard paste by clicking "Paste" \
+in the context menu that appears.
+`);
             }
           } else if (!keyMapping[KEY_CODE_META] && !keyMapping[KEY_CODE_CONTROL] && key.length === 1) {
             setCommand(prev => prev.slice(0, cursorIndex) + key + prev.slice(cursorIndex));


### PR DESCRIPTION
# Summary
- Paste error was occurring in Firefox browsers when users didn't have certain browser settings enabled. Added details to alert to inform users how to enable these settings.

# Tests
- Was able to recreate user's error (`navigator.clipboard.read is not a function`) and resolved it.
- New alert: ![image](https://user-images.githubusercontent.com/78053898/224122950-fbb59d20-a4a1-4cde-be17-6c7636696585.png)
