### PR TITLE
[hw] Fix a format issue with a terminal bash command and update instructions based on the latest UI

### DIFF
--- a/docs/tutorials/setup-dbt.mdx
+++ b/docs/tutorials/setup-dbt.mdx
@@ -29,7 +29,11 @@ For the rest of this tutorial, we’ll use the project name `demo_project`.
 1. Open Mage and go to the terminal page: http://localhost:6789/terminal
 2. Add `dbt-postgres` to your project’s dependencies file (`requirements.txt`)
    by typing the following into the terminal in your browser:
-   `bash echo dbt-postgres > demo_project/requirements.txt `
+
+   ```bash
+   echo dbt-postgres > demo_project/requirements.txt
+   ```
+
 3. Install your project’s dependencies using `pip` by typing the following:
 
    ```bash

--- a/docs/tutorials/setup-dbt.mdx
+++ b/docs/tutorials/setup-dbt.mdx
@@ -64,8 +64,8 @@ For the rest of this tutorial, we’ll use the project name `demo_project`.
 
 1. Go to the [Mage dashboard](http://localhost:6789/) and click the button
    **`+ New pipeline`** and select the option labeled `Standard (batch)`.
-2. Near the top of the page, click the pipeline name and change it to
-   `dbt demo pipeline`.
+2. Click the `Pipeline settings` icon in the left pane, and change its name
+   to `dbt demo pipeline`, the click the `Save pipeline settings` button.
 
 ---
 
@@ -97,10 +97,9 @@ For the rest of this tutorial, we’ll use the project name `demo_project`.
 ## 5. Add data loader block to pipeline
 
 1. Click the **`+ Data loader`** button, select `Python`, then click `API`.
-2. At the top of the block, on the right of `DATA LOADER`, click the name of the
-   block.
-3. Change the name to `load data`.
-4. Paste the following code in that block:
+2. In the popup dialog `Data loader block name`, change the name to `load data`,
+   then click the `Save and add block` button.
+3. Paste the following code in that block:
 
     ```python
     import io
@@ -124,13 +123,13 @@ For the rest of this tutorial, we’ll use the project name `demo_project`.
 
 1. Under the data loader block you just added, click the button **`DBT model`**,
    then click the option `Single model`.
-1. In the file browser that pops up, click the file named
+2. In the file browser that pops up, click the file named
    `my_second_dbt_model.sql` under the folders `demo/models/example/`. 
    
    1. This will add 2 DBT blocks to your pipeline: 1 for the DBT model named
    `my_first_dbt_model` and the 2nd for the DBT model named `my_second_dbt_model`. 
    
-   1. The model named `my_first_dbt_model` was added to
+   2. The model named `my_first_dbt_model` was added to
    the pipeline because `my_second_dbt_model` references it.
 
 ![](https://github.com/mage-ai/assets/blob/main/dbt/add-dbt-model.gif?raw=true)

--- a/docs/tutorials/setup-dbt.mdx
+++ b/docs/tutorials/setup-dbt.mdx
@@ -65,7 +65,7 @@ For the rest of this tutorial, we’ll use the project name `demo_project`.
 1. Go to the [Mage dashboard](http://localhost:6789/) and click the button
    **`+ New pipeline`** and select the option labeled `Standard (batch)`.
 2. Click the `Pipeline settings` icon in the left pane, and change its name
-   to `dbt demo pipeline`, the click the `Save pipeline settings` button.
+   to `dbt demo pipeline`, then click the `Save pipeline settings` button.
 
 ---
 
@@ -97,7 +97,7 @@ For the rest of this tutorial, we’ll use the project name `demo_project`.
 ## 5. Add data loader block to pipeline
 
 1. Click the **`+ Data loader`** button, select `Python`, then click `API`.
-2. In the popup dialog `Data loader block name`, change the name to `load data`,
+2. In the popup dialog `Data loader block name`, change its name to `load data`,
    then click the `Save and add block` button.
 3. Paste the following code in that block:
 


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

Encountered the following error following the current user guide for dbt:
```
root@488dc9529cf3:/home/src# bash echo dbt-postgres > demo_project/requirements.txt

/bin/echo: /bin/echo: cannot execute binary file
```

It was caused by a wrong format for a code section in the user guide, which has been fixed in this PR.

# Tests
<!-- How did you test your change? -->
Manually tested in the Mage terminal:
```
root@488dc9529cf3:/home/src# echo dbt-postgres > demo_project/requirements.txt

root@488dc9529cf3:/home/src# ls demo_project/requirements.txt

demo_project/requirements.txt

root@488dc9529cf3:/home/src# cat demo_project/requirements.txt

dbt-postgres
```
cc:
<!-- Optionally mention someone to let them know about this pull request -->
@dy46 @wangxiaoyou1993 