### PR TITLE
[td] 0.8.46

### DIFF
--- a/mage_ai/server/constants.py
+++ b/mage_ai/server/constants.py
@@ -12,4 +12,4 @@ DATAFRAME_OUTPUT_SAMPLE_COUNT = 10
 # Dockerfile depends on it because it runs ./scripts/install_mage.sh and uses
 # the last line to determine the version to install.
 VERSION = \
-'0.8.45'
+'0.8.46'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     name='mage-ai',
     # NOTE: when you change this, change the value of VERSION in the following file:
     # mage_ai/server/constants.py
-    version='0.8.45',
+    version='0.8.46',
     author='Mage',
     author_email='eng@mage.ai',
     description='Mage is a tool for building and deploying data pipelines.',


### PR DESCRIPTION
# Summary
- https://github.com/mage-ai/mage-ai/pull/2392
- https://github.com/mage-ai/mage-ai/pull/2393
- https://github.com/mage-ai/mage-ai/pull/2391
- Support +schema in dbt profile
- Don’t store entire dbt model output to disk unless there is at least 1 non-dbt model as a downstream block