### PR TITLE
[td] Support more Trino settings

### DIFF
--- a/docs/development/blocks/sql/trino.mdx
+++ b/docs/development/blocks/sql/trino.mdx
@@ -16,12 +16,21 @@ Open the file named `io_config.yaml` at the root of your Mage project and enter 
 ```yaml
 version: 0.1.1
 default:
-  TRINO_CATALOG: postgresql # Change this to the catalog of your choice
-  TRINO_HOST: 127.0.0.1
-  TRINO_PORT: 8080
-  TRINO_SCHEMA: core_data
-  TRINO_USER: admin
-  TRINO_PASSWORD: mage1337  # Optional
+  trino:
+    catalog: postgresql                       # Change this to the catalog of your choice
+    host: 127.0.0.1
+    http_headers:
+      X-Something: 'mage=power'
+    http_scheme: http
+    password: mage1337                        # Optional
+    port: 8080
+    schema: core_data
+    session_properties:                       # Optional
+      acc01.optimize_locality_enabled: false
+      optimize_hash_generation: true
+    source: trino-cli                         # Optional
+    user: admin
+    verify: /path/to/your/ca.crt              # Optional
 ```
 
 <Note>Change the values according to your Trino settings.</Note>

--- a/mage_ai/io/config.py
+++ b/mage_ai/io/config.py
@@ -349,6 +349,8 @@ class ConfigFileLoader(BaseConfigLoader):
             profile (str, optional): Profile to load configuration settings from. Defaults to
                                         'default'.
         """
+        self.version = None
+
         if config:
             self.config = config
         else:
@@ -360,7 +362,9 @@ class ConfigFileLoader(BaseConfigLoader):
                 config_file = Template(fin.read()).render(
                     **get_template_vars(),
                 )
-                self.config = yaml.full_load(config_file)[profile]
+                config = yaml.full_load(config_file)
+                self.config = config[profile]
+                self.version = config.get('version')
 
         self.use_verbose_format = any(
             source in self.config.keys() for source in VerboseConfigKey)

--- a/mage_ai/io/trino.py
+++ b/mage_ai/io/trino.py
@@ -72,6 +72,23 @@ class Trino(BaseSQL):
 
     @classmethod
     def with_config(cls, config: BaseConfigLoader) -> 'Trino':
+        if config.version >= '0.1.2':
+            settings = config.get('trino') or {}
+
+            return cls(
+                catalog=settings.get('catalog'),
+                host=settings.get('host'),
+                http_headers=settings.get('http_headers'),
+                http_scheme=settings.get('http_scheme'),
+                password=settings.get('password'),
+                port=settings.get('port'),
+                schema=settings.get('schema'),
+                session_properties=settings.get('session_properties'),
+                source=settings.get('source'),
+                user=settings.get('user'),
+                verify=settings.get('verify'),
+            )
+
         return cls(
             catalog=config[ConfigKey.TRINO_CATALOG],
             host=config[ConfigKey.TRINO_HOST],
@@ -97,18 +114,23 @@ class Trino(BaseSQL):
     def open(self) -> None:
         with self.printer.print_msg('Opening connection to Trino database'):
             connect_kwargs = dict(
-                catalog=self.settings['catalog'],
-                host=self.settings['host'],
-                port=self.settings['port'],
-                schema=self.settings['schema'],
-                user=self.settings['user'],
+                catalog=self.settings.get('catalog'),
+                host=self.settings.get('host'),
+                http_headers=self.settings.get('http_headers'),
+                http_scheme=self.settings.get('http_scheme'),
+                port=self.settings.get('port'),
+                schema=self.settings.get('schema'),
+                session_properties=self.settings.get('session_properties'),
+                source=self.settings.get('source'),
+                verify=self.settings.get('verify'),
             )
 
             if self.settings.get('password'):
                 connect_kwargs['auth'] = \
                     BasicAuthentication(
                         self.settings['user'], self.settings['password'])
-                connect_kwargs['http_scheme'] = 'https'
+                if 'http_scheme' not in connect_kwargs:
+                    connect_kwargs['http_scheme'] = 'https'
             self._ctx = ConnectionWrapper(**connect_kwargs)
 
     def table_exists(self, schema_name: str, table_name: str) -> bool:

--- a/mage_ai/io/trino.py
+++ b/mage_ai/io/trino.py
@@ -72,8 +72,8 @@ class Trino(BaseSQL):
 
     @classmethod
     def with_config(cls, config: BaseConfigLoader) -> 'Trino':
-        if config.version >= '0.1.2':
-            settings = config.get('trino') or {}
+        if config.get('trino'):
+            settings = config['trino']
 
             return cls(
                 catalog=settings.get('catalog'),
@@ -122,6 +122,7 @@ class Trino(BaseSQL):
                 schema=self.settings.get('schema'),
                 session_properties=self.settings.get('session_properties'),
                 source=self.settings.get('source'),
+                user=self.settings.get('user'),
                 verify=self.settings.get('verify'),
             )
 


### PR DESCRIPTION
# Summary
Add support for more Trino settings:

```
catalog
host
http_headers
http_scheme
password
port
schema
session_properties
source
user
verify
```

## Update `io_config.yaml`:

```yaml
version: 0.1.1
default:
  trino:
    catalog: postgresql                       # Change this to the catalog of your choice
    host: 127.0.0.1
    http_headers:
      X-Something: 'mage=power'
    http_scheme: http
    password: mage1337                        # Optional
    port: 8080
    schema: core_data
    session_properties:                       # Optional
      acc01.optimize_locality_enabled: false
      optimize_hash_generation: true
    source: trino-cli                         # Optional
    user: admin
    verify: /path/to/your/ca.crt              # Optional
```