### PR TITLE
[dy] Add sentry integration

### DIFF
--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -1,10 +1,15 @@
 from click import Context
 from mage_ai.cli.utils import parse_runtime_variables
+from mage_ai.settings import (
+    SENTRY_DSN,
+    SENTRY_TRACES_SAMPLE_RATE,
+)
 from rich import print
 from typer.core import TyperGroup
 from typing import List, Union
 import json
 import os
+import sentry_sdk
 import sys
 import typer
 
@@ -18,6 +23,13 @@ class OrderCommands(TyperGroup):
 app = typer.Typer(
     cls=OrderCommands,
 )
+
+sentry_dsn = SENTRY_DSN
+if sentry_dsn:
+    sentry_sdk.init(
+        sentry_dsn,
+        traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
+    )
 
 
 @app.command()

--- a/mage_ai/settings/__init__.py
+++ b/mage_ai/settings/__init__.py
@@ -29,3 +29,7 @@ LDAP_ADMIN_USERNAME = os.getenv('LDAP_ADMIN_USERNAME', 'admin')
 SERVER_VERBOSITY = os.getenv('SERVER_VERBOSITY', 'info') or 'info'
 
 SHELL_COMMAND = os.getenv('SHELL_COMMAND', None)
+
+# sentry environment variables
+SENTRY_DSN = os.getenv('SENTRY_DSN', None)
+SENTRY_TRACES_SAMPLE_RATE = os.getenv('SENTRY_TRACES_SAMPLE_RATE', 1.0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ pytz==2022.1
 pyyaml~=6.0
 requests==2.27.1
 scikit-learn>=1.0
+sentry-sdk==1.19.1
 simplejson
 six>=1.15.0
 sqlalchemy>=1.4.20, <2.0.0


### PR DESCRIPTION
# Summary

Add sentry integration to output exceptions from pipeline runs and block runs as well as from `mage run` commands. The integration can be enabled by setting the `SENTRY_DSN` environment variable.
<!-- Brief summary of what your code does -->

# Tests

tested locally
<!-- How did you test your change? -->

cc:
<!-- Optionally mention someone to let them know about this pull request -->
