### PR TITLE
[jk] Fix markdown links and make border more transparent

### DIFF
--- a/mage_ai/frontend/oracle/components/Markdown/index.tsx
+++ b/mage_ai/frontend/oracle/components/Markdown/index.tsx
@@ -8,19 +8,26 @@ import dark from '@oracle/styles/themes/dark';
 import { MarkdownContainer } from './index.style';
 
 type MarkdownProps = {
-  maxWidth?: number;
   children: string;
 };
 
 function Markdown({
-  maxWidth,
   children,
 }: MarkdownProps) {
   return (
     <MarkdownContainer>
       <ReactMarkdown
         components={{
-          a: ({ children }) => <Link inline primary>{children}</Link>,
+          a: ({ children, href }) => (
+            <Link
+              href={href}
+              inline
+              openNewWindow
+              primary
+            >
+              {children}
+            </Link>
+          ),
           code: ({ children }) => (
             <Text
               backgroundColor={dark.interactive.defaultBorder}

--- a/mage_ai/frontend/oracle/styles/themes/dark.ts
+++ b/mage_ai/frontend/oracle/styles/themes/dark.ts
@@ -71,7 +71,7 @@ export default {
     rose: '#D1A2AB',
     roseLight: 'rgba(209, 162, 171, 0.5)',
     sky: BLUE_SKY_DARK,
-    skyLight: 'rgba(106, 161, 224, 0.5)',
+    skyLight: 'rgba(106, 161, 224, 0.05)',
     teal: '#00B4CC',
     tealLight: 'rgba(0, 180, 204, 0.5)',
     warning: '#DD9900',


### PR DESCRIPTION
# Summary
- See title.

# Tests
- Confirmed link opens new tab
-More transparent markdown block border when not focused:
![image](https://user-images.githubusercontent.com/78053898/235258634-70ff79c3-91ff-441b-a780-dde0edc5e3f5.png)
