### PR TITLE
[xy] Fix race conditions for multiple runs within one second.

### DIFF
--- a/mage_ai/api/resources/LogResource.py
+++ b/mage_ai/api/resources/LogResource.py
@@ -1,12 +1,18 @@
 from datetime import datetime
+from typing import Dict, List
+
+from sqlalchemy.orm import aliased
+
 from mage_ai.api.errors import ApiError
 from mage_ai.api.operations.constants import META_KEY_LIMIT
 from mage_ai.api.resources.GenericResource import GenericResource
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.orchestration.db import safe_db_query
-from mage_ai.orchestration.db.models.schedules import BlockRun, PipelineRun, PipelineSchedule
-from sqlalchemy.orm import aliased
-from typing import Dict, List
+from mage_ai.orchestration.db.models.schedules import (
+    BlockRun,
+    PipelineRun,
+    PipelineSchedule,
+)
 
 MAX_LOG_FILES = 20
 
@@ -96,6 +102,7 @@ class LogResource(GenericResource):
             a.pipeline_schedule_id,
             a.pipeline_schedule_id,
             a.pipeline_uuid,
+            a.variables,
         ]
 
         total_pipeline_run_log_count = 0
@@ -155,6 +162,7 @@ class LogResource(GenericResource):
                 model.execution_date = row.execution_date
                 model.pipeline_schedule_id = row.pipeline_schedule_id
                 model.pipeline_uuid = row.pipeline_uuid
+                model.variables = row.variables
                 logs = await model.logs_async()
                 pipeline_log_file_path = logs.get('path')
                 if pipeline_log_file_path not in processed_pipeline_run_log_files:
@@ -235,6 +243,7 @@ class LogResource(GenericResource):
             model.execution_date = row.execution_date
             model.pipeline_schedule_id = row.pipeline_schedule_id
             model.pipeline_uuid = row.pipeline_uuid
+            model.variables = row.variables
 
             model2 = BlockRun()
             model2.block_uuid = row.block_uuid

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -237,6 +237,8 @@ class PipelineRun(BaseModel):
 
     @property
     def execution_partition(self) -> str:
+        if self.variables and self.variables.get('execution_partition'):
+            return self.variables.get('execution_partition')
         if self.execution_date is None:
             return str(self.pipeline_schedule_id)
         else:

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -1,3 +1,4 @@
+import os
 import traceback
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Tuple
@@ -900,7 +901,10 @@ def configure_pipeline_run_payload(
 
     # Set execution_partition in variables
     payload['variables']['execution_partition'] = \
-        payload['execution_date'].strftime(format='%Y%m%dT%H%M%S_%f')
+        os.sep.join([
+            str(pipeline_schedule.id),
+            payload['execution_date'].strftime(format='%Y%m%dT%H%M%S_%f'),
+        ])
 
     is_integration = PipelineType.INTEGRATION == pipeline_type
     if is_integration:


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Fix race conditions for multiple runs within one second.
* Use `%Y%m%dT%H%M%S_%f` format when triggering pipeline runs from API or code
* Set the execution_partition in variables.
* If execution_partition is not in variables, fall back to `%Y%m%dT%H%M%S` format (for backward compability)

# Tests
<!-- How did you test your change? -->
unit tests
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
