### PR TITLE
[jk] Bulk retry pipeline runs

### DIFF
--- a/mage_ai/api/resources/PipelineResource.py
+++ b/mage_ai/api/resources/PipelineResource.py
@@ -199,8 +199,11 @@ class PipelineResource(BaseResource):
             for pipeline_run in pipeline_runs:
                 PipelineScheduler(pipeline_run).stop()
 
-        status = payload.get('status')
+        def retry_pipeline_runs(pipeline_runs):
+            for run in pipeline_runs:
+                self.model.retry_pipeline_run(run)
 
+        status = payload.get('status')
         pipeline_uuid = self.model.uuid
 
         def _update_callback(resource):
@@ -212,6 +215,8 @@ class PipelineResource(BaseResource):
                     update_schedule_status(status, pipeline_uuid)
                 elif status == PipelineRun.PipelineRunStatus.CANCELLED.value:
                     cancel_pipeline_runs(status, pipeline_uuid)
+                elif status == 'retry' and payload.get('pipeline_runs'):
+                    retry_pipeline_runs(payload.get('pipeline_runs'))
 
         self.on_update_callback = _update_callback
 

--- a/mage_ai/api/resources/PipelineResource.py
+++ b/mage_ai/api/resources/PipelineResource.py
@@ -201,7 +201,12 @@ class PipelineResource(BaseResource):
 
         def retry_pipeline_runs(pipeline_runs):
             for run in pipeline_runs:
-                self.model.retry_pipeline_run(run)
+                pipeline_run = PipelineRun(
+                    id=run['id'],
+                    pipeline_schedule_id=run['pipeline_schedule_id'],
+                    pipeline_uuid=run['pipeline_uuid']
+                )
+                pipeline_run.retry_pipeline_run(run)
 
         status = payload.get('status')
         pipeline_uuid = self.model.uuid

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -848,39 +848,6 @@ class Pipeline:
 
         return mapping
 
-    @safe_db_query
-    def retry_pipeline_run(
-        self,
-        pipeline_run,
-    ):
-        from mage_ai.orchestration.db.models.schedules import PipelineSchedule, PipelineRun
-        from mage_ai.orchestration.pipeline_scheduler import PipelineScheduler, get_variables
-        from mage_ai.data_integrations.utils.scheduler import initialize_state_and_runs
-
-        is_integration = PipelineType.INTEGRATION == self.type
-        schedule = PipelineSchedule.get(pipeline_run['pipeline_schedule_id'])
-        execution_date = datetime.datetime.fromisoformat(pipeline_run['execution_date'])
-        pipeline_run = PipelineRun.create(
-            create_block_runs=False,
-            execution_date=execution_date,
-            pipeline_schedule_id=schedule.id,
-            pipeline_uuid=self.uuid,
-            variables=pipeline_run.get('variables', {}),
-        )
-        pipeline_scheduler = PipelineScheduler(pipeline_run)
-        if is_integration:
-            initialize_state_and_runs(
-                pipeline_run,
-                pipeline_scheduler.logger,
-                get_variables(pipeline_run),
-            )
-        else:
-            pipeline_run.create_block_runs()
-
-        pipeline_scheduler.start(should_schedule=False)
-
-        return pipeline_run
-
     def add_block(
         self,
         block: Block,

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -26,7 +26,6 @@ import { PopupContainerStyle } from './Table.style';
 import { ScheduleTypeEnum } from '@interfaces/PipelineScheduleType';
 import { TableContainerStyle } from '@components/shared/Table/index.style';
 import { UNIT } from '@oracle/styles/units/spacing';
-import { dateFormatLong } from '@utils/date';
 import { getTimeInUTCString } from '@components/Triggers/utils';
 import { indexBy } from '@utils/array';
 import { isViewer } from '@utils/session';
@@ -92,13 +91,7 @@ function RetryButton({
     // @ts-ignore
     createPipelineRun({
       pipeline_run: {
-        execution_date: dateFormatLong(
-          new Date().toISOString(),
-          {
-            includeSeconds: true,
-            utcFormat: true,
-          },
-        ),
+        execution_date: pipelineRun?.execution_date,
         pipeline_schedule_id: pipelineRun?.pipeline_schedule_id,
         pipeline_uuid: pipelineRun?.pipeline_uuid,
         variables: pipelineRun?.variables,

--- a/mage_ai/frontend/interfaces/PipelineType.ts
+++ b/mage_ai/frontend/interfaces/PipelineType.ts
@@ -26,6 +26,7 @@ export enum PipelineStatusEnum {
   ACTIVE = 'active',    // At least one active trigger
   INACTIVE = 'inactive',    // All inactive triggers
   NO_SCHEDULES = 'no_schedules',    // No triggers
+  RETRY = 'retry',
 }
 
 export enum PipelineQueryEnum {

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -266,6 +266,7 @@ function PipelineRuns({
   ), [
     fetchPipelineRuns,
     paginationEl,
+    pipeline?.type,
     pipelineRuns,
     selectedRun,
     selectedRuns,

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -59,7 +59,7 @@ const TABS = [
   TAB_BLOCK_RUNS,
 ];
 
-const LIMIT = 25;
+const LIMIT = 30;
 const MAX_PAGES = 9;
 
 type PipelineRunsProp = {

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -33,6 +33,7 @@ import {
 } from '@oracle/icons';
 import { OFFSET_PARAM, goToWithQuery } from '@utils/routing';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
+import { PipelineTypeEnum } from '@interfaces/PipelineType';
 import { RunStatus as RunStatusEnum } from '@interfaces/BlockRunType';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { ignoreKeys, isEqual } from '@utils/hash';
@@ -247,7 +248,7 @@ function PipelineRuns({
   const tablePipelineRuns = useMemo(() => (
     <>
       <PipelineRunsTable
-        allowBulkSelect
+        allowBulkSelect={pipeline?.type !== PipelineTypeEnum.STREAMING}
         fetchPipelineRuns={fetchPipelineRuns}
         onClickRow={(rowIndex: number) => setSelectedRun((prev) => {
           const run = pipelineRuns[rowIndex];

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -33,7 +33,7 @@ import {
 } from '@oracle/icons';
 import { OFFSET_PARAM, goToWithQuery } from '@utils/routing';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
-import { PipelineTypeEnum } from '@interfaces/PipelineType';
+import { PipelineStatusEnum, PipelineTypeEnum } from '@interfaces/PipelineType';
 import { RunStatus as RunStatusEnum } from '@interfaces/BlockRunType';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { ignoreKeys, isEqual } from '@utils/hash';
@@ -340,7 +340,7 @@ function PipelineRuns({
                     updatePipeline({
                       pipeline: {
                         pipeline_runs: selectedRunsArr,
-                        status: 'retry',
+                        status: PipelineStatusEnum.RETRY,
                       },
                     });
                   }}


### PR DESCRIPTION
# Summary
- Allow all pipeline runs on a page to be selected and retried.
- Bulk retry runs not enabled for streaming pipelines.

# Tests
Standard pipeline:
![bulk retry standard pipeline runs](https://user-images.githubusercontent.com/78053898/234075582-6b9198b9-f982-479e-9d55-9f1d02755b8c.gif)

Integration pipeline:
![bulk retry integration pipeline runs](https://user-images.githubusercontent.com/78053898/234075614-75ea3aec-196c-4e91-97a4-a96210959ce7.gif)

cc:
@tommydangerous 
