### PR TITLE
[td] 0.8.40

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -883,10 +883,22 @@ function CodeBlock({
 
   const closeBlockMenu = useCallback(() => setBlockMenuVisible(false), []);
 
+  const timeout = useRef(null);
   const updateDataProviderConfig = useCallback((payload) => {
+    clearTimeout(timeout.current);
+
     setDataProviderConfig((dataProviderConfigPrev) => {
       const data = {
         ...dataProviderConfigPrev,
+        ...payload,
+      };
+
+      return data;
+    });
+
+    timeout.current = setTimeout(() => {
+      const data = {
+        ...dataProviderConfig,
         ...payload,
       };
 
@@ -904,11 +916,10 @@ function CodeBlock({
           },
         });
       }
-
-      return data;
-    });
+    }, 1000);
   }, [
     block,
+    dataProviderConfig,
     savePipelineContent,
   ]);
 

--- a/mage_ai/server/constants.py
+++ b/mage_ai/server/constants.py
@@ -12,4 +12,4 @@ DATAFRAME_OUTPUT_SAMPLE_COUNT = 10
 # Dockerfile depends on it because it runs ./scripts/install_mage.sh and uses
 # the last line to determine the version to install.
 VERSION = \
-'0.8.39'
+'0.8.40'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     name='mage-ai',
     # NOTE: when you change this, change the value of VERSION in the following file:
     # mage_ai/server/constants.py
-    version='0.8.39',
+    version='0.8.40',
     author='Mage',
     author_email='eng@mage.ai',
     description='Mage is a tool for building and deploying data pipelines.',


### PR DESCRIPTION
# Summary
- Don’t save block configuration until finish typing for 1 second using debounce
- https://github.com/mage-ai/mage-ai/pull/2343
- https://github.com/mage-ai/mage-ai/pull/2342
- https://github.com/mage-ai/mage-ai/pull/2341