### PR TITLE
[jk] Fix tooltip spacing in runs charts

### DIFF
--- a/mage_ai/frontend/components/Monitor/constants.ts
+++ b/mage_ai/frontend/components/Monitor/constants.ts
@@ -3,3 +3,5 @@ export enum MonitorTypeEnum {
   BLOCK_RUNTIME = 'block_runtime',
   PIPELINE_RUNS = 'pipeline_runs',
 }
+
+export const TOOLTIP_LEFT_OFFSET = -50;

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/monitors/block-runs.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/monitors/block-runs.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useState } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import moment from 'moment';
 import { ThemeContext } from 'styled-components';
 
@@ -11,16 +11,13 @@ import PipelineType from '@interfaces/PipelineType';
 import PrivateRoute from '@components/shared/PrivateRoute';
 import Select from '@oracle/elements/Inputs/Select';
 import Spacing from '@oracle/elements/Spacing';
-import api, { MONITOR_STATS } from '@api';
-import buildUrl from '@api/utils/url';
+import api from '@api';
 import dark from '@oracle/styles/themes/dark';
 import { BAR_STACK_COLORS, BAR_STACK_STATUSES } from '.';
 import { ICON_SIZE } from '@components/FileBrowser/index.style';
-import { MonitorTypeEnum } from '@components/Monitor/constants';
+import { MonitorTypeEnum, TOOLTIP_LEFT_OFFSET } from '@components/Monitor/constants';
 import { getColorsForBlockType } from '@components/CodeBlock/index.style';
 import { indexBy } from '@utils/array';
-import { onSuccess } from '@api/utils/response';
-import { useMutation } from 'react-query';
 
 type BlockRunsMonitorProps = {
   pipeline: PipelineType;
@@ -110,9 +107,7 @@ function BlockRunsMonitor({
     });
 
     return arr;
-  }, [
-    pipeline,
-  ]);
+  }, []);
 
   return (
     <Monitor
@@ -140,7 +135,7 @@ function BlockRunsMonitor({
               All
             </option>
             {pipelineSchedules && pipelineSchedules.map(schedule => (
-              <option value={schedule.id}>
+              <option key={schedule.id} value={schedule.id}>
                 {schedule.name}
               </option>
             ))}
@@ -182,6 +177,7 @@ function BlockRunsMonitor({
                   right: 0,
                   top: 10,
                 }}
+                tooltipLeftOffset={TOOLTIP_LEFT_OFFSET}
                 xLabelFormat={label => moment(label).format('MMM DD')}
               />
             </Spacing>

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/monitors/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/monitors/index.tsx
@@ -15,7 +15,7 @@ import Text from '@oracle/elements/Text';
 import api from '@api';
 import dark from '@oracle/styles/themes/dark';
 import { ChevronRight } from '@oracle/icons';
-import { MonitorTypeEnum } from '@components/Monitor/constants';
+import { MonitorTypeEnum, TOOLTIP_LEFT_OFFSET } from '@components/Monitor/constants';
 import { SCHEDULE_TYPE_TO_LABEL } from '@interfaces/PipelineScheduleType';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { capitalize } from '@utils/string';
@@ -86,8 +86,8 @@ function PipelineRunsMonitor({
   } = dataMonitor?.monitor_stat || {};
 
   const dateRange = useMemo(() => {
-    let date = new Date()
-    const dateRange = []
+    const date = new Date();
+    const dateRange = [];
     for (let i = 0; i < 90; i++) {
       dateRange.unshift(date.toISOString().split('T')[0]);
       date.setDate(date.getDate() - 1);
@@ -167,9 +167,7 @@ function PipelineRunsMonitor({
     });
 
     return arr;
-  }, [
-    pipeline,
-  ]);
+  }, []);
 
   return (
     <Monitor
@@ -193,18 +191,19 @@ function PipelineRunsMonitor({
             height={200}
             keys={BAR_STACK_STATUSES}
             margin={{
-              top: 10,
               bottom: 30,
               left: 35,
-              right: 0
+              right: 0,
+              top: 10,
             }}
+            tooltipLeftOffset={TOOLTIP_LEFT_OFFSET}
             xLabelFormat={label => moment(label).format('MMM DD')}
           />
         </Spacing>
         {pipelineRunsData && Object.entries(pipelineRunsData).map(([id, stats]) => {
           const pipelineSchedule = pipelineSchedulesById?.[id];
           return (
-            <Spacing mt={3}>
+            <Spacing key={id} mt={3}>
               <FlexContainer alignItems="center">
                 <Spacing mx={1}>
                   <GradientTextStyle>
@@ -238,11 +237,12 @@ function PipelineRunsMonitor({
                   height={200}
                   keys={BAR_STACK_STATUSES}
                   margin={{
-                    top: 10,
                     bottom: 30,
                     left: 35,
-                    right: 0
+                    right: 0,
+                    top: 10,
                   }}
+                  tooltipLeftOffset={TOOLTIP_LEFT_OFFSET}
                   xLabelFormat={label => moment(label).format('MMM DD')}
                 />
               </Spacing>


### PR DESCRIPTION
# Summary
- Tooltips on the very right of the Pipeline Runs and Block Runs charts would cause a horizontal overflow and not be readable as users hovered off of the bar. This PR centers the tooltips to stay within view.

# Tests
![image](https://user-images.githubusercontent.com/78053898/227073639-4000d7ed-1a69-47a4-a6bf-3d00a140dc45.png)
