### PR TITLE
[xy] Fix bigquery replace str.

### DIFF
--- a/mage_integrations/mage_integrations/destinations/bigquery/utils.py
+++ b/mage_integrations/mage_integrations/destinations/bigquery/utils.py
@@ -13,10 +13,11 @@ import re
 
 
 def replace_single_quotes_with_double(v: str) -> str:
-    if type(v) is dict:
+    if type(v) is dict or type(v) is list:
         v = json.dumps(v)
     # Remove emoji code
-    v = re.sub(r'(\\ud83d\\ude[0-4][0-f])|(\\ud83c\\udf[0-f][0-f])|(\\ud83d\\u[0-d][-d][0-f][0-f]])|(\\ud83d\\ude[8-f][0-f])|(\\ud83c\\udd[e-f][0-f])|(\\ud83e\\udd[1-f][0-f])', '', v)
+    if type(v) is str:
+        v = re.sub(r'(\\ud83d\\ude[0-4][0-f])|(\\ud83c\\udf[0-f][0-f])|(\\ud83d\\u[0-d][-d][0-f][0-f]])|(\\ud83d\\ude[8-f][0-f])|(\\ud83c\\udd[e-f][0-f])|(\\ud83e\\udd[1-f][0-f])', '', v)
     return v.replace("'", '"')
 
 


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Fix bigquery replace str.

Error
```
  File \"/usr/local/lib/python3.10/site-packages/mage_integrations/destinations/bigquery/utils.py\", line 19, in replace_single_quotes_with_double
    v = re.sub(r'(\\\\ud83d\\\\ude[0-4][0-f])|(\\\\ud83c\\\\udf[0-f][0-f])|(\\\\ud83d\\\\u[0-d][-d][0-f][0-f]])|(\\\\ud83d\\\\ude[8-f][0-f])|(\\\\ud83c\\\\udd[e-f][0-f])|(\\\\ud83e\\\\udd[1-f][0-f])', '', v)
  File \"/usr/local/lib/python3.10/re.py\", line 209, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: expected string or bytes-like object
", "caller": "BigQuery", "level": "EXCEPTION", "timestamp": 1679852652, "uuid": "40dda5aac4f743a0b378ba7b9260d63a", "type": "LOG"}
```

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
