### PR TITLE
[dg] Fix dev script to always use 'docker-compose' if it exists

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -95,17 +95,19 @@ export DATABASE_CONNECTION_URL=$DATABASE_CONNECTION_URL
 export MAX_NUMBER_OF_FILE_VERSIONS=$MAX_NUMBER_OF_FILE_VERSIONS
 export REQUIRE_USER_AUTHENTICATION=$REQUIRE_USER_AUTHENTICATION
 
-docker_version=$(docker version --format '{{.Server.Version}}')
-if [[ "$docker_version" == 2*.* ]]; then
-  HOST=$HOST \
-  PORT=$PORT \
-  PROJECT=$PROJECT_NAME \
-  MANAGE_INSTANCE=$MANAGE_INSTANCE \
-  docker compose -f docker-compose.yml up
+if command -v docker-compose &> /dev/null
+then
+    # docker-compose exists
+    HOST=$HOST \
+    PORT=$PORT \
+    PROJECT=$PROJECT_NAME \
+    MANAGE_INSTANCE=$MANAGE_INSTANCE \
+    docker-compose -f docker-compose.yml up
 else
-  HOST=$HOST \
-  PORT=$PORT \
-  PROJECT=$PROJECT_NAME \
-  MANAGE_INSTANCE=$MANAGE_INSTANCE \
-  docker-compose -f docker-compose.yml up
+    # docker-compose does not exist
+    HOST=$HOST \
+    PORT=$PORT \
+    PROJECT=$PROJECT_NAME \
+    MANAGE_INSTANCE=$MANAGE_INSTANCE \
+    docker compose -f docker-compose.yml up
 fi


### PR DESCRIPTION
# Summary
Check if `docker-compose` exists before running it. If it doesn't exist, use `docker compose` instead. 

# Tests
local
cc:
@tommydangerous 