### PR TITLE
[td] Fix dbt test not reading profile

### DIFF
--- a/mage_ai/data_preparation/models/block/dbt/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/__init__.py
@@ -2,6 +2,7 @@ from mage_ai.data_preparation.models.block import Block
 from mage_ai.data_preparation.models.block.dbt.utils import (
     build_command_line_arguments,
     create_upstream_tables,
+    create_temporary_profile,
     fetch_model_data,
     load_profiles_async,
     load_profiles_file,
@@ -122,19 +123,16 @@ class DBTBlock(Block):
             run_settings=run_settings,
             test_execution=test_execution,
         )
+
         project_full_path = command_line_dict['project_full_path']
         profiles_dir = command_line_dict['profiles_dir']
         dbt_profile_target = command_line_dict['profile_target']
 
         # Create a temporary profiles file with variables and secrets interpolated
-        profiles_full_path = os.path.join(project_full_path, 'profiles.yml')
-        profile = load_profiles_file(profiles_full_path)
-
-        temp_profile_full_path = os.path.join(profiles_dir, 'profiles.yml')
-        os.makedirs(os.path.dirname(temp_profile_full_path), exist_ok=True)
-
-        with open(temp_profile_full_path, 'w') as f:
-            yaml.safe_dump(profile, f)
+        _, temp_profile_full_path = create_temporary_profile(
+            project_full_path,
+            profiles_dir,
+        )
 
         is_sql = BlockLanguage.SQL == self.language
         if is_sql:

--- a/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
@@ -30,11 +30,15 @@ from typing import Callable, Dict, List, Tuple
 import aiofiles
 import os
 import re
+import shutil
 import simplejson
 import subprocess
 import sys
 import uuid
 import yaml
+
+
+PROFILES_FILE_NAME = 'profiles.yml'
 
 
 def parse_attributes(block) -> Dict:
@@ -60,7 +64,7 @@ def parse_attributes(block) -> Dict:
     sources_full_path = os.path.join(models_folder_path, 'mage_sources.yml')
     sources_full_path_legacy = full_path.replace(filename, 'mage_sources.yml')
 
-    profiles_full_path = os.path.join(project_full_path, 'profiles.yml')
+    profiles_full_path = os.path.join(project_full_path, PROFILES_FILE_NAME)
     profile_target = configuration.get('dbt_profile_target')
     profile = load_profile(project_name, profiles_full_path, profile_target)
 
@@ -388,7 +392,9 @@ def config_file_loader_and_configuration(block, profile_target: str) -> Dict:
     profile = get_profile(block, profile_target)
 
     if not profile:
-        raise Exception(f'No profile target named {profile_target}, check the profiles.yml file.')
+        raise Exception(
+            f'No profile target named {profile_target}, check the {PROFILES_FILE_NAME} file.',
+        )
     profile_type = profile.get('type')
 
     config_file_loader = None
@@ -945,6 +951,18 @@ def build_command_line_arguments(
     )
 
 
+def create_temporary_profile(project_full_path: str, profiles_dir: str) -> Tuple[str, str]:
+    profiles_full_path = os.path.join(project_full_path, PROFILES_FILE_NAME)
+    profile = load_profiles_file(profiles_full_path)
+
+    temp_profile_full_path = os.path.join(profiles_dir, PROFILES_FILE_NAME)
+    os.makedirs(os.path.dirname(temp_profile_full_path), exist_ok=True)
+
+    with open(temp_profile_full_path, 'w') as f:
+        yaml.safe_dump(profile, f)
+
+    return (profile, temp_profile_full_path)
+
 def run_dbt_tests(
     block,
     build_block_output_stdout: Callable[..., object] = None,
@@ -959,7 +977,19 @@ def run_dbt_tests(
     else:
         stdout = sys.stdout
 
-    dbt_command, args, _ = build_command_line_arguments(block, global_vars, run_tests=True)
+    dbt_command, args, command_line_dict = build_command_line_arguments(
+        block,
+        global_vars,
+        run_tests=True,
+    )
+
+    project_full_path = command_line_dict['project_full_path']
+    profiles_dir = command_line_dict['profiles_dir']
+
+    _, temp_profile_full_path = create_temporary_profile(
+        project_full_path,
+        profiles_dir,
+    )
 
     proc1 = subprocess.run([
         'dbt',
@@ -976,6 +1006,11 @@ def run_dbt_tests(
             match = re.search('ERROR=([0-9]+)', line)
             if match:
                 number_of_errors += int(match.groups()[0])
+
+    try:
+        shutil.rmtree(profiles_dir)
+    except Exception as err:
+        print(f'Error removing temporary profile at {temp_profile_full_path}: {err}')
 
     if number_of_errors >= 1:
         raise Exception('DBT test failed.')


### PR DESCRIPTION
# Summary
When running a dbt model in a pipeline run, at the end of loading the sample data, there is a dbt error: Could not find profile named ‘…’