### PR TITLE
[jk] Load sample data from deleted stream

### DIFF
--- a/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
+++ b/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
@@ -271,6 +271,10 @@ class IntegrationPipeline(Pipeline):
                     json_object = next(extract_json_objects(line))
 
             error = dig(json_object, 'tags.error')
+            if not error:
+                raise Exception('The sample data was not able to be loaded. Please check \
+                                if the stream still exists. If it does not, click the "View and \
+                                select streams" button and deselect the invalid stream.')
             raise Exception(error)
 
     def count_records(self) -> List[Dict]:

--- a/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
+++ b/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
@@ -274,7 +274,7 @@ class IntegrationPipeline(Pipeline):
             if not error:
                 raise Exception('The sample data was not able to be loaded. Please check \
                                 if the stream still exists. If it does not, click the "View and \
-                                select streams" button and deselect the invalid stream.')
+                                select streams" button and confirm the valid streams.')
             raise Exception(error)
 
     def count_records(self) -> List[Dict]:

--- a/mage_ai/frontend/components/IntegrationPipeline/SelectStreams/index.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SelectStreams/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 import Button from '@oracle/elements/Button';
 import Checkbox from '@oracle/elements/Checkbox';

--- a/mage_ai/frontend/components/IntegrationPipeline/SelectStreams/index.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SelectStreams/index.tsx
@@ -27,10 +27,12 @@ type SelectStreamsProps = {
   catalog: CatalogType;
   isLoading: boolean;
   onActionCallback: (selectedStreams: {
-    [key: string]: boolean;
+    [key: string]: StreamType;
   }) => void;
   streams: StreamType[];
 };
+
+type StreamTypeWithMissingProp = StreamType & { isMissingStream?: boolean };
 
 enum FilterSelectionEnum {
   ALL = 'All',
@@ -46,7 +48,7 @@ function SelectStreams({
   onActionCallback,
   streams,
 }: SelectStreamsProps) {
-  const selectedStreamsInit = indexBy(catalog?.streams || [], ({ stream }) => stream);
+  const selectedStreamsInit: { [key: string]: StreamType } = indexBy(catalog?.streams || [], ({ stream }) => stream);
   const [selectedStreams, setSelectedStreams] = useState(selectedStreamsInit);
   const [filterText, setFilterText] = useState<string>(null);
   const [filterMenuOpen, setFilterMenuOpen] = useState<boolean>(false);
@@ -55,7 +57,7 @@ function SelectStreams({
 
   const selectedStreamIds: string[] = getSelectedStreamIds(selectedStreams);
   const filteredSearchStreams = useMemo(() => {
-    let filteredStreams: StreamType[] = streams;
+    let filteredStreams: StreamTypeWithMissingProp[] = streams;
     filteredStreams = filteredStreams.filter(({ tap_stream_id }) => {
       if (dropdownFilter === FilterSelectionEnum.SELECTED) {
         return selectedStreamIds.includes(tap_stream_id);
@@ -71,6 +73,13 @@ function SelectStreams({
         stream?.toLowerCase().includes(filterText?.toLowerCase())
       )) : filteredStreams;
   }, [dropdownFilter, filterText, selectedStreamIds, streams]);
+
+  const missingSelectedStreams = useMemo(() => {
+    const fetchedStreamsSet = new Set(streams.map(({ stream }) => stream));
+    return Object.values(selectedStreamsInit)
+      .filter(({ stream }) => !fetchedStreamsSet.has(stream))
+      .map(stream => ({ ...stream, isMissingStream: true }));
+  }, [selectedStreamsInit, streams]);
 
   const allStreamsSelected = useMemo(() =>
     streams.every(({ stream }) => !!selectedStreams[stream]),
@@ -167,8 +176,9 @@ function SelectStreams({
               uuid: 'Stream name',
             },
           ]}
-          rows={filteredSearchStreams.map((stream) => {
+          rows={filteredSearchStreams.concat(missingSelectedStreams).map((stream) => {
             const {
+              isMissingStream,
               stream: streamID,
             } = stream;
             const selected: boolean = !!selectedStreams[streamID];
@@ -184,8 +194,13 @@ function SelectStreams({
                   }));
                 }}
               />,
-              <Text key={`stream-${streamID}`}>
-                {streamID}
+              <Text
+                danger={isMissingStream}
+                key={`stream-${streamID}`}
+                title={streamID}
+                width={TABLE_WIDTH - 48 - 32}
+              >
+                {streamID}{isMissingStream ? ' (no longer available)' : ''}
               </Text>,
             ];
           })}

--- a/mage_ai/frontend/components/IntegrationPipeline/index.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/index.tsx
@@ -566,7 +566,7 @@ function IntegrationPipeline({
       catalog={catalog}
       isLoading={isLoadingFetchIntegrationSource}
       onActionCallback={(selectedStreams: {
-        [key: string]: boolean;
+        [key: string]: StreamType;
       }) => {
         const ids =
           Object.entries(selectedStreams).reduce((acc, [k, v]) => v ? acc.concat(k) : acc, []);

--- a/mage_ai/frontend/oracle/elements/Checkbox/index.tsx
+++ b/mage_ai/frontend/oracle/elements/Checkbox/index.tsx
@@ -154,7 +154,7 @@ const Checkbox = ({
       <LabelStyle
         onClick={(e) => {
           e.preventDefault();
-          if (onClick) {
+          if (onClick && !disabled) {
             onClick(e);
           }
         }}


### PR DESCRIPTION
# Summary
- Show more descriptive error (instead of `{}`) when a stream that was previously selected may have been deleted or renamed.
- If a previously selected stream was deleted or renamed, it will still appear in the `SelectStreams` modal but will automatically be deselected and indicate that the stream is no longer available in red font. User needs to click "Confirm" to remove the deleted stream from the schema.

# Tests
![image](https://user-images.githubusercontent.com/78053898/230695336-ddcb4cd1-f28c-4e28-b02d-56ba79da4c6d.png)

![loading sample data from deleted stream](https://user-images.githubusercontent.com/78053898/230695294-a0a0cffe-6446-4ce1-a037-daa7379b2230.gif)
