### PR TITLE
[dy] Update block run status logic

### DIFF
--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -323,10 +323,19 @@ class PipelineScheduler:
 
     @property
     def executable_block_runs(self) -> List[BlockRun]:
+        completed_block_uuids = set(b.block_uuid for b in self.completed_block_runs)
+        finished_block_uuids = set(
+            b.block_uuid for b in self.pipeline_run.block_runs
+            if b.status in [
+                BlockRun.BlockRunStatus.COMPLETED,
+                BlockRun.BlockRunStatus.UPSTREAM_FAILED,
+                BlockRun.BlockRunStatus.FAILED,
+            ]
+        )
+
         executable_block_runs = list()
         for block_run in self.initial_block_runs:
             completed = False
-            completed_block_uuids = set(b.block_uuid for b in self.completed_block_runs)
 
             dynamic_upstream_block_uuids = block_run.metrics and block_run.metrics.get(
                 'dynamic_upstream_block_uuids',
@@ -334,16 +343,11 @@ class PipelineScheduler:
 
             if dynamic_upstream_block_uuids:
                 if self.allow_blocks_to_fail:
-                    completed_block_uuids = [
-                        b.block_uuid for b in self.pipeline_run.block_runs
-                        if b.status in [
-                            BlockRun.BlockRunStatus.COMPLETED,
-                            BlockRun.BlockRunStatus.UPSTREAM_FAILED,
-                            BlockRun.BlockRunStatus.FAILED,
-                        ]
-                    ]
-                completed = all(uuid in completed_block_uuids
-                                for uuid in dynamic_upstream_block_uuids)
+                    completed = all(uuid in finished_block_uuids
+                                    for uuid in dynamic_upstream_block_uuids)
+                else:
+                    completed = all(uuid in completed_block_uuids
+                                    for uuid in dynamic_upstream_block_uuids)
             else:
                 block = self.pipeline.get_block(block_run.block_uuid)
                 completed = block is not None and \
@@ -354,16 +358,17 @@ class PipelineScheduler:
 
         return executable_block_runs
 
-    def __update_block_run_statuses(self) -> None:
-        failed_block_uuids = [
+    def __update_block_run_statuses(self, block_runs: List[BlockRun]) -> None:
+        failed_block_uuids = set(
             b.block_uuid for b in self.pipeline_run.block_runs
             if b.status in [
                 BlockRun.BlockRunStatus.UPSTREAM_FAILED,
                 BlockRun.BlockRunStatus.FAILED,
             ]
-        ]
-        updated_status = False
-        for block_run in self.initial_block_runs:
+        )
+        not_updated_block_runs = []
+        for block_run in block_runs:
+            updated_status = False
             dynamic_upstream_block_uuids = block_run.metrics and block_run.metrics.get(
                 'dynamic_upstream_block_uuids',
             )
@@ -386,13 +391,16 @@ class PipelineScheduler:
                         status=BlockRun.BlockRunStatus.UPSTREAM_FAILED)
                     updated_status = True
 
+            if not updated_status:
+                not_updated_block_runs.append(block_run)
+
         self.pipeline_run.refresh()
         # keep iterating through block runs until no more updates can be made
-        if updated_status:
-            self.__update_block_run_statuses()
+        if len(block_runs) != len(not_updated_block_runs):
+            self.__update_block_run_statuses(not_updated_block_runs)
 
     def __schedule_blocks(self, block_runs: List[BlockRun] = None) -> None:
-        self.__update_block_run_statuses()
+        self.__update_block_run_statuses(self.initial_block_runs)
         block_runs_to_schedule = \
             self.executable_block_runs if block_runs is None else block_runs
         block_runs_to_schedule = \

--- a/mage_ai/tests/factory.py
+++ b/mage_ai/tests/factory.py
@@ -34,6 +34,28 @@ def create_pipeline_with_blocks(name: str, repo_path: str):
     return pipeline
 
 
+def create_pipeline_with_dynamic_blocks(name: str, repo_path: str):
+    pipeline = Pipeline.create(
+        name,
+        repo_path=repo_path,
+    )
+    block1 = Block.create(
+        'block1',
+        'data_loader',
+        repo_path,
+        language='python',
+        configuration=dict(dynamic=True),
+    )
+    block2 = Block.create(
+        'block2', 'transformer', repo_path, language='python')
+    block3 = Block.create(
+        'block3', 'data_exporter', repo_path, language='python')
+    pipeline.add_block(block1)
+    pipeline.add_block(block2, upstream_block_uuids=['block1'])
+    pipeline.add_block(block3, upstream_block_uuids=['block2'])
+    return pipeline
+
+
 def create_pipeline_run(pipeline_uuid: str):
     pipeline_run = PipelineRun.create(pipeline_uuid='test_pipeline')
     return pipeline_run


### PR DESCRIPTION
# Summary

Update `allow_block_to_fail` logic for pipelines that have dynamic blocks. A block with upstream dynamic blocks will only not run if *all* of the upstream dynamic blocks failed.
<!-- Brief summary of what your code does -->

# Tests

tested locally. added some dynamic block unit tests, but it's hard to mock everything that happens for the dynamic blocks :(
<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
