### PR TITLE
[jk] Allow bulk retry runs when DISABLE_NOTEBOOK_EDIT_ACCESS enabled

### DIFF
--- a/mage_ai/api/policies/PipelinePolicy.py
+++ b/mage_ai/api/policies/PipelinePolicy.py
@@ -18,10 +18,15 @@ PipelinePolicy.allow_actions([
 PipelinePolicy.allow_actions([
     constants.CREATE,
     constants.DELETE,
-    constants.UPDATE,
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
 ], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
+
+PipelinePolicy.allow_actions([
+    constants.UPDATE,
+], scopes=[
+    OauthScope.CLIENT_PRIVATE,
+], condition=lambda policy: policy.has_at_least_editor_role())
 
 PipelinePolicy.allow_read(PipelinePresenter.default_attributes + [
     'callbacks',
@@ -40,8 +45,16 @@ PipelinePolicy.allow_read(PipelinePresenter.default_attributes + [
 ], on_action=[
     constants.CREATE,
     constants.DELETE,
-    constants.UPDATE,
 ], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
+
+PipelinePolicy.allow_read(PipelinePresenter.default_attributes + [
+    'callbacks',
+    'extensions',
+], scopes=[
+    OauthScope.CLIENT_PRIVATE,
+], on_action=[
+    constants.UPDATE,
+], condition=lambda policy: policy.has_at_least_editor_role())
 
 PipelinePolicy.allow_read(PipelinePresenter.default_attributes + [
     'callbacks',
@@ -69,14 +82,21 @@ PipelinePolicy.allow_write([
     'add_upstream_for_block_uuid',
     'callbacks',
     'extensions',
-    'pipeline_runs',
     'schedules',
-    'status',
 ] + PipelinePresenter.default_attributes, scopes=[
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.UPDATE,
 ], condition=lambda policy: policy.has_at_least_editor_role_and_edit_access())
+
+PipelinePolicy.allow_write([
+    'pipeline_runs',
+    'status',
+], scopes=[
+    OauthScope.CLIENT_PRIVATE,
+], on_action=[
+    constants.UPDATE,
+], condition=lambda policy: policy.has_at_least_editor_role())
 
 PipelinePolicy.allow_query([
     'includes_block_metadata',


### PR DESCRIPTION
# Summary
- See title.
- Updated `PipelinePolicy` to allow bulk retry runs (individual run retries were already allowed due to less strict policy in `PipelineRunPolicy`).

# Tests
Before - Cannot cancel all runs or bulk retry runs:
![Before - Cannot cancel all runs or bulk retry runs](https://user-images.githubusercontent.com/78053898/235812472-16997db6-3b8d-4386-bf05-6ff691d37d25.gif)

After - Can cancel all runs and bulk retry runs:
![After - Can cancel all runs and bulk retry runs](https://user-images.githubusercontent.com/78053898/235812500-28662527-2c3e-413c-a37f-71a2ce6c0b8b.gif)
