### PR TITLE
[jk] Update zoom on dependency graph

### DIFF
--- a/mage_ai/frontend/components/Dashboard/index.style.tsx
+++ b/mage_ai/frontend/components/Dashboard/index.style.tsx
@@ -26,22 +26,22 @@ export const ContainerStyle = styled.div`
 
 type VerticalNavigationStyleProps = {
   aligned?: 'left' | 'right';
-  borderLess?: boolean;
+  borderless?: boolean;
   showMore?: boolean;
 };
 
 const VerticalNavigationStyleComponent = styled.div<VerticalNavigationStyleProps>`
   height: calc(100% - ${HEADER_HEIGHT}px);
 
-  ${props => !props.borderLess && `
+  ${props => `
     background-color: ${(props.theme.background || dark.background).panel};
   `}
 
-  ${props => !props.borderLess && props.aligned !== 'right' && `
+  ${props => !props.borderless && props.aligned !== 'right' && `
     border-right: 1px solid ${(props.theme.borders || dark.borders).medium};
   `}
 
-  ${props => !props.borderLess && props.aligned === 'right' && `
+  ${props => !props.borderless && props.aligned === 'right' && `
     border-left: 1px solid ${(props.theme.borders || dark.borders).medium};
   `}
 
@@ -73,7 +73,7 @@ const VerticalNavigationStyleComponent = styled.div<VerticalNavigationStyleProps
 
 export function VerticalNavigationStyle({
   aligned,
-  borderLess,
+  borderless,
   children,
   showMore,
 }: {
@@ -84,7 +84,7 @@ export function VerticalNavigationStyle({
   return (
     <VerticalNavigationStyleComponent
       aligned={aligned}
-      borderLess={borderLess && !visible}
+      borderless={borderless && !visible}
       onMouseEnter={showMore ? () => setVisible(true) : null}
       onMouseLeave={showMore ? () => setVisible(false) : null}
       showMore={showMore}

--- a/mage_ai/frontend/components/DependencyGraph/constants.ts
+++ b/mage_ai/frontend/components/DependencyGraph/constants.ts
@@ -5,7 +5,11 @@ import BlockType, {
 import { UNIT } from '@oracle/styles/units/spacing';
 
 export const MIN_NODE_WIDTH = UNIT * 20;
+
 export const ZOOMABLE_CANVAS_SIZE = 10000;
+export const SHARED_ZOOM_BUTTON_PROPS = {
+  compact: true,
+};
 
 export const SHARED_PORT_PROPS = {
   height: 10,

--- a/mage_ai/frontend/components/DependencyGraph/index.style.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.style.tsx
@@ -8,7 +8,7 @@ import { UNIT } from '@oracle/styles/units/spacing';
 export const GraphContainerStyle = styled.div<{
   height?: number;
 }>`
-  div:only-child {
+  div {
     ${ScrollbarStyledCss}
   }
 

--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useContext,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { useMutation } from 'react-query';
@@ -155,6 +156,9 @@ function DependencyGraph({
   zoomable = true,
 }: DependencyGraphProps) {
   const themeContext: ThemeType = useContext(ThemeContext);
+  const treeInnerRef = useRef<CanvasRef>(null);
+  const canvasRef = treeRef || treeInnerRef;
+
   const [edgeSelections, setEdgeSelections] = useState<string[]>([]);
   const [showPortsState, setShowPorts] = useState<boolean>(false);
   const [activePort, setActivePort] = useState<{ id: string, side: SideEnum }>(null);
@@ -599,7 +603,7 @@ function DependencyGraph({
 
       <GraphContainerStyle
         height={containerHeight}
-        onDoubleClick={() => treeRef?.current?.fitCanvas?.()}
+        onDoubleClick={() => canvasRef?.current?.fitCanvas?.()}
       >
         <Canvas
           arrow={null}
@@ -637,7 +641,7 @@ function DependencyGraph({
           }}
           edges={edges}
           fit
-          forwardedRef={treeRef}
+          forwardedRef={canvasRef}
           maxHeight={ZOOMABLE_CANVAS_SIZE}
           maxWidth={ZOOMABLE_CANVAS_SIZE}
           maxZoom={1}

--- a/mage_ai/frontend/components/Sidekick/Header.tsx
+++ b/mage_ai/frontend/components/Sidekick/Header.tsx
@@ -10,6 +10,7 @@ import Link from '@oracle/elements/Link';
 import PipelineType from '@interfaces/PipelineType';
 import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
+import Tooltip from '@oracle/components/Tooltip';
 import api from '@api';
 import { GLOBAL_VARIABLES_UUID } from '@interfaces/PipelineVariableType';
 import { SHARED_ZOOM_BUTTON_PROPS } from '@components/DependencyGraph/constants';
@@ -106,16 +107,26 @@ function SidekickHeader({
             </Text>
           </Button>
           <Spacing mr={1} />
-          <Button
-            {...SHARED_ZOOM_BUTTON_PROPS}
-            onClick={() => {
-              treeRef?.current?.fitCanvas?.();
-            }}
+          <Tooltip
+            appearAbove
+            appearBefore
+            default
+            label="Shortcut: Double-click canvas"
+            lightBackground
+            size={null}
+            widthFitContent
           >
-            <Text noWrapping>
-              Reset
-            </Text>
-          </Button>
+            <Button
+              {...SHARED_ZOOM_BUTTON_PROPS}
+              onClick={() => {
+                treeRef?.current?.fitCanvas?.();
+              }}
+            >
+              <Text noWrapping>
+                Reset
+              </Text>
+            </Button>
+          </Tooltip>
           <Spacing mr={1} />
           <Text bold>{depGraphZoom?.toFixed(2)}x</Text>
         </Flex>

--- a/mage_ai/frontend/components/Sidekick/Header.tsx
+++ b/mage_ai/frontend/components/Sidekick/Header.tsx
@@ -12,6 +12,7 @@ import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
 import Tooltip from '@oracle/components/Tooltip';
 import api from '@api';
+import { AsideHeaderInnerStyle } from '@components/TripleLayout/index.style';
 import { GLOBAL_VARIABLES_UUID } from '@interfaces/PipelineVariableType';
 import { SHARED_ZOOM_BUTTON_PROPS } from '@components/DependencyGraph/constants';
 import {
@@ -19,7 +20,6 @@ import {
   VIEW_QUERY_PARAM,
   ViewKeyEnum,
 } from '@components/Sidekick/constants';
-import { SidekickHeaderContainerStyle } from './index.style';
 import { getFormattedVariables } from './utils';
 import { indexBy } from '@utils/array';
 import { queryFromUrl } from '@utils/url';
@@ -157,9 +157,9 @@ function SidekickHeader({
   }
 
   return (
-    <SidekickHeaderContainerStyle>
+    <AsideHeaderInnerStyle>
       {el}
-    </SidekickHeaderContainerStyle>
+    </AsideHeaderInnerStyle>
   );
 }
 

--- a/mage_ai/frontend/components/Sidekick/Header.tsx
+++ b/mage_ai/frontend/components/Sidekick/Header.tsx
@@ -1,7 +1,10 @@
 import NextLink from 'next/link';
+import { CanvasRef } from 'reaflow';
 import { useMemo } from 'react';
 
+import Button from '@oracle/elements/Button';
 import ExtensionOptionType from '@interfaces/ExtensionOptionType';
+import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
 import Link from '@oracle/elements/Link';
 import PipelineType from '@interfaces/PipelineType';
@@ -9,12 +12,13 @@ import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
 import api from '@api';
 import { GLOBAL_VARIABLES_UUID } from '@interfaces/PipelineVariableType';
-import { PADDING_UNITS } from '@oracle/styles/units/spacing';
+import { SHARED_ZOOM_BUTTON_PROPS } from '@components/DependencyGraph/constants';
 import {
   SIDEKICK_VIEWS_BY_KEY,
   VIEW_QUERY_PARAM,
   ViewKeyEnum,
 } from '@components/Sidekick/constants';
+import { SidekickHeaderContainerStyle } from './index.style';
 import { getFormattedVariables } from './utils';
 import { indexBy } from '@utils/array';
 import { queryFromUrl } from '@utils/url';
@@ -22,10 +26,12 @@ import { queryFromUrl } from '@utils/url';
 
 type SidekickHeaderProps = {
   activeView: ViewKeyEnum;
+  depGraphZoom?: number;
   pipeline: PipelineType;
   secrets?: {
     [key: string]: any;
   }[];
+  treeRef?: { current?: CanvasRef };
   variables?: {
     [key: string]: any;
   }[];
@@ -33,8 +39,10 @@ type SidekickHeaderProps = {
 
 function SidekickHeader({
   activeView,
+  depGraphZoom,
   pipeline,
   secrets,
+  treeRef,
   variables,
 }: SidekickHeaderProps) {
   const pipelineUUID = pipeline?.uuid;
@@ -66,6 +74,53 @@ function SidekickHeader({
 
   if (!activeView) {
     return <div />;
+  } else if (treeRef && ViewKeyEnum.TREE === activeView) {
+    el = (
+      <FlexContainer
+        alignItems="center"
+        fullWidth
+        justifyContent="space-between"
+      >
+        {el}
+        <Spacing mr={1} />
+        <Flex alignItems="center">
+          <Button
+            {...SHARED_ZOOM_BUTTON_PROPS}
+            onClick={() => {
+              treeRef?.current?.zoomIn?.();
+            }}
+          >
+            <Text noWrapping>
+              Zoom in
+            </Text>
+          </Button>
+          <Spacing mr={1} />
+          <Button
+            {...SHARED_ZOOM_BUTTON_PROPS}
+            onClick={() => {
+              treeRef?.current?.zoomOut?.();
+            }}
+          >
+            <Text noWrapping>
+              Zoom out
+            </Text>
+          </Button>
+          <Spacing mr={1} />
+          <Button
+            {...SHARED_ZOOM_BUTTON_PROPS}
+            onClick={() => {
+              treeRef?.current?.fitCanvas?.();
+            }}
+          >
+            <Text noWrapping>
+              Reset
+            </Text>
+          </Button>
+          <Spacing mr={1} />
+          <Text bold>{depGraphZoom?.toFixed(2)}x</Text>
+        </Flex>
+      </FlexContainer>
+    );
   } else if (showExtensionDetails) {
     const extensionOption = extensionOptionsByUUID[query?.extension];
 
@@ -91,9 +146,9 @@ function SidekickHeader({
   }
 
   return (
-    <Spacing px={PADDING_UNITS}>
+    <SidekickHeaderContainerStyle>
       {el}
-    </Spacing>
+    </SidekickHeaderContainerStyle>
   );
 }
 

--- a/mage_ai/frontend/components/Sidekick/index.style.ts
+++ b/mage_ai/frontend/components/Sidekick/index.style.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { ALL_HEADERS_HEIGHT } from '@components/TripleLayout/index.style';
 import { COLUMN_HEADER_CHART_HEIGHT } from '@components/datasets/overview/utils';
 import { REGULAR_LINE_HEIGHT } from '@oracle/styles/fonts/sizes';
-import { ScrollbarStyledCss } from '@oracle/styles/scrollbars';
+import { ScrollbarStyledCss, hideScrollBar } from '@oracle/styles/scrollbars';
 import { UNIT } from '@oracle/styles/units/spacing';
 
 export const TOTAL_PADDING = UNIT * 4;
@@ -22,6 +22,14 @@ export const SidekickContainerStyle = styled.div<{
   ${props => `
     height: calc(100vh - ${ALL_HEADERS_HEIGHT}px - ${props.heightOffset}px);
   `}
+`;
+
+export const SidekickHeaderContainerStyle = styled.div`
+  display: flex;
+  flex: 1;
+  overflow: auto;
+  padding: 0 ${UNIT}px;
+  ${hideScrollBar()}
 `;
 
 export const PaddingContainerStyle = styled.div<{ noPadding?: boolean }>`

--- a/mage_ai/frontend/components/Sidekick/index.style.ts
+++ b/mage_ai/frontend/components/Sidekick/index.style.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { ALL_HEADERS_HEIGHT } from '@components/TripleLayout/index.style';
 import { COLUMN_HEADER_CHART_HEIGHT } from '@components/datasets/overview/utils';
 import { REGULAR_LINE_HEIGHT } from '@oracle/styles/fonts/sizes';
-import { ScrollbarStyledCss, hideScrollBar } from '@oracle/styles/scrollbars';
+import { ScrollbarStyledCss } from '@oracle/styles/scrollbars';
 import { UNIT } from '@oracle/styles/units/spacing';
 
 export const TOTAL_PADDING = UNIT * 4;
@@ -22,14 +22,6 @@ export const SidekickContainerStyle = styled.div<{
   ${props => `
     height: calc(100vh - ${ALL_HEADERS_HEIGHT}px - ${props.heightOffset}px);
   `}
-`;
-
-export const SidekickHeaderContainerStyle = styled.div`
-  display: flex;
-  flex: 1;
-  overflow: auto;
-  padding: 0 ${UNIT * 2}px;
-  ${hideScrollBar()}
 `;
 
 export const PaddingContainerStyle = styled.div<{ noPadding?: boolean }>`

--- a/mage_ai/frontend/components/Sidekick/index.style.ts
+++ b/mage_ai/frontend/components/Sidekick/index.style.ts
@@ -28,7 +28,7 @@ export const SidekickHeaderContainerStyle = styled.div`
   display: flex;
   flex: 1;
   overflow: auto;
-  padding: 0 ${UNIT}px;
+  padding: 0 ${UNIT * 2}px;
   ${hideScrollBar()}
 `;
 

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -33,6 +33,7 @@ import Spacing from '@oracle/elements/Spacing';
 import StatsTable, { StatRow as StatRowType } from '@components/datasets/StatsTable';
 import Text from '@oracle/elements/Text';
 import Terminal from '@components/Terminal';
+
 import { ALL_HEADERS_HEIGHT, ASIDE_SUBHEADER_HEIGHT } from '@components/TripleLayout/index.style';
 import { Charts as ChartsIcon, Close } from '@oracle/icons';
 import {

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
+import { CanvasRef } from 'reaflow';
 
 import ApiReloader from '@components/ApiReloader';
 import BlockCharts from '@components/BlockCharts';
@@ -90,7 +91,6 @@ export type SidekickProps = {
   insights: InsightType[][];
   interruptKernel: () => void;
   isPipelineExecuting: boolean;
-  isPipelineUpdating?: boolean;
   globalVariables: PipelineVariableType[];
   lastTerminalMessage: WebSocketEventMap['message'] | null;
   metadata: MetadataType;
@@ -102,11 +102,8 @@ export type SidekickProps = {
   selectedBlock: BlockType;
   selectedFilePath?: string;
   sendTerminalMessage: (message: string, keep?: boolean) => void;
-  setActiveSidekickView?: (
-    newView: ViewKeyEnum,
-    pushHistory?: boolean,
-  ) => void;
   setAllowCodeBlockShortcuts?: (allowCodeBlockShortcuts: boolean) => void;
+  setDepGraphZoom?: (zoom: number) => void;
   setDisableShortcuts: (disableShortcuts: boolean) => void;
   setHiddenBlocks: ((opts: {
     [uuid: string]: BlockType;
@@ -115,7 +112,7 @@ export type SidekickProps = {
   });
   setErrors: (errors: ErrorsType) => void;
   statistics: StatisticsType;
-  updatePipelineMetadata: (name: string, type?: string) => void;
+  treeRef?: { current?: CanvasRef };
 } & SetEditingBlockType & ChartsPropsShared & ExtensionsProps & CallbacksProps;
 
 function Sidekick({
@@ -141,7 +138,6 @@ function Sidekick({
   insights,
   interruptKernel,
   isPipelineExecuting,
-  isPipelineUpdating,
   lastTerminalMessage,
   messages,
   metadata,
@@ -159,9 +155,9 @@ function Sidekick({
   selectedBlock,
   selectedFilePath,
   sendTerminalMessage,
-  setActiveSidekickView,
   setAllowCodeBlockShortcuts,
   setAnyInputFocused,
+  setDepGraphZoom,
   setDisableShortcuts,
   setEditingBlock,
   setErrors,
@@ -170,7 +166,7 @@ function Sidekick({
   setTextareaFocused,
   statistics,
   textareaFocused,
-  updatePipelineMetadata,
+  treeRef,
   updateWidget,
   widgets,
 }: SidekickProps) {
@@ -379,6 +375,8 @@ function Sidekick({
                 setEditingBlock={setEditingBlock}
                 setErrors={setErrors}
                 setSelectedBlock={setSelectedBlock}
+                setZoom={setDepGraphZoom}
+                treeRef={treeRef}
               />
               {!blockEditing && PipelineTypeEnum.STREAMING === pipeline?.type && (
                 <Spacing p={1}>

--- a/mage_ai/frontend/components/TripleLayout/index.style.tsx
+++ b/mage_ai/frontend/components/TripleLayout/index.style.tsx
@@ -151,6 +151,20 @@ export const AsideHeaderStyle = styled.div<{
   `}
 `;
 
+export const AsideHeaderInnerStyle = styled.div<{
+  noPadding?: boolean;
+}>`
+  display: flex;
+  flex: 1;
+  overflow: auto;
+  padding: 0 ${UNIT * 2}px;
+  ${hideScrollBar()}
+
+  ${props => props.noPadding && `
+    padding: 0;
+  `}
+`;
+
 export const AsideSubheaderStyle = styled.div<{
   visible: boolean;
 }>`

--- a/mage_ai/frontend/components/TripleLayout/index.tsx
+++ b/mage_ai/frontend/components/TripleLayout/index.tsx
@@ -460,7 +460,7 @@ function TripleLayout({
                   <NavigationInnerStyle aligned="left">
                     <VerticalNavigationStyle
                       aligned="left"
-                      borderLess
+                      borderless
                       showMore={navigationShowMore}
                     >
                       <VerticalNavigation
@@ -534,7 +534,7 @@ function TripleLayout({
                   <NavigationInnerStyle aligned="right">
                     <VerticalNavigationStyle
                       aligned="right"
-                      borderLess
+                      borderless
                       showMore={navigationShowMore}
                     >
                       <VerticalNavigation

--- a/mage_ai/frontend/components/TripleLayout/index.tsx
+++ b/mage_ai/frontend/components/TripleLayout/index.tsx
@@ -20,6 +20,7 @@ import {
   AfterInnerStyle,
   AfterStyle,
   AsideHeaderStyle,
+  AsideHeaderInnerStyle,
   AsideSubheaderStyle,
   BEFORE_MIN_WIDTH,
   BeforeInnerStyle,
@@ -339,7 +340,7 @@ function TripleLayout({
           style={{
             overflow: beforeHidden
               ? 'visible'
-              : (hasBeforeNavigationItems ? 'auto' : 'hidden'),
+              : 'hidden',
             width: hasBeforeNavigationItems
               // Required
               ? beforeWidthFinal - (VERTICAL_NAVIGATION_WIDTH + 2)
@@ -353,11 +354,10 @@ function TripleLayout({
             fullWidth
             justifyContent="space-between"
           >
-            <Flex>
+            <AsideHeaderInnerStyle noPadding>
               <Spacing pl={beforeHidden ? 1 : 0} />
-
               {!beforeHidden && beforeHeader}
-            </Flex>
+            </AsideHeaderInnerStyle>
 
             <Flex>
               <Tooltip

--- a/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.tsx
+++ b/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.tsx
@@ -65,7 +65,7 @@ function ButtonTabs({
           <Text
             bold
             default={!selected}
-            noWrapping={allowScroll}
+            noWrapping
             small
           >
             {displayText}
@@ -125,7 +125,6 @@ function ButtonTabs({
 
     return arr;
   }, [
-    allowScroll,
     onClickTab,
     selectedTabUUID,
     small,

--- a/mage_ai/frontend/oracle/components/Tooltip/TooltipWrapper.tsx
+++ b/mage_ai/frontend/oracle/components/Tooltip/TooltipWrapper.tsx
@@ -123,7 +123,7 @@ const ContentStyle = styled.div<TooltipWrapperProps>`
   `}
 
   ${props => props.appearBefore && `
-    right: 0;
+    right: ${UNIT * 2}px;
   `}
 
   ${props => props.leftPosition && `

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -135,6 +135,7 @@ function PipelineDetailPage({
   const [anyInputFocused, setAnyInputFocused] = useState<boolean>(false);
   const [disableShortcuts, setDisableShortcuts] = useState<boolean>(false);
   const [allowCodeBlockShortcuts, setAllowCodeBlockShortcuts] = useState<boolean>(false);
+  const [depGraphZoom, setDepGraphZoom] = useState<number>(1);
 
   const localStorageTabSelectedKey =
     `${LOCAL_STORAGE_KEY_PIPELINE_EDIT_BEFORE_TAB_SELECTED}_${pipelineUUID}`;
@@ -325,6 +326,7 @@ function PipelineDetailPage({
 
   const blockRefs = useRef({});
   const chartRefs = useRef({});
+  const treeRef = useRef(null);
   const callbackByBlockUUID = useRef({});
   const contentByBlockUUID = useRef({});
   const contentByWidgetUUID = useRef({});
@@ -1838,6 +1840,7 @@ function PipelineDetailPage({
       setActiveSidekickView={setActiveSidekickView}
       setAllowCodeBlockShortcuts={setAllowCodeBlockShortcuts}
       setAnyInputFocused={setAnyInputFocused}
+      setDepGraphZoom={setDepGraphZoom}
       setDisableShortcuts={setDisableShortcuts}
       setEditingBlock={setEditingBlock}
       setErrors={setErrors}
@@ -1847,6 +1850,7 @@ function PipelineDetailPage({
       setTextareaFocused={setTextareaFocused}
       statistics={statistics}
       textareaFocused={textareaFocused}
+      treeRef={treeRef}
       updatePipelineMetadata={updatePipelineMetadata}
       updateWidget={updateWidget}
       widgets={widgets}
@@ -2262,8 +2266,10 @@ function PipelineDetailPage({
         afterHeader={(
           <SidekickHeader
             activeView={activeSidekickView}
+            depGraphZoom={depGraphZoom}
             pipeline={pipeline}
             secrets={secrets}
+            treeRef={treeRef}
             variables={globalVariables}
           />
         )}

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -2242,7 +2242,6 @@ function PipelineDetailPage({
   const buttonTabs = useMemo(() => (
     <Spacing px={1}>
       <ButtonTabs
-        allowScroll
         noPadding
         onClickTab={(tab: TabType) => {
           setSelectedTab(tab);


### PR DESCRIPTION
# Summary
- Add buttons for zooming in/out of and resetting dependency graph.
- Added shortcut to reset dependency graph view (double-clicking anywhere on the canvas).
- Fixed positioning of left chevron icon to minimize left panel in Pipeline Editor.

# Tests
![dep graph zooming](https://github.com/mage-ai/mage-ai/assets/78053898/5b497245-f612-4009-beaa-2fad6db2c6ca)
