### PR TITLE
[xy] Fix Outreach rate limit issue

### DIFF
--- a/mage_integrations/mage_integrations/sources/outreach/__init__.py
+++ b/mage_integrations/mage_integrations/sources/outreach/__init__.py
@@ -27,7 +27,7 @@ class Outreach(Source):
         return Catalog(catalog_entries)
 
     def sync(self, catalog: Catalog) -> None:
-        with OutreachClient(self.config) as client:
+        with OutreachClient(self.config, logger=self.logger) as client:
             check_auth(client)
             sync(
                 client,

--- a/mage_integrations/mage_integrations/sources/outreach/tap_outreach/client.py
+++ b/mage_integrations/mage_integrations/sources/outreach/tap_outreach/client.py
@@ -21,7 +21,7 @@ class RateLimitError(Exception):
 class OutreachClient(object):
     BASE_URL = 'https://api.outreach.io/api/v2/'
 
-    def __init__(self, config):
+    def __init__(self, config, logger=LOGGER):
         self.__user_agent = config.get('user_agent')
         self.__client_id = config.get('client_id')
         self.__client_secret = config.get('client_secret')
@@ -31,6 +31,7 @@ class OutreachClient(object):
         self.__access_token = None
         self.__expires_at = None
         self.__session = requests.Session()
+        self.logger = logger
 
     def __enter__(self):
         return self
@@ -58,11 +59,14 @@ class OutreachClient(object):
                       10)  # pad by 10 seconds for clock drift
 
     def sleep_for_reset_period(self, response):
-        reset = datetime.fromtimestamp(
-            int(response.headers['x-ratelimit-reset']))
-        sleep_time = (reset - datetime.now()).total_seconds() + \
-            10  # pad for clock drift/sync issues
-        LOGGER.warn(
+        if response.headers.get('x-ratelimit-reset'):
+            reset = datetime.fromtimestamp(
+                int(response.headers['x-ratelimit-reset']))
+            sleep_time = (reset - datetime.now()).total_seconds() + 10
+        else:
+            self.logger.warn('Key x-ratelimit-reset is not in response header.')
+            sleep_time = 30
+        self.logger.warn(
             'Sleeping for {:.2f} seconds for next rate limit window'.format(sleep_time))
         time.sleep(sleep_time)
 
@@ -104,7 +108,7 @@ class OutreachClient(object):
             raise Server5xxError(response.text)
 
         if response.status_code == 429:
-            LOGGER.warn('Rate limit hit - 429')
+            self.logger.warn('Rate limit hit - 429')
             self.sleep_for_reset_period(response)
             raise RateLimitError()
 
@@ -115,7 +119,7 @@ class OutreachClient(object):
             quota_used = 1 - int(response.headers['x-ratelimit-remaining']) / \
                 int(response.headers['x-ratelimit-remaining'])
             if quota_used > float(self.__quota_limit):
-                LOGGER.warn(
+                self.logger.warn(
                     'Quota used: {:.2f} / {}'.format(quota_used, self.__quota_limit))
                 self.sleep_for_reset_period(response)
 

--- a/mage_integrations/mage_integrations/sources/outreach/tap_outreach/client.py
+++ b/mage_integrations/mage_integrations/sources/outreach/tap_outreach/client.py
@@ -64,9 +64,9 @@ class OutreachClient(object):
                 int(response.headers['x-ratelimit-reset']))
             sleep_time = (reset - datetime.now()).total_seconds() + 10
         else:
-            self.logger.warn('Key x-ratelimit-reset is not in response header.')
+            self.logger.info('Key x-ratelimit-reset is not in response header.')
             sleep_time = 30
-        self.logger.warn(
+        self.logger.info(
             'Sleeping for {:.2f} seconds for next rate limit window'.format(sleep_time))
         time.sleep(sleep_time)
 
@@ -108,7 +108,7 @@ class OutreachClient(object):
             raise Server5xxError(response.text)
 
         if response.status_code == 429:
-            self.logger.warn('Rate limit hit - 429')
+            self.logger.info('Rate limit hit - 429')
             self.sleep_for_reset_period(response)
             raise RateLimitError()
 
@@ -119,7 +119,7 @@ class OutreachClient(object):
             quota_used = 1 - int(response.headers['x-ratelimit-remaining']) / \
                 int(response.headers['x-ratelimit-remaining'])
             if quota_used > float(self.__quota_limit):
-                self.logger.warn(
+                self.logger.info(
                     'Quota used: {:.2f} / {}'.format(quota_used, self.__quota_limit))
                 self.sleep_for_reset_period(response)
 


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Fix Outreach rate limit issue

Error
```
  File \"/usr/local/lib/python3.10/site-packages/mage_integrations/sources/outreach/tap_outreach/client.py\", line 62, in sleep_for_reset_period

    int(response.headers['x-ratelimit-reset']))

  File \"/usr/local/lib/python3.10/site-packages/requests/structures.py\", line 54, in __getitem__

    return self._store[key.lower()][1]

KeyError: 'x-ratelimit-reset'
```

# Tests
<!-- How did you test your change? -->
tested with outreach source

cc:
<!-- Optionally mention someone to let them know about this pull request -->
