### PR TITLE
[jk] Cancel pipeline runs without associated pipelines

### DIFF
--- a/mage_ai/api/resources/PipelineRunResource.py
+++ b/mage_ai/api/resources/PipelineRunResource.py
@@ -221,13 +221,10 @@ class PipelineRunResource(DatabaseResource):
 
             return super().update(dict(status=PipelineRun.PipelineRunStatus.RUNNING))
         elif PipelineRun.PipelineRunStatus.CANCELLED == payload.get('status'):
-            pipeline = None
-            if os.path.exists(os.path.join(
-                get_repo_path(),
-                PIPELINES_FOLDER,
+            pipeline = Pipeline.get(
                 self.model.pipeline_uuid,
-            )):
-                pipeline = Pipeline.get(self.model.pipeline_uuid)
+                check_if_exists=True,
+            )
 
             stop_pipeline_run(self.model, pipeline)
 

--- a/mage_ai/api/resources/PipelineRunResource.py
+++ b/mage_ai/api/resources/PipelineRunResource.py
@@ -2,14 +2,12 @@ from datetime import datetime
 from mage_ai.api.operations.constants import META_KEY_LIMIT, META_KEY_OFFSET
 from mage_ai.api.resources.DatabaseResource import DatabaseResource
 from mage_ai.data_integrations.utils.scheduler import initialize_state_and_runs
-from mage_ai.data_preparation.models.constants import PipelineType, PIPELINES_FOLDER
+from mage_ai.data_preparation.models.constants import PipelineType
 from mage_ai.data_preparation.models.pipeline import Pipeline
-from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.orchestration.db import safe_db_query
 from mage_ai.orchestration.db.models.schedules import BlockRun, PipelineRun
 from mage_ai.orchestration.pipeline_scheduler import get_variables, stop_pipeline_run
 from sqlalchemy.orm import selectinload
-import os
 
 
 class PipelineRunResource(DatabaseResource):

--- a/mage_ai/api/resources/PipelineRunResource.py
+++ b/mage_ai/api/resources/PipelineRunResource.py
@@ -2,12 +2,14 @@ from datetime import datetime
 from mage_ai.api.operations.constants import META_KEY_LIMIT, META_KEY_OFFSET
 from mage_ai.api.resources.DatabaseResource import DatabaseResource
 from mage_ai.data_integrations.utils.scheduler import initialize_state_and_runs
-from mage_ai.data_preparation.models.constants import PipelineType
+from mage_ai.data_preparation.models.constants import PipelineType, PIPELINES_FOLDER
 from mage_ai.data_preparation.models.pipeline import Pipeline
+from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.orchestration.db import safe_db_query
 from mage_ai.orchestration.db.models.schedules import BlockRun, PipelineRun
-from mage_ai.orchestration.pipeline_scheduler import get_variables
+from mage_ai.orchestration.pipeline_scheduler import get_variables, stop_pipeline_run
 from sqlalchemy.orm import selectinload
+import os
 
 
 class PipelineRunResource(DatabaseResource):
@@ -219,8 +221,14 @@ class PipelineRunResource(DatabaseResource):
 
             return super().update(dict(status=PipelineRun.PipelineRunStatus.RUNNING))
         elif PipelineRun.PipelineRunStatus.CANCELLED == payload.get('status'):
-            from mage_ai.orchestration.pipeline_scheduler import PipelineScheduler
+            pipeline = None
+            if os.path.exists(os.path.join(
+                get_repo_path(),
+                PIPELINES_FOLDER,
+                self.model.pipeline_uuid,
+            )):
+                pipeline = Pipeline.get(self.model.pipeline_uuid)
 
-            PipelineScheduler(self.model).stop()
+            stop_pipeline_run(self.model, pipeline)
 
         return self

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -180,9 +180,18 @@ class Pipeline:
         )
 
     @classmethod
-    def get(self, uuid, repo_path: str = None):
+    def get(self, uuid, repo_path: str = None, check_if_exists: bool = False):
         from mage_ai.data_preparation.models.pipelines.integration_pipeline \
             import IntegrationPipeline
+
+        if check_if_exists and not os.path.exists(
+            os.path.join(
+                repo_path or get_repo_path(),
+                PIPELINES_FOLDER,
+                uuid,
+            ),
+        ):
+            return None
 
         pipeline = self(uuid, repo_path=repo_path)
         if PipelineType.INTEGRATION == pipeline.type:

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -73,7 +73,7 @@ function RetryButton({
           callback: () => {
             onSuccessProp();
           },
-          onErrorCallback: (response, errors) => setErrors({
+          onErrorCallback: (response, errors) => setErrors?.({
             errors,
             response,
           }),
@@ -260,7 +260,7 @@ function PipelineRunsTable({
           },
           onErrorCallback: (response, errors) => {
             setCancelingRunId(null);
-            setErrors({
+            setErrors?.({
               errors,
               response,
             });

--- a/mage_ai/frontend/pages/pipeline-runs/index.tsx
+++ b/mage_ai/frontend/pages/pipeline-runs/index.tsx
@@ -1,7 +1,8 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 
 import Dashboard from '@components/Dashboard';
+import ErrorsType from '@interfaces/ErrorsType';
 import FlexContainer from '@oracle/components/FlexContainer';
 import Paginate, { ROW_LIMIT } from '@components/shared/Paginate';
 import PipelineRunsTable from '@components/PipelineDetail/Runs/Table';
@@ -21,6 +22,7 @@ import { queryFromUrl, queryString } from '@utils/url';
 
 function RunListPage() {
   const router = useRouter();
+  const [errors, setErrors] = useState<ErrorsType>(null);
   const q = queryFromUrl();
   const page = q?.page ? q.page : 0;
 
@@ -47,6 +49,8 @@ function RunListPage() {
 
   return (
     <Dashboard
+      errors={errors}
+      setErrors={setErrors}
       title="Pipeline runs"
       uuid="pipeline_runs/index"
     >
@@ -90,6 +94,7 @@ function RunListPage() {
       <PipelineRunsTable
         fetchPipelineRuns={fetchPipelineRuns}
         pipelineRuns={pipelineRuns}
+        setErrors={setErrors}
       />
       <Spacing p={2}>
         <Paginate

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/syncs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/syncs/index.tsx
@@ -28,7 +28,6 @@ function PipelineSyncs({
   const pipelineUUID = pipeline.uuid;
   const {
     data: dataPipelineRuns,
-    mutate: fetchPipelineRuns,
   } = api.pipeline_runs.list({
     _limit: 20,
     _offset: 0,
@@ -111,8 +110,9 @@ function PipelineSyncs({
 
     return arr;
   }, [
+    pipelineUUID,
     selectedPipelineRun,
-    selectedStream
+    selectedStream,
   ]);
 
   return (

--- a/mage_ai/frontend/utils/models/pipelineRun.ts
+++ b/mage_ai/frontend/utils/models/pipelineRun.ts
@@ -57,7 +57,7 @@ export function getRecordsData(pipelineRun: PipelineRunType, streamToSelect: str
       && blockRunsForStream.every(({ status }) => RunStatusBlockRun.COMPLETED === status)
       && records === null
     ) {
-      records = 0
+      records = 0;
     }
 
     if (metricsPipeline?.[stream]?.record_counts) {
@@ -104,7 +104,7 @@ export function getRecordsData(pipelineRun: PipelineRunType, streamToSelect: str
 
       if (obj2?.error) {
         if (!errors[stream]) {
-          errors[stream] = {}
+          errors[stream] = {};
         }
 
         errors[stream][key] = {

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -44,40 +44,6 @@ import traceback
 MEMORY_USAGE_MAXIMUM = 0.95
 
 
-def stop_pipeline_run(
-    pipeline_run: PipelineRun,
-    pipeline: Pipeline = None,
-) -> None:
-    if pipeline_run.status not in [PipelineRun.PipelineRunStatus.INITIAL,
-                                   PipelineRun.PipelineRunStatus.RUNNING]:
-        return
-
-    pipeline_run.update(status=PipelineRun.PipelineRunStatus.CANCELLED)
-
-    # Cancel all the block runs
-    block_runs_to_cancel = []
-    running_blocks = []
-    for b in pipeline_run.block_runs:
-        if b.status in [
-            BlockRun.BlockRunStatus.INITIAL,
-            BlockRun.BlockRunStatus.QUEUED,
-            BlockRun.BlockRunStatus.RUNNING,
-        ]:
-            block_runs_to_cancel.append(b)
-        if b.status == BlockRun.BlockRunStatus.RUNNING:
-            running_blocks.append(b)
-    BlockRun.batch_update_status(
-        [b.id for b in block_runs_to_cancel],
-        BlockRun.BlockRunStatus.CANCELLED,
-    )
-
-    if pipeline and pipeline.type in [PipelineType.INTEGRATION, PipelineType.STREAMING]:
-        job_manager.kill_pipeline_run_job(pipeline_run.id)
-    else:
-        for b in running_blocks:
-            job_manager.kill_block_run_job(b.id)
-
-
 class PipelineScheduler:
     def __init__(
         self,
@@ -814,6 +780,40 @@ def run_pipeline(pipeline_run_id, variables, tags):
         global_vars=variables,
         tags=tags,
     )
+
+
+def stop_pipeline_run(
+    pipeline_run: PipelineRun,
+    pipeline: Pipeline = None,
+) -> None:
+    if pipeline_run.status not in [PipelineRun.PipelineRunStatus.INITIAL,
+                                   PipelineRun.PipelineRunStatus.RUNNING]:
+        return
+
+    pipeline_run.update(status=PipelineRun.PipelineRunStatus.CANCELLED)
+
+    # Cancel all the block runs
+    block_runs_to_cancel = []
+    running_blocks = []
+    for b in pipeline_run.block_runs:
+        if b.status in [
+            BlockRun.BlockRunStatus.INITIAL,
+            BlockRun.BlockRunStatus.QUEUED,
+            BlockRun.BlockRunStatus.RUNNING,
+        ]:
+            block_runs_to_cancel.append(b)
+        if b.status == BlockRun.BlockRunStatus.RUNNING:
+            running_blocks.append(b)
+    BlockRun.batch_update_status(
+        [b.id for b in block_runs_to_cancel],
+        BlockRun.BlockRunStatus.CANCELLED,
+    )
+
+    if pipeline and pipeline.type in [PipelineType.INTEGRATION, PipelineType.STREAMING]:
+        job_manager.kill_pipeline_run_job(pipeline_run.id)
+    else:
+        for b in running_blocks:
+            job_manager.kill_block_run_job(b.id)
 
 
 def check_sla():

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -44,6 +44,40 @@ import traceback
 MEMORY_USAGE_MAXIMUM = 0.95
 
 
+def stop_pipeline_run(
+    pipeline_run: PipelineRun,
+    pipeline: Pipeline = None,
+) -> None:
+    if pipeline_run.status not in [PipelineRun.PipelineRunStatus.INITIAL,
+                                   PipelineRun.PipelineRunStatus.RUNNING]:
+        return
+
+    pipeline_run.update(status=PipelineRun.PipelineRunStatus.CANCELLED)
+
+    # Cancel all the block runs
+    block_runs_to_cancel = []
+    running_blocks = []
+    for b in pipeline_run.block_runs:
+        if b.status in [
+            BlockRun.BlockRunStatus.INITIAL,
+            BlockRun.BlockRunStatus.QUEUED,
+            BlockRun.BlockRunStatus.RUNNING,
+        ]:
+            block_runs_to_cancel.append(b)
+        if b.status == BlockRun.BlockRunStatus.RUNNING:
+            running_blocks.append(b)
+    BlockRun.batch_update_status(
+        [b.id for b in block_runs_to_cancel],
+        BlockRun.BlockRunStatus.CANCELLED,
+    )
+
+    if pipeline and pipeline.type in [PipelineType.INTEGRATION, PipelineType.STREAMING]:
+        job_manager.kill_pipeline_run_job(pipeline_run.id)
+    else:
+        for b in running_blocks:
+            job_manager.kill_block_run_job(b.id)
+
+
 class PipelineScheduler:
     def __init__(
         self,
@@ -81,34 +115,10 @@ class PipelineScheduler:
             self.schedule()
 
     def stop(self) -> None:
-        if self.pipeline_run.status not in [PipelineRun.PipelineRunStatus.INITIAL,
-                                            PipelineRun.PipelineRunStatus.RUNNING]:
-            return
-
-        self.pipeline_run.update(status=PipelineRun.PipelineRunStatus.CANCELLED)
-
-        # Cancel all the block runs
-        block_runs_to_cancel = []
-        running_blocks = []
-        for b in self.pipeline_run.block_runs:
-            if b.status in [
-                BlockRun.BlockRunStatus.INITIAL,
-                BlockRun.BlockRunStatus.QUEUED,
-                BlockRun.BlockRunStatus.RUNNING,
-            ]:
-                block_runs_to_cancel.append(b)
-            if b.status == BlockRun.BlockRunStatus.RUNNING:
-                running_blocks.append(b)
-        BlockRun.batch_update_status(
-            [b.id for b in block_runs_to_cancel],
-            BlockRun.BlockRunStatus.CANCELLED,
+        stop_pipeline_run(
+            self.pipeline_run,
+            self.pipeline,
         )
-
-        if self.pipeline.type in [PipelineType.INTEGRATION, PipelineType.STREAMING]:
-            job_manager.kill_pipeline_run_job(self.pipeline_run.id)
-        else:
-            for b in running_blocks:
-                job_manager.kill_block_run_job(b.id)
 
     def schedule(self, block_runs: List[BlockRun] = None) -> None:
         self.__run_heartbeat()


### PR DESCRIPTION
# Summary
- If a pipeline is deleted while a pipeline run is still running, users weren't able to cancel those pipeline runs in the UI, so this PR allows users to cancel pipeline runs even if their related pipeline was deleted.

# Tests
Before (cannot cancel running pipeline run):
![Before - cancel pipeline run without pipeline](https://user-images.githubusercontent.com/78053898/229932480-c655dfa6-d95f-4bd7-8b9e-a599d950909e.gif)

After (can cancel running run, but not retry because the pipeline no longer exists):
![After - cancel pipeline run without pipeline](https://user-images.githubusercontent.com/78053898/229932501-f701c058-097a-4da6-bbb2-5c14674bf89c.gif)
