### PR TITLE
[dy] Update notebook error display

### DIFF
--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -266,7 +266,6 @@ from mage_ai.shared.array import find
 import datetime
 import json
 import pandas as pd
-import traceback
 
 
 db_connection.start_session()

--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -266,6 +266,7 @@ from mage_ai.shared.array import find
 import datetime
 import json
 import pandas as pd
+import traceback
 
 
 db_connection.start_session()

--- a/mage_ai/server/websocket_server.py
+++ b/mage_ai/server/websocket_server.py
@@ -46,7 +46,7 @@ from mage_ai.shared.hash import merge_dict
 from mage_ai.shared.security import filter_out_env_var_values
 from mage_ai.utils.code import reload_all_repo_modules
 from jupyter_client import KernelClient
-from typing import Dict
+from typing import Dict, List
 import asyncio
 import json
 import multiprocessing
@@ -289,6 +289,10 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
         block_type = msg_id_value.get('block_type')
         block_uuid = msg_id_value.get('block_uuid')
         pipeline_uuid = msg_id_value.get('pipeline_uuid')
+        
+        error = message.get('error')
+        if error:
+            message['data'] = error[0:1] + error[-2:]
 
         output_dict = dict(
             block_type=block_type,
@@ -484,6 +488,12 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
 
             task = asyncio.create_task(check_for_messages())
             set_current_message_task(task)
+
+    # def __format_error(error: List[str]) -> List[str]:
+    #     for line in error:
+    #         if line 
+    #         print(line)
+    #     return error[0:1] + error[-2:]
 
 
 class StreamBlockOutputToQueue(object):


### PR DESCRIPTION
# Summary

Add some regex to remove the `Block` specific parts of the stack trace to reduce the amount of useless information in the output. It works the best on standard blocks, and doesn't completely remove the mage specific error logging for sql and dbt blocks, but it does reduce the clutter.
<!-- Brief summary of what your code does -->

# Tests

tested on normal blocks, sql blocks, and dbt blocks. 

for normal blocks:

before:
![Screenshot 2023-03-20 at 5 31 17 PM](https://user-images.githubusercontent.com/14357209/226493901-6cd1b697-5358-4f58-9a0f-2b80703139d1.png)

after: 
![Screenshot 2023-03-20 at 5 29 53 PM](https://user-images.githubusercontent.com/14357209/226493907-d91ab503-9a7b-4bd2-bc93-4b88cce9a838.png)


<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
