### PR TITLE
Re-enable feedback buttons

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -15,6 +15,10 @@
       "dark": "#121212"
     }
   },
+  "feedback": {
+    "suggestEdit": true,
+    "raiseIssue": true
+  },
   "metadata": {
     "og:image": "https://media.graphassets.com/j4XVqcsxTG2x50kBJryE",
     "twitter:site": "@mage_ai"


### PR DESCRIPTION
# Summary

This PR re-enables the feedback buttons for the documentation that were recently set to be hidden by default.