### PR TITLE
[jk] Update admin abilities

### DIFF
--- a/mage_ai/api/policies/UserPolicy.py
+++ b/mage_ai/api/policies/UserPolicy.py
@@ -10,7 +10,6 @@ class UserPolicy(BasePolicy):
 
 
 UserPolicy.allow_actions([
-    constants.CREATE,
     constants.DELETE,
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
@@ -21,17 +20,18 @@ UserPolicy.allow_actions([
     constants.UPDATE,
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
-], condition=lambda policy: policy.is_current_user() or policy.is_owner())
+], condition=lambda policy: policy.is_current_user() or policy.has_at_least_admin_role())
 
 UserPolicy.allow_actions([
+    constants.CREATE,
     constants.LIST,
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
-], condition=lambda policy: policy.is_owner())
+], condition=lambda policy: policy.has_at_least_admin_role())
 
 UserPolicy.allow_read(UserPresenter.default_attributes, scopes=[
     OauthScope.CLIENT_PRIVATE,
-], condition=lambda policy: policy.is_current_user() or policy.is_owner())
+], condition=lambda policy: policy.is_current_user() or policy.has_at_least_admin_role())
 
 UserPolicy.allow_read(UserPresenter.default_attributes + [
     'token',
@@ -40,7 +40,7 @@ UserPolicy.allow_read(UserPresenter.default_attributes + [
 ], on_action=[
     constants.CREATE,
     constants.DELETE,
-], condition=lambda policy: policy.is_current_user() or policy.is_owner())
+], condition=lambda policy: policy.is_current_user() or policy.has_at_least_admin_role())
 
 UserPolicy.allow_write([
     'avatar',
@@ -55,14 +55,29 @@ UserPolicy.allow_write([
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.UPDATE,
-], condition=lambda policy: policy.is_current_user() or policy.is_owner())
+], condition=lambda policy: policy.is_current_user() or policy.has_at_least_admin_role())
+
+UserPolicy.allow_write([
+    'roles',
+], scopes=[
+    OauthScope.CLIENT_PRIVATE,
+], on_action=[
+    constants.UPDATE,
+], condition=lambda policy: policy.has_at_least_admin_role())
+
+UserPolicy.allow_write([
+    'owner',
+], scopes=[
+    OauthScope.CLIENT_PRIVATE,
+], on_action=[
+    constants.UPDATE,
+], condition=lambda policy: policy.is_owner())
 
 UserPolicy.allow_write([
     'avatar',
     'email',
     'first_name',
     'last_name',
-    'owner',
     'password',
     'password_confirmation',
     'roles',
@@ -71,4 +86,4 @@ UserPolicy.allow_write([
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.CREATE,
-], condition=lambda policy: policy.is_owner())
+], condition=lambda policy: policy.has_at_least_admin_role())

--- a/mage_ai/api/policies/UserPolicy.py
+++ b/mage_ai/api/policies/UserPolicy.py
@@ -10,6 +10,7 @@ class UserPolicy(BasePolicy):
 
 
 UserPolicy.allow_actions([
+    constants.CREATE,
     constants.DELETE,
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
@@ -23,7 +24,6 @@ UserPolicy.allow_actions([
 ], condition=lambda policy: policy.is_current_user() or policy.has_at_least_admin_role())
 
 UserPolicy.allow_actions([
-    constants.CREATE,
     constants.LIST,
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
@@ -40,7 +40,7 @@ UserPolicy.allow_read(UserPresenter.default_attributes + [
 ], on_action=[
     constants.CREATE,
     constants.DELETE,
-], condition=lambda policy: policy.is_current_user() or policy.has_at_least_admin_role())
+], condition=lambda policy: policy.is_current_user() or policy.is_owner())
 
 UserPolicy.allow_write([
     'avatar',
@@ -86,4 +86,4 @@ UserPolicy.allow_write([
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.CREATE,
-], condition=lambda policy: policy.has_at_least_admin_role())
+], condition=lambda policy: policy.is_owner())

--- a/mage_ai/api/resources/UserResource.py
+++ b/mage_ai/api/resources/UserResource.py
@@ -17,6 +17,22 @@ class UserResource(DatabaseResource):
 
     @classmethod
     @safe_db_query
+    def collection(self, query_arg, meta, user, **kwargs):
+        results = (
+            User.
+            query.
+            order_by(User.username.asc())
+        )
+
+        if user.is_admin:
+            results = results \
+                .filter(User.owner == False) \
+                .filter(User.roles > 1)
+
+        return results
+
+    @classmethod
+    @safe_db_query
     async def create(self, payload, user, **kwargs):
         email = payload.get('email')
         password = payload.get('password')
@@ -90,13 +106,21 @@ class UserResource(DatabaseResource):
     def update(self, payload, **kwargs):
         error = ApiError.RESOURCE_INVALID.copy()
 
-        if self.current_user.is_admin and self.owner:
-            error.update(
-                {'message': 'Admins cannot update users who are Owners.'})
-            raise ApiError(error)
+        if self.current_user.is_admin:
+            if self.owner:
+                error.update(
+                    {'message': 'Admins cannot update users who are Owners.'})
+                raise ApiError(error)
+            elif self.is_admin:
+                error.update(
+                    {'message': 'Admins cannot update users who are Admins.'})
+                raise ApiError(error)
+            elif payload.get('roles') and int(payload.get('roles')) & 1 != 0:
+                error.update(
+                    {'message': 'Admins cannot make other users Admins.'})
+                raise ApiError(error)
 
         password = payload.get('password')
-
         if password:
             password_current = payload.get('password_current')
             password_confirmation = payload.get('password_confirmation')

--- a/mage_ai/api/resources/UserResource.py
+++ b/mage_ai/api/resources/UserResource.py
@@ -111,7 +111,7 @@ class UserResource(DatabaseResource):
                 error.update(
                     {'message': 'Admins cannot update users who are Owners.'})
                 raise ApiError(error)
-            elif self.is_admin:
+            elif self.is_admin and self.current_user.id != self.id:
                 error.update(
                     {'message': 'Admins cannot update users who are Admins.'})
                 raise ApiError(error)

--- a/mage_ai/api/resources/UserResource.py
+++ b/mage_ai/api/resources/UserResource.py
@@ -26,8 +26,7 @@ class UserResource(DatabaseResource):
 
         if user.is_admin:
             results = results \
-                .filter(User.owner == False) \
-                .filter(User.roles > 1)
+                .filter(User.owner == False).filter(User.roles > 1)     # noqa: E712
 
         return results
 

--- a/mage_ai/frontend/components/settings/Dashboard/constants.ts
+++ b/mage_ai/frontend/components/settings/Dashboard/constants.ts
@@ -19,7 +19,7 @@ export const SECTIONS = ({ owner, roles }: UserType) => {
     },
   ];
 
-  if (owner) {
+  if (owner || roles === RoleValueEnum.ADMIN) {
     workspaceItems.push({
       linkProps: {
         href: '/settings/workspace/users',
@@ -27,7 +27,6 @@ export const SECTIONS = ({ owner, roles }: UserType) => {
       uuid: SECTION_ITEM_UUID_USERS,
     });
   }
-
   if (!REQUIRE_USER_AUTHENTICATION() || roles <= RoleValueEnum.EDITOR) {
     workspaceItems.push({
       linkProps: {

--- a/mage_ai/frontend/components/users/edit/Form/index.tsx
+++ b/mage_ai/frontend/components/users/edit/Form/index.tsx
@@ -88,13 +88,14 @@ function UserEditForm({
           },
           onErrorCallback: ({
             error: {
+              errors,
               exception,
               message,
               type,
             },
           }) => {
             toast.error(
-              exception || message,
+              errors?.error || exception || message,
               {
                 position: toast.POSITION.BOTTOM_RIGHT,
                 toastId: type,

--- a/mage_ai/frontend/components/users/edit/Form/index.tsx
+++ b/mage_ai/frontend/components/users/edit/Form/index.tsx
@@ -51,7 +51,16 @@ function UserEditForm({
     [key: string]: string;
   }>({});
   const [profile, setProfile] = useState<UserType>(null);
-  const { owner: isOwner } = getUser() || {};
+  const {
+    id: currentUserId,
+    owner: isOwner,
+    roles: currentUserRoles,
+  } = getUser() || {};
+  const roleOptions = ROLES.filter((role: number) => (
+    (currentUserRoles === RoleValueEnum.ADMIN && currentUserId !== user?.id)
+      ? role > RoleValueEnum.ADMIN
+      : true
+  ));
 
   const [updateUser, { isLoading }] = useMutation(
     newUser ? api.users.useCreate() : api.users.useUpdate(user?.id),
@@ -239,7 +248,7 @@ function UserEditForm({
                 || (user?.roles || '')}
             >
               <option value="" />
-              {ROLES.map((value) => (
+              {roleOptions.map((value) => (
                 <option key={value} value={value}>
                   {ROLE_DISPLAY_MAPPING[value]}
                 </option>

--- a/mage_ai/frontend/components/users/edit/Form/index.tsx
+++ b/mage_ai/frontend/components/users/edit/Form/index.tsx
@@ -21,6 +21,7 @@ import {
   USER_PROFILE_FIELDS,
   UserFieldType,
 } from './constants';
+import { getUser } from '@utils/session';
 import { isEmptyObject, selectKeys } from '@utils/hash';
 import { onSuccess } from '@api/utils/response';
 
@@ -50,6 +51,7 @@ function UserEditForm({
     [key: string]: string;
   }>({});
   const [profile, setProfile] = useState<UserType>(null);
+  const { owner: isOwner } = getUser() || {};
 
   const [updateUser, { isLoading }] = useMutation(
     newUser ? api.users.useCreate() : api.users.useUpdate(user?.id),
@@ -219,10 +221,15 @@ function UserEditForm({
                     roles: null,
                   }));
                 } else {
+                  const updatedProfile: UserType = {
+                    roles: e.target.value,
+                  };
+                  if (isOwner) {
+                    updatedProfile.owner = false;
+                  }
                   setProfile(prev => ({
                     ...prev,
-                    owner: false,
-                    roles: e.target.value,
+                    ...updatedProfile,
                   }));
                 }
               }}
@@ -237,7 +244,7 @@ function UserEditForm({
                   {ROLE_DISPLAY_MAPPING[value]}
                 </option>
               ))}
-              {!newUser &&
+              {(!newUser && isOwner) &&
                 <option key="owner_role" value={RoleValueEnum.OWNER}>
                   {ROLE_DISPLAY_MAPPING[RoleValueEnum.OWNER]}
                 </option>
@@ -300,7 +307,7 @@ function UserEditForm({
               {newUser ? 'Create new user' : 'Update user profile'}
             </Button>
 
-            {showDelete && (
+            {(showDelete && isOwner) && (
               <Spacing ml={1}>
                 <Button
                   danger

--- a/mage_ai/frontend/pages/settings/workspace/users/index.tsx
+++ b/mage_ai/frontend/pages/settings/workspace/users/index.tsx
@@ -26,7 +26,7 @@ import { queryFromUrl } from '@utils/url';
 
 function UsersListPage() {
   const router = useRouter();
-  const { id: currentUserID } = getUser() || {};
+  const { id: currentUserID, owner: isOwner } = getUser() || {};
   const [query, setQuery] = useState<{
     add_new_user: boolean;
     user_id: number;
@@ -136,18 +136,20 @@ function UsersListPage() {
       uuidItemSelected={SECTION_ITEM_UUID_USERS}
       uuidWorkspaceSelected={SECTION_UUID_WORKSPACE}
     >
-      <Spacing p={PADDING_UNITS}>
-        <Button
-          beforeIcon={<Add />}
-          onClick={() => goToWithQuery({
-            add_new_user: 1,
-            user_id: null,
-          })}
-          primary
-        >
-          Add new user
-        </Button>
-      </Spacing>
+      {isOwner &&
+        <Spacing p={PADDING_UNITS}>
+          <Button
+            beforeIcon={<Add />}
+            onClick={() => goToWithQuery({
+              add_new_user: 1,
+              user_id: null,
+            })}
+            primary
+          >
+            Add new user
+          </Button>
+        </Spacing>
+      }
 
       <Spacing p={PADDING_UNITS}>
         <Headline>

--- a/mage_ai/frontend/pages/settings/workspace/users/index.tsx
+++ b/mage_ai/frontend/pages/settings/workspace/users/index.tsx
@@ -23,11 +23,10 @@ import { getUser } from '@utils/session';
 import { goToWithQuery } from '@utils/routing';
 import { isEqual } from '@utils/hash';
 import { queryFromUrl } from '@utils/url';
-import { sortByKey } from '@utils/array';
 
 function UsersListPage() {
   const router = useRouter();
-  const { id: currentUserID, owner: isOwner } = getUser() || {};
+  const { id: currentUserID } = getUser() || {};
   const [query, setQuery] = useState<{
     add_new_user: boolean;
     user_id: number;
@@ -37,12 +36,8 @@ function UsersListPage() {
     revalidateOnFocus: false,
   });
   const users = useMemo(
-    () => {
-      const filteredUsers = (data?.users || [])
-        .filter(({ owner }) => isOwner ? true : !owner);
-      return sortByKey(filteredUsers, 'username');
-    },
-    [data, isOwner],
+    () => data?.users || [],
+    [data?.users],
   );
   const { data: dataUser, mutate: fetchUser } = api.users.detail(query?.user_id, {}, {
     revalidateOnFocus: false,

--- a/mage_ai/frontend/pages/settings/workspace/users/index.tsx
+++ b/mage_ai/frontend/pages/settings/workspace/users/index.tsx
@@ -27,7 +27,7 @@ import { sortByKey } from '@utils/array';
 
 function UsersListPage() {
   const router = useRouter();
-  const { id: currentUserID } = getUser() || {};
+  const { id: currentUserID, owner: isOwner } = getUser() || {};
   const [query, setQuery] = useState<{
     add_new_user: boolean;
     user_id: number;
@@ -37,8 +37,12 @@ function UsersListPage() {
     revalidateOnFocus: false,
   });
   const users = useMemo(
-    () => sortByKey(data?.users || [], 'username'),
-    [data],
+    () => {
+      const filteredUsers = (data?.users || [])
+        .filter(({ owner }) => isOwner ? true : !owner);
+      return sortByKey(filteredUsers, 'username');
+    },
+    [data, isOwner],
   );
   const { data: dataUser, mutate: fetchUser } = api.users.detail(query?.user_id, {}, {
     revalidateOnFocus: false,

--- a/mage_ai/orchestration/db/models/oauth.py
+++ b/mage_ai/orchestration/db/models/oauth.py
@@ -73,6 +73,13 @@ class User(BaseModel):
             elif self.roles & 4 != 0:
                 return 'Viewer'
 
+    @property
+    def is_admin(self) -> bool:
+        if not self.owner and self.roles:
+            return self.roles & 1 != 0
+
+        return False
+
 
 class Oauth2Application(BaseModel):
     class AuthorizationGrantType(str, enum.Enum):


### PR DESCRIPTION
# Summary
- Allow admins to view and update existing users' usernames/emails/roles/passwords (except for owners and other admins).
- Admins can only view Viewers/Editors and adjust their roles between those two.
- Admins cannot create or delete users (only owners can).
- Admins cannot make other users owners or admins (only owners can).

# Tests
![image](https://user-images.githubusercontent.com/78053898/236063119-8b3cc849-dc1e-4518-9cf6-e143660b6b68.png)
