### PR TITLE
[jk] Do not switch kernels when deleting pipeline

### DIFF
--- a/mage_ai/api/operations/base.py
+++ b/mage_ai/api/operations/base.py
@@ -171,7 +171,7 @@ class BaseOperation():
     async def __delete_show_or_update(self):
         updated_options = await self.__updated_options()
         res = await self.__resource_class().process_member(
-            self.pk, self.user, **updated_options)
+            self.pk, self.user, action=self.action, **updated_options)
 
         policy = self.__policy_class()(res, self.user, **updated_options)
         policy.authorize_action(self.action)

--- a/mage_ai/api/operations/base.py
+++ b/mage_ai/api/operations/base.py
@@ -171,7 +171,7 @@ class BaseOperation():
     async def __delete_show_or_update(self):
         updated_options = await self.__updated_options()
         res = await self.__resource_class().process_member(
-            self.pk, self.user, action=self.action, **updated_options)
+            self.pk, self.user, **updated_options)
 
         policy = self.__policy_class()(res, self.user, **updated_options)
         policy.authorize_action(self.action)

--- a/mage_ai/api/resources/PipelineResource.py
+++ b/mage_ai/api/resources/PipelineResource.py
@@ -135,7 +135,7 @@ class PipelineResource(BaseResource):
     async def member(self, pk, user, **kwargs):
         pipeline = await Pipeline.get_async(pk)
 
-        if kwargs.get('action', None) != DELETE:
+        if kwargs.get('api_operation_action', None) != DELETE:
             switch_active_kernel(PIPELINE_TO_KERNEL_NAME[pipeline.type])
 
         return self(pipeline, user, **kwargs)

--- a/mage_ai/api/resources/PipelineResource.py
+++ b/mage_ai/api/resources/PipelineResource.py
@@ -1,3 +1,4 @@
+from mage_ai.api.operations.constants import DELETE
 from mage_ai.api.resources.BaseResource import BaseResource
 from mage_ai.data_preparation.models.block.dbt.utils import add_blocks_upstream_from_refs
 from mage_ai.data_preparation.models.constants import PipelineStatus
@@ -134,7 +135,8 @@ class PipelineResource(BaseResource):
     async def member(self, pk, user, **kwargs):
         pipeline = await Pipeline.get_async(pk)
 
-        switch_active_kernel(PIPELINE_TO_KERNEL_NAME[pipeline.type])
+        if kwargs.get('action', None) != DELETE:
+            switch_active_kernel(PIPELINE_TO_KERNEL_NAME[pipeline.type])
 
         return self(pipeline, user, **kwargs)
 


### PR DESCRIPTION
# Summary
- Error was occurring when trying to delete pyspark pipelines due to an attempt to switch kernels. For DELETE actions, we do not need to switch kernels.

# Tests
Before (error when trying to delete):
![image](https://user-images.githubusercontent.com/78053898/233171518-75a0348f-d217-4219-9bd9-277f268bd02c.png)

After (no issues deleting same pipeline):
![delete spark pipeline](https://user-images.githubusercontent.com/78053898/233171635-73338023-ee2f-4d81-bb09-12267dd672b9.gif)
