### PR TITLE
[jk] Fix execution date used for re-run pipeline runs

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -22,6 +22,7 @@ import { PopupContainerStyle } from './Table.style';
 import { ScheduleTypeEnum } from '@interfaces/PipelineScheduleType';
 import { TableContainerStyle } from '@components/shared/Table/index.style';
 import { UNIT } from '@oracle/styles/units/spacing';
+import { dateFormatLong } from '@utils/date';
 import { getTimeInUTC } from '@components/Triggers/utils';
 import { isViewer } from '@utils/session';
 import { onSuccess } from '@api/utils/response';
@@ -86,7 +87,13 @@ function RetryButton({
     // @ts-ignore
     createPipelineRun({
       pipeline_run: {
-        execution_date: pipelineRun?.execution_date,
+        execution_date: dateFormatLong(
+          new Date().toISOString(),
+          {
+            includeSeconds: true,
+            utcFormat: true,
+          },
+        ),
         pipeline_schedule_id: pipelineRun?.pipeline_schedule_id,
         pipeline_uuid: pipelineRun?.pipeline_uuid,
         variables: pipelineRun?.variables,

--- a/mage_ai/frontend/utils/date.ts
+++ b/mage_ai/frontend/utils/date.ts
@@ -12,9 +12,21 @@ export function dateFormatShort(text) {
   return formatDateShort(moment(text));
 }
 
-export function dateFormatLong(text, opts?) {
-  const { utcFormat, dayAgo } = opts;
+export function dateFormatLong(
+  text: string,
+  opts?: {
+    dayAgo?: boolean;
+    includeSeconds?: boolean;
+    utcFormat?: boolean;
+  },
+) {
+  const {
+    dayAgo,
+    includeSeconds,
+    utcFormat,
+  } = opts;
   let momentObj = moment(text);
+  let dateFormat = DATE_FORMAT_LONG_NO_SEC;
 
   if (utcFormat) {
     momentObj = momentObj.utc();
@@ -22,8 +34,11 @@ export function dateFormatLong(text, opts?) {
   if (dayAgo) {
     momentObj = momentObj.subtract(1, 'days');
   }
+  if (includeSeconds) {
+    dateFormat = DATE_FORMAT_LONG;
+  }
 
-  return momentObj.format(DATE_FORMAT_LONG_NO_SEC);
+  return momentObj.format(dateFormat);
 }
 
 export function dateFormatLongFromUnixTimestamp(text, opts: { withSeconds?: boolean } = {}) {


### PR DESCRIPTION
# Summary
- Fix issue with logs not appearing for timestamp filters.
- Use now timestamp as execution date for pipeline re-runs. Previously, the execution date of the original pipeline run was used when re-running a pipeline run, which caused the log timestamp filters to use only the original pipeline run's date even on reruns that occurred later.

# Tests
Before (original run execution date used on re-runs; past hour/day logs don't appear even for a rerun that just happened):
![pipeline rerun old execution date](https://user-images.githubusercontent.com/78053898/227668084-a32df7a9-eda2-491c-a5a6-c39bb49f5ec3.gif)

After (now timestamp used for execution date of re-run; past hour/day logs appear immediately for new rerun):
![pipeline rerun new execution date](https://user-images.githubusercontent.com/78053898/227668267-63c8e316-9dbe-45a4-a6ab-1dfb909272df.gif)
