### PR TITLE
[td] Create dir if it doesnt exist for dbt files

### DIFF
--- a/mage_ai/data_preparation/models/file.py
+++ b/mage_ai/data_preparation/models/file.py
@@ -296,13 +296,15 @@ class File:
             self.filename,
         )
         if os.path.exists(file_path_versions_dir):
+            new_path = self.file_path_versions_dir(
+                self.repo_path,
+                dir_path,
+                filename,
+            )
+            os.makedirs(new_path, exist_ok=True)
             os.rename(
                 file_path_versions_dir,
-                self.file_path_versions_dir(
-                    self.repo_path,
-                    dir_path,
-                    filename,
-                ),
+                new_path,
             )
 
     def to_dict(self, include_content=False):


### PR DESCRIPTION
# Summary
When trying to create a file in a nested folder, if the folder doesn’t exist, create it.