### PR TITLE
Use timestamp column type in Redshift for datetime data

### DIFF
--- a/mage_ai/shared/utils.py
+++ b/mage_ai/shared/utils.py
@@ -72,6 +72,8 @@ def convert_python_type_to_redshift_type(python_type):
         return 'FLOAT8'
     elif python_type is bool:
         return 'BOOLEAN'
+    elif python_type is datetime:
+        return 'TIMESTAMP'
     return 'VARCHAR'
 
 


### PR DESCRIPTION
# Summary
For datetime data, use a timestamp column type in Redshift.
