### PR TITLE
[jk] Update generic block templates

### DIFF
--- a/mage_ai/data_preparation/templates/custom/python/default.jinja
+++ b/mage_ai/data_preparation/templates/custom/python/default.jinja
@@ -6,12 +6,16 @@ if 'custom' not in globals():
 
 {% block content %}
 @custom
-def transform_custom(*args, **kwargs):
+def transform_custom(data, *args, **kwargs):
     """
+    Args:
+        data: The output from the upstream parent block (if applicable)
+        args: The output from any additional upstream blocks
+
     Returns:
         Anything (e.g. data frame, dictionary, array, int, str, etc.)
     """
     # Specify your custom logic here
 {{ code }}
-    return {}
+    return data
 {% endblock %}

--- a/mage_ai/data_preparation/templates/data_exporters/default.jinja
+++ b/mage_ai/data_preparation/templates/data_exporters/default.jinja
@@ -6,12 +6,13 @@ if 'data_exporter' not in globals():
 
 {% block content %}
 @data_exporter
-def export_data(*args, **kwargs):
+def export_data(data, *args, **kwargs):
     """
-    Exports data to some source
+    Exports data to some source.
 
     Args:
-        args: The input variables from upstream blocks
+        data: The output from the upstream parent block
+        args: The output from any additional upstream blocks (if applicable)
 
     Output (optional):
         Optionally return any object and it'll be logged and

--- a/mage_ai/data_preparation/templates/transformers/default.jinja
+++ b/mage_ai/data_preparation/templates/transformers/default.jinja
@@ -6,7 +6,7 @@ if 'transformer' not in globals():
 
 {% block content %}
 @transformer
-def transform(*args, **kwargs):
+def transform(data, *args, **kwargs):
     """
     Template code for a transformer block.
 
@@ -14,12 +14,13 @@ def transform(*args, **kwargs):
     There should be one parameter for each output variable from each parent block.
 
     Args:
-        args: The input variables from upstream blocks
+        data: The output from the upstream parent block
+        args: The output from any additional upstream blocks (if applicable)
 
     Returns:
         Anything (e.g. data frame, dictionary, array, int, str, etc.)
     """
     # Specify your transformation logic here
 {{ code }}
-    return {}
+    return data
 {% endblock %}

--- a/mage_ai/frontend/components/Sidekick/GlobalVariables/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/GlobalVariables/index.tsx
@@ -439,15 +439,18 @@ ${BUILD_CODE_SNIPPET_PREVIEW(pipelineUUID, selectedBlock?.uuid, uuid)}`;
                 bold
                 inline
                 monospace
+                warning
               >
                 {BlockTypeEnum.SCRATCHPAD}
-              </Text> block.
+              </Text> block. They are for scratchpad blocks, specifically.
+              To get upstream block outputs inside of other blocks, use
+              the positional arguments.
             </Text>
           </Spacing>
 
           <Spacing mb={PADDING_UNITS}>
             <Text>
-              To load the variable, use the following syntax:
+              To load the variable in a scratchpad block, use the following syntax:
             </Text>
           </Spacing>
 

--- a/mage_ai/tests/data_preparation/test_templates.py
+++ b/mage_ai/tests/data_preparation/test_templates.py
@@ -278,7 +278,7 @@ if 'test' not in globals():
 
 
 @transformer
-def transform(*args, **kwargs):
+def transform(data, *args, **kwargs):
     \"\"\"
     Template code for a transformer block.
 
@@ -286,14 +286,15 @@ def transform(*args, **kwargs):
     There should be one parameter for each output variable from each parent block.
 
     Args:
-        args: The input variables from upstream blocks
+        data: The output from the upstream parent block
+        args: The output from any additional upstream blocks (if applicable)
 
     Returns:
         Anything (e.g. data frame, dictionary, array, int, str, etc.)
     \"\"\"
     # Specify your transformation logic here
 
-    return {}
+    return data
 
 
 @test
@@ -491,12 +492,13 @@ def test_output(output, *args) -> None:
 
 
 @data_exporter
-def export_data(*args, **kwargs):
+def export_data(data, *args, **kwargs):
     \"\"\"
-    Exports data to some source
+    Exports data to some source.
 
     Args:
-        args: The input variables from upstream blocks
+        data: The output from the upstream parent block
+        args: The output from any additional upstream blocks (if applicable)
 
     Output (optional):
         Optionally return any object and it'll be logged and


### PR DESCRIPTION
# Summary
- Update generic block templates for custom, transformer, and data exporter blocks so it's easier for users to pass the output from upstream blocks.
- Clarified language for block output variables in Sidekick.

# Tests
![image](https://user-images.githubusercontent.com/78053898/232953296-5ef4de9d-9203-4118-8524-abc218b52078.png)
