### PR TITLE
[jk] Disable shortcuts from file editor

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -131,7 +131,6 @@ type CodeBlockProps = {
   blocks: BlockType[];
   dataProviders?: DataProviderType[];
   defaultValue?: string;
-  disableShortcuts?: boolean;
   executionState: ExecutionStateEnum;
   extraContent?: any;
   fetchFileTree: () => void;
@@ -183,7 +182,6 @@ function CodeBlock({
   dataProviders,
   defaultValue = '',
   deleteBlock,
-  disableShortcuts,
   executionState,
   extraContent,
   fetchFileTree,
@@ -629,10 +627,6 @@ function CodeBlock({
   registerOnKeyDown(
     uuidKeyboard,
     (event, keyMapping, keyHistory) => {
-      if (disableShortcuts) {
-        return;
-      }
-
       if (isEditingBlock
         && String(keyHistory[0]) === String(KEY_CODE_ENTER)
         && String(keyHistory[1]) !== String(KEY_CODE_META)

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -124,6 +124,7 @@ import { useKeyboardContext } from '@context/Keyboard';
 type CodeBlockProps = {
   addNewBlock?: (block: BlockType) => Promise<any>;
   addNewBlockMenuOpenIdx?: number;
+  allowCodeBlockShortcuts?: boolean;
   autocompleteItems: AutocompleteItemType[];
   block: BlockType;
   blockRefs: any;
@@ -175,6 +176,7 @@ function CodeBlock({
   addNewBlock,
   addNewBlockMenuOpenIdx,
   addWidget,
+  allowCodeBlockShortcuts,
   autocompleteItems,
   block,
   blockIdx,
@@ -629,7 +631,7 @@ function CodeBlock({
   registerOnKeyDown(
     uuidKeyboard,
     (event, keyMapping, keyHistory) => {
-      if (disableShortcuts) {
+      if (disableShortcuts && !allowCodeBlockShortcuts) {
         return;
       }
 

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -131,6 +131,7 @@ type CodeBlockProps = {
   blocks: BlockType[];
   dataProviders?: DataProviderType[];
   defaultValue?: string;
+  disableShortcuts?: boolean;
   executionState: ExecutionStateEnum;
   extraContent?: any;
   fetchFileTree: () => void;
@@ -182,6 +183,7 @@ function CodeBlock({
   dataProviders,
   defaultValue = '',
   deleteBlock,
+  disableShortcuts,
   executionState,
   extraContent,
   fetchFileTree,
@@ -627,6 +629,10 @@ function CodeBlock({
   registerOnKeyDown(
     uuidKeyboard,
     (event, keyMapping, keyHistory) => {
+      if (disableShortcuts) {
+        return;
+      }
+
       if (isEditingBlock
         && String(keyHistory[0]) === String(KEY_CODE_ENTER)
         && String(keyHistory[1]) !== String(KEY_CODE_META)

--- a/mage_ai/frontend/components/FileEditor/index.tsx
+++ b/mage_ai/frontend/components/FileEditor/index.tsx
@@ -59,6 +59,7 @@ type FileEditorProps = {
   pipeline: PipelineType;
   selectedFilePath: string;
   sendTerminalMessage: (message: string, keep?: boolean) => void;
+  setDisableShortcuts: (disableShortcuts: boolean) => void;
   setErrors?: (errors: ErrorsType) => void;
   setFilesTouched: (data: {
     [path: string]: boolean;
@@ -76,6 +77,7 @@ function FileEditor({
   pipeline,
   selectedFilePath,
   sendTerminalMessage,
+  setDisableShortcuts,
   setErrors,
   setFilesTouched,
   setSelectedBlock,
@@ -96,6 +98,12 @@ function FileEditor({
 
   const [content, setContent] = useState<string>(file?.content);
   const [touched, setTouched] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (active) {
+      setDisableShortcuts(true);
+    }
+  }, [active, setDisableShortcuts]);
 
   useEffect(() => {
     if (selectedFilePath) {

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -402,6 +402,7 @@ function PipelineDetail({
             deleteBlock(b);
             setAnyInputFocused(false);
           }}
+          disableShortcuts={disableShortcuts}
           executionState={executionState}
           fetchFileTree={fetchFileTree}
           fetchPipeline={fetchPipeline}

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -62,7 +62,6 @@ import { addScratchpadNote, addSqlBlockNote } from '@components/PipelineDetail/A
 import { addUnderscores, randomNameGenerator, removeExtensionFromFilename } from '@utils/string';
 import { getUpstreamBlockUuids } from '@components/CodeBlock/utils';
 import { onlyKeysPresent } from '@utils/hooks/keyboardShortcuts/utils';
-import { pauseEvent } from '@utils/events';
 import { selectKeys } from '@utils/hash';
 import { useKeyboardContext } from '@context/Keyboard';
 

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -75,6 +75,7 @@ type PipelineDetailProps = {
   addWidget: (widget: BlockType, opts?: {
     onCreateCallback?: (block: BlockType) => void;
   }) => Promise<any>;
+  allowCodeBlockShortcuts?: boolean;
   anyInputFocused: boolean;
   autocompleteItems: AutocompleteItemType[];
   blockRefs: any;
@@ -132,6 +133,7 @@ type PipelineDetailProps = {
 function PipelineDetail({
   addNewBlockAtIndex,
   addWidget,
+  allowCodeBlockShortcuts,
   anyInputFocused,
   autocompleteItems,
   blockRefs,
@@ -391,6 +393,7 @@ function PipelineDetail({
           }}
           addNewBlockMenuOpenIdx={addNewBlockMenuOpenIdx}
           addWidget={addWidget}
+          allowCodeBlockShortcuts={allowCodeBlockShortcuts}
           autocompleteItems={autocompleteItems}
           block={block}
           blockIdx={idx}
@@ -443,11 +446,13 @@ function PipelineDetail({
     addNewBlockAtIndex,
     addNewBlockMenuOpenIdx,
     addWidget,
+    allowCodeBlockShortcuts,
     autocompleteItems,
     blockRefs,
     blocks,
     dataProviders,
     deleteBlock,
+    disableShortcuts,
     fetchFileTree,
     fetchPipeline,
     interruptKernel,

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -402,7 +402,6 @@ function PipelineDetail({
             deleteBlock(b);
             setAnyInputFocused(false);
           }}
-          disableShortcuts={disableShortcuts}
           executionState={executionState}
           fetchFileTree={fetchFileTree}
           fetchPipeline={fetchPipeline}

--- a/mage_ai/frontend/components/Sidekick/GlobalVariables/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/GlobalVariables/index.tsx
@@ -133,7 +133,7 @@ function GlobalVariables({
 
   const handleKeyDown = useCallback((e) => {
     if (e.key === 'Enter') {
-      let updatedValue = newVariableValue
+      let updatedValue = newVariableValue;
       try {
         updatedValue = JSON.parse(newVariableValue);
       } catch {
@@ -245,6 +245,7 @@ function GlobalVariables({
         <VariableRow
           deleteVariable={() => deleteVariable(variable.uuid)}
           fetchVariables={fetchVariables}
+          key={variable.uuid}
           pipelineUUID={pipelineUUID}
           variable={variable}
         />
@@ -277,6 +278,7 @@ ${BUILD_CODE_SNIPPET_PREVIEW(pipelineUUID, selectedBlock?.uuid, uuid)}`;
           <VariableRow
             copyText={copyText(variable.uuid)}
             hideEdit
+            key={variable.uuid}
             pipelineUUID={pipelineUUID}
             variable={variable}
           />
@@ -398,18 +400,22 @@ ${BUILD_CODE_SNIPPET_PREVIEW(pipelineUUID, selectedBlock?.uuid, uuid)}`;
         </Text>
       </Spacing>
 
-      {Object.values(ScheduleTypeEnum).map((value) => (
-        <Spacing mb={PADDING_UNITS}>
+      {Object.values(ScheduleTypeEnum).map((value, idx) => (
+        <Spacing
+          key={`${value}_${idx}`}
+          mb={PADDING_UNITS}
+        >
           <Spacing mb={PADDING_UNITS}>
             <Text large monospace>
               {capitalizeRemoveUnderscoreLower(SCHEDULE_TYPE_TO_LABEL[value]?.())}
             </Text>
           </Spacing>
-          {addTriggerVariables([], value).map((variable) => (
+          {addTriggerVariables([], value).map((variable, idx) => (
             <VariableRow
               hideEdit
-              variable={variable}
+              key={`var_${value}_${idx}`}
               pipelineUUID={pipelineUUID}
+              variable={variable}
             />
           ))}
         </Spacing>

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -110,6 +110,7 @@ export type SidekickProps = {
     newView: ViewKeyEnum,
     pushHistory?: boolean,
   ) => void;
+  setAllowCodeBlockShortcuts?: (allowCodeBlockShortcuts: boolean) => void;
   setDisableShortcuts: (disableShortcuts: boolean) => void;
   setErrors: (errors: ErrorsType) => void;
   statistics: StatisticsType;
@@ -155,6 +156,7 @@ function Sidekick({
   selectedFilePath,
   sendTerminalMessage,
   setActiveSidekickView,
+  setAllowCodeBlockShortcuts,
   setAnyInputFocused,
   setDisableShortcuts,
   setEditingBlock,
@@ -303,8 +305,18 @@ function Sidekick({
         <SidekickContainerStyle
           fullWidth={FULL_WIDTH_VIEWS.includes(activeView)}
           heightOffset={ViewKeyEnum.TERMINAL === activeView ? 0 : SCROLLBAR_WIDTH}
-          onBlur={() => setDisableShortcuts(false)}
-          onFocus={() => setDisableShortcuts(true)}
+          onBlur={() => {
+            if (!selectedFilePath) {
+              setDisableShortcuts(false);
+            }
+            setAllowCodeBlockShortcuts?.(false);
+          }}
+          onFocus={() => {
+            setDisableShortcuts(true);
+            if (activeView === ViewKeyEnum.TREE) {
+              setAllowCodeBlockShortcuts?.(true);
+            }
+          }}
           widthOffset={widthOffset}
         >
           {activeView === ViewKeyEnum.TREE &&

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -112,7 +112,7 @@ function PipelineDetailPage({
   const [textareaFocused, setTextareaFocused] = useState<boolean>(false);
   const [anyInputFocused, setAnyInputFocused] = useState<boolean>(false);
   const [disableShortcuts, setDisableShortcuts] = useState<boolean>(false);
-
+  const [allowCodeBlockShortcuts, setAllowCodeBlockShortcuts] = useState<boolean>(false);
   const mainContainerRef = useRef(null);
 
   // Kernels
@@ -1663,6 +1663,7 @@ function PipelineDetailPage({
       selectedFilePath={selectedFilePath}
       sendTerminalMessage={sendTerminalMessage}
       setActiveSidekickView={setActiveSidekickView}
+      setAllowCodeBlockShortcuts={setAllowCodeBlockShortcuts}
       setAnyInputFocused={setAnyInputFocused}
       setDisableShortcuts={setDisableShortcuts}
       setEditingBlock={setEditingBlock}
@@ -1744,6 +1745,7 @@ function PipelineDetailPage({
           onCreateCallback?: (block: BlockType) => void;
         },
       ) => addWidgetAtIndex(widget, widgets.length, onCreateCallback)}
+      allowCodeBlockShortcuts={allowCodeBlockShortcuts}
       anyInputFocused={anyInputFocused}
       autocompleteItems={autocompleteItems}
       blockRefs={blockRefs}

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -462,6 +462,9 @@ function PipelineDetailPage({
   const autocompleteItems = dataAutocompleteItems?.autocomplete_items;
 
   useEffect(() => {
+    if (!filePathFromUrl) {
+      setDisableShortcuts(false);
+    }
     setSelectedFilePath(filePathFromUrl);
   }, [
     filePathFromUrl,
@@ -2100,6 +2103,7 @@ function PipelineDetailPage({
                 pipeline={pipeline}
                 selectedFilePath={selectedFilePath}
                 sendTerminalMessage={sendTerminalMessage}
+                setDisableShortcuts={setDisableShortcuts}
                 setErrors={setErrors}
                 setFilesTouched={setFilesTouched}
                 setSelectedBlock={setSelectedBlock}


### PR DESCRIPTION
# Summary
- Disable keyboard shortcuts while in File Editor for individual file.
- The `allowCodeBlockShortcuts` prop was added so users can still run blocks with keyboard shortcut (CMD + ENTER) when clicking on a node in the Sidekick dependency graph and running it with shortcut.

# Tests
Before - shortcuts enabled on file editor:
![Before - shortcuts enabled on file editor](https://user-images.githubusercontent.com/78053898/230456825-75fb3175-d9a4-4b5d-a1e0-e1df76b03fdc.gif)

After - shortcuts disabled on file editor:
![After - shortcuts disabled on file editor](https://user-images.githubusercontent.com/78053898/230456871-e46500b8-c02a-40f8-931e-96a3097b4464.gif)
