### PR TITLE
[dy] Pass in git settings as environment variables

### DIFF
--- a/docs/development/environment-variables.mdx
+++ b/docs/development/environment-variables.mdx
@@ -23,3 +23,13 @@ description: "Configure Mage settings through environment variables."
 | `HIDE_ENV_VAR_VALUES` | Filter out environment variables in notebook output. | 1 |
 | `DEBUG` | Turn on "debug" mode. Mage will output more logs that could be useful for debugging issues. | 1 |
 | `ULIMIT_NO_FILE` | Override the maximum number of open files allowed in Mage processes. | 8192 |
+| `GIT_REPO_LINK`               | [More information](/production/data-sync/git#git-settings-as-environment-variables) | See link |
+| `GIT_REPO_PATH`               | [More information](/production/data-sync/git#git-settings-as-environment-variables) | See link |
+| `GIT_USERNAME`                | [More information](/production/data-sync/git#git-settings-as-environment-variables) | See link |
+| `GIT_EMAIL`                   | [More information](/production/data-sync/git#git-settings-as-environment-variables) | See link |
+| `GIT_AUTH_TYPE`               | [More information](/production/data-sync/git#git-settings-as-environment-variables) | See link |
+| `GIT_BRANCH`                  | [More information](/production/data-sync/git#git-settings-as-environment-variables) | See link |
+| `GIT_SYNC_ON_PIPELINE_RUN`    | [More information](/production/data-sync/git#git-settings-as-environment-variables) | See link |
+| `GIT_SSH_PUBLIC_KEY`          | [More information](/production/data-sync/git#git-settings-as-environment-variables) | See link |
+| `GIT_SSH_PRIVATE_KEY`         | [More information](/production/data-sync/git#git-settings-as-environment-variables) | See link |
+| `GIT_ACCESS_TOKEN`            | [More information](/production/data-sync/git#git-settings-as-environment-variables) | See link |

--- a/docs/production/data-sync/git.mdx
+++ b/docs/production/data-sync/git.mdx
@@ -97,3 +97,23 @@ Git settings page, or before every trigger run if you selected the `Sync before 
 
 This feature should only be used if you are not planning to make any local changes to your Mage repository.
 
+## Git settings as environment variables
+
+You can choose to pass in Git settings as environment variables. Mage will read from these environment
+variables to configure your Git repo.
+
+Git settings
+* GIT_REPO_LINK: corresponds to `Remote repo url`
+* GIT_REPO_PATH: corresponds to `Local directory path`
+* GIT_USERNAME: corresponds to `Username`
+* GIT_EMAIL: corresponds to `Email`
+* GIT_AUTH_TYPE: Authentication type, options: "ssh" or "https"
+
+Git sync settings (optional)
+* GIT_BRANCH: corresponds to `Branch name`
+* GIT_SYNC_ON_PIPELINE_RUN: corresponds to `Sync before each triggger run`, options: 0 or 1
+
+Authentication environment variables (optional). Mage will use your saved git secrets if they are available.
+* GIT_SSH_PUBLIC_KEY: SSH public key encoded in base64, used for ssh auth type
+* GIT_SSH_PRIVATE_KEY: SSH private key encoded in base64, used for ssh auth type
+* GIT_ACCESS_TOKEN: Git access token, used for https auth type

--- a/mage_ai/data_preparation/git/__init__.py
+++ b/mage_ai/data_preparation/git/__init__.py
@@ -311,7 +311,7 @@ class Git:
                         repo_name=get_repo_path(),
                     )
                     if os.getenv(GIT_SSH_PRIVATE_KEY_VAR):
-                        public_key = os.getenv(GIT_SSH_PRIVATE_KEY_VAR)
+                        private_key = os.getenv(GIT_SSH_PRIVATE_KEY_VAR)
                     if private_key:
                         with open(custom_private_key_file, 'w') as f:
                             f.write(base64.b64decode(private_key).decode('utf-8'))

--- a/mage_ai/data_preparation/preferences.py
+++ b/mage_ai/data_preparation/preferences.py
@@ -6,6 +6,14 @@ import os
 import traceback
 import yaml
 
+# Git environment variables
+GIT_REPO_LINK_VAR = 'GIT_REPO_LINK'
+GIT_REPO_PATH_VAR = 'GIT_REPO_PATH'
+GIT_USERNAME_VAR = 'GIT_USERNAME'
+GIT_EMAIL_VAR = 'GIT_EMAIL'
+GIT_AUTH_TYPE_VAR = 'GIT_AUTH_TYPE'
+GIT_ACCESS_TOKEN_VAR = 'GIT_ACCESS_TOKEN'
+
 
 class Preferences:
     def __init__(
@@ -31,7 +39,16 @@ class Preferences:
             traceback.print_exc()
             pass
 
-        self.sync_config = preferences.get('sync_config', dict())
+        if os.getenv(GIT_REPO_LINK_VAR):
+            self.sync_config = dict(
+                remote_repo_link=os.getenv(GIT_REPO_LINK_VAR),
+                repo_path=os.getenv(GIT_REPO_PATH_VAR),
+                username=os.getenv(GIT_USERNAME_VAR),
+                email=os.getenv(GIT_EMAIL_VAR),
+                auth_type=os.getenv(GIT_AUTH_TYPE_VAR),
+            )
+        else:
+            self.sync_config = preferences.get('sync_config', dict())
 
     def has_valid_git_config(self) -> bool:
         return 'remote_repo_link' in self.sync_config and 'repo_path' in self.sync_config

--- a/mage_ai/data_preparation/preferences.py
+++ b/mage_ai/data_preparation/preferences.py
@@ -12,7 +12,8 @@ GIT_REPO_PATH_VAR = 'GIT_REPO_PATH'
 GIT_USERNAME_VAR = 'GIT_USERNAME'
 GIT_EMAIL_VAR = 'GIT_EMAIL'
 GIT_AUTH_TYPE_VAR = 'GIT_AUTH_TYPE'
-GIT_ACCESS_TOKEN_VAR = 'GIT_ACCESS_TOKEN'
+GIT_BRANCH_VAR = 'GIT_BRANCH'
+GIT_SYNC_ON_PIPELINE_RUN_TYPE = 'GIT_SYNC_ON_PIPELINE_RUN'
 
 
 class Preferences:
@@ -43,9 +44,11 @@ class Preferences:
             self.sync_config = dict(
                 remote_repo_link=os.getenv(GIT_REPO_LINK_VAR),
                 repo_path=os.getenv(GIT_REPO_PATH_VAR),
+                auth_type=os.getenv(GIT_AUTH_TYPE_VAR),
                 username=os.getenv(GIT_USERNAME_VAR),
                 email=os.getenv(GIT_EMAIL_VAR),
-                auth_type=os.getenv(GIT_AUTH_TYPE_VAR),
+                branch=os.getenv(GIT_BRANCH_VAR),
+                sync_on_pipeline_run=bool(int(os.getenv(GIT_SYNC_ON_PIPELINE_RUN_TYPE))),
             )
         else:
             self.sync_config = preferences.get('sync_config', dict())

--- a/mage_ai/data_preparation/sync/git_sync.py
+++ b/mage_ai/data_preparation/sync/git_sync.py
@@ -6,7 +6,7 @@ from mage_ai.shared.logger import VerboseFunctionExec
 
 class GitSync(BaseSync):
     def __init__(self, sync_config: GitConfig):
-        self.branch = sync_config.branch
+        self.branch = sync_config.branch or 'main'
         self.remote_repo_link = sync_config.remote_repo_link
         self.git_manager = Git(sync_config)
 


### PR DESCRIPTION
# Summary

Support passing in git settings as environment variables. If Mage detects git environment variables, it will try to use the environment variables to fill out the git config and to set up the git repo.
<!-- Brief summary of what your code does -->

# Tests

tested locally
<!-- How did you test your change? -->

cc:
<!-- Optionally mention someone to let them know about this pull request -->
