### PR TITLE
Update streaming pipeline documentation with kafka container name

### DIFF
--- a/docs/guides/streaming-pipeline.mdx
+++ b/docs/guides/streaming-pipeline.mdx
@@ -31,6 +31,7 @@ use Kafka locally:
          - "2181:2181"
      kafka:
        build: .
+       container_name: docker_kafka
        ports:
          - "9092:9092"
        expose:


### PR DESCRIPTION
# Summary
The Kafka container's default name has been changed, resulting in the failure of the 5th step ` docker ps | grep docker_kafka` returns empty. To resolve this issue, you need to specify the container_name in the configuration.

# Tests
<!-- How did you test your change? -->

cc:
@dy46 