### PR TITLE
[xy] Use RotatingFileHandler for logs.

### DIFF
--- a/mage_ai/data_preparation/logging/logger_manager.py
+++ b/mage_ai/data_preparation/logging/logger_manager.py
@@ -7,6 +7,8 @@ import io
 import logging
 import os
 
+MAX_LOG_FILE_SIZE = 5 * 1024 * 1024
+
 
 class LoggerManager:
     def __init__(
@@ -50,7 +52,11 @@ class LoggerManager:
                 handler = self.create_stream_handler()
             else:
                 log_filepath = self.get_log_filepath(create_dir=True)
-                handler = logging.FileHandler(log_filepath)
+                handler = logging.RotatingFileHandler(
+                    log_filepath,
+                    backupCount=10,
+                    maxBytes=MAX_LOG_FILE_SIZE,
+                )
 
             handler.setLevel(self.log_level)
             handler.setFormatter(self.formatter)

--- a/mage_ai/data_preparation/logging/logger_manager.py
+++ b/mage_ai/data_preparation/logging/logger_manager.py
@@ -52,7 +52,7 @@ class LoggerManager:
                 handler = self.create_stream_handler()
             else:
                 log_filepath = self.get_log_filepath(create_dir=True)
-                handler = logging.RotatingFileHandler(
+                handler = logging.handlers.RotatingFileHandler(
                     log_filepath,
                     backupCount=10,
                     maxBytes=MAX_LOG_FILE_SIZE,


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Use RotatingFileHandler for logs so that the log file doesn't get very big.
https://docs.python.org/3/library/logging.handlers.html#rotatingfilehandler

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
