### PR TITLE
[xy] Support setting default executor type.

### DIFF
--- a/docs/production/configuring-production-settings/compute-resource.mdx
+++ b/docs/production/configuring-production-settings/compute-resource.mdx
@@ -20,9 +20,16 @@ service by updating the Terraform variables and then running `terraform apply`
   [`mage-ai-terraform-templates/gcp/variables.tf`](https://github.com/mage-ai/mage-ai-terraform-templates/blob/master/gcp/variables.tf)
   file.
 
-## 2. Customize the compute resource of the Mage executor
+## 2. Set executor type and customize the compute resource of the Mage executor
 
-Mage provides multiple executors to execute blocks.
+Mage provides multiple executors to execute blocks. Here are the available executor types:
+* `local_python`
+* `ecs`
+* `gcp_cloud_run`
+* `k8s`
+
+Mage uses `local_python` executor type by default. If you want to specify another executor_type as the default executor type for blocks,
+you can set the environment variable `DEFAULT_EXECUTOR_TYPE` to one executor type mentioned above.
 
 ### Local python executor
 
@@ -49,25 +56,35 @@ blocks:
 ```
 By default, Mage uses `default` as the Kubernetes namespace. You can customize the namespace by setting the `KUBE_NAMESPACE` environment variable.
 
-To customize the compute resource for Kubernetes executor, you can add the `executor_config` at block level.
+There're two ways to customize the compute resource for Kubernetes executor:
 
-Example config:
-
-```yaml
-blocks:
-- uuid: example_data_loader
-  type: data_loader
-  upstream_blocks: []
-  downstream_blocks: []
-  executor_type: k8s
-  executor_config:
-    resource_limits:
-      cpu: 1000m
-      memory: 2048Mi
-    resource_requests:
-      cpu: 500m
-      memory: 1024Mi
-```
+1. Add the `executor_config` at block level in pipeline's metadata.yaml file. Example config:
+    ```yaml
+    blocks:
+    - uuid: example_data_loader
+      type: data_loader
+      upstream_blocks: []
+      downstream_blocks: []
+      executor_type: k8s
+      executor_config:
+        resource_limits:
+          cpu: 1000m
+          memory: 2048Mi
+        resource_requests:
+          cpu: 500m
+          memory: 1024Mi
+    ```
+2. Add the `k8s_executor_config` to project's metadata.yaml. This `k8s_executor_config` will apply to all the blocks that use k8s executor
+in this project. Example config:
+    ```yaml
+    k8s_executor_config:
+      resource_limits:
+        cpu: 1000m
+        memory: 2048Mi
+      resource_requests:
+        cpu: 500m
+        memory: 1024Mi
+    ```
 
 
 ### AWS ECS executor

--- a/mage_ai/data_preparation/executors/ecs_block_executor.py
+++ b/mage_ai/data_preparation/executors/ecs_block_executor.py
@@ -8,7 +8,7 @@ from typing import Dict
 class EcsBlockExecutor(BlockExecutor):
     def __init__(self, pipeline, block_uuid: str, execution_partition: str = None):
         super().__init__(pipeline, block_uuid, execution_partition=execution_partition)
-        self.executor_config = self.pipeline.repo_config.ecs_config
+        self.executor_config = self.pipeline.repo_config.ecs_config or dict()
         if self.block.executor_config is not None:
             self.executor_config = merge_dict(self.executor_config, self.block.executor_config)
 

--- a/mage_ai/data_preparation/executors/executor_factory.py
+++ b/mage_ai/data_preparation/executors/executor_factory.py
@@ -14,7 +14,10 @@ import os
 class ExecutorFactory:
     @classmethod
     def get_default_executor_type(self):
-        return os.getenv('DEFAULT_EXECUTOR_TYPE', ExecutorType.LOCAL_PYTHON)
+        executor_type = os.getenv('DEFAULT_EXECUTOR_TYPE', ExecutorType.LOCAL_PYTHON)
+        if ExecutorType.is_valid_type(executor_type):
+            return executor_type
+        return ExecutorType.LOCAL_PYTHON
 
     @classmethod
     def get_pipeline_executor(

--- a/mage_ai/data_preparation/executors/executor_factory.py
+++ b/mage_ai/data_preparation/executors/executor_factory.py
@@ -8,9 +8,14 @@ from mage_ai.data_preparation.models.constants import (
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.shared.code import is_pyspark_code
 from typing import Union
+import os
 
 
 class ExecutorFactory:
+    @classmethod
+    def get_default_executor_type(self):
+        return os.getenv('DEFAULT_EXECUTOR_TYPE', ExecutorType.LOCAL_PYTHON)
+
     @classmethod
     def get_pipeline_executor(
         self,
@@ -51,6 +56,9 @@ class ExecutorFactory:
                 executor_type = ExecutorType.PYSPARK
             else:
                 executor_type = block.executor_type
+                if executor_type == ExecutorType.LOCAL_PYTHON:
+                    # Use default executor type
+                    executor_type = self.get_default_executor_type()
         if executor_type == ExecutorType.PYSPARK:
             from mage_ai.data_preparation.executors.pyspark_block_executor import (
                 PySparkBlockExecutor,

--- a/mage_ai/data_preparation/executors/k8s_block_executor.py
+++ b/mage_ai/data_preparation/executors/k8s_block_executor.py
@@ -7,7 +7,7 @@ from typing import Dict
 class K8sBlockExecutor(BlockExecutor):
     def __init__(self, pipeline, block_uuid: str, execution_partition: str = None):
         super().__init__(pipeline, block_uuid, execution_partition=execution_partition)
-        self.executor_config = dict()
+        self.executor_config = self.pipeline.repo_config.k8s_executor_config or dict()
         if self.block.executor_config is not None:
             self.executor_config = merge_dict(self.executor_config, self.block.executor_config)
 

--- a/mage_ai/data_preparation/models/constants.py
+++ b/mage_ai/data_preparation/models/constants.py
@@ -66,6 +66,10 @@ class ExecutorType(str, Enum):
     K8S = 'k8s'
     PYSPARK = 'pyspark'
 
+    @classmethod
+    def is_valid_type(cls, executor_type: str) -> bool:
+        return executor_type.upper() in cls.__members__
+
 
 class PipelineType(str, Enum):
     INTEGRATION = 'integration'

--- a/mage_ai/data_preparation/repo_manager.py
+++ b/mage_ai/data_preparation/repo_manager.py
@@ -66,6 +66,7 @@ class RepoConfig:
             self.ecs_config = repo_config.get('ecs_config')
             self.emr_config = repo_config.get('emr_config')
             self.gcp_cloud_run_config = repo_config.get('gcp_cloud_run_config')
+            self.k8s_executor_config = repo_config.get('k8s_executor_config')
             self.notification_config = repo_config.get('notification_config', dict())
             self.queue_config = repo_config.get('queue_config', dict())
 


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Support setting default executor type. User can set `DEFAULT_EXECUTOR_TYPE` environment variable to select the default executor type (e.g. DEFAULT_EXECUTOR_TYPE=k8s)

For k8s executor, also provide the option to configure executor config in project's metadata.yaml
```
k8s_executor_config:
  resource_limits:
    cpu: 1000m
    memory: 2048Mi
  resource_requests:
    cpu: 500m
    memory: 1024Mi
```

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
