### PR TITLE
[jk] Accommodate longer block names in dep graph by increasing canvas size further

### DIFF
--- a/mage_ai/frontend/components/DependencyGraph/constants.ts
+++ b/mage_ai/frontend/components/DependencyGraph/constants.ts
@@ -5,7 +5,7 @@ import BlockType, {
 import { UNIT } from '@oracle/styles/units/spacing';
 
 export const MIN_NODE_WIDTH = UNIT * 20;
-export const ZOOMABLE_CANVAS_SIZE = 5200;
+export const ZOOMABLE_CANVAS_SIZE = 10000;
 
 export const SHARED_PORT_PROPS = {
   height: 10,


### PR DESCRIPTION
# Summary
- Increase canvas size of dependency graph to accommodate longer block names.

# Tests
- Local
