### PR TITLE
[jk]  Add new block with downstream blocks connected

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -131,7 +131,7 @@ import { useKeyboardContext } from '@context/Keyboard';
 export const DEFAULT_SQL_CONFIG_KEY_LIMIT = 1000;
 
 type CodeBlockProps = {
-  addNewBlock?: (block: BlockType) => Promise<any>;
+  addNewBlock?: (block: BlockType, downstreamBlocks?: string[]) => Promise<any>;
   addNewBlockMenuOpenIdx?: number;
   allBlocks: BlockType[];
   allowCodeBlockShortcuts?: boolean;
@@ -2065,6 +2065,7 @@ function CodeBlock({
                     let content = newBlock.content;
                     let configuration = newBlock.configuration;
                     const upstreamBlocks = getUpstreamBlockUuids(block, newBlock);
+                    const downstreamBlocks = block.downstream_blocks || [];
 
                     if ([BlockTypeEnum.DATA_LOADER, BlockTypeEnum.TRANSFORMER].includes(blockType)
                       && BlockTypeEnum.SCRATCHPAD === newBlock.type
@@ -2092,12 +2093,15 @@ function CodeBlock({
                       content = addSqlBlockNote(content);
                     }
 
-                    return addNewBlock({
-                      ...newBlock,
-                      configuration,
-                      content,
-                      upstream_blocks: upstreamBlocks,
-                    });
+                    return addNewBlock(
+                      {
+                        ...newBlock,
+                        configuration,
+                        content,
+                        upstream_blocks: upstreamBlocks,
+                      },
+                      downstreamBlocks,
+                    );
                   }}
                   blockIdx={blockIdx}
                   blockTemplates={blockTemplates}

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -114,7 +114,12 @@ import {
 } from './constants';
 import { ViewKeyEnum } from '@components/Sidekick/constants';
 import { addScratchpadNote, addSqlBlockNote } from '@components/PipelineDetail/AddNewBlocks/utils';
-import { buildBorderProps, buildConvertBlockMenuItems, getUpstreamBlockUuids } from './utils';
+import {
+  buildBorderProps,
+  buildConvertBlockMenuItems,
+  getDownstreamBlockUuids,
+  getUpstreamBlockUuids,
+} from './utils';
 import { capitalize, pluralize } from '@utils/string';
 import { executeCode } from '@components/CodeEditor/keyboard_shortcuts/shortcuts';
 import { get, set } from '@storage/localStorage';
@@ -2065,7 +2070,7 @@ function CodeBlock({
                     let content = newBlock.content;
                     let configuration = newBlock.configuration;
                     const upstreamBlocks = getUpstreamBlockUuids(block, newBlock);
-                    const downstreamBlocks = block.downstream_blocks || [];
+                    const downstreamBlocks = getDownstreamBlockUuids(block, newBlock);
 
                     if ([BlockTypeEnum.DATA_LOADER, BlockTypeEnum.TRANSFORMER].includes(blockType)
                       && BlockTypeEnum.SCRATCHPAD === newBlock.type

--- a/mage_ai/frontend/components/CodeBlock/utils.ts
+++ b/mage_ai/frontend/components/CodeBlock/utils.ts
@@ -31,6 +31,21 @@ export const getUpstreamBlockUuids = (
   return upstreamBlocks;
 };
 
+export const getDownstreamBlockUuids = (
+  currentBlock: BlockType,
+  newBlock?: BlockRequestPayloadType,
+): string[] => {
+  let downstreamBlocks = [];
+
+  if (!BLOCK_TYPES_WITH_NO_PARENTS.includes(currentBlock?.type)
+    && !BLOCK_TYPES_WITH_NO_PARENTS.includes(newBlock?.type)
+  ) {
+    downstreamBlocks = downstreamBlocks.concat(currentBlock?.downstream_blocks || []);
+  }
+
+  return downstreamBlocks;
+};
+
 export const buildConvertBlockMenuItems = (
   b: BlockType,
   blocks: BlockType[],

--- a/mage_ai/frontend/components/IntegrationPipeline/index.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/index.tsx
@@ -165,6 +165,8 @@ function IntegrationPipeline({
     onChangeCodeBlock,
     pipeline,
   ]);
+  const transformerBlock: BlockType =
+    useMemo(() => find(blocks, ({ type }) => BlockTypeEnum.TRANSFORMER === type), [blocks]);
 
   const catalog: CatalogType =
     useMemo(() => (!isEmptyObject(dataLoaderBlockContent?.catalog)
@@ -896,6 +898,7 @@ function IntegrationPipeline({
                 hideMarkdown
                 hideScratchpad
                 hideSensor
+                hideTransformer={!!transformerBlock}
                 hideTransformerDataSources
                 pipeline={pipeline}
               />


### PR DESCRIPTION
# Summary
- If a new block is added between two blocks, include the downstream connection.
- If a new block is added after a block that has multiple downstream blocks, the downstream connections will not be added since it is unclear which downstream connections should be made.
- Hide Add transformer block button in integration pipelines if a transformer block already exists (Mage currently only supports 1 transformer block for integration pipelines).

# Tests
![add new block with upstream downstream](https://github.com/mage-ai/mage-ai/assets/78053898/51ac616a-9788-4aa9-a1d1-1186454a7196)