### PR TITLE
[hw] Add a virtual environment when installing `Mage` locally with `pip` or `conda`

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,32 +197,27 @@ You can install and run Mage using Docker (recommended), `pip`, or `conda`.
 ### Using `pip` or `conda`
 
 1. Install Mage
-    <sub> (a) To the current virtual environment:
+
+    #### (a) To the current virtual environment:
     ```bash
     pip install mage-ai
     ```
-
     or
-
     ```bash
     conda install -c conda-forge mage-ai
     ```
-    </sub>
 
-    <sub> (b) To a new virtual environment (e.g., `myenv`):
+    #### (b) To a new virtual environment (e.g., `myenv`):
     ```bash
     python3 -m venv myenv
     source myenv/bin/activate
     pip install mage-ai
     ```
-
     or
-
     ```bash
     conda create -n myenv -c conda-forge mage-ai
     conda activate myenv
     ```
-    </sub>
 
     <sub>For additional packages (e.g. `spark`, `postgres`, etc), please see [Installing extra packages](https://docs.mage.ai/getting-started/setup#installing-extra-packages).</sub>
 

--- a/README.md
+++ b/README.md
@@ -198,13 +198,16 @@ You can install and run Mage using Docker (recommended), `pip`, or `conda`.
 
 1. Install Mage
     ```bash
+    python3 -m venv myenv
+    source myenv/bin/activate
     pip install mage-ai
     ```
 
     or
 
     ```bash
-    conda install -c conda-forge mage-ai
+    conda create -n myenv -c conda-forge mage-ai
+    conda activate myenv
     ```
 
     <sub>For additional packages (e.g. `spark`, `postgres`, etc), please see [Installing extra packages](https://docs.mage.ai/getting-started/setup#installing-extra-packages).</sub>

--- a/README.md
+++ b/README.md
@@ -197,6 +197,19 @@ You can install and run Mage using Docker (recommended), `pip`, or `conda`.
 ### Using `pip` or `conda`
 
 1. Install Mage
+    <sub> (a) To the current virtual environment:
+    ```bash
+    pip install mage-ai
+    ```
+
+    or
+
+    ```bash
+    conda install -c conda-forge mage-ai
+    ```
+    </sub>
+
+    <sub> (b) To a new virtual environment (e.g., `myenv`):
     ```bash
     python3 -m venv myenv
     source myenv/bin/activate
@@ -209,6 +222,7 @@ You can install and run Mage using Docker (recommended), `pip`, or `conda`.
     conda create -n myenv -c conda-forge mage-ai
     conda activate myenv
     ```
+    </sub>
 
     <sub>For additional packages (e.g. `spark`, `postgres`, etc), please see [Installing extra packages](https://docs.mage.ai/getting-started/setup#installing-extra-packages).</sub>
 


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

When installing `Mage` locally through `pip` or `conda`, run it a virtual environment to be safe.

# Tests
<!-- How did you test your change? -->
Manually tested the newly added commands on a local Mac.
cc:
<!-- Optionally mention someone to let them know about this pull request -->
@dy46 @wangxiaoyou1993