### PR TITLE
[td] Catch TrinoUserError instead of internal error

### DIFF
--- a/mage_ai/io/trino.py
+++ b/mage_ai/io/trino.py
@@ -15,7 +15,7 @@ from pandas import DataFrame, Series
 from time import sleep
 from trino.auth import BasicAuthentication
 from trino.dbapi import Connection, Cursor as CursorParent
-from trino.exceptions import TrinoExternalError
+from trino.exceptions import TrinoUserError
 from trino.transaction import IsolationLevel
 from typing import IO, List, Mapping, Union
 
@@ -138,7 +138,7 @@ class Trino(BaseSQL):
 
             try:
                 data = super().execute_queries(queries, **kwargs)
-            except TrinoExternalError as err:
+            except TrinoUserError as err:
                 print(err)
 
             tries += 1
@@ -159,7 +159,7 @@ class Trino(BaseSQL):
 
             try:
                 data = super().load(query_string, **kwargs)
-            except TrinoExternalError as err:
+            except TrinoUserError as err:
                 print(err)
 
             tries += 1


### PR DESCRIPTION
# Summary
Catch this error:

```
TrinoUserError(type=USER_ERROR, name=TABLE_NOT_FOUND, message="line 1:15: Table 'hudi_ingest.etl_tmp.cwang_test_changes_yeah' does not exist", query_id=20230420_180015_34890_xnaun)
```