### PR TITLE
fix failure to obtain numpy array type from dataframe

### DIFF
--- a/mage_ai/data_preparation/models/variable.py
+++ b/mage_ai/data_preparation/models/variable.py
@@ -399,9 +399,9 @@ class Variable:
                         # df_output[c] = series_non_null.astype(str)
                         pass
 
-                colNotNumpyType = coltype.__module__ != np.__name__
-                colIsNumpyArrayType = coltype.__name__ == np.ndarray.__name__
-                if colNotNumpyType or colIsNumpyArrayType:
+                col_not_numpy_type = coltype.__module__ != np.__name__
+                col_is_numpy_array_type = coltype.__name__ == np.ndarray.__name__
+                if col_not_numpy_type or col_is_numpy_array_type:
                     column_types[c] = coltype.__name__
                 else:
                     column_types[c] = type(series_non_null.iloc[0].item()).__name__

--- a/mage_ai/data_preparation/models/variable.py
+++ b/mage_ai/data_preparation/models/variable.py
@@ -399,10 +399,12 @@ class Variable:
                         # df_output[c] = series_non_null.astype(str)
                         pass
 
-                if coltype.__module__ == np.__name__:
-                    column_types[c] = type(series_non_null.iloc[0].item()).__name__
-                else:
+                colNotNumpyType = coltype.__module__ != np.__name__
+                colIsNumpyArrayType = coltype.__name__ == np.ndarray.__name__
+                if colNotNumpyType or colIsNumpyArrayType:
                     column_types[c] = coltype.__name__
+                else:
+                    column_types[c] = type(series_non_null.iloc[0].item()).__name__
 
         self.storage.makedirs(self.variable_path, exist_ok=True)
 


### PR DESCRIPTION
# Summary
Issue: Failure to load s3 parquet file
Root Cause: dataframe loaded contains columns that are of `numpy.ndarray` type, resulting in the following error
```
File /usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/models/variable.py:399, in Variable.__write_parquet(self, data)

    396         pass

    398 if coltype.__module__ == np.__name__:

--> 399     column_types[c] = type(series_non_null.iloc[0].item()).__name__

    400 else:

    401     column_types[c] = coltype.__name__


ValueError: can only convert an array of size 1 to a Python scalar
```
fix: add conditional checking of `numpy.ndarray` column type

# Tests
local tests
