### PR TITLE
[dy] Allow users to force delete block file

### DIFF
--- a/mage_ai/api/resources/BlockResource.py
+++ b/mage_ai/api/resources/BlockResource.py
@@ -98,7 +98,12 @@ class BlockResource(GenericResource):
 
     @safe_db_query
     def delete(self, **kwargs):
-        return self.model.delete()
+        query = kwargs.get('query', {})
+
+        force = query.get('force', [False])
+        if force:
+            force = force[0]
+        return self.model.delete(force=force)
 
     @safe_db_query
     def update(self, payload, **kwargs):

--- a/mage_ai/data_preparation/models/block/errors.py
+++ b/mage_ai/data_preparation/models/block/errors.py
@@ -3,3 +3,7 @@ from mage_ai.errors.base import MageBaseException
 
 class NoMultipleDynamicUpstreamBlocks(MageBaseException):
     pass
+
+
+class HasDownstreamDependencies(MageBaseException):
+    pass

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -1,6 +1,9 @@
 from mage_ai.data_preparation.models.block import Block, run_blocks, run_blocks_sync
 from mage_ai.data_preparation.models.block.dbt.utils import update_model_settings
-from mage_ai.data_preparation.models.block.errors import NoMultipleDynamicUpstreamBlocks
+from mage_ai.data_preparation.models.block.errors import (
+    HasDownstreamDependencies,
+    NoMultipleDynamicUpstreamBlocks,
+)
 from mage_ai.data_preparation.models.block.utils import is_dynamic_block
 from mage_ai.data_preparation.models.constants import (
     BlockLanguage,
@@ -253,7 +256,7 @@ class Pipeline:
         ]
 
     @classmethod
-    def get_pipelines_by_block(self, block, repo_path=None, widget=False):
+    def get_pipelines_by_block(self, block, repo_path=None, widget=False) -> List['Pipeline']:
         repo_path = repo_path or get_repo_path()
         pipelines_folder = os.path.join(repo_path, PIPELINES_FOLDER)
         pipelines = []
@@ -994,7 +997,13 @@ class Pipeline:
                 os.remove(block.file_path)
         shutil.rmtree(self.dir_path)
 
-    def delete_block(self, block: Block, widget: bool = False, commit: bool = True) -> None:
+    def delete_block(
+        self,
+        block: Block,
+        widget: bool = False,
+        commit: bool = True,
+        force: bool = False,
+    ) -> None:
         is_extension = BlockType.EXTENSION == block.type
 
         mapping = {}
@@ -1007,11 +1016,12 @@ class Pipeline:
 
         if block.uuid not in mapping:
             raise Exception(f'Block {block.uuid} is not in pipeline {self.uuid}.')
+
         if len(block.downstream_blocks) > 0:
             downstream_block_uuids = [
                 b.uuid for b in block.downstream_blocks if b.type != BlockType.CHART
             ]
-            if self.type == PipelineType.INTEGRATION:
+            if self.type == PipelineType.INTEGRATION or force:
                 for downstream_block in block.downstream_blocks:
                     upstream_block_uuids = list(filter(
                         lambda uuid: uuid != block.uuid,
@@ -1021,7 +1031,7 @@ class Pipeline:
                         upstream_blocks=[*upstream_block_uuids, *block.upstream_block_uuids]
                     ))
             elif len(downstream_block_uuids) > 0:
-                raise Exception(
+                raise HasDownstreamDependencies(
                     f'Block(s) {downstream_block_uuids} are depending on block {block.uuid}'
                     '. Please remove the downstream blocks first.'
                 )

--- a/mage_ai/frontend/oracle/components/PopupMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/PopupMenu/index.tsx
@@ -49,7 +49,7 @@ function PopupMenu({
     >
       <FlexContainer alignItems="center" flexDirection="column">
         <Spacing pb={1}>
-          <Text bold large warning whiteSpaceNormal>
+          <Text bold danger={danger} large warning={!danger} whiteSpaceNormal>
             {title}
           </Text>
         </Spacing>

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -932,6 +932,22 @@ function PipelineDetailPage({
     },
   );
 
+  const [showDeleteConfirmation, hideDeleteConfirmation] = useModal((block: BlockType) => (
+    <PopupMenu
+      centerOnScreen
+      neutral
+      onClick={() => deleteBlockFile(block)}
+      onCancel={hideDeleteConfirmation}
+      subtitle={
+        "Deleting this block is dangerous. Your block may have downstream " +
+        "dependencies that depend on this block. You can delete this block anyway " +
+        "and remove it as a dependency from downstream blocks."
+      }
+      title="Your block has dependencies"
+      width={UNIT * 34}
+    />
+  ))
+
   const [deleteBlockFile] = useMutation(
     ({
       language,
@@ -953,12 +969,16 @@ function PipelineDetailPage({
             fetchPipeline();
             fetchFileTree();
           },
-          onErrorCallback: (response, errors) => setErrors({
-            displayMessage: 'Error deleting block file. ' +
-              'Check that there are no downstream blocks, then try again.',
-            errors,
-            response,
-          }),
+          onErrorCallback: (response, errors) => {
+            console.log('response:', response);
+            console.log('errors:', errors);
+            showDeleteConfirmation();
+            // setErrors({
+            //   displayMessage: response.exception,
+            //   errors,
+            //   response,
+            // });
+          },
         },
       ),
     },
@@ -1926,8 +1946,9 @@ function PipelineDetailPage({
         }
       }}
       blocks={blocks}
-      deleteBlockFile={deleteBlockFile}
+      // deleteBlockFile={deleteBlockFile}
       deleteWidget={deleteWidget}
+      fetchAutocompleteItems={fetchAutocompleteItems}
       fetchFileTree={fetchFileTree}
       fetchPipeline={fetchPipeline}
       files={files}
@@ -1949,6 +1970,7 @@ function PipelineDetailPage({
     blocks,
     deleteBlockFile,
     deleteWidget,
+    fetchAutocompleteItems,
     fetchFileTree,
     fetchPipeline,
     filePathsFromUrl?.length,


### PR DESCRIPTION
# Summary

I added another modal that pops up when a user tries to delete a block file that has downstream dependencies. They can override the safeguards we have in place for blocks with downstream dependencies and choose to overwrite them.
<!-- Brief summary of what your code does -->

# Tests

unit tests and local testing

<img width="1949" alt="Screenshot 2023-04-07 at 6 09 59 PM" src="https://user-images.githubusercontent.com/14357209/230696879-d9ed90e1-04e9-4f48-b1cc-df02083fcb43.png">

<!-- How did you test your change? -->

cc:
<!-- Optionally mention someone to let them know about this pull request -->
