### PR TITLE
[jk] Fix disappearing upstream connections when running block in editor

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -688,6 +688,7 @@ function CodeBlock({
       <CodeEditor
         autoHeight
         autocompleteProviders={autocompleteProviders}
+        block={block}
         height={height}
         language={block.language}
         onChange={(val: string) => {
@@ -706,6 +707,10 @@ function CodeBlock({
           (monaco, editor) => executeCode(monaco, () => {
             if (!hideRunButton) {
               runBlockAndTrack({
+                /*
+                 * This block doesn't get updated when the upstream dependencies change,
+                 * so we need to update the shortcuts in the CodeEditor component.
+                 */
                 block,
                 code: editor.getValue(),
               });

--- a/mage_ai/frontend/components/CodeEditor/index.tsx
+++ b/mage_ai/frontend/components/CodeEditor/index.tsx
@@ -6,6 +6,8 @@ import React, {
 } from 'react';
 import * as ReactDOM from 'react-dom';
 import Editor from '@monaco-editor/react';
+
+import BlockType from '@interfaces/BlockType';
 import Text from '@oracle/elements/Text';
 import usePrevious from '@utils/usePrevious';
 import {
@@ -50,6 +52,7 @@ type CodeEditorProps = {
   autocompleteProviders?: ProvidersType;
   autoHeight?: boolean;
   autoSave?: boolean;
+  block?: BlockType;
   fontSize?: number;
   language?: string;
   onChange?: (value: string) => void;
@@ -57,7 +60,7 @@ type CodeEditorProps = {
   padding?: boolean;
   placeholder?: string;
   readOnly?: boolean;
-  shortcuts?: ((monaco: any, editor: any) => void)[];
+  shortcuts?: ((monaco: any, editor: any, block?: BlockType) => void)[];
   showLineNumbers?: boolean;
   tabSize?: number;
   theme?: any;
@@ -69,6 +72,7 @@ function CodeEditor({
   autocompleteProviders,
   autoHeight,
   autoSave,
+  block,
   fontSize = DEFAULT_FONT_SIZE,
   height,
   language,
@@ -96,7 +100,6 @@ function CodeEditor({
   const [completionDisposable, setCompletionDisposable] = useState([]);
   const [monacoInstance, setMonacoInstance] = useState(null);
   const [mounted, setMounted] = useState<boolean>(false);
-  const [heightOfContent, setHeightOfContent] = useState(height);
   const [theme, setTheme] = useState(themeProp || DEFAULT_THEME);
 
   const handleEditorWillMount = useCallback((monaco) => {
@@ -240,6 +243,23 @@ function CodeEditor({
     textareaFocused,
     textareaFocusedPrevious,
   ]);
+
+  useEffect(() => {
+    if (monacoRef?.current && editorRef?.current) {
+      const shortcuts = [];
+      shortcutsProp?.forEach((func) => {
+        shortcuts.push(func(monacoRef?.current, editorRef?.current));
+      });
+      addKeyboardShortcut(monacoRef?.current, editorRef?.current, shortcuts);
+    }
+  /*
+   * The original block scope when the component was mounted is retained in the
+   * shortcuts unless we re-add them when the block connections change. For example,
+   * if a block originally had 1 upstream dependency but we add an additional dependency
+   * and then try to execute the block via editor shortcut, the code execution only includes
+   * the initial single upstream dependency because the shortcut's scope doesn't change.
+   */
+  }, [block?.downstream_blocks, block?.upstream_blocks]);
 
   useEffect(
     () => () => {

--- a/mage_ai/frontend/components/CodeEditor/index.tsx
+++ b/mage_ai/frontend/components/CodeEditor/index.tsx
@@ -60,7 +60,7 @@ type CodeEditorProps = {
   padding?: boolean;
   placeholder?: string;
   readOnly?: boolean;
-  shortcuts?: ((monaco: any, editor: any, block?: BlockType) => void)[];
+  shortcuts?: ((monaco: any, editor: any) => void)[];
   showLineNumbers?: boolean;
   tabSize?: number;
   theme?: any;

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -452,6 +452,7 @@ function PipelineDetail({
     fetchPipeline,
     interruptKernel,
     isIntegration,
+    isStreaming,
     mainContainerRef,
     mainContainerWidth,
     messages,

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -58,7 +58,6 @@ import {
   SpecialFileEnum,
 } from '@interfaces/FileType';
 import {
-  SIDEKICK_VIEWS,
   VIEW_QUERY_PARAM,
   ViewKeyEnum,
 } from '@components/Sidekick/constants';
@@ -104,7 +103,6 @@ function PipelineDetailPage({
   const [recentlyAddedChart, setRecentlyAddedChart] = useState(null);
   const [selectedFilePath, setSelectedFilePath] = useState<string>(null);
   const [selectedFilePaths, setSelectedFilePaths] = useState<string[]>([]);
-  const [showAddCharts, setShowAddCharts] = useState<boolean>(false);
   const [filesTouched, setFilesTouched] = useState<{
     [filePath: string]: boolean;
   }>({});
@@ -144,7 +142,6 @@ function PipelineDetailPage({
   });
   const { data: filesData, mutate: fetchFileTree } = api.files.list();
   const files = useMemo(() => filesData?.files || [], [filesData]);
-  const projectName = useMemo(() => files?.[0]?.name, [files]);
   const pipeline = data?.pipeline;
 
   const isIntegration = useMemo(() => PipelineTypeEnum.INTEGRATION === pipeline?.type, [pipeline]);
@@ -200,7 +197,6 @@ function PipelineDetailPage({
     setAfterHidden(false);
   }, [setActiveSidekickView]);
 
-  const refAddChart = useRef(null);
   const blockRefs = useRef({});
   const chartRefs = useRef({});
   const callbackByBlockUUID = useRef({});
@@ -483,7 +479,10 @@ function PipelineDetailPage({
     {
       onSuccess: (response: any) => onSuccess(
         response, {
-          callback: () => setPipelineContentTouched(false),
+          callback: () => {
+            setPipelineContentTouched(false);
+            fetchPipeline();
+          },
           onErrorCallback: (response, errors) => setErrors({
             errors,
             response,
@@ -591,12 +590,12 @@ function PipelineDetailPage({
       }
 
       if (contentOnly) {
-        return {
+        return blocksToSave.push({
           callback_content: blockPayload.callback_content,
           content: blockPayload.content,
           outputs: blockPayload.outputs,
           uuid: blockPayload.uuid,
-        };
+        });
       }
 
       if ([BlockTypeEnum.EXTENSION].includes(type)) {
@@ -1271,7 +1270,6 @@ function PipelineDetailPage({
     blocks,
     blocksPrevious,
     pipeline?.blocks,
-    setBlocks,
     setMessages,
   ]);
 
@@ -1290,7 +1288,6 @@ function PipelineDetailPage({
     }
   }, [
     pipeline?.widgets,
-    setBlocks,
     setMessages,
     widgets,
   ]);


### PR DESCRIPTION
# Summary
- Update code editor keyboard shortcut (i.e. execute code) block dependencies when they change. There was an issue with the original block being run with outdated upstream dependencies when using the code editor keyboard shortcut (not to be confused with the custom app keyboard shortcuts).

# Tests
Before (upstream dependency not updated when running a block, so block is run without new upstream dependency and is removed):
![running block BEFORE](https://user-images.githubusercontent.com/78053898/226998450-fb0e9e77-644c-49be-8845-97b9ecbffa28.gif)

After (blocks are run with upstream dependencies as expected):
![running block with updated shortcut](https://user-images.githubusercontent.com/78053898/226998546-7b1625bd-0163-460f-a5b4-873f7aca8180.gif)
