### PR TITLE
[jk] Make pipeline error on PipelineDetailPage visible to user

### DIFF
--- a/mage_ai/frontend/components/Dashboard/index.tsx
+++ b/mage_ai/frontend/components/Dashboard/index.tsx
@@ -98,7 +98,6 @@ function Dashboard({
         },
       },
       {
-        // gradientColor: PURPLE_BLUE,
         bold: true,
         label: () => title,
       },

--- a/mage_ai/frontend/components/Monitor/index.tsx
+++ b/mage_ai/frontend/components/Monitor/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useRouter } from 'next/router';
 
+import ErrorsType from '@interfaces/ErrorsType';
 import Headline from '@oracle/elements/Headline';
 import PipelineDetailPage from '@components/PipelineDetailPage';
 import PipelineType from '@interfaces/PipelineType';
@@ -16,16 +17,20 @@ import { PageNameEnum } from '@components/PipelineDetailPage/constants';
 type MonitorProps = {
   breadcrumbs: BreadcrumbType[];
   children: any;
+  errors?: ErrorsType
   monitorType: MonitorTypeEnum;
   pipeline: PipelineType;
+  setErrors?: (errors: ErrorsType) => void;
   subheader?: any;
 };
 
 function Monitor({
   breadcrumbs,
   children,
+  errors,
   monitorType,
   pipeline,
+  setErrors,
   subheader,
 }: MonitorProps) {
   const router = useRouter();
@@ -49,7 +54,7 @@ function Monitor({
               router.push(
                 '/pipelines/[pipeline]/monitors',
                 `/pipelines/${pipeline?.uuid}/monitors`,
-              )
+              );
             }}
             selected={MonitorTypeEnum.PIPELINE_RUNS == monitorType}
           >
@@ -64,7 +69,7 @@ function Monitor({
               router.push(
                 '/pipelines/[pipeline]/monitors/block-runs',
                 `/pipelines/${pipeline?.uuid}/monitors/block-runs`,
-              )
+              );
             }}
             selected={MonitorTypeEnum.BLOCK_RUNS == monitorType}
           >
@@ -79,7 +84,7 @@ function Monitor({
               router.push(
                 '/pipelines/[pipeline]/monitors/block-runtime',
                 `/pipelines/${pipeline?.uuid}/monitors/block-runtime`,
-              )
+              );
             }}
             selected={MonitorTypeEnum.BLOCK_RUNTIME == monitorType}
           >
@@ -90,8 +95,10 @@ function Monitor({
         </BeforeStyle>
       }
       breadcrumbs={breadcrumbs}
+      errors={errors}
       pageName={PageNameEnum.MONITOR}
       pipeline={pipeline}
+      setErrors={setErrors}
       subheader={subheader}
       uuid="pipeline/monitor"
     >

--- a/mage_ai/frontend/components/PipelineDetailPage/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetailPage/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import ClickOutside from '@oracle/components/ClickOutside';
 import Dashboard, { DashboardSharedProps } from '@components/Dashboard';
@@ -20,6 +20,7 @@ import {
   UNITS_BETWEEN_ITEMS_IN_SECTIONS,
 } from '@oracle/styles/units/spacing';
 import { buildNavigationItems } from './utils';
+import { parseErrorFromResponse } from '@api/utils/response';
 import { useWindowSize } from '@utils/sizes';
 
 type PipelineDetailPageProps = {
@@ -76,6 +77,16 @@ function PipelineDetailPage({
     revalidateOnFocus: false,
   });
   const pipeline = data?.pipeline;
+  useEffect(() => {
+    if (data?.error) {
+      setErrors({
+        errors: parseErrorFromResponse(data),
+        response: data,
+      });
+    } else {
+      setErrors(null);
+    }
+  }, [data, setErrors]);
 
   const after = useMemo(() => {
     if (afterProp) {
@@ -119,23 +130,25 @@ function PipelineDetailPage({
           },
         });
         arr.push(...breadcrumbsProp);
-
-        // if (!arr[arr.length - 1].gradientColor) {
-        //   arr[arr.length - 1].gradientColor = PURPLE_BLUE;
-        // }
         arr[arr.length - 1].bold = true;
       } else {
         arr.push({
-          // gradientColor: PURPLE_BLUE,
           bold: true,
           label: () => pipeline.name,
         });
       }
+    } else if (data?.error) {
+      arr.push({
+        bold: true,
+        danger: true,
+        label: () => 'Error loading pipeline',
+      });
     }
 
     return arr;
   }, [
     breadcrumbsProp,
+    data?.error,
     pipeline,
     pipelineUUID,
   ]);

--- a/mage_ai/frontend/components/PipelineDetailPage/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetailPage/index.tsx
@@ -79,12 +79,12 @@ function PipelineDetailPage({
   const pipeline = data?.pipeline;
   useEffect(() => {
     if (data?.error) {
-      setErrors({
+      setErrors?.({
         errors: parseErrorFromResponse(data),
         response: data,
       });
     } else {
-      setErrors(null);
+      setErrors?.(null);
     }
   }, [data, setErrors]);
 

--- a/mage_ai/frontend/components/PipelineLayout/index.tsx
+++ b/mage_ai/frontend/components/PipelineLayout/index.tsx
@@ -148,7 +148,6 @@ function PipelineLayout({
     if (pipeline) {
       breadcrumbs.push(...[
         {
-          // gradientColor: PAGE_NAME_EDIT === page ? null : PURPLE_BLUE,
           bold: PAGE_NAME_EDIT !== page,
           label: () => pipeline?.uuid,
           linkProps: {
@@ -161,7 +160,6 @@ function PipelineLayout({
       if (PAGE_NAME_EDIT === page) {
         breadcrumbs.push(...[
           {
-            // gradientColor: PURPLE_BLUE,
             bold: true,
             label: () => capitalize(page),
           },

--- a/mage_ai/frontend/components/shared/Header/index.tsx
+++ b/mage_ai/frontend/components/shared/Header/index.tsx
@@ -37,7 +37,7 @@ import { useModal } from '@context/Modal';
 
 export type BreadcrumbType = {
   bold?: boolean;
-  gradientColor?: string;
+  danger?: string;
   label: () => string;
   linkProps?: {
     href: string;
@@ -114,7 +114,7 @@ function Header({
 
     breadcrumbs.forEach(({
       bold,
-      gradientColor,
+      danger,
       label,
       linkProps,
     }, idx: number) => {
@@ -135,6 +135,7 @@ function Header({
       const titleEl = (
         <Text
           bold={bold}
+          danger={danger}
           default={!bold}
           monospace
         >
@@ -146,12 +147,7 @@ function Header({
           key={`breadcrumb-${title}`}
           ml={idx === 0 ? 2 : 0}
         >
-          {gradientColor && (
-            <GradientText backgroundGradient={gradientColor}>
-              {titleEl}
-            </GradientText>
-          )}
-          {!gradientColor && titleEl}
+          {titleEl}
         </Spacing>
       );
 

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -14,6 +14,7 @@ import {
 import BlockType, { BlockTypeEnum } from '@interfaces/BlockType';
 import Circle from '@oracle/elements/Circle';
 import Divider from '@oracle/elements/Divider';
+import ErrorsType from '@interfaces/ErrorsType';
 import Filter, { FilterQueryType } from '@components/Logs/Filter';
 import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
@@ -71,6 +72,7 @@ function PipelineLogsPage({
   const [selectedLog, setSelectedLog] = useState<LogType>(null);
   const [selectedRange, setSelectedRange] = useState<LogRangeEnum>(null);
   const [scrollToBottom, setScrollToBottom] = useState(false);
+  const [errors, setErrors] = useState<ErrorsType>(null);
 
   const { data: dataPipeline } = api.pipelines.detail(pipelineUUID, {
     includes_content: false,
@@ -321,8 +323,10 @@ function PipelineLogsPage({
           label: () => 'Logs',
         },
       ]}
+      errors={errors}
       pageName={PageNameEnum.PIPELINE_LOGS}
       pipeline={pipeline}
+      setErrors={setErrors}
       subheader={null}
       title={({ name }) => `${name} logs`}
       uuid="pipeline/logs"

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/monitors/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/monitors/index.tsx
@@ -1,9 +1,10 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import NextLink from 'next/link';
 import moment from 'moment';
 import styled from 'styled-components';
 
 import BarStackChart from '@components/charts/BarStack';
+import ErrorsType from '@interfaces/ErrorsType';
 import FlexContainer from '@oracle/components/FlexContainer';
 import Headline from '@oracle/elements/Headline';
 import Link from '@oracle/elements/Link';
@@ -45,6 +46,7 @@ function PipelineRunsMonitor({
   pipeline: pipelineProp,
 }: PipelineRunsMonitorProps) {
   const pipelineUUID = pipelineProp.uuid;
+  const [errors, setErrors] = useState<ErrorsType>(null);
 
   const { data: dataPipelineSchedules } = api.pipeline_schedules.pipelines.list(pipelineUUID);
   const pipelineSchedules = useMemo(
@@ -172,8 +174,10 @@ function PipelineRunsMonitor({
   return (
     <Monitor
       breadcrumbs={breadcrumbs}
+      errors={errors}
       monitorType={MonitorTypeEnum.PIPELINE_RUNS}
       pipeline={pipeline}
+      setErrors={setErrors}
     >
       <Spacing mt={2} mx={2}>
         <Spacing ml={1}>
@@ -251,7 +255,7 @@ function PipelineRunsMonitor({
         })}
       </Spacing>
     </Monitor>
-  )
+  );
 }
 
 PipelineRunsMonitor.getInitialProps = async (ctx: any) => {

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/settings/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/settings/index.tsx
@@ -1,3 +1,6 @@
+import { useState } from 'react';
+
+import ErrorsType from '@interfaces/ErrorsType';
 import PipelineDetailPage from '@components/PipelineDetailPage';
 import PipelineType from '@interfaces/PipelineType';
 import PrivateRoute from '@components/shared/PrivateRoute';
@@ -14,6 +17,7 @@ type PipelineSettingsProps = {
 function PipelineSettings({
   pipeline: pipelineProp,
 }: PipelineSettingsProps) {
+  const [errors, setErrors] = useState<ErrorsType>(null);
   const pipelineUUID = pipelineProp?.uuid;
   const { data } = api.pipelines.detail(pipelineUUID);
   const pipeline = {
@@ -51,8 +55,10 @@ function PipelineSettings({
           label: () => 'Settings',
         },
       ]}
+      errors={errors}
       pageName={PageNameEnum.SETTINGS}
       pipeline={pipeline}
+      setErrors={setErrors}
       title={({ name }) => `${name} settings`}
       uuid={`${PageNameEnum.SETTINGS}_${pipelineUUID}`}
     >

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/syncs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/syncs/index.tsx
@@ -5,6 +5,7 @@ import {
   useState,
 } from 'react';
 
+import ErrorsType from '@interfaces/ErrorsType';
 import PipelineDetailPage from '@components/PipelineDetailPage';
 import PipelineRunType from '@interfaces/PipelineRunType';
 import PrivateRoute from '@components/shared/PrivateRoute';
@@ -39,6 +40,7 @@ function PipelineSyncs({
 
   const q = queryFromUrl();
 
+  const [errors, setErrors] = useState<ErrorsType>(null);
   const [selectedStream, setSelectedStream] = useState<string>(null);
   const [selectedPipelineRun, setSelectedPipelineRun] = useState<PipelineRunType>(null);
 
@@ -119,8 +121,10 @@ function PipelineSyncs({
     <PipelineDetailPage
       breadcrumbs={breadcrumbs}
       buildSidekick={buildSidekick}
+      errors={errors}
       pageName={PageNameEnum.SYNCS}
       pipeline={pipeline}
+      setErrors={setErrors}
       title={({ name }) => `${name} syncs`}
       uuid={`${PageNameEnum.SYNCS}_${pipelineUUID}`}
     >


### PR DESCRIPTION
# Summary
- The error when loading the pipeline wasn't being displayed to users after clicking a pipeline from the Dashboard and redirecting to the Triggers page. This PR makes the error popup visible with the stack trace. Also shows "Error loading pipeline" in red font in the header to make it more apparent.
- Update various pages to display error popup, including Triggers, Backfills, Logs, Monitors, Settings, and Syncs pages.

# Tests
![pipeline error](https://user-images.githubusercontent.com/78053898/236089952-e2bbd6d8-8fa4-4335-885c-654bf7b6c331.gif)

cc:
@wangxiaoyou1993 
