### PR TITLE
[hw] Add return type hints for some methods

### DIFF
--- a/mage_ai/io/bigquery.py
+++ b/mage_ai/io/bigquery.py
@@ -321,8 +321,7 @@ WHERE table_id = '{table_name}'
             if fetch_query_at_indexes and idx < len(fetch_query_at_indexes) and \
                     fetch_query_at_indexes[idx]:
                 result = result.to_dataframe()
-
-            results.append(result)
+                results.append(result)
 
         return results
 

--- a/mage_ai/io/bigquery.py
+++ b/mage_ai/io/bigquery.py
@@ -321,7 +321,7 @@ WHERE table_id = '{table_name}'
             if fetch_query_at_indexes:
                 # Only fetch query results if specified
                 if idx < len(fetch_query_at_indexes) and \
-                    fetch_query_at_indexes[idx]:
+                        fetch_query_at_indexes[idx]:
                     result = result.to_dataframe()
                     results.append(result)
             else:

--- a/mage_ai/io/bigquery.py
+++ b/mage_ai/io/bigquery.py
@@ -318,9 +318,13 @@ WHERE table_id = '{table_name}'
             query = self._clean_query(query)
             result = self.client.query(query, **variables)
 
-            if fetch_query_at_indexes and idx < len(fetch_query_at_indexes) and \
+            if fetch_query_at_indexes:
+                # Only fetch query results if specified
+                if idx < len(fetch_query_at_indexes) and \
                     fetch_query_at_indexes[idx]:
-                result = result.to_dataframe()
+                    result = result.to_dataframe()
+                    results.append(result)
+            else:
                 results.append(result)
 
         return results

--- a/mage_ai/io/bigquery.py
+++ b/mage_ai/io/bigquery.py
@@ -318,14 +318,11 @@ WHERE table_id = '{table_name}'
             query = self._clean_query(query)
             result = self.client.query(query, **variables)
 
-            if fetch_query_at_indexes:
-                # Only fetch query results if specified
-                if idx < len(fetch_query_at_indexes) and \
-                        fetch_query_at_indexes[idx]:
-                    result = result.to_dataframe()
-                    results.append(result)
-            else:
-                results.append(result)
+            if fetch_query_at_indexes and idx < len(fetch_query_at_indexes) and \
+                    fetch_query_at_indexes[idx]:
+                result = result.to_dataframe()
+
+            results.append(result)
 
         return results
 

--- a/mage_ai/io/config.py
+++ b/mage_ai/io/config.py
@@ -113,7 +113,7 @@ class BaseConfigLoader(ABC):
 
 
 class AWSSecretLoader(BaseConfigLoader):
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         import boto3
 
         self.client = boto3.client('secretsmanager', **kwargs)

--- a/mage_ai/io/mssql.py
+++ b/mage_ai/io/mssql.py
@@ -19,7 +19,7 @@ class MSSQL(BaseSQL):
         schema: str = None,
         port: int = 1433,
         **kwargs,
-    ):
+    ) -> None:
         super().__init__(
             database=database,
             server=host,

--- a/mage_ai/io/snowflake.py
+++ b/mage_ai/io/snowflake.py
@@ -67,7 +67,7 @@ class Snowflake(BaseSQLConnection):
         query_variables: List[Dict] = None,
         fetch_query_at_indexes: List[bool] = None,
         **kwargs,
-    ):
+    ) -> List:
         results = []
 
         with self.conn.cursor() as cursor:

--- a/mage_ai/io/sql.py
+++ b/mage_ai/io/sql.py
@@ -111,7 +111,7 @@ class BaseSQL(BaseSQLConnection):
         query_variables: List[Dict] = None,
         commit: bool = False,
         fetch_query_at_indexes: List[bool] = None,
-    ):
+    ) -> List:
         results = []
 
         with self.conn.cursor() as cursor:

--- a/mage_ai/io/trino.py
+++ b/mage_ai/io/trino.py
@@ -58,7 +58,7 @@ class Trino(BaseSQL):
         schema: str = None,
         verbose: bool = True,
         **kwargs,
-    ):
+    ) -> None:
         super().__init__(
             verbose=verbose,
             catalog=catalog,


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

When executing a list of queries, the results of execution-only query do not need to be added to the final returned query results.

For some methods, missing return type hints are added back.

# Tests
<!-- How did you test your change? -->
CI
cc:
<!-- Optionally mention someone to let them know about this pull request -->
@dy46 @wangxiaoyou1993 @tommydangerous 