### PR TITLE
[td] Callback trigger template

### DIFF
--- a/mage_ai/data_preparation/templates/callbacks/orchestration/triggers/default.jinja
+++ b/mage_ai/data_preparation/templates/callbacks/orchestration/triggers/default.jinja
@@ -1,0 +1,26 @@
+{% extends "callbacks/base.jinja" %}
+{% block imports %}
+from mage_ai.orchestration.triggers.api import trigger_pipeline
+{{ super() -}}
+{% endblock %}
+
+
+{% block content %}
+@callback('success')
+def trigger(**kwargs):
+    """
+    Trigger another pipeline to run.
+
+    Documentation: https://docs.mage.ai/orchestration/triggers/trigger-pipeline
+    """
+
+    trigger_pipeline(
+        'pipeline_uuid',        # Required: enter the UUID of the pipeline to trigger
+        variables={},           # Optional: runtime variables for the pipeline
+        check_status=False,     # Optional: poll and check the status of the triggered pipeline
+        error_on_failure=False, # Optional: if triggered pipeline fails, raise an exception
+        poll_interval=60,       # Optional: check the status of triggered pipeline every N seconds
+        poll_timeout=None,      # Optional: raise an exception after N seconds
+        verbose=True,           # Optional: print status of triggered pipeline run
+    )
+{% endblock %}

--- a/mage_ai/data_preparation/templates/constants.py
+++ b/mage_ai/data_preparation/templates/constants.py
@@ -76,6 +76,14 @@ TEMPLATES = [
         name='Base template',
         path='callbacks/base.jinja',
     ),
+    dict(
+        block_type=BlockType.CALLBACK,
+        description='Trigger another pipeline to run.',
+        groups=[GROUP_ORCHESTRATION],
+        language=BlockLanguage.PYTHON,
+        name='Trigger pipeline',
+        path='callbacks/orchestration/triggers/default.jinja',
+    ),
 ]
 
 TEMPLATES_BY_UUID = index_by(lambda x: x['name'], TEMPLATES)


### PR DESCRIPTION
# Summary
```
from mage_ai.orchestration.triggers.api import trigger_pipeline
if 'callback' not in globals():
    from mage_ai.data_preparation.decorators import callback


@callback('success')
def trigger(**kwargs):
    """
    Trigger another pipeline to run.

    Documentation: https://docs.mage.ai/orchestration/triggers/trigger-pipeline
    """

    trigger_pipeline(
        'pipeline_uuid',        # Required: enter the UUID of the pipeline to trigger
        variables={},           # Optional: runtime variables for the pipeline
        check_status=False,     # Optional: poll and check the status of the triggered pipeline
        error_on_failure=False, # Optional: if triggered pipeline fails, raise an exception
        poll_interval=60,       # Optional: check the status of triggered pipeline every N seconds
        poll_timeout=None,      # Optional: raise an exception after N seconds
        verbose=True,           # Optional: print status of triggered pipeline run
    )

```