### PR TITLE
[td] Fix circular issues with dbt variables

### DIFF
--- a/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
@@ -1,4 +1,5 @@
 from contextlib import redirect_stdout
+from datetime import datetime
 from jinja2 import Template
 from logging import Logger
 from mage_ai.data_preparation.models.block import Block
@@ -861,10 +862,22 @@ def build_command_line_arguments(
         elif run_settings.get('test_model'):
             dbt_command = 'test'
 
+    variables_json = {}
+    for k, v in variables.items():
+        if type(v) is str or \
+            type(v) is int or \
+            type(v) is bool or \
+            type(v) is float or \
+            type(v) is dict or \
+            type(v) is list or \
+            type(v) is datetime:
+
+            variables_json[k] = v
+
     args = [
         '--vars',
         simplejson.dumps(
-            variables,
+            variables_json,
             default=encode_complex,
             ignore_nan=True,
         ),
@@ -1038,8 +1051,6 @@ def upstream_blocks_from_sources(block: Block) -> List[Block]:
         if source_name not in mapping:
             mapping[source_name] = {}
         mapping[source_name][table_name] = True
-
-    print(mapping)
 
     attributes_dict = parse_attributes(block)
     source_name = attributes_dict['source_name']


### PR DESCRIPTION
# Summary
Fix this error when running 2 dbt models and using Mage via pip:

```
Traceback (most recent call last):
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "./mage_ai/orchestration/queue/process_queue.py", line 91, in run
    start_session_and_run(args[1], *args[2], **args[3])
  File "./mage_ai/orchestration/db/process.py", line 15, in start_session_and_run
    results = target(*args)
  File "./mage_ai/orchestration/pipeline_scheduler.py", line 769, in run_block
    return ExecutorFactory.get_block_executor(
  File "./mage_ai/data_preparation/executors/block_executor.py", line 107, in execute
    raise e
  File "./mage_ai/data_preparation/executors/block_executor.py", line 64, in execute
    result = self._execute(
  File "./mage_ai/data_preparation/executors/block_executor.py", line 146, in _execute
    result = self.block.execute_sync(
  File "./mage_ai/data_preparation/models/block/__init__.py", line 721, in execute_sync
    raise err
  File "./mage_ai/data_preparation/models/block/__init__.py", line 652, in execute_sync
    output = self.execute_block(
  File "./mage_ai/data_preparation/models/block/__init__.py", line 889, in execute_block
    outputs = self._execute_block(
  File "./mage_ai/data_preparation/models/block/dbt/__init__.py", line 116, in _execute_block
    dbt_command, args, command_line_dict = build_command_line_arguments(
  File "./mage_ai/data_preparation/models/block/dbt/utils/__init__.py", line 866, in build_command_line_arguments
    simplejson.dumps(
  File "/Users/dangerous/Code/materia/mage-ai/env/lib/python3.8/site-packages/simplejson/__init__.py", line 398, in dumps
    return cls(
  File "/Users/dangerous/Code/materia/mage-ai/env/lib/python3.8/site-packages/simplejson/encoder.py", line 297, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/Users/dangerous/Code/materia/mage-ai/env/lib/python3.8/site-packages/simplejson/encoder.py", line 379, in iterencode
    return _iterencode(o, 0)
ValueError: Circular reference detected
```