### PR TITLE
init file update to support docker latest versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+.idea
 # C extensions
 *.so
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -99,4 +99,11 @@ HOST=$HOST \
 PORT=$PORT \
 PROJECT=$PROJECT_NAME \
 MANAGE_INSTANCE=$MANAGE_INSTANCE \
-docker-compose -f docker-compose.yml up
+docker_version=$(docker version --format '{{.Server.Version}}')
+if [[ "$docker_version" == 2*.* ]]; then
+  docker compose -f docker-compose.yml up
+else
+  docker-compose -f docker-compose.yml up
+fi
+
+

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -12,3 +12,4 @@ if [[ "$docker_version" == 2*.* ]]; then
 else
   docker-compose run server python mage_ai/cli/main.py init $PROJECT_NAME
 fi
+

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -6,4 +6,9 @@ PROJECT_NAME="$1"
 HOST='' \
 PORT='' \
 PROJECT='' \
-docker-compose run server python mage_ai/cli/main.py init $PROJECT_NAME
+docker_version=$(docker version --format '{{.Server.Version}}')
+if [[ "$docker_version" == 2*.* ]]; then
+  docker compose run server python mage_ai/cli/main.py init $PROJECT_NAME
+else
+  docker-compose run server python mage_ai/cli/main.py init $PROJECT_NAME
+fi


### PR DESCRIPTION
# Summary
Init file `./scripts/init.sh` will not work with docker-compose version greater than 2.0, made changes to make it compatible with latest docker-compose version

# Tests
Ran init script with docker-compose versions greater than and less than 2.0

cc:
@tommydangerous 
