### PR TITLE
[jk] Allow Mage default port on Docker to be changed

### DIFF
--- a/mage_ai/frontend/api/utils/url.ts
+++ b/mage_ai/frontend/api/utils/url.ts
@@ -6,14 +6,17 @@ function getHostCore(
   defaultPort: string = '6789',
 ){
   let host = defaultHost;
-  if(windowDefined){
+  if (windowDefined) {
     host = window.location.hostname;
   }
-  if(host === defaultHost){
-    host = `${host}:${defaultPort}`;
-  } else if (windowDefined && !!window.location.port){
-    host = `${host}:${window.location.port}`;
+  if (windowDefined && !!window.location.port) {
+    if (host === defaultHost && window.location.port === '3000') {
+      host = `${host}:${defaultPort}`;
+    } else {
+      host = `${host}:${window.location.port}`;
+    }
   }
+
   return host;
 }
 
@@ -23,9 +26,9 @@ function getProtocol(
   defaultHost: string = 'localhost',
 ){
   let protocol = 'http://';
-  if(host !== defaultHost){
+  if (host !== defaultHost) {
     protocol = 'https://';
-    if(windowDefined && !window.location.protocol?.match(/https/)) {
+    if (windowDefined && !window.location.protocol?.match(/https/)) {
       protocol = 'http://';
     }
   }

--- a/mage_ai/frontend/api/utils/url.ts
+++ b/mage_ai/frontend/api/utils/url.ts
@@ -15,6 +15,8 @@ function getHostCore(
     } else {
       host = `${host}:${window.location.port}`;
     }
+  } else {
+    host = `${host}:${defaultPort}`;
   }
 
   return host;


### PR DESCRIPTION
# Summary
- Instead of hardcoding port 6789 for localhost, use the window location port so that a different port can be used to run Mage via Docker.

# Tests
- Tested changing port locally and building local docker containers to run Mage on that port.
