### PR TITLE
[jk] Retry block runs from specific block

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -296,6 +296,12 @@
             "orchestration/backfills/overview",
             "orchestration/backfills/guides"
           ]
+        },
+        {
+          "group": "Pipeline runs",
+          "pages": [
+            "orchestration/pipeline-runs/retrying-block-runs"
+          ]
         }
       ]
     },

--- a/docs/orchestration/pipeline-runs/retrying-block-runs.mdx
+++ b/docs/orchestration/pipeline-runs/retrying-block-runs.mdx
@@ -1,0 +1,36 @@
+---
+title: "Retrying block runs from a pipeline run"
+sidebarTitle: "Retrying block runs"
+---
+
+<Note>Requires version `0.8.72` or greater.</Note>
+
+## Retry incomplete blocks
+
+- Supported pipeline types: Integration and Standard pipelines
+- If a pipeline run fails, you can retry from the failed block
+run (instead of retrying the entire pipeline run) by going to the individual
+pipeline runs page (`/pipelines/[pipeline_uuid]/runs/[pipeline_run_id]`).
+- At the top of the individual pipeline runs page, there should be a red
+`Retry incomplete blocks` button. Click on it, and the block runs should
+retry from the failed block.
+
+## Retry from selected block
+
+- Supported pipeline type: Standard
+- If you want to retry block runs for a pipeline run starting from a specific
+block (regardless of the block run's status), go to the same page for the individual
+pipeline run.
+- Select a block run row, and a blue `Retry from selected block` button should appear.
+- Note that the `Retry from selected block` button will only appear if the pipeline
+run is not currently running.
+- If there is a failed block run and you try to retry from a selected block that is
+downstream from that failed block, you may get `upstream_failed` block run errors.
+
+### Accessing the individual pipeline runs page
+
+1. Click on a pipeline from the main Pipelines Dashboard.
+2. Click on the `Runs` section or on an individual trigger from the `Triggers` section.
+3. Underneath the `Block runs` column of the pipeline runs table, there is a link that
+says something like `See block runs (x)`. Click on that link to redirect to the
+individual pipeline runs page, which lists the blocks runs specific to a pipeline run.

--- a/mage_ai/api/policies/PipelineRunPolicy.py
+++ b/mage_ai/api/policies/PipelineRunPolicy.py
@@ -61,6 +61,7 @@ PipelineRunPolicy.allow_write([
 ], condition=lambda policy: policy.has_at_least_editor_role())
 
 PipelineRunPolicy.allow_write([
+    'from_block_uuid',
     'pipeline_run_action',
     'status',
 ], scopes=[

--- a/mage_ai/api/resources/PipelineRunResource.py
+++ b/mage_ai/api/resources/PipelineRunResource.py
@@ -166,23 +166,33 @@ class PipelineRunResource(DatabaseResource):
 
     @safe_db_query
     def update(self, payload, **kwargs):
-        if 'retry_blocks' == payload.get('pipeline_run_action') and \
-                PipelineRun.PipelineRunStatus.COMPLETED != self.model.status:
+        if 'retry_blocks' == payload.get('pipeline_run_action'):
             self.model.refresh()
-
             pipeline = Pipeline.get(self.model.pipeline_uuid)
-
-            incomplete_block_runs = \
-                list(
-                    filter(
-                        lambda br: br.status != BlockRun.BlockRunStatus.COMPLETED,
-                        self.model.block_runs
+            block_runs_to_retry = []
+            if PipelineRun.PipelineRunStatus.COMPLETED != self.model.status:
+                block_runs_to_retry = \
+                    list(
+                        filter(
+                            lambda br: br.status != BlockRun.BlockRunStatus.COMPLETED,
+                            self.model.block_runs
+                        )
                     )
+            elif payload.get('from_block_uuid') is not None:
+                downstream_block_uuids = pipeline.get_downstream_block_uuids(
+                    payload.get('from_block_uuid'),
                 )
+                block_runs_to_retry = \
+                    list(
+                        filter(
+                            lambda br: br.block_uuid in downstream_block_uuids,
+                            self.model.block_runs
+                        )
+                    )
 
             # Update block run status to INITIAL
             BlockRun.batch_update_status(
-                [b.id for b in incomplete_block_runs],
+                [b.id for b in block_runs_to_retry],
                 BlockRun.BlockRunStatus.INITIAL,
             )
 
@@ -193,7 +203,7 @@ class PipelineRunResource(DatabaseResource):
                 if PipelineType.INTEGRATION == pipeline.type:
                     execution_process_manager.terminate_pipeline_process(self.model.id)
                 else:
-                    for br in incomplete_block_runs:
+                    for br in block_runs_to_retry:
                         execution_process_manager.terminate_block_process(
                             self.model.id,
                             br.id,

--- a/mage_ai/api/resources/PipelineRunResource.py
+++ b/mage_ai/api/resources/PipelineRunResource.py
@@ -171,15 +171,7 @@ class PipelineRunResource(DatabaseResource):
             pipeline = Pipeline.get(self.model.pipeline_uuid)
             block_runs_to_retry = []
             from_block_uuid = payload.get('from_block_uuid')
-            if PipelineRun.PipelineRunStatus.COMPLETED != self.model.status:
-                block_runs_to_retry = \
-                    list(
-                        filter(
-                            lambda br: br.status != BlockRun.BlockRunStatus.COMPLETED,
-                            self.model.block_runs
-                        )
-                    )
-            elif from_block_uuid is not None:
+            if from_block_uuid is not None:
                 from_block = pipeline.blocks_by_uuid.get(from_block_uuid)
                 if from_block:
                     downstream_blocks = from_block.get_all_downstream_blocks()
@@ -191,6 +183,14 @@ class PipelineRunResource(DatabaseResource):
                                 self.model.block_runs
                             )
                         )
+            elif PipelineRun.PipelineRunStatus.COMPLETED != self.model.status:
+                block_runs_to_retry = \
+                    list(
+                        filter(
+                            lambda br: br.status != BlockRun.BlockRunStatus.COMPLETED,
+                            self.model.block_runs
+                        )
+                    )
 
             # Update block run status to INITIAL
             BlockRun.batch_update_status(

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -954,6 +954,26 @@ class Pipeline:
     def get_executable_blocks(self):
         return [b for b in self.blocks_by_uuid.values() if b.executable]
 
+    def get_downstream_block_uuids(
+        self,
+        starting_block_uuid: str,
+    ) -> List[str]:
+        final_downstream_block_uuids_set = set()
+        starting_block = self.blocks_by_uuid.get(starting_block_uuid)
+        if starting_block:
+            final_downstream_block_uuids_set.add(starting_block_uuid)
+            downstream_block_uuids = starting_block.downstream_block_uuids
+            for block_uuid in downstream_block_uuids:
+                nested_downstream_block_uuids = self.get_downstream_block_uuids(
+                    block_uuid,
+                )
+                for block_uuid in nested_downstream_block_uuids:
+                    final_downstream_block_uuids_set.add(block_uuid)
+        else:
+            return []
+
+        return list(final_downstream_block_uuids_set)
+
     def has_block(self, block_uuid: str, block_type: str = None, extension_uuid: str = None):
         if extension_uuid:
             return self.extensions and \

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -954,26 +954,6 @@ class Pipeline:
     def get_executable_blocks(self):
         return [b for b in self.blocks_by_uuid.values() if b.executable]
 
-    def get_downstream_block_uuids(
-        self,
-        starting_block_uuid: str,
-    ) -> List[str]:
-        final_downstream_block_uuids_set = set()
-        starting_block = self.blocks_by_uuid.get(starting_block_uuid)
-        if starting_block:
-            final_downstream_block_uuids_set.add(starting_block_uuid)
-            downstream_block_uuids = starting_block.downstream_block_uuids
-            for block_uuid in downstream_block_uuids:
-                nested_downstream_block_uuids = self.get_downstream_block_uuids(
-                    block_uuid,
-                )
-                for block_uuid in nested_downstream_block_uuids:
-                    final_downstream_block_uuids_set.add(block_uuid)
-        else:
-            return []
-
-        return list(final_downstream_block_uuids_set)
-
     def has_block(self, block_uuid: str, block_type: str = None, extension_uuid: str = None):
         if extension_uuid:
             return self.extensions and \

--- a/mage_ai/frontend/components/PipelineRun/shared/buildTableSidekick.tsx
+++ b/mage_ai/frontend/components/PipelineRun/shared/buildTableSidekick.tsx
@@ -12,6 +12,7 @@ import {
 import { createBlockStatus } from '@components/Triggers/utils';
 import { isEmptyObject, isObject } from '@utils/hash';
 
+export const TABS_HEIGHT_OFFSET = 76;
 const TAB_DETAILS = { uuid: 'Run details' };
 const TAB_TREE = { uuid: 'Dependency tree' };
 export const TABS = [
@@ -117,7 +118,7 @@ export default function({
         <DependencyGraph
           {...updatedProps}
           height={height}
-          heightOffset={(heightOffset || 0) + (showTabs ? 76 : 0)}
+          heightOffset={(heightOffset || 0) + (showTabs ? TABS_HEIGHT_OFFSET : 0)}
           pipeline={pipeline}
         />
       )}

--- a/mage_ai/frontend/interfaces/PipelineRunType.ts
+++ b/mage_ai/frontend/interfaces/PipelineRunType.ts
@@ -3,6 +3,17 @@ import { ScheduleTypeEnum } from './PipelineScheduleType';
 
 export const RunStatus = RunStatusEnum;
 
+export const RUNNING_STATUSES = [
+  RunStatus.INITIAL,
+  RunStatus.RUNNING,
+];
+
+export const COMPLETED_STATUSES = [
+  RunStatus.CANCELLED,
+  RunStatus.COMPLETED,
+  RunStatus.FAILED,
+];
+
 export const MAGE_VARIABLES_KEY = '__mage_variables';
 
 export const RUN_STATUS_TO_LABEL = {

--- a/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.tsx
+++ b/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.tsx
@@ -104,7 +104,7 @@ function ButtonTabs({
         );
       } else {
         arr.push(
-          <div key={`button-tab-${uuid}`} style={{ padding: 4 }}>
+          <div key={`button-tab-${uuid}`} style={{ padding: 2 }}>
             <Button
               borderLess
               compact={small}

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useMutation } from 'react-query';
 
 import BlockRunsTable from '@components/PipelineDetail/BlockRuns/Table';
@@ -13,10 +13,15 @@ import PipelineType from '@interfaces/PipelineType';
 import PrivateRoute from '@components/shared/PrivateRoute';
 import Spacing from '@oracle/elements/Spacing';
 import api from '@api';
-import buildTableSidekick from '@components/PipelineDetail/BlockRuns/buildTableSidekick';
+import buildTableSidekick, {
+  TAB_OUTPUT,
+  TAB_TREE,
+  TABS as TABS_SIDEKICK,
+} from '@components/PipelineDetail/BlockRuns/buildTableSidekick';
 import { OutputType } from '@interfaces/BlockType';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
 import { PADDING_UNITS } from '@oracle/styles/units/spacing';
+import { TabType } from '@oracle/components/Tabs/ButtonTabs';
 import { onSuccess } from '@api/utils/response';
 import { pauseEvent } from '@utils/events';
 
@@ -32,6 +37,7 @@ function PipelineBlockRuns({
   pipelineRun: pipelineRunProp,
 }: PipelineBlockRunsProps) {
   const [selectedRun, setSelectedRun] = useState<BlockRunType>();
+  const [selectedTabSidekick, setSelectedTabSidekick] = useState<TabType>(TABS_SIDEKICK[0]);
   const [errors, setErrors] = useState<ErrorsType>(null);
 
   const pipelineUUID = pipelineProp.uuid;
@@ -94,6 +100,12 @@ function PipelineBlockRuns({
     type: dataType,
   }: OutputType = dataOutput?.outputs?.[0] || {};
 
+  useEffect(() => {
+    if (!selectedRun && selectedTabSidekick?.uuid === TAB_OUTPUT.uuid) {
+      setSelectedTabSidekick(TAB_TREE);
+    }
+  }, [selectedRun, selectedTabSidekick?.uuid]);
+
   const blockRuns = useMemo(() => pipelineRun?.block_runs, [pipelineRun]);
 
   const columns = (blockSampleData?.columns || []).slice(0, MAX_COLUMNS);
@@ -138,6 +150,8 @@ function PipelineBlockRuns({
         loadingData: loadingOutput,
         rows,
         selectedRun,
+        selectedTab: selectedTabSidekick,
+        setSelectedTab: setSelectedTabSidekick,
         showDynamicBlocks: true,
         textData,
       })}

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
@@ -153,28 +153,30 @@ function PipelineBlockRuns({
       pageName={PageNameEnum.RUNS}
       pipeline={pipeline}
       setErrors={setErrors}
-      subheader={
-        <FlexContainer alignItems="center">
-          {(pipelineRun?.status && pipelineRun.status !== RunStatus.COMPLETED) && (
-            <Button
-              danger
-              loading={isLoadingUpdatePipelineRun}
-              onClick={(e) => {
-                pauseEvent(e);
-                updatePipelineRun({
-                  pipeline_run: {
-                    'pipeline_run_action': 'retry_blocks',
-                  },
-                });
-              }}
-              outline
-            >
-              Retry incomplete blocks
-            </Button>
-          )}
-          {(selectedRun && COMPLETED_STATUSES.includes(pipelineRun?.status)) && (
-            <>
-              <Spacing ml={2} />
+      subheader={((pipelineRun?.status && pipelineRun.status !== RunStatus.COMPLETED)
+        || (selectedRun && COMPLETED_STATUSES.includes(pipelineRun?.status))) && (
+          <FlexContainer alignItems="center">
+            {(pipelineRun?.status && pipelineRun.status !== RunStatus.COMPLETED) && (
+              <>
+                <Button
+                  danger
+                  loading={isLoadingUpdatePipelineRun}
+                  onClick={(e) => {
+                    pauseEvent(e);
+                    updatePipelineRun({
+                      pipeline_run: {
+                        'pipeline_run_action': 'retry_blocks',
+                      },
+                    });
+                  }}
+                  outline
+                >
+                  Retry incomplete blocks
+                </Button>
+                <Spacing mr={2} />
+              </>
+            )}
+            {(selectedRun && COMPLETED_STATUSES.includes(pipelineRun?.status)) && (
               <Button
                 loading={isLoadingUpdatePipelineRun}
                 onClick={(e) => {
@@ -191,9 +193,9 @@ function PipelineBlockRuns({
               >
                 Retry from selected block ({selectedRun.block_uuid})
               </Button>
-            </>
-          )}
-        </FlexContainer>
+            )}
+          </FlexContainer>
+        )
       }
       title={({ name }) => `${name} runs`}
       uuid={`${PageNameEnum.RUNS}_${pipelineUUID}_${pipelineRun?.id}`}

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
@@ -37,7 +37,7 @@ function PipelineBlockRuns({
   pipeline: pipelineProp,
   pipelineRun: pipelineRunProp,
 }: PipelineBlockRunsProps) {
-  const [selectedRun, setSelectedRun] = useState<BlockRunType>();
+  const [selectedRun, setSelectedRun] = useState<BlockRunType>(null);
   const [selectedTabSidekick, setSelectedTabSidekick] = useState<TabType>(TABS_SIDEKICK[0]);
   const [errors, setErrors] = useState<ErrorsType>(null);
 
@@ -74,6 +74,9 @@ function PipelineBlockRuns({
     {
       onSuccess: (response: any) => onSuccess(
         response, {
+          callback: () => {
+            setSelectedRun(null);
+          },
           onErrorCallback: (response, errors) => setErrors({
             errors,
             response,

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
@@ -129,7 +129,10 @@ function PipelineBlockRuns({
     && pipelineRun?.status
     && pipelineRun.status !== RunStatus.COMPLETED
   );
-  const showRetryFromBlockButton = selectedRun && COMPLETED_STATUSES.includes(pipelineRun?.status);
+  const showRetryFromBlockButton = (pipeline?.type === PipelineTypeEnum.PYTHON
+    && selectedRun
+    && COMPLETED_STATUSES.includes(pipelineRun?.status)
+  );
 
   return (
     <PipelineDetailPage


### PR DESCRIPTION
# Summary
- For standard python pipelines, retry block runs from a selected block. The selected block and all downstream blocks will be re-ran after clicking the `Retry from selected block` button.
- This feature is not available for other types of pipelines (e.g. streaming or integration). Streaming pipelines don't have block runs, and users can still retry from failed block runs in integration pipelines.

# Tests
![retry from selected block](https://user-images.githubusercontent.com/78053898/236369406-1bb744cf-599e-48be-908d-94346f81256c.gif)
