### PR TITLE
[td] Fix time series parsing numpy datetime64

### DIFF
--- a/mage_ai/data_preparation/models/widget/charts.py
+++ b/mage_ai/data_preparation/models/widget/charts.py
@@ -82,10 +82,29 @@ def build_time_series_buckets(df, datetime_column, time_interval, metrics):
         return []
 
     datetimes = datetimes.unique()
-    min_value_datetime = dateutil.parser.parse(datetimes.min())
-    max_value_datetime = dateutil.parser.parse(datetimes.max())
+    min_value_datetime = datetimes.min()
+    max_value_datetime = datetimes.max()
 
-    a, b = [dateutil.parser.parse(d) for d in sorted(datetimes)[:2]]
+    if type(min_value_datetime) is str:
+        min_value_datetime = dateutil.parser.parse(min_value_datetime)
+    if type(max_value_datetime) is str:
+        max_value_datetime = dateutil.parser.parse(max_value_datetime)
+
+    # If you manually convert the datetime column to a datetime, Pandas will use numpy.datetime64
+    # type. This type does not have the methods year, month, day, etc that is used down below.
+    datetimes_temp = []
+    for dt in datetimes:
+        if type(dt) is np.datetime64:
+            datetimes_temp.append(pd.to_datetime(dt.astype(datetime)).to_pydatetime())
+        else:
+            datetimes_temp.append(dt)
+    datetimes = datetimes_temp
+    if type(min_value_datetime) is np.datetime64:
+        min_value_datetime = pd.to_datetime(min_value_datetime.astype(datetime)).to_pydatetime()
+    if type(max_value_datetime) is np.datetime64:
+        max_value_datetime = pd.to_datetime(max_value_datetime.astype(datetime)).to_pydatetime()
+
+    a, b = [dateutil.parser.parse(d) if type(d) is str else d for d in sorted(datetimes)[:2]]
 
     year = min_value_datetime.year
     month = min_value_datetime.month

--- a/mage_ai/frontend/components/ChartBlock/index.tsx
+++ b/mage_ai/frontend/components/ChartBlock/index.tsx
@@ -326,6 +326,7 @@ function ChartBlock({
     />
   ), [
     autocompleteProviders,
+    block,
     chartType,
     content,
     isEditing,
@@ -336,7 +337,7 @@ function ChartBlock({
     updateContent,
   ]);
 
-  const codeOutputEl = useMemo(() => hasError && hasOutput && (
+  const codeOutputEl = useMemo(() => (hasError || hasOutput) && (
     <CodeOutput
       {...borderColorShareProps}
       block={block}
@@ -374,7 +375,7 @@ function ChartBlock({
   }, [
     isEditing,
     isEditingPrevious,
-    refChartContainer.current,
+    refChartContainer,
     setChartWidth,
     width,
     widthPrevious,
@@ -425,13 +426,15 @@ function ChartBlock({
               {blockUUID}
             </Text>
           </Link>
-        </Spacing>
+        </Spacing>,
       );
     });
 
     return arr;
   }, [
+    blockRefs,
     blocksMapping,
+    themeContext,
     upstreamBlocks,
   ]);
 
@@ -483,6 +486,7 @@ function ChartBlock({
 
     return arr;
   }, [
+    chartType,
     configuration,
     configurationOptions,
   ]);
@@ -512,6 +516,7 @@ function ChartBlock({
     chartTypePrevious,
     configuration,
     content,
+    defaultSettings,
     updateConfiguration,
     updateContent,
     upstreamBlocks,
@@ -757,13 +762,12 @@ function ChartBlock({
     }), {
     noCode: [],
   }), [
-    blocksMapping,
+    block,
     configuration,
     configurationOptions,
-    outputs,
+    dataBlock,
     setSelectedBlock,
     updateConfiguration,
-    upstreamBlocks,
   ]);
 
   const [updateBlock] = useMutation(

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
@@ -522,7 +522,7 @@ function CodeOutput({
     tableContent,
   ]);
 
-  if (!buttonTabs && !hasOutput) {
+  if (!buttonTabs && !hasError && !hasOutput) {
     return null;
   }
 


### PR DESCRIPTION
# Summary
If you manually convert a column to Python `datetime`, then the time series logic will convert that to a `numpy.datetime64`. 

Add logic in the time series chart to convert `numpy.datetime64` to `datetime`.