### PR TITLE
[td] Trino SQL blocks can use unique table names for exported upstream blocks

### DIFF
--- a/mage_ai/data_preparation/models/block/sql/trino.py
+++ b/mage_ai/data_preparation/models/block/sql/trino.py
@@ -18,6 +18,7 @@ def create_upstream_block_tables(
     execution_partition: str = None,
     cache_upstream_dbt_models: bool = False,
     query: str = None,
+    unique_table_name_suffix: str = None,
 ):
     from mage_ai.data_preparation.models.block.dbt.utils import (
         parse_attributes,
@@ -48,6 +49,8 @@ def create_upstream_block_tables(
                 continue
 
             table_name = upstream_block.table_name
+            if unique_table_name_suffix:
+                table_name = f'{table_name}_{unique_table_name_suffix}'
 
             df = get_variable(
                 upstream_block.pipeline.uuid,
@@ -94,10 +97,15 @@ def create_upstream_block_tables(
             )
 
 
-def interpolate_input_data(block, query, loader):
+def interpolate_input_data(block, query, loader, unique_table_name_suffix: str = None):
+    get_table = None
+    if unique_table_name_suffix:
+        get_table = lambda opts: f"{opts['table']}_{unique_table_name_suffix}"
+
     return interpolate_input(
         block,
         query,
         get_database=lambda opts: loader.default_database(),
         get_schema=lambda opts: loader.default_schema(),
+        get_table=get_table,
     )

--- a/mage_ai/data_preparation/models/block/sql/trino.py
+++ b/mage_ai/data_preparation/models/block/sql/trino.py
@@ -98,14 +98,14 @@ def create_upstream_block_tables(
 
 
 def interpolate_input_data(block, query, loader, unique_table_name_suffix: str = None):
-    get_table = None
-    if unique_table_name_suffix:
-        get_table = lambda opts: f"{opts['table']}_{unique_table_name_suffix}"
+    def _get_table(opts):
+        table_name = opts['table']
+        return f'{table_name}_{unique_table_name_suffix}'
 
     return interpolate_input(
         block,
         query,
         get_database=lambda opts: loader.default_database(),
         get_schema=lambda opts: loader.default_schema(),
-        get_table=get_table,
+        get_table=_get_table if unique_table_name_suffix else None,
     )

--- a/mage_ai/data_preparation/models/block/sql/utils/shared.py
+++ b/mage_ai/data_preparation/models/block/sql/utils/shared.py
@@ -75,6 +75,7 @@ def interpolate_input(
     replace_func: Callable = None,
     get_database: Callable = None,
     get_schema: Callable = None,
+    get_table: Callable = None,
 ) -> str:
     def __replace_func(db, schema, tn):
         if replace_func:
@@ -116,7 +117,14 @@ def interpolate_input(
         if not schema and get_schema:
             schema = get_schema(dict(configuration=configuration))
 
-        replace_with = __replace_func(database, schema, upstream_block.table_name)
+        table_name = upstream_block.table_name
+        if get_table:
+            table_name = get_table(dict(
+                configuration=configuration,
+                table=table_name,
+            ))
+
+        replace_with = __replace_func(database, schema, table_name)
 
         upstream_block_content = upstream_block.content
         if is_sql and \
@@ -127,7 +135,7 @@ def interpolate_input(
             upstream_query = interpolate_input(upstream_block, upstream_block_content)
             replace_with = f"""(
     {upstream_query}
-) AS {upstream_block.table_name}"""
+) AS {table_name}"""
 
         query = re.sub(
             build_variable_pattern(f'df_{idx + 1}'),

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -90,6 +90,7 @@ import {
   CONFIG_KEY_DBT_PROJECT_NAME,
   CONFIG_KEY_EXPORT_WRITE_POLICY,
   CONFIG_KEY_LIMIT,
+  CONFIG_KEY_UNIQUE_UPSTREAM_TABLE_NAME,
   CONFIG_KEY_USE_RAW_SQL,
 } from '@interfaces/ChartBlockType';
 import { DataSourceTypeEnum } from '@interfaces/DataSourceType';
@@ -250,6 +251,7 @@ function CodeBlock({
     [CONFIG_KEY_EXPORT_WRITE_POLICY]: blockConfiguration[CONFIG_KEY_EXPORT_WRITE_POLICY]
       || ExportWritePolicyEnum.APPEND,
     [CONFIG_KEY_LIMIT]: blockConfiguration[CONFIG_KEY_LIMIT],
+    [CONFIG_KEY_UNIQUE_UPSTREAM_TABLE_NAME]: blockConfiguration[CONFIG_KEY_UNIQUE_UPSTREAM_TABLE_NAME],
     [CONFIG_KEY_USE_RAW_SQL]: !!blockConfiguration[CONFIG_KEY_USE_RAW_SQL],
   });
 
@@ -1473,10 +1475,9 @@ function CodeBlock({
                 <CodeHelperStyle>
                   <FlexContainer
                     flexWrap="wrap"
-                    justifyContent="space-between"
-                    style={{marginTop: '-8px'}}
+                    style={{ marginTop: '-8px' }}
                   >
-                    <FlexContainer style={{marginTop: '8px'}}>
+                    <FlexContainer style={{ marginTop: '8px' }}>
                       <Select
                         compact
                         label="Connection"
@@ -1765,9 +1766,56 @@ function CodeBlock({
                             </Select>
                           </FlexContainer>
                         </Tooltip>
-
-                        <Spacing mr={5} />
                       </FlexContainer>
+                    )}
+
+                    {dataProviderConfig?.[CONFIG_KEY_DATA_PROVIDER] === DataProviderEnum.TRINO
+                      && block.upstream_blocks.length >= 1
+                      && (
+                      <>
+                        <Spacing mr={1} />
+
+                        <FlexContainer alignItems="center"  style={{ marginTop: '8px' }}>
+                          <Tooltip
+                            appearBefore
+                            block
+                            description={
+                              <Text default inline>
+                                If checked, upstream blocks that aren’t SQL blocks
+                                <br />
+                                will have their data exported into a table that is
+                                <br />
+                                uniquely named upon each block run. For example,
+                                <br />
+                                <Text default inline monospace>
+                                  [pipeline_uuid]_[block_uuid]_[unique_timestamp]
+                                </Text>.
+                              </Text>
+                            }
+                            size={null}
+                            widthFitContent
+                          >
+                            <FlexContainer alignItems="center">
+                              <Checkbox
+                                checked={dataProviderConfig[CONFIG_KEY_UNIQUE_UPSTREAM_TABLE_NAME]}
+                                label={
+                                  <Text muted small>
+                                    Unique upstream table names
+                                  </Text>
+                                }
+                                onClick={(e) => {
+                                  pauseEvent(e);
+                                  updateDataProviderConfig({
+                                    [CONFIG_KEY_UNIQUE_UPSTREAM_TABLE_NAME]: !dataProviderConfig[CONFIG_KEY_UNIQUE_UPSTREAM_TABLE_NAME],
+                                  });
+                                }}
+                              />
+                              <span>&nbsp;</span>
+                              <Info muted />
+                            </FlexContainer>
+                          </Tooltip>
+                        </FlexContainer>
+                      </>
                     )}
                   </FlexContainer>
                 </CodeHelperStyle>

--- a/mage_ai/frontend/interfaces/ChartBlockType.ts
+++ b/mage_ai/frontend/interfaces/ChartBlockType.ts
@@ -17,11 +17,11 @@ export const CONFIG_KEY_DATA_PROVIDER_DATABASE = 'data_provider_database';
 export const CONFIG_KEY_DATA_PROVIDER_PROFILE = 'data_provider_profile';
 export const CONFIG_KEY_DATA_PROVIDER_SCHEMA = 'data_provider_schema';
 export const CONFIG_KEY_DATA_PROVIDER_TABLE = 'data_provider_table';
-export const CONFIG_KEY_DBT_PROJECT_NAME = 'dbt_project_name';
 export const CONFIG_KEY_DBT_PROFILE_TARGET = 'dbt_profile_target';
-export const CONFIG_KEY_DISABLE_CREATE_TABLE = 'disable_create_table';
+export const CONFIG_KEY_DBT_PROJECT_NAME = 'dbt_project_name';
 export const CONFIG_KEY_EXPORT_WRITE_POLICY = 'export_write_policy';
 export const CONFIG_KEY_LIMIT = 'limit';
+export const CONFIG_KEY_UNIQUE_UPSTREAM_TABLE_NAME = 'unique_upstream_table_name';
 export const CONFIG_KEY_USE_RAW_SQL = 'use_raw_sql';
 
 export const VARIABLE_NAMES = [


### PR DESCRIPTION
# Summary
If checked, upstream blocks that aren’t SQL blocks will have their data exported into a table that is uniquely named upon each block run. 

For example, `[pipeline_uuid]_[block_uuid]_[unique_timestamp]`.

<img width="1050" alt="Screenshot 2023-04-20 at 00 58 03" src="https://user-images.githubusercontent.com/1066980/233299705-f4dc3378-4ed9-4af1-a2b4-93d00539d9c3.png">
