### PR TITLE
[xh] Fix link in streaming document to point to unit test directory

### DIFF
--- a/docs/guides/streaming/contributing.mdx
+++ b/docs/guides/streaming/contributing.mdx
@@ -46,5 +46,5 @@ Example PR for adding a sink: https://github.com/mage-ai/mage-ai/pull/2121
     * https://github.com/mage-ai/mage-ai/blob/master/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/utils.tsx#L37
     * https://github.com/mage-ai/mage-ai/blob/master/mage_ai/frontend/interfaces/DataSourceType.ts#L3
     * https://github.com/mage-ai/mage-ai/blob/master/mage_ai/frontend/interfaces/DataSourceType.ts#L22
-* Add unit tests: https://github.com/mage-ai/mage-ai/tree/master/mage_ai/streaming/sinks
+* Add unit tests: https://github.com/mage-ai/mage-ai/tree/master/mage_ai/tests/streaming/sinks
 * Add doc: https://github.com/mage-ai/mage-ai/tree/master/docs/guides/streaming/destinations


### PR DESCRIPTION
# Summary
Fix link in streaming document to point to unit test directory

