### PR TITLE
[jk] Fix scrolling issue when code block is folded inside code editor

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -416,11 +416,10 @@ function CodeBlock({
 
   const onDidChangeCursorPosition = useCallback(({
     editorRect: {
-      height,
       top,
     },
     position: {
-      lineNumber,
+      lineNumberTop,
     },
   }: OnDidChangeCursorPositionParameterType) => {
     if (mainContainerRef?.current) {
@@ -428,16 +427,14 @@ function CodeBlock({
         height: mainContainerHeight,
       } = mainContainerRef.current.getBoundingClientRect();
 
-      const heightAtLineNumber = lineNumber * SINGLE_LINE_HEIGHT;
-
-      if (top + heightAtLineNumber > mainContainerHeight) {
+      if (top + lineNumberTop > mainContainerHeight) {
         const newY = mainContainerRef.current.scrollTop
-          + ((heightAtLineNumber - mainContainerHeight) + top);
+          + ((lineNumberTop - mainContainerHeight) + top);
 
         mainContainerRef.current.scrollTo(0, newY);
-      } else if (heightAtLineNumber + top < SINGLE_LINE_HEIGHT) {
+      } else if (lineNumberTop + top < SINGLE_LINE_HEIGHT) {
         const newY = mainContainerRef.current.scrollTop
-          + ((heightAtLineNumber + top) - SINGLE_LINE_HEIGHT);
+          + ((lineNumberTop + top) - SINGLE_LINE_HEIGHT);
         mainContainerRef.current.scrollTo(0, newY);
       }
     }

--- a/mage_ai/frontend/components/CodeEditor/index.tsx
+++ b/mage_ai/frontend/components/CodeEditor/index.tsx
@@ -31,11 +31,12 @@ import { saveCode } from './keyboard_shortcuts/shortcuts';
 
 export type OnDidChangeCursorPositionParameterType = {
   editorRect: {
-    height: number;
+    height?: number;
     top: number;
   };
   position: {
-    lineNumber: number;
+    lineNumber?: number;
+    lineNumberTop: number;
   };
 };
 
@@ -165,6 +166,7 @@ function CodeEditor({
           height,
           top,
         } = editor._domElement.getBoundingClientRect();
+        const lineNumberTop = editor.getTopForLineNumber(lineNumber);
 
         onDidChangeCursorPosition({
           editorRect: {
@@ -172,7 +174,7 @@ function CodeEditor({
             top: Number(top),
           },
           position: {
-            lineNumber: Number(lineNumber),
+            lineNumberTop,
           },
         });
       });

--- a/mage_ai/frontend/components/TripleLayout/index.tsx
+++ b/mage_ai/frontend/components/TripleLayout/index.tsx
@@ -216,7 +216,6 @@ function TripleLayout({
     width,
   ]);
 
-
   const shouldHideAfterWrapper = hideAfterCompletely && afterHidden;
   const afterWidthFinal = shouldHideAfterWrapper
     ? 0


### PR DESCRIPTION
# Summary
- See "Before" and "After" under `Tests`.

# Tests
Before - The code block scrolls out of view when a block inside the code block editor is folded/collapsed and user clicks underneath it:
![Before - scrolls out of view when code block folded](https://user-images.githubusercontent.com/78053898/228694714-253e1ed3-1756-40d7-ac32-e016b5520c92.gif)

After - The block inside the code block editor is folded but does not scroll out of focus when clicking beneath it. Scroll position stays in place as expected:
![After - code block is folded but does not scroll out of focus](https://user-images.githubusercontent.com/78053898/228694848-e8698e59-594d-4b72-a8ed-3c400bd63b91.gif)
