### PR TITLE
[hw] Add support for a Mage docker image with a Hadoop Yarn cluster

### DIFF
--- a/docs/integrations/spark-pyspark.mdx
+++ b/docs/integrations/spark-pyspark.mdx
@@ -162,7 +162,7 @@ spark_config:
 ```
 
 ### 4. Run PySpark code in Mage
-When Mage is running, you can create a "Standard (batch)" pipeline, and add a block,
+When Mage is running, you can create a "Standard (batch)" pipeline (`python` kernel), and add a block,
 then write PySpark code using the Spark session via `kwargs['spark']`, e.g.,
 
 ```python
@@ -181,6 +181,68 @@ spark_config = SparkConfig.load(
 spark = get_spark_session(spark_config)
 print(spark.sql('select 1'))
 ```
+
+---
+
+## Hadoop and Yarn cluster for Spark
+
+### 1. Build Mage docker image with a Hadoop Yarn environment
+* Download the [Dockerfile template](https://github.com/mage-ai/mage-ai/blob/master/integrations/hadoop/Dockerfile) for Mage with Hadoop environment.
+* Build the docker image with the command `docker build -t mage_hadoop .`
+
+
+### 2. Start Mage with the following command in your terminal using docker
+
+```bash
+docker run -it --name mage_hadoop -p 6789:6789 -v $(pwd):/home/src mage_hadoop \
+  /app/run_app_with_hadoop.sh mage start demo_project
+```
+Notes
+* `demo_project` is the name of your project, you can change it to anything you want
+
+### 3. Run PySpark code in Mage using Hadoop Yarn
+
+* Change the `metadata.yaml` file in the main pipeline folder to include the following Spark settings:
+```yaml
+spark_config:
+  # Application name
+  app_name: 'my spark yarn app'
+  # Master URL to connect to
+  # e.g., spark_master: 'spark://host:port', or spark_master: 'yarn'
+  spark_master: 'yarn'
+  # Executor environment variables
+  # e.g., executor_env: {'PYTHONPATH': '/home/path'}
+  executor_env: {}
+  # Jar files to be uploaded to the cluster and added to the classpath
+  # e.g., spark_jars: ['/home/path/example1.jar']
+  spark_jars: []
+  # Path where Spark is installed on worker nodes,
+  # e.g. spark_home: '/usr/lib/spark'
+  spark_home: null
+  # List of key-value pairs to be set in SparkConf
+  # e.g., others: {'spark.executor.memory': '4g', 'spark.executor.cores': '2'}
+  others: {}
+```
+* Create a new `Standalone (batch)` pipeline and add a `Data loader`, then run it with the following code:
+```python
+@data_loader
+def load_data(*args, **kwargs):
+    """
+    Template code for loading data from any source.
+
+    Returns:
+        Anything (e.g. data frame, dictionary, array, int, str, etc.)
+    """
+    # Specify your data loading logic here
+    spark = kwargs.get('spark')
+    spark_conf = spark.sparkContext.getConf()
+    print('#' * 40)
+    print(spark_conf.toDebugString())
+    print('#' * 40)
+    print(spark.sql('select 1'))
+    return {}
+```
+* Verify that the added Spark code is running through a Yarn master.
 
 ---
 

--- a/integrations/hadoop/Dockerfile
+++ b/integrations/hadoop/Dockerfile
@@ -5,13 +5,21 @@ RUN apt-get update && \
 apt-get install -y --no-install-recommends \
         openjdk-11-jre
 
+RUN apt-get install -y openssh-server
+RUN mkdir /var/run/sshd
+RUN sed -i'' -e's/^#PermitRootLogin prohibit-password$/PermitRootLogin yes/' /etc/ssh/sshd_config \
+        && sed -i'' -e's/^#PasswordAuthentication yes$/PasswordAuthentication yes/' /etc/ssh/sshd_config \
+        && sed -i'' -e's/^#PermitEmptyPasswords no$/PermitEmptyPasswords yes/' /etc/ssh/sshd_config \
+        && sed -i'' -e's/^#StrictHostKeyChecking ask$/StrictHostKeyChecking no/' /etc/ssh/ssh_config
+
+EXPOSE 22
+
 # Install dependencies
 RUN apt-get install -y ssh rsync
 
 # Download and extract Hadoop
 RUN wget -qO- https://archive.apache.org/dist/hadoop/common/hadoop-3.3.4/hadoop-3.3.4.tar.gz | tar xvz -C /opt/
 RUN ln -s /opt/hadoop-3.3.4 /opt/hadoop
-RUN echo export JAVA_HOME=$JAVA_HOME >> /opt/hadoop/etc/hadoop/hadoop-env.sh 
 
 # Set environment variables
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
@@ -25,12 +33,18 @@ ENV HDFS_SECONDARYNAMENODE_USER=root
 ENV YARN_NODEMANAGER_USER=root
 ENV YARN_RESOURCEMANAGER_USER=root
 
+RUN echo export JAVA_HOME=$JAVA_HOME >> /opt/hadoop/etc/hadoop/hadoop-env.sh
+RUN echo export HADOOP_SSH_OPTS=\"-p 22\" >> /opt/hadoop/etc/hadoop/hadoop-env.sh
+
+# Start ssh server
+RUN ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -q -N "" && \
+        cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+
 # Format the Hadoop filesystem
 RUN hdfs namenode -format
+RUN ${PIP} install pyspark
 
 # Start the Hadoop services
-CMD start-dfs.sh && start-yarn.sh && tail -f /dev/null
-
-RUN ${PIP} install pyspark
+CMD "/etc/init.d/ssh start" && start-dfs.sh && start-yarn.sh && tail -f /dev/null
 
 ENV MAGE_DATA_DIR=

--- a/integrations/hadoop/Dockerfile
+++ b/integrations/hadoop/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get install -y ssh rsync
 # Download and extract Hadoop
 RUN wget -qO- https://archive.apache.org/dist/hadoop/common/hadoop-3.3.4/hadoop-3.3.4.tar.gz | tar xvz -C /opt/
 RUN ln -s /opt/hadoop-3.3.4 /opt/hadoop
+RUN echo export JAVA_HOME=$JAVA_HOME >> /opt/hadoop/etc/hadoop/hadoop-env.sh 
 
 # Set environment variables
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
@@ -18,6 +19,11 @@ ENV HADOOP_HOME=/opt/hadoop
 ENV HADOOP_CONF_DIR=$HADOOP_HOME/etc/hadoop/
 ENV YARN_CONF_DIR=$HADOOP_HOME/etc/hadoop
 ENV PATH=$PATH:$HADOOP_HOME/bin:$HADOOP_HOME/sbin
+ENV HDFS_DATANODE_USER=root
+ENV HDFS_NAMENODE_USER=root
+ENV HDFS_SECONDARYNAMENODE_USER=root
+ENV YARN_NODEMANAGER_USER=root
+ENV YARN_RESOURCEMANAGER_USER=root
 
 # Format the Hadoop filesystem
 RUN hdfs namenode -format

--- a/integrations/hadoop/Dockerfile
+++ b/integrations/hadoop/Dockerfile
@@ -7,10 +7,10 @@ apt-get install -y --no-install-recommends \
 
 RUN apt-get install -y openssh-server
 RUN mkdir /var/run/sshd
-RUN sed -i'' -e's/^#PermitRootLogin prohibit-password$/PermitRootLogin yes/' /etc/ssh/sshd_config \
-        && sed -i'' -e's/^#PasswordAuthentication yes$/PasswordAuthentication yes/' /etc/ssh/sshd_config \
-        && sed -i'' -e's/^#PermitEmptyPasswords no$/PermitEmptyPasswords yes/' /etc/ssh/sshd_config \
-        && sed -i'' -e's/^#StrictHostKeyChecking ask$/StrictHostKeyChecking no/' /etc/ssh/ssh_config
+RUN echo "    PermitRootLogin yes" >> /etc/ssh/sshd_config \
+    echo "    PasswordAuthentication yes" >> /etc/ssh/sshd_config \
+    echo "    PermitEmptyPasswords yes" >> /etc/ssh/sshd_config \
+    echo "    StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 
 EXPOSE 22
 
@@ -39,12 +39,13 @@ RUN echo export HADOOP_SSH_OPTS=\"-p 22\" >> /opt/hadoop/etc/hadoop/hadoop-env.s
 # Start ssh server
 RUN ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -q -N "" && \
         cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+RUN /etc/init.d/ssh start
 
 # Format the Hadoop filesystem
 RUN hdfs namenode -format
 RUN ${PIP} install pyspark
 
 # Start the Hadoop services
-CMD "/etc/init.d/ssh start" && start-dfs.sh && start-yarn.sh && tail -f /dev/null
+CMD "/usr/sbin/sshd -D" && start-dfs.sh && start-yarn.sh && tail -f /dev/null
 
 ENV MAGE_DATA_DIR=

--- a/integrations/hadoop/Dockerfile
+++ b/integrations/hadoop/Dockerfile
@@ -1,0 +1,30 @@
+FROM mageai/mageai:latest
+ARG PIP=pip3
+
+RUN apt-get update && \
+apt-get install -y --no-install-recommends \
+        openjdk-11-jre
+
+# Install dependencies
+RUN apt-get install -y ssh rsync
+
+# Download and extract Hadoop
+RUN wget -qO- https://archive.apache.org/dist/hadoop/common/hadoop-3.3.4/hadoop-3.3.4.tar.gz | tar xvz -C /opt/
+RUN ln -s /opt/hadoop-3.3.4 /opt/hadoop
+
+# Set environment variables
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+ENV HADOOP_HOME=/opt/hadoop
+ENV HADOOP_CONF_DIR=$HADOOP_HOME/etc/hadoop/
+ENV YARN_CONF_DIR=$HADOOP_HOME/etc/hadoop
+ENV PATH=$PATH:$HADOOP_HOME/bin:$HADOOP_HOME/sbin
+
+# Format the Hadoop filesystem
+RUN hdfs namenode -format
+
+# Start the Hadoop services
+CMD start-dfs.sh && start-yarn.sh && tail -f /dev/null
+
+RUN ${PIP} install pyspark
+
+ENV MAGE_DATA_DIR=

--- a/integrations/hadoop/Dockerfile
+++ b/integrations/hadoop/Dockerfile
@@ -7,10 +7,10 @@ apt-get install -y --no-install-recommends \
 
 RUN apt-get install -y openssh-server
 RUN mkdir /var/run/sshd
-RUN echo "    PermitRootLogin yes" >> /etc/ssh/sshd_config \
-    echo "    PasswordAuthentication yes" >> /etc/ssh/sshd_config \
-    echo "    PermitEmptyPasswords yes" >> /etc/ssh/sshd_config \
-    echo "    StrictHostKeyChecking no" >> /etc/ssh/ssh_config
+RUN echo "    PermitRootLogin yes" >> /etc/ssh/sshd_config
+RUN echo "    PasswordAuthentication yes" >> /etc/ssh/sshd_config
+RUN echo "    PermitEmptyPasswords yes" >> /etc/ssh/sshd_config
+RUN echo "    StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 
 EXPOSE 22
 
@@ -33,19 +33,18 @@ ENV HDFS_SECONDARYNAMENODE_USER=root
 ENV YARN_NODEMANAGER_USER=root
 ENV YARN_RESOURCEMANAGER_USER=root
 
-RUN echo export JAVA_HOME=$JAVA_HOME >> /opt/hadoop/etc/hadoop/hadoop-env.sh
-RUN echo export HADOOP_SSH_OPTS=\"-p 22\" >> /opt/hadoop/etc/hadoop/hadoop-env.sh
+RUN echo "export JAVA_HOME=$JAVA_HOME" >> /opt/hadoop/etc/hadoop/hadoop-env.sh
+RUN echo "export HADOOP_SSH_OPTS=\"-p 22\"" >> /opt/hadoop/etc/hadoop/hadoop-env.sh
 
-# Start ssh server
+# Enable passwordless SSH
 RUN ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -q -N "" && \
         cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-RUN /etc/init.d/ssh start
 
 # Format the Hadoop filesystem
 RUN hdfs namenode -format
 RUN ${PIP} install pyspark
 
-# Start the Hadoop services
-CMD "/usr/sbin/sshd -D" && start-dfs.sh && start-yarn.sh && tail -f /dev/null
+COPY run_app_with_hadoop.sh /app/run_app_with_hadoop.sh
+RUN chmod +x /app/run_app_with_hadoop.sh
 
 ENV MAGE_DATA_DIR=

--- a/integrations/hadoop/run_app_with_hadoop.sh
+++ b/integrations/hadoop/run_app_with_hadoop.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+/etc/init.d/ssh start
+start-dfs.sh
+start-yarn.sh
+
+if [ "$#" -gt 0 ]; then
+    echo "Execute command: ${@}"
+    /app/run_app.sh "$@"
+else
+    /app/run_app.sh
+fi

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -2038,7 +2038,11 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
         )
 
     def _block_decorator(self, decorated_functions) -> Callable:
+<<<<<<< HEAD
         def custom_code(function) -> Callable:
+=======
+        def custom_code(function):
+>>>>>>> 4dd38153 ([hw] Add more method return type hints)
             decorated_functions.append(function)
             return function
 

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -2038,11 +2038,7 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
         )
 
     def _block_decorator(self, decorated_functions) -> Callable:
-<<<<<<< HEAD
         def custom_code(function) -> Callable:
-=======
-        def custom_code(function):
->>>>>>> 4dd38153 ([hw] Add more method return type hints)
             decorated_functions.append(function)
             return function
 


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

For testing Spark sessions running on Hadoop Yarn with Mage, additional docker image setup is needed.

# Tests
<!-- How did you test your change? -->
Manually tested the changes locally with the following procedure:

(1) In a terminal, switch to the following folder in the Mage code repository:
```
% cd integrations/hadoop/
```
(2) Build the docker image with the following command:
```
% docker build -t mage_hadoop .
```
(3) Type this command in your terminal to start Mage using docker:
```
docker run -it --name mage_hadoop -p 6789:6789 -v $(pwd):/home/src mage_hadoop \
  /app/run_app_with_hadoop.sh mage start demo_project
```
(4) Change the `metadata.yaml` file in the main pipeline folder to include the following Spark settings:
```
spark_config:
  # Application name
  app_name: 'my spark yarn app'
  # Master URL to connect to
  # e.g., spark_master: 'spark://host:port', or spark_master: 'yarn'
  spark_master: 'yarn'
  # Executor environment variables
  # e.g., executor_env: {'PYTHONPATH': '/home/path'}
  executor_env: {}
  # Jar files to be uploaded to the cluster and added to the classpath
  # e.g., spark_jars: ['/home/path/example1.jar']
  spark_jars: []
  # Path where Spark is installed on worker nodes,
  # e.g. spark_home: '/usr/lib/spark'
  spark_home: null
  # List of key-value pairs to be set in SparkConf
  # e.g., others: {'spark.executor.memory': '4g', 'spark.executor.cores': '2'}
  others: {}
```
(5) Create a new `Standalone (batch)` pipeline and add a `Data loader`, then run it with the following code:
```
@data_loader
def load_data(*args, **kwargs):
    """
    Template code for loading data from any source.

    Returns:
        Anything (e.g. data frame, dictionary, array, int, str, etc.)
    """
    # Specify your data loading logic here    
    spark = kwargs.get('spark')
    spark_conf = spark.sparkContext.getConf()
    print('#' * 40)
    print(spark_conf.toDebugString())
    print('#' * 40)
    print(spark.sql('select 1'))
    return {}
```
(6) Verify that the added Spark code is running through a Yarn master, similar to the following: 
<img width="960" alt="Screenshot 2023-05-24 at 1 15 41 AM" src="https://github.com/mage-ai/mage-ai/assets/42320565/6baabc88-16f6-4c95-b8cd-599977f64152">

The steps to set up local Hadoop and Spark on Mac are listed at [Hadoop + Spark installation (OSX)](https://gist.github.com/cjzamora/9fcc740228875f4642a1), and summarized below (it is not used for testing this PR,  though it could be potentially useful in the future):
1. Install Homebrew following the instructions given at [Homebrew](https://brew.sh/), or run the following command in a terminal:
```
% /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
```
2. Install Java:
```
% brew install openjdk@11
```
3. Install Hadoop (with Yarn)
```
% brew install hadoop
```
4. Install Apache Spark (and dependencies):
```
# Install Apache Spark
% brew install apache-spark scala sbt
```
5. Open `~/.zshrc` and add the following settings (replace the Hadoop version `3.3.4` to the right one when needed):
```
# Added for Hadoop
export HADOOP_VERSION=3.3.4
export HADOOP_HOME=/usr/local/Cellar/hadoop/3.3.4/libexec
export HADOOP_CONF_DIR=$HADOOP_HOME/etc/hadoop/
export PATH=$HADOOP_HOME/bin:$HADOOP_HOME/sbin:$PATH

alias hstart="/usr/local/Cellar/hadoop/3.3.4/sbin/start-all.sh"
alias hstop="/usr/local/Cellar/hadoop/3.3.4/sbin/stop-all.sh"
```
Run the following command to set up the required environment variables:
```
% source ~/.zshrc
```
6. For Hadoop to run on Mac OSX, Remote Login and `File Sharing` under `System Preferences` also need to be turned on. Configure `passphraseless` SSH on localhost if it is not already set up, using the following steps:
```
i). ssh-keygen -t rsa
Press enter for each line 
ii). cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
iii). chmod og-wx ~/.ssh/authorized_keys
```
7. Start the Hadoop and Yarn cluster with the following command:
```
% hstart
```
9. Run `spark-shell` from the command line to launch Spark shell for Scala for testing:
```
% spark-shell
```
. Create a Spark `DataFrame` with some sample data to validate the installation:
```
import spark.implicits._
val data = Seq(("Java", "20000"), ("Python", "100000"), ("Scala", "3000"))
val df = data.toDF() 
df.show()
```
10. To start the Spark shell for Python, run the following command:
```
% ./bin/pyspark
```
Or if `PySpark` is installed with pip in your current environment:
```
% pyspark
```
11. Create a Python test script `pi.py` with the following code:
```
import sys
from random import random
from operator import add

from pyspark.sql import SparkSession


if __name__ == "__main__":
    """
        Usage: pi [partitions]
    """
    spark = SparkSession\
        .builder\
        .appName("PythonPi")\
        .getOrCreate()

    partitions = int(sys.argv[1]) if len(sys.argv) > 1 else 2
    n = 100000 * partitions

    def f(_: int) -> float:
        x = random() * 2 - 1
        y = random() * 2 - 1
        return 1 if x ** 2 + y ** 2 <= 1 else 0

    count = spark.sparkContext.parallelize(range(1, n + 1), partitions).map(f).reduce(add)
    print("Pi is roughly %f" % (4.0 * count / n))

    spark.stop()
```
12. Run the following command to test `spark-submit` with `pi.py`:
```
% spark-submit pi.py
```
13. To run `pi.py` with the local Hadoop Yarn cluster, run the following command:
```
% spark-submit --master yarn --name test_job pi.py
```
It should generate outputs similar to the following
```
23/05/20 17:15:22 INFO DAGScheduler: Job 0 finished: reduce at /Users/hw/workspace/spark/pi.py:42, took 2.374661 s
Pi is roughly 3.142480
```

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@dy46 @wangxiaoyou1993 