### PR TITLE
[jk] Bump to v0.8.28

### DIFF
--- a/mage_ai/server/constants.py
+++ b/mage_ai/server/constants.py
@@ -12,4 +12,4 @@ DATAFRAME_OUTPUT_SAMPLE_COUNT = 10
 # Dockerfile depends on it because it runs ./scripts/install_mage.sh and uses
 # the last line to determine the version to install.
 VERSION = \
-'0.8.27'
+'0.8.28'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     name='mage-ai',
     # NOTE: when you change this, change the value of VERSION in the following file:
     # mage_ai/server/constants.py
-    version='0.8.27',
+    version='0.8.28',
     author='Mage',
     author_email='eng@mage.ai',
     description='Mage is a tool for building and deploying data pipelines.',


### PR DESCRIPTION
# Summary
- Bump to v0.8.28
- Includes:
- https://github.com/mage-ai/mage-ai/pull/2229
- https://github.com/mage-ai/mage-ai/pull/2235
- https://github.com/mage-ai/mage-ai/pull/2242
- https://github.com/mage-ai/mage-ai/pull/2231
- https://github.com/mage-ai/mage-ai/pull/2244
- https://github.com/mage-ai/mage-ai/pull/2246
- https://github.com/mage-ai/mage-ai/pull/2247
- https://github.com/mage-ai/mage-ai/pull/2252
- https://github.com/mage-ai/mage-ai/pull/2253
- https://github.com/mage-ai/mage-ai/pull/2254

# Tests
N/A