### PR TITLE
[dy] Fix dbt file delete error

### DIFF
--- a/mage_ai/api/resources/BlockResource.py
+++ b/mage_ai/api/resources/BlockResource.py
@@ -74,8 +74,8 @@ class BlockResource(GenericResource):
         parts2 = block_uuid_with_extension.split('.')
         language = None
         if len(parts2) >= 2:
-            block_uuid = parts2[0]
-            language = FILE_EXTENSION_TO_BLOCK_LANGUAGE[parts2[1]]
+            block_uuid = '.'.join(parts2[:-1])
+            language = FILE_EXTENSION_TO_BLOCK_LANGUAGE[parts2[-1]]
         else:
             block_uuid = block_uuid_with_extension
 
@@ -88,7 +88,7 @@ class BlockResource(GenericResource):
                 language=language,
             )
         else:
-            block = Block(block_uuid, block_uuid, block_type, language=language)
+            block = Block.get_block(block_uuid, block_uuid, block_type, language=language)
 
         if not block.exists():
             error.update(ApiError.RESOURCE_NOT_FOUND)

--- a/mage_ai/frontend/components/FileBrowser/utils.ts
+++ b/mage_ai/frontend/components/FileBrowser/utils.ts
@@ -107,13 +107,13 @@ export function getBlockFromFile(
   ].join('|');
   const extensionRegex = new RegExp(`${extensions}$`);
   if (BLOCK_TYPES.concat(BlockTypeEnum.DBT).includes(blockType) && fileName.match(extensionRegex)) {
-    const parts = fileName.split('.');
-    const extension = parts[parts.length - 1];
+    const idx = fileName.lastIndexOf('.');
+    const extension = fileName.slice(idx + 1);
 
     return {
       language: FILE_EXTENSION_TO_LANGUAGE_MAPPING[extension],
       type: blockType,
-      uuid: parts.slice(0, -1).join('.'),
+      uuid: fileName.slice(0, idx),
     };
   }
 }

--- a/mage_ai/frontend/components/FileBrowser/utils.ts
+++ b/mage_ai/frontend/components/FileBrowser/utils.ts
@@ -108,12 +108,12 @@ export function getBlockFromFile(
   const extensionRegex = new RegExp(`${extensions}$`);
   if (BLOCK_TYPES.concat(BlockTypeEnum.DBT).includes(blockType) && fileName.match(extensionRegex)) {
     const parts = fileName.split('.');
-    const extension = parts[1];
+    const extension = parts[parts.length - 1];
 
     return {
       language: FILE_EXTENSION_TO_LANGUAGE_MAPPING[extension],
       type: blockType,
-      uuid: parts[0],
+      uuid: parts.slice(0, -1).join('.'),
     };
   }
 }

--- a/mage_ai/frontend/utils/string.ts
+++ b/mage_ai/frontend/utils/string.ts
@@ -296,6 +296,12 @@ export function cleanName(name: string): string {
 
 export function removeExtensionFromFilename(filename: string): string {
   const parts = filename.split('/');
-  const fn = parts[parts.length - 1].split('.')[0];
+  const fileParts = parts[parts.length - 1].split('.');
+  let fn;
+  if (fileParts.length === 1) {
+    fn = fileParts[0];
+  } else {
+    fn = fileParts.slice(0, -1).join('.');
+  }
   return parts.slice(0, parts.length - 1).concat(fn).join('/');
 }


### PR DESCRIPTION
# Summary

Use the last index of `parts` to determine the extension, and use the first n-1 elements of `parts` to determine the block uuid. For a block named `block.py.sql`, the extension is `.sql`, and the block uuid would be `block.py`.
<!-- Brief summary of what your code does -->

# Tests

tested locally
<!-- How did you test your change? -->

cc: @johnson-mage 
<!-- Optionally mention someone to let them know about this pull request -->
