### PR TITLE
[jk] Show sample data for streams with non-clean names

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -73,11 +73,11 @@ import {
   removeDataOutputBlockUUID,
   updateCollapsedBlockStates,
 } from '@components/PipelineDetail/utils';
+import { cleanName, randomNameGenerator } from '@utils/string';
 import { equals, find, indexBy, removeAtIndex } from '@utils/array';
 import { getWebSocket } from '@api/utils/url';
 import { goToWithQuery } from '@utils/routing';
 import { isEmptyObject } from '@utils/hash';
-import { randomNameGenerator } from '@utils/string';
 import { parseErrorFromResponse, onSuccess } from '@api/utils/response';
 import { queryFromUrl } from '@utils/url';
 import { useModal } from '@context/Modal';
@@ -396,7 +396,7 @@ function PipelineDetailPage({
     if (isIntegration) {
       return find(
         blockSampleData?.outputs,
-        ({ variable_uuid }) => variable_uuid === `output_sample_data_${selectedStream}`,
+        ({ variable_uuid }) => variable_uuid === `output_sample_data_${cleanName(selectedStream)}`,
       )?.sample_data;
     } else {
       return blockSampleData?.outputs?.[0]?.sample_data;
@@ -1871,7 +1871,7 @@ function PipelineDetailPage({
     () => integrationStreams
       ?.filter(stream => find(
         blockSampleData?.outputs,
-        ({ variable_uuid }) => variable_uuid === `output_sample_data_${stream}`,
+        ({ variable_uuid }) => variable_uuid === `output_sample_data_${cleanName(stream)}`,
       ))
       ?.map(stream => (
         <Spacing key={stream} pl={1}>

--- a/mage_ai/frontend/utils/string.ts
+++ b/mage_ai/frontend/utils/string.ts
@@ -291,7 +291,7 @@ export function randomSimpleHashGenerator() {
 }
 
 export function cleanName(name: string): string {
-  return name.toLowerCase().replace(/\W+/g, '_');
+  return name?.toLowerCase().replace(/\W+/g, '_');
 }
 
 export function removeExtensionFromFilename(filename: string): string {


### PR DESCRIPTION
# Summary
- Fix issue with sample data not rendering in Sidekick for streams that had capital letters and/or spaces in their names.

# Tests
![load sample data](https://user-images.githubusercontent.com/78053898/229259433-3879c35f-b60c-48b5-8caa-32941c7295da.gif)

cc:
@wangxiaoyou1993 