### PR TITLE
[jk] Sidekick resizing

### DIFF
--- a/mage_ai/frontend/components/TripleLayout/index.style.tsx
+++ b/mage_ai/frontend/components/TripleLayout/index.style.tsx
@@ -8,8 +8,8 @@ import { ScrollbarStyledCss } from '@oracle/styles/scrollbars';
 import { hideScrollBar } from '@oracle/styles/scrollbars';
 
 export const AFTER_DEFAULT_WIDTH = UNIT * 64;
-export const AFTER_MIN_WIDTH = PADDING_UNITS * 3 * UNIT;
-export const BEFORE_MIN_WIDTH = AFTER_MIN_WIDTH;
+export const AFTER_MIN_WIDTH = UNIT * 30;
+export const BEFORE_MIN_WIDTH = UNIT * 21.25;
 export const BEFORE_DEFAULT_WIDTH = UNIT * 35;
 export const DRAGGABLE_WIDTH = UNIT * 0.5;
 export const MAIN_MIN_WIDTH = UNIT * 13;

--- a/mage_ai/frontend/components/TripleLayout/index.tsx
+++ b/mage_ai/frontend/components/TripleLayout/index.tsx
@@ -337,7 +337,9 @@ function TripleLayout({
       {setBeforeHidden && (
         <AsideHeaderStyle
           style={{
-            overflow: hasBeforeNavigationItems ? 'auto' : 'hidden',
+            overflow: beforeHidden
+              ? 'visible'
+              : (hasBeforeNavigationItems ? 'auto' : 'hidden'),
             width: hasBeforeNavigationItems
               // Required
               ? beforeWidthFinal - (VERTICAL_NAVIGATION_WIDTH + 2)
@@ -359,6 +361,8 @@ function TripleLayout({
 
             <Flex>
               <Tooltip
+                appearAbove={!beforeHidden}
+                appearBefore={!beforeHidden}
                 block
                 key={beforeHidden ? 'before-is-hidden' : 'before-is-visible'}
                 label={beforeHidden ? 'Show sidebar' : 'Hide sidebar'}


### PR DESCRIPTION
# Summary
- Set higher min widths for File Browser (before panel) and Sidekick (after panel) so they don't become hidden behind the expanding navigation buttons.
- Fix positioning of "Show sidebar" tooltip for left panel.

# Tests
![sidekick resizing](https://github.com/mage-ai/mage-ai/assets/78053898/6f5ba087-14b0-4194-b934-dc9f50995c93)
