### PR TITLE
[xy] Mask env var values with stars in terminal output

### DIFF
--- a/mage_ai/server/websocket_server.py
+++ b/mage_ai/server/websocket_server.py
@@ -39,6 +39,7 @@ from mage_ai.server.utils.output_display import (
 )
 from mage_ai.settings import (
     DISABLE_NOTEBOOK_EDIT_ACCESS,
+    HIDE_ENV_VAR_VALUES,
     REQUIRE_USER_AUTHENTICATION,
 )
 from mage_ai.shared.hash import merge_dict
@@ -261,7 +262,7 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
             return False
 
         def filter_out_sensitive_data(message):
-            if not message.get('data'):
+            if not message.get('data') or not HIDE_ENV_VAR_VALUES:
                 return message
             data = message['data']
             if type(data) is str:

--- a/mage_ai/settings/__init__.py
+++ b/mage_ai/settings/__init__.py
@@ -2,6 +2,7 @@ import os
 
 
 DEBUG = os.getenv('DEBUG', False)
+HIDE_ENV_VAR_VALUES = int(os.getenv('HIDE_ENV_VAR_VALUES', 1) or 1) == 1
 QUERY_API_KEY = 'api_key'
 
 """

--- a/mage_ai/shared/security.py
+++ b/mage_ai/shared/security.py
@@ -1,0 +1,14 @@
+import os
+
+MIN_SECRET_ENV_VAR_LENGTH = 5
+
+
+def filter_out_env_var_values(value: str):
+    env_var_values = dict(os.environ).values()
+    env_var_values = [v for v in env_var_values if v and len(v) >= MIN_SECRET_ENV_VAR_LENGTH]
+    env_var_values.sort(key=len, reverse=True)
+    value_clean = value
+    for env_var_value in env_var_values:
+        replace_value = '*' * len(env_var_value)
+        value_clean = value_clean.replace(env_var_value, replace_value)
+    return value_clean

--- a/mage_ai/tests/shared/test_security.py
+++ b/mage_ai/tests/shared/test_security.py
@@ -1,0 +1,23 @@
+from mage_ai.shared.security import filter_out_env_var_values
+from mage_ai.tests.base_test import TestCase
+from unittest.mock import patch
+import os
+
+
+MOCK_ENV_VARS = {
+    'VAR1': '123',
+    'VAR2': '45678',
+    'VAR3': 'abcdefg',
+    'VAR4': '',
+}
+
+
+class SecurityTests(TestCase):
+    @patch.dict(os.environ, MOCK_ENV_VARS)
+    def test_filter_out_env_var_values(self):
+        value1 = filter_out_env_var_values('12345678abcdefghij')
+        value2 = filter_out_env_var_values('testdata')
+        value3 = filter_out_env_var_values('test45645678')
+        self.assertEqual(value1, '123************hij')
+        self.assertEqual(value2, 'testdata')
+        self.assertEqual(value3, 'test456*****')


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
For env var values that have length larger than 5, we mask the values with `***` in the terminal and block output.

Setting `HIDE_ENV_VAR_VALUES` to 1 (default value) to enable this feature. Setting it to 0 to disable the feature.

# Tests
<!-- How did you test your change? -->
tested locally
<img width="838" alt="image" src="https://user-images.githubusercontent.com/80284865/225155388-c004f47c-b6c8-40af-be6d-43433478bb4e.png">


cc:
<!-- Optionally mention someone to let them know about this pull request -->
