### PR TITLE
[td] Support callbacks for data integrations

### DIFF
--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -200,11 +200,13 @@ class BlockExecutor:
                     global_vars=global_vars,
                     logger=self.logger,
                     logging_tags=logging_tags,
+                    parent_block=self.block,
                     pipeline_run=pipeline_run,
                 )
             except Exception as callback_err:
                 self.logger.exception(
-                    f'Failed to execute {callback} callback block for {self.block.uuid}',
+                    f'Failed to execute {callback} callback block {callback_block.uuid} ' +
+                    f'for block {self.block.uuid}.',
                     **merge_dict(logging_tags, dict(
                         error=callback_err,
                     )),

--- a/mage_ai/frontend/components/PipelineDetail/Extensions/GreatExpectations/CodeBlockExtraContent.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Extensions/GreatExpectations/CodeBlockExtraContent.tsx
@@ -37,6 +37,7 @@ type CodeBlockExtraContentProps = {
     runUpstream?: boolean,
     runTests?: boolean,
   }) => void;
+  supportedUpstreamBlockLanguages?: BlockLanguageEnum[];
   supportedUpstreamBlockTypes: BlockTypeEnum[];
   updateBlock: (payload: {
     block: BlockType;
@@ -52,6 +53,7 @@ function CodeBlockExtraContent({
   loading,
   onClickTag,
   runBlockAndTrack,
+  supportedUpstreamBlockLanguages,
   supportedUpstreamBlockTypes,
   updateBlock,
 }: CodeBlockExtraContentProps) {
@@ -109,7 +111,9 @@ function CodeBlockExtraContent({
       }
 
       const checked: boolean = !!upstreamBlocksByUUID?.[uuid];
-      const disabled: boolean = ![BlockLanguageEnum.PYTHON].includes(language);
+      const disabled: boolean = supportedUpstreamBlockLanguages !== null
+        && typeof supportedUpstreamBlockLanguages !== 'undefined'
+        && !supportedUpstreamBlockLanguages?.includes(language);
 
       arr.push(
         <Spacing

--- a/mage_ai/frontend/components/PipelineDetail/Extensions/GreatExpectations/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Extensions/GreatExpectations/index.tsx
@@ -7,7 +7,7 @@ import {
  } from 'react';
 import { useMutation } from 'react-query';
 
-import BlockType, { BlockTypeEnum } from '@interfaces/BlockType';
+import BlockType, { BlockLanguageEnum, BlockTypeEnum } from '@interfaces/BlockType';
 import ClickOutside from '@oracle/components/ClickOutside';
 import CodeBlock from '@components/CodeBlock';
 import CodeBlockExtraContent from './CodeBlockExtraContent';
@@ -183,6 +183,9 @@ function GreatExpectations({
               blocks={blocksInNotebook}
               inputPlaceholder="Select blocks to run expectations on"
               loading={isLoadingUpdateBlock}
+              supportedUpstreamBlockLanguages={[
+                BlockLanguageEnum.PYTHON,
+              ]}
               supportedUpstreamBlockTypes={[
                 BlockTypeEnum.DATA_EXPORTER,
                 BlockTypeEnum.DATA_LOADER,


### PR DESCRIPTION
# Summary
- Support callbacks for data integrations
- Pass in stream, destination table, and whether block run is the last one

```
{'ds': '2023-04-26', 'hr': '20', 'env': 'prod', 'event': {}, 'execution_date': datetime.datetime(2023, 4, 26, 20, 28, 17, 335254, tzinfo=datetime.timezone.utc), 'execution_partition': '207/20230426T202817', 'pipeline_uuid': 'withered_violet', 'block_uuid': 'bold_shadow', 'pipeline_run': PipelineRun(id=2357, pipeline_uuid=withered_violet, execution_date=2023-04-26 20:28:17.335254+00:00), 'index': 1, 'is_last_block_run': True, 'stream': 'account_sf_v22_dev', 'destination_table': 'account_sf_v22_dev_copy'}
```