### PR TITLE
[jk] Show all ports for data loader and exporter blocks

### DIFF
--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -389,7 +389,7 @@ function DependencyGraph({
           id: `${uuid}-${block2.uuid}-from`,
           side: SideEnum.SOUTH,
         })));
-      } else if (blockType !== BlockTypeEnum.DATA_EXPORTER) {
+      } else {
         ports.push({
           ...SHARED_PORT_PROPS,
           id: `${uuid}-from`,
@@ -397,7 +397,7 @@ function DependencyGraph({
         });
       }
 
-      if (upstreamBlocks.length === 0 && blockType !== BlockTypeEnum.DATA_LOADER) {
+      if (upstreamBlocks.length === 0) {
         ports.push({
           ...SHARED_PORT_PROPS,
           id: `${uuid}-to`,


### PR DESCRIPTION
# Summary
- Show all ports on the data loader/exporter blocks. Previously, the top port for data loader blocks with no upstream blocks was not displayed, and the bottom port for data exporter blocks with no downstream blocks was not displayed.

# Tests
![exporter loader ports](https://user-images.githubusercontent.com/78053898/236539577-03ec7e29-b5bd-4a3f-bfbe-6465e5cbc23c.gif)
