### PR TITLE
[jk] Fix timezone inconsistencies between pg and sqlite metadata db pipeline run dates

### DIFF
--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -50,6 +50,7 @@ import {
   getFormattedVariable,
   getFormattedVariables,
 } from '@components/Sidekick/utils';
+import { getTimeInUTCString } from '@components/Triggers/utils';
 import { goToWithQuery } from '@utils/routing';
 import { isEmptyObject } from '@utils/hash';
 import { isViewer } from '@utils/session';
@@ -283,7 +284,7 @@ function BackfillDetail({
             key="backfill_start_date"
             monospace
           >
-            {startDatetime}
+            {getTimeInUTCString(startDatetime)}
           </Text>,
         ],
         [
@@ -301,7 +302,7 @@ function BackfillDetail({
             key="backfill_end_date"
             monospace
           >
-            {endDatetime}
+            {getTimeInUTCString(endDatetime)}
           </Text>,
         ],
         [

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -9,7 +9,10 @@ import ErrorsType from '@interfaces/ErrorsType';
 import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
 import Link from '@oracle/elements/Link';
-import PipelineRunType, { RunStatus, RUN_STATUS_TO_LABEL } from '@interfaces/PipelineRunType';
+import PipelineRunType, {
+  RunStatus,
+  RUN_STATUS_TO_LABEL,
+} from '@interfaces/PipelineRunType';
 import Spacing from '@oracle/elements/Spacing';
 import Spinner from '@oracle/components/Spinner';
 import Table, { ColumnType } from '@components/shared/Table';
@@ -23,7 +26,7 @@ import { ScheduleTypeEnum } from '@interfaces/PipelineScheduleType';
 import { TableContainerStyle } from '@components/shared/Table/index.style';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { dateFormatLong } from '@utils/date';
-import { getTimeInUTC } from '@components/Triggers/utils';
+import { getTimeInUTCString } from '@components/Triggers/utils';
 import { isViewer } from '@utils/session';
 import { onSuccess } from '@api/utils/response';
 
@@ -380,7 +383,7 @@ function PipelineRunsTable({
                     </Link>
                   </NextLink>,
                   <Text key="row_completed" monospace muted>
-                    {(completedAt && getTimeInUTC(completedAt).toISOString().split('.')[0]) || '-'}
+                    {(completedAt && getTimeInUTCString(completedAt)) || '-'}
                   </Text>,
                   <Button
                     default
@@ -414,7 +417,7 @@ function PipelineRunsTable({
                     {pipelineUUID}
                   </Text>,
                   <Text default key="row_date" monospace>
-                    {(executionDate && getTimeInUTC(executionDate).toISOString().split('.')[0]) || '-'}
+                    {(executionDate && getTimeInUTCString(executionDate)) || '-'}
                   </Text>,
                   <NextLink
                     as={`/pipelines/${pipelineUUID}/triggers/${pipelineScheduleId}`}
@@ -441,7 +444,7 @@ function PipelineRunsTable({
                     </Link>
                   </NextLink>,
                   <Text default key="row_completed" monospace>
-                    {(completedAt && getTimeInUTC(completedAt).toISOString().split('.')[0]) || '-'}
+                    {(completedAt && getTimeInUTCString(completedAt)) || '-'}
                   </Text>,
                   <Button
                     default

--- a/mage_ai/frontend/components/Triggers/utils.ts
+++ b/mage_ai/frontend/components/Triggers/utils.ts
@@ -50,7 +50,14 @@ export function getTimeInUTC(dateTime: string) {
 }
 
 export function getTimeInUTCString(dateTime: string) {
-  return getTimeInUTC(dateTime).toISOString().split('.')[0]
+  if (typeof dateTime !== 'string') {
+    return dateTime;
+  }
+  const formattedDate = dateTime.split('+')[0];
+
+  return getTimeInUTC(formattedDate)
+    .toISOString()
+    .split('.')[0];
 }
 
 export enum TimeUnitEnum {

--- a/mage_ai/frontend/interfaces/BackfillType.ts
+++ b/mage_ai/frontend/interfaces/BackfillType.ts
@@ -17,7 +17,7 @@ export enum IntervalTypeEnum {
 }
 
 export const INTERVAL_TYPES = [
-  IntervalTypeEnum.SECOND,
+  // IntervalTypeEnum.SECOND,
   IntervalTypeEnum.MINUTE,
   IntervalTypeEnum.HOUR,
   IntervalTypeEnum.DAY,

--- a/mage_ai/frontend/interfaces/PipelineRunType.ts
+++ b/mage_ai/frontend/interfaces/PipelineRunType.ts
@@ -78,6 +78,12 @@ interface PipelineRunMetricsType {
   source: string;
 }
 
+export type PipelineRunDateType = {
+  ds: string;
+  execution_date: string;
+  hr: string;
+};
+
 export default interface PipelineRunType {
   block_runs?: BlockRunType[];
   block_runs_count?: number;

--- a/mage_ai/frontend/utils/date.ts
+++ b/mage_ai/frontend/utils/date.ts
@@ -80,8 +80,11 @@ export function utcDateFromDateAndTime(
   date: Date,
   hour: string,
   minute: string,
+  second?: string,
 ): string {
-  return `${date.toISOString().split('T')[0]} ${hour}:${minute}`;
+  const utcDateNoSeconds = `${date.toISOString().split('T')[0]} ${hour}:${minute}`;
+
+  return second ? `${utcDateNoSeconds}:${second}` : utcDateNoSeconds;
 }
 
 export function getDatePartsFromUnixTimestamp(


### PR DESCRIPTION
# Summary
- Dates in the postgres metadata db (compared to the sqlite db) had an additional `+00:00` that was causing dates in the UI to be formatted incorrectly (included timezone hour difference). For example, the pg db would store a date as `2023-04-01T00:00:00+00:00`, while the sqlite db would store the date as `2023-04-01T00:00:00`.
- Updated date utility method to account for this difference and make the date format displayed in the UI consistent.

# Tests
Dates using postgres db are consistent with start date and time:
![image](https://user-images.githubusercontent.com/78053898/232162933-d6b5d46c-9fdb-46be-9b9d-276c7d3c2ea8.png)
![image](https://user-images.githubusercontent.com/78053898/232163073-ba7823fb-b248-4f78-9171-db80c65bd6ac.png)

Dates using sqlite db:
![image](https://user-images.githubusercontent.com/78053898/232163510-4bd785c2-3a7f-42c1-a1f6-e3c161fc3a0e.png)
![image](https://user-images.githubusercontent.com/78053898/232163529-973eeec6-08b6-4fec-926b-1f66a04915b9.png)


