### PR TITLE
[jk] Increase dependency graph canvas size

### DIFF
--- a/mage_ai/frontend/components/DependencyGraph/constants.ts
+++ b/mage_ai/frontend/components/DependencyGraph/constants.ts
@@ -5,6 +5,7 @@ import BlockType, {
 import { UNIT } from '@oracle/styles/units/spacing';
 
 export const MIN_NODE_WIDTH = UNIT * 20;
+export const ZOOMABLE_CANVAS_SIZE = 5200;
 
 export const SHARED_PORT_PROPS = {
   height: 10,

--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -28,7 +28,9 @@ import {
   NodeType,
   PortType,
   SideEnum,
-  SHARED_PORT_PROPS } from './constants';
+  SHARED_PORT_PROPS,
+  ZOOMABLE_CANVAS_SIZE,
+} from './constants';
 import { GraphContainerStyle } from './index.style';
 import { RunStatus } from '@interfaces/BlockRunType';
 import { ThemeType } from '@oracle/styles/themes/constants';
@@ -580,6 +582,8 @@ function DependencyGraph({
           }}
           edges={edges}
           fit
+          maxHeight={ZOOMABLE_CANVAS_SIZE}
+          maxWidth={ZOOMABLE_CANVAS_SIZE}
           node={(node) => (
             <Node
               {...node}


### PR DESCRIPTION
# Summary
- Increase canvas size for dependency graph to allow 60+ blocks to be visible.

# Tests
![increased canvas size](https://user-images.githubusercontent.com/78053898/227052391-8b7e94e4-2c44-4746-b599-92322e0c65c7.gif)
