### PR TITLE
Automatically open app in a new tab using default browser

### DIFF
--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -269,7 +269,8 @@ async def main(
         address=host if host != 'localhost' else None,
     )
 
-    webbrowser.open_new_tab(url := f'http://{host or "localhost"}:{port}')
+    url = f'http://{host or "localhost"}:{port}'
+    webbrowser.open_new_tab(url)
     print(f'Mage is running at {url} and serving project {project}')
 
     db_connection.start_session(force=True)

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -61,6 +61,7 @@ import json
 import os
 import tornado.ioloop
 import tornado.web
+import webbrowser
 
 
 class MainPageHandler(tornado.web.RequestHandler):
@@ -268,7 +269,8 @@ async def main(
         address=host if host != 'localhost' else None,
     )
 
-    print(f'Mage is running at http://{host or "localhost"}:{port} and serving project {project}')
+    webbrowser.open_new_tab(url := f'http://{host or "localhost"}:{port}')
+    print(f'Mage is running at {url} and serving project {project}')
 
     db_connection.start_session(force=True)
 


### PR DESCRIPTION
# Summary
When the app starts listening in the defined `host:port`, a new tab on the default browser is opened.

Solves #2233. It doesn't work with Docker, and the explanation is in the issue's comments.

# Tests
Tested locally with MacOS/Chrome, but since it's a standard library from Python, it shouldn't have any issues with other OS/browser.
