### PR TITLE
Add alerting option for Google Chat

### DIFF
--- a/mage_ai/orchestration/notification/config.py
+++ b/mage_ai/orchestration/notification/config.py
@@ -3,6 +3,7 @@ from enum import Enum
 from mage_ai.services.email.config import EmailConfig
 from mage_ai.services.slack.config import SlackConfig
 from mage_ai.services.teams.config import TeamsConfig
+from mage_ai.services.google_chat.config import GoogleChatConfig
 from mage_ai.shared.config import BaseConfig
 from typing import Dict, List
 import traceback
@@ -26,6 +27,7 @@ class NotificationConfig(BaseConfig):
     email_config: EmailConfig = None
     slack_config: SlackConfig = None
     teams_config: TeamsConfig = None
+    google_chat_config: GoogleChatConfig = None
 
     @classmethod
     def load(self, config_path: str = None, config: Dict = None):
@@ -48,6 +50,15 @@ class NotificationConfig(BaseConfig):
             except Exception:
                 traceback.print_exc()
                 notification_config.teams_config = None
+        if notification_config.google_chat_config is not None and \
+                type(notification_config.google_chat_config) is dict:
+            try:
+                notification_config.google_chat_config = GoogleChatConfig.load(
+                    config=notification_config.google_chat_config,
+                )
+            except Exception:
+                traceback.print_exc()
+                notification_config.google_chat_config = None
         if notification_config.email_config is not None and \
                 type(notification_config.email_config) is dict:
             try:

--- a/mage_ai/orchestration/notification/config.py
+++ b/mage_ai/orchestration/notification/config.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass, field
 from enum import Enum
 from mage_ai.services.email.config import EmailConfig
+from mage_ai.services.google_chat.config import GoogleChatConfig
 from mage_ai.services.slack.config import SlackConfig
 from mage_ai.services.teams.config import TeamsConfig
-from mage_ai.services.google_chat.config import GoogleChatConfig
 from mage_ai.shared.config import BaseConfig
 from typing import Dict, List
 import traceback
@@ -25,9 +25,9 @@ DEFAULT_ALERT_ON = [
 class NotificationConfig(BaseConfig):
     alert_on: List[AlertOn] = field(default_factory=lambda: DEFAULT_ALERT_ON)
     email_config: EmailConfig = None
+    google_chat_config: GoogleChatConfig = None
     slack_config: SlackConfig = None
     teams_config: TeamsConfig = None
-    google_chat_config: GoogleChatConfig = None
 
     @classmethod
     def load(self, config_path: str = None, config: Dict = None):

--- a/mage_ai/orchestration/notification/sender.py
+++ b/mage_ai/orchestration/notification/sender.py
@@ -23,10 +23,10 @@ class NotificationSender:
 
         if self.config.teams_config is not None and self.config.teams_config.is_valid:
             send_teams_message(self.config.teams_config, message)
-        
+
         if self.config.google_chat_config is not None and self.config.google_chat_config.is_valid:
             send_google_chat_message(self.config.google_chat_config, message)
-            
+
         if self.config.email_config is not None and email_subject is not None:
             send_email(
                 self.config.email_config,

--- a/mage_ai/orchestration/notification/sender.py
+++ b/mage_ai/orchestration/notification/sender.py
@@ -2,6 +2,7 @@ from mage_ai.orchestration.notification.config import AlertOn, NotificationConfi
 from mage_ai.services.email.email import send_email
 from mage_ai.services.slack.slack import send_slack_message
 from mage_ai.services.teams.teams import send_teams_message
+from mage_ai.services.google_chat.google_chat import send_google_chat_message
 import os
 
 
@@ -22,7 +23,10 @@ class NotificationSender:
 
         if self.config.teams_config is not None and self.config.teams_config.is_valid:
             send_teams_message(self.config.teams_config, message)
-
+        
+        if self.config.google_chat_config is not None and self.config.google_chat_config.is_valid:
+            send_google_chat_message(self.config.google_chat_config, message)
+            
         if self.config.email_config is not None and email_subject is not None:
             send_email(
                 self.config.email_config,

--- a/mage_ai/services/google_chat/config.py
+++ b/mage_ai/services/google_chat/config.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from mage_ai.shared.config import BaseConfig
+
+
+@dataclass
+class GoogleChatConfig(BaseConfig):
+    webhook_url: str = None
+
+    @property
+    def is_valid(self) -> bool:
+        return self.webhook_url is not None and self.webhook_url != 'None'

--- a/mage_ai/services/google_chat/google_chat.py
+++ b/mage_ai/services/google_chat/google_chat.py
@@ -1,0 +1,15 @@
+from mage_ai.services.google_chat.config import GoogleChatConfig
+import requests
+
+
+def send_google_chat_message(
+    config: GoogleChatConfig,
+    message: str,
+    title: str = 'Mage pipeline run status logs',
+) -> None:
+    requests.post(
+        url=config.webhook_url,
+        json={
+            'text': '*{title}*\n{message}'.format(title=title, message=message),
+        },
+    )

--- a/mage_ai/tests/orchestration/notification/constants.py
+++ b/mage_ai/tests/orchestration/notification/constants.py
@@ -22,6 +22,15 @@ SLACK_NOTIFICATION_CONFIG = dict(
     )
 )
 
+GOOGLE_CHAT_NOTIFICATION_CONFIG = dict(
+    alert_on=[
+        'trigger_failure',
+        'trigger_success',
+    ],
+    google_chat_config=dict(
+        webhook_url='test_webhook_url',
+    )
+)
 
 TEAMS_NOTIFICATION_CONFIG = dict(
     alert_on=[

--- a/mage_ai/tests/orchestration/notification/test_config.py
+++ b/mage_ai/tests/orchestration/notification/test_config.py
@@ -4,6 +4,7 @@ from mage_ai.tests.orchestration.notification.constants import (
     EMAIL_NOTIFICATION_CONFIG,
     SLACK_NOTIFICATION_CONFIG,
     TEAMS_NOTIFICATION_CONFIG,
+    GOOGLE_CHAT_NOTIFICATION_CONFIG
 )
 
 
@@ -14,14 +15,17 @@ class NotificationConfigTests(TestCase):
         notification_config_email = EMAIL_NOTIFICATION_CONFIG
         notification_config_slack = SLACK_NOTIFICATION_CONFIG
         notification_config_teams = TEAMS_NOTIFICATION_CONFIG
+        notification_config_google_chat = GOOGLE_CHAT_NOTIFICATION_CONFIG
         config1 = NotificationConfig.load(config=notification_config_empty)
         config2 = NotificationConfig.load(config=notification_config_email)
         config3 = NotificationConfig.load(config=notification_config_slack)
         config4 = NotificationConfig.load(config=notification_config_teams)
+        config5 = NotificationConfig.load(config=notification_config_google_chat)
 
         self.assertIsNone(config1.email_config)
         self.assertIsNone(config1.slack_config)
         self.assertIsNone(config1.teams_config)
+        self.assertIsNone(config1.google_chat_config)
 
         self.assertEqual(config2.email_config.smtp_host, 'test_host')
         self.assertEqual(config2.email_config.smtp_mail_from, 'test_from@abc.com')
@@ -36,3 +40,4 @@ class NotificationConfigTests(TestCase):
         self.assertIsNone(config3.email_config)
         self.assertEqual(config3.slack_config.webhook_url, 'test_webhook_url')
         self.assertEqual(config4.teams_config.webhook_url, 'test_webhook_url')
+        self.assertEqual(config5.google_chat_config.webhook_url, 'test_webhook_url')


### PR DESCRIPTION
# Summary
Added option to send an alert to Google Chat in the same way as Teams/Slack using a webhook.

# Tests
Tested a successful and failing flow. Both runs produced a messages in a Google Chat room.
