### PR TITLE
[jk] Fix perpetual run block spinner when restarting kernel.

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
@@ -8,6 +8,7 @@ import {
 import { ThemeContext } from 'styled-components';
 import { useMutation } from 'react-query';
 
+import BlockType from '@interfaces/BlockType';
 import Circle from '@oracle/elements/Circle';
 import ClickOutside from '@oracle/components/ClickOutside';
 import ClusterType, { ClusterStatusEnum } from '@interfaces/ClusterType';
@@ -69,6 +70,7 @@ type KernelStatusProps = {
   savePipelineContent: () => void;
   selectedFilePath?: string;
   setErrors: (errors: ErrorsType) => void;
+  setRunningBlocks: (blocks: BlockType[]) => void;
   updatePipelineMetadata: (name: string, type?: string) => void;
 };
 
@@ -86,6 +88,7 @@ function KernelStatus({
   savePipelineContent,
   selectedFilePath,
   setErrors,
+  setRunningBlocks,
   updatePipelineMetadata,
 }: KernelStatusProps) {
   const themeContext: ThemeType = useContext(ThemeContext);
@@ -226,11 +229,13 @@ function KernelStatus({
     const hide = get(LOCAL_STORAGE_KEY_HIDE_KERNEL_WARNING, 0);
     if (kernelPid !== kernelPidPrevious && isBusy && !hide) {
       showKernelWarning();
+      setRunningBlocks([]);
     }
   }, [
     isBusy,
     kernelPid,
     kernelPidPrevious,
+    setRunningBlocks,
   ]);
 
   const kernelStatus = useMemo(() => (

--- a/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
@@ -91,7 +91,6 @@ function KernelStatus({
   const themeContext: ThemeType = useContext(ThemeContext);
   const {
     alive,
-    name,
     usage,
   } = kernel || {};
   const [isEditingPipeline, setIsEditingPipeline] = useState(false);
@@ -190,35 +189,38 @@ function KernelStatus({
   const kernelMemory = useMemo(() => {
     if (usage?.kernel_memory) {
       const memory = usage.kernel_memory;
-      const k = 1024
-      const dm = 2
-      const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+      const k = 1024;
+      const dm = 2;
+      const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
-      const i = Math.floor(Math.log(memory) / Math.log(k))
+      const i = Math.floor(Math.log(memory) / Math.log(k));
 
-      return `${parseFloat((memory / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`
+      return `${parseFloat((memory / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
     }
   }, [usage?.kernel_memory]);
 
   const [showKernelWarning, hideKernelWarning] = useModal(() => (
     <PopupMenu
-      centerOnScreen
       cancelText="Close"
+      centerOnScreen
       confirmText="Don't show again"
       neutral
+      onCancel={hideKernelWarning}
       onClick={() => {
         set(LOCAL_STORAGE_KEY_HIDE_KERNEL_WARNING, 1);
         hideKernelWarning();
       }}
-      onCancel={hideKernelWarning}
       subtitle={
-        "You may need to refresh your page to continue using the notebook. Unexpected " +
-        "kernel restarts may be caused by your kernel running out of memory."
+        'You may need to refresh your page to continue using the notebook. Unexpected ' +
+        'kernel restarts may be caused by your kernel running out of memory.'
       }
       title="The kernel has restarted"
       width={UNIT * 34}
     />
-  ));
+  ), {}, [], {
+    background: true,
+    uuid: 'restart_kernel_warning',
+  });
 
   useEffect(() => {
     const hide = get(LOCAL_STORAGE_KEY_HIDE_KERNEL_WARNING, 0);

--- a/mage_ai/frontend/components/TripleLayout/index.tsx
+++ b/mage_ai/frontend/components/TripleLayout/index.tsx
@@ -17,7 +17,6 @@ import {
   AFTER_MIN_WIDTH,
   ALL_HEADERS_HEIGHT,
   ASIDE_HEADER_HEIGHT,
-  ASIDE_SUBHEADER_HEIGHT,
   AfterInnerStyle,
   AfterStyle,
   AsideHeaderStyle,
@@ -318,6 +317,7 @@ function TripleLayout({
     afterHeader,
     afterHeightOffset,
     afterHidden,
+    afterOverflow,
     afterSubheader,
     afterWidthFinal,
     hasAfterNavigationItems,
@@ -334,6 +334,7 @@ function TripleLayout({
       {setBeforeHidden && (
         <AsideHeaderStyle
           style={{
+            overflow: hasBeforeNavigationItems ? 'auto' : 'hidden',
             width: hasBeforeNavigationItems
               ? beforeWidthFinal - (VERTICAL_NAVIGATION_WIDTH + 1)
               : beforeWidthFinal,

--- a/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.tsx
+++ b/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.tsx
@@ -4,6 +4,7 @@ import Button from '@oracle/elements/Button';
 import FlexContainer from '@oracle/components/FlexContainer';
 import GradientButton from '@oracle/elements/Button/GradientButton';
 import Spacing from '@oracle/elements/Spacing';
+import Text from '@oracle/elements/Text';
 import { PURPLE_BLUE } from '@oracle/styles/colors/gradients';
 import { TabsContainerStyle } from './index.style';
 import { UNIT } from '@oracle/styles/units/spacing';
@@ -61,7 +62,14 @@ function ButtonTabs({
             </>
           )}
 
-          {displayText}
+          <Text
+            bold
+            default={!selected}
+            noWrapping={allowScroll}
+            small
+          >
+            {displayText}
+          </Text>
         </FlexContainer>
       );
 
@@ -117,6 +125,7 @@ function ButtonTabs({
 
     return arr;
   }, [
+    allowScroll,
     onClickTab,
     selectedTabUUID,
     small,

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -2180,6 +2180,7 @@ function PipelineDetailPage({
   const buttonTabs = useMemo(() => (
     <Spacing px={1}>
       <ButtonTabs
+        allowScroll
         noPadding
         onClickTab={(tab: TabType) => {
           setSelectedTab(tab);

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1080,15 +1080,12 @@ function PipelineDetailPage({
       ),
     },
   );
-
-  const restartKernel = useCallback(() => {
-    updateKernel({
-      kernel: {
-        action_type: 'restart',
-      },
-    });
-    setRunningBlocks([]);
-  }, [updateKernel]);
+  // @ts-ignore
+  const restartKernel = useCallback(() => updateKernel({
+    kernel: {
+      action_type: 'restart',
+    },
+  }), [updateKernel]);
   const interruptKernel = useCallback(() => {
     updateKernel({
       kernel: {

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1080,7 +1080,7 @@ function PipelineDetailPage({
       ),
     },
   );
-  // @ts-ignore
+
   const restartKernel = useCallback(() => updateKernel({
     kernel: {
       action_type: 'restart',
@@ -2035,6 +2035,7 @@ function PipelineDetailPage({
             savePipelineContent={savePipelineContent}
             selectedFilePath={selectedFilePath}
             setErrors={setErrors}
+            setRunningBlocks={setRunningBlocks}
             updatePipelineMetadata={updatePipelineMetadata}
           >
             {beforeHeader}

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1080,12 +1080,15 @@ function PipelineDetailPage({
       ),
     },
   );
-  // @ts-ignore
-  const restartKernel = useCallback(() => updateKernel({
-    kernel: {
-      action_type: 'restart',
-    },
-  }), [updateKernel]);
+
+  const restartKernel = useCallback(() => {
+    updateKernel({
+      kernel: {
+        action_type: 'restart',
+      },
+    });
+    setRunningBlocks([]);
+  }, [updateKernel]);
   const interruptKernel = useCallback(() => {
     updateKernel({
       kernel: {

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1066,7 +1066,7 @@ function PipelineDetailPage({
     },
   );
 
-  const [updateKernel] = useMutation(
+  const [updateKernel]: any = useMutation(
     api.kernels.useUpdate(kernel?.id),
     {
       onSuccess: (response: any) => onSuccess(
@@ -1086,12 +1086,14 @@ function PipelineDetailPage({
       action_type: 'restart',
     },
   }), [updateKernel]);
-  // @ts-ignore
-  const interruptKernel = useCallback(() => updateKernel({
-    kernel: {
-      action_type: 'interrupt',
-    },
-  }), [updateKernel]);
+  const interruptKernel = useCallback(() => {
+    updateKernel({
+      kernel: {
+        action_type: 'interrupt',
+      },
+    });
+    setRunningBlocks([]);
+  }, [updateKernel]);
 
   const [createBlock] = useMutation(api.blocks.pipelines.useCreate(pipelineUUID));
   const addNewBlockAtIndex = useCallback((


### PR DESCRIPTION
# Summary
- Restarting or interrupting kernel will reset running blocks so spinner is not perpetually spinning.
- Fix broken overflow of browser navigation tabs (tabs scroll now).

# Tests
Before - perpetual spinner:
![Before - Perpetual spinner (cannot be stopped)](https://user-images.githubusercontent.com/78053898/234127942-afa81877-c221-4a46-a01c-69e8f46e0e54.gif)

After - Running blocks reset after restarting kernel / Interrupting kernel stops spinner:
![After - Fix perpetual spinner on kernel restart](https://user-images.githubusercontent.com/78053898/234128071-60066973-6125-4d86-98c7-fe1f638acae6.gif)

