### PR TITLE
[jk] Use correct content for new non-SQL block added between blocks

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -1781,7 +1781,6 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')`;
                   content = addScratchpadNote(newBlock, content);
 
                   if (BlockLanguageEnum.SQL === block.language) {
-                    content = addSqlBlockNote(content);
                     configuration = {
                       ...selectKeys(block.configuration, [
                         CONFIG_KEY_DATA_PROVIDER,
@@ -1792,6 +1791,9 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')`;
                       ]),
                       ...configuration,
                     };
+                  }
+                  if (BlockLanguageEnum.SQL === newBlock.language) {
+                    content = addSqlBlockNote(content);
                   }
 
                   return addNewBlock({

--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/utils.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/utils.tsx
@@ -201,6 +201,7 @@ export const createColorMenuItems = (
         </Text>
       </FlexContainer>
     ),
+    leftAligned: true,
     onClick: () => {
       addNewBlock({
         color,

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -32,6 +32,7 @@ export type FlyoutMenuItemType = {
   keyTextGroups?: NumberOrString[][];
   keyboardShortcutValidation?: (ks: KeyboardShortcutType, index?: number) => boolean;
   label: () => string | any;
+  leftAligned?: boolean;
   linkProps?: {
     as?: string;
     href: string;
@@ -185,6 +186,7 @@ function FlyoutMenu({
           isGroupingTitle,
           keyTextGroups,
           label,
+          leftAligned,
           linkProps,
           onClick,
           openConfirmationDialogue,
@@ -255,7 +257,7 @@ function FlyoutMenu({
               <FlexContainer
                 alignItems="center"
                 fullWidth
-                justifyContent="space-between"
+                justifyContent={leftAligned ? 'flex-start' : 'space-between'}
               >
                 <Flex alignItems="center">
                   {beforeIcon &&


### PR DESCRIPTION
# Summary
- Fix issue with SQL block content being used for new non-SQL blocks.
- Left-align items in flyout menu when adding new custom block.

# Tests
![adding between blocks](https://user-images.githubusercontent.com/78053898/227044037-6a5c473c-147f-4a10-bf37-9dabc053fbca.gif)
