### PR TITLE
[jk] Truncate messages in pipeline execution to prevent app freezing

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/PipelineExecution/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/PipelineExecution/index.tsx
@@ -41,6 +41,9 @@ function PipelineExecution({
   setPipelineExecutionHidden,
 }: PipelineExecutionProps) {
   const numberOfMessages = useMemo(() => pipelineMessages?.length || 0, [pipelineMessages]);
+  const truncatedPipelineMessages = useMemo(() => (
+    numberOfMessages > 100 ? pipelineMessages.slice(-100) : pipelineMessages
+  ), [numberOfMessages, pipelineMessages]);
 
   const togglePipelineExecution = useCallback(() => {
     const val = !pipelineExecutionHidden;
@@ -108,7 +111,7 @@ function PipelineExecution({
               hasError={false}
               selected
             >
-              {pipelineMessages.map(({
+              {truncatedPipelineMessages.map(({
                 data: dataInit,
                 type: dataType,
               }: KernelOutputType, idx: number) => {


### PR DESCRIPTION
# Summary
- When clicking `Execute pipeline` in Pipeline Editor, the output is limited to rendering 100 messages to mitigate app performance issues.

# Tests
Local
