### PR TITLE
[xy] Support using date partition for s3 destination.

### DIFF
--- a/mage_integrations/mage_integrations/destinations/amazon_s3/README.md
+++ b/mage_integrations/mage_integrations/destinations/amazon_s3/README.md
@@ -16,5 +16,6 @@ You must enter the following credentials when configuring this source:
 | `bucket` | Name of the AWS S3 bucket to save data in. | `user_generated_content` |
 | `file_type` | The type of S3 files. Supported file type values: `parquet`, `csv`. | `parquet` or `csv` |
 | `object_key_path` | The path of the location where you have files. Don’t include the `s3`, the bucket name, or the table name in this path value.  | `users/ds/20221225` |
+| `date_partition_format` | (Optional) The datetime format of the partition. If it's null, files will not be saved into paratitions. | `null`, `%Y%m%d`, `%Y%m%dT%H` |
 
 <br />

--- a/mage_integrations/mage_integrations/destinations/amazon_s3/templates/config.json
+++ b/mage_integrations/mage_integrations/destinations/amazon_s3/templates/config.json
@@ -5,5 +5,6 @@
   "bucket": null,
   "file_type": "parquet",
   "object_key_path": null,
-  "table": null
+  "table": null,
+  "date_partition_format": null
 }


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Support using date partition for s3 destination.

| Key | Description | Sample value
| --- | --- | --- |
| `date_partition_format` | (Optional) The datetime format of the partition. If it's null, files will not be saved into paratitions. | `null`, `%Y%m%d`, `%Y%m%dT%H` |


# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
