### PR TITLE
[xy] Fix Snowflake destination column comparison and escape quote

### DIFF
--- a/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
@@ -31,6 +31,7 @@ def convert_array(value, column_settings):
         elif is_number(val_str):
             return val_str
         else:
+            val_str = val_str.replace("'", "\\'")
             return f"'{val_str}'"
 
     if type(value) is list and value:

--- a/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
@@ -130,7 +130,14 @@ WHERE TABLE_SCHEMA = '{schema_name}' AND TABLE_NAME ILIKE '%{table_name}%'
         results = self.build_connection().load(query)
         current_columns = [r[0].lower() for r in results]
         schema_columns = schema['properties'].keys()
-        new_columns = [c for c in schema_columns if clean_column_name(c) not in current_columns]
+
+        def format_col_name(col_name: str):
+            if self.disable_double_quotes and col_name:
+                return col_name.upper()
+            return col_name
+
+        new_columns = [c for c in schema_columns
+                       if format_col_name(clean_column_name(c)) not in current_columns]
 
         if not new_columns:
             return []

--- a/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
@@ -11,12 +11,12 @@ from mage_integrations.destinations.snowflake.utils import (
 )
 from mage_integrations.destinations.sql.base import Destination, main
 from mage_integrations.destinations.sql.utils import (
+    clean_column_name,
     build_create_table_command,
     build_insert_command,
     column_type_mapping,
     convert_column_to_type,
 )
-from mage_integrations.destinations.utils import clean_column_name
 from mage_integrations.utils.array import batch
 from mage_integrations.utils.strings import is_number
 from typing import Dict, List, Tuple


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
* Fix Snowflake destination column comparison when alter table
    * Use uppercase if disable_double_quotes is True
* Use correct `clean_column_name` method
* Escape single quote when converting array values.

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
