### PR TITLE
[hw] Add pipeline-level configuration settings for the Spark session

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -1786,11 +1786,11 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
         if self.spark_init:
             return self.spark
         try:
-            repo_config = RepoConfig(repo_path=self.repo_path)
-            spark_config = repo_config.get('spark_config')
-
             from pyspark.conf import SparkConf
             from pyspark.sql import SparkSession
+
+            repo_config = RepoConfig(repo_path=self.repo_path)
+            spark_config = repo_config.spark_config
 
             if spark_config:
                 conf = SparkConf()

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -1801,7 +1801,7 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
                 if spark_config.get('spark_home'):
                     conf.setSparkHome(spark_config.get('spark_home'))
                 if spark_config.get('spark_jars'):
-                    conf.setJars(spark_config.get('spark_jars'))
+                    conf.set('spark.jars', ','.join(spark_config.get('spark_jars')))
                 if spark_config.get('others'):
                     conf.setAll(spark_config.get('others'))
 

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -1800,6 +1800,11 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
                     conf.setMaster(spark_config.get('spark_master'))
                 if spark_config.get('spark_home'):
                     conf.setSparkHome(spark_config.get('spark_home'))
+                if spark_config.get('executor_env'):
+                    list_kv_pairs = []
+                    for key, value in spark_config.get('executor_env').items():
+                        list_kv_pairs.append((key, value))
+                    conf.setExecutorEnv(key=None, value=None, pairs=list_kv_pairs)
                 if spark_config.get('spark_jars'):
                     conf.set('spark.jars', ','.join(spark_config.get('spark_jars')))
                 if spark_config.get('others'):

--- a/mage_ai/data_preparation/repo_manager.py
+++ b/mage_ai/data_preparation/repo_manager.py
@@ -78,6 +78,7 @@ class RepoConfig:
             self.queue_config = repo_config.get('queue_config', dict())
             self.project_uuid = repo_config.get('project_uuid')
             self.help_improve_mage = repo_config.get('help_improve_mage')
+            self.spark_config = repo_config.get('spark_config')
 
             self.s3_bucket = None
             self.s3_path_prefix = None
@@ -118,6 +119,7 @@ class RepoConfig:
             remote_variables_dir=self.remote_variables_dir,
             project_uuid=self.project_uuid,
             help_improve_mage=self.help_improve_mage,
+            spark_config=self.spark_config,
         )
 
     def save(self, **kwargs) -> None:

--- a/mage_ai/data_preparation/templates/main/metadata.yaml
+++ b/mage_ai/data_preparation/templates/main/metadata.yaml
@@ -25,6 +25,9 @@ spark_config:
   # Master URL to connect to
   # e.g., spark_master: 'spark://host:port', or spark_master: 'yarn'
   spark_master: 'local'
+  # Executor environment variables
+  # e.g., executor_env: {'PYTHONPATH': '/home/path'}
+  executor_env: {}
   # Jar files to be uploaded to the cluster and added to the classpath
   # e.g., spark_jars: ['/home/path/example1.jar']
   spark_jars: []

--- a/mage_ai/data_preparation/templates/main/metadata.yaml
+++ b/mage_ai/data_preparation/templates/main/metadata.yaml
@@ -19,6 +19,22 @@ emr_config:
   # You can create a key pair in page https://console.aws.amazon.com/ec2#KeyPairs and download the key file.
   # ec2_key_name: '[ec2_key_pair_name]'
 
+spark_config:
+  # Application name
+  app_name: 'my spark app'
+  # Master URL to connect to
+  # e.g., spark_master: 'spark://host:port', or spark_master: 'yarn'
+  spark_master: 'local'
+  # Jar files to be uploaded to the cluster and added to the classpath
+  # e.g., spark_jars: ['/home/path/example1.jar']
+  spark_jars: []
+  # Path where Spark is installed on worker nodes,
+  # e.g. spark_home: '/usr/lib/spark'
+  spark_home: null
+  # List of key-value pairs to be set in SparkConf
+  # e.g., others: {'spark.executor.memory': '4g', 'spark.executor.cores': '2'}
+  others: {}
+
 notification_config:
   alert_on:
     - trigger_failure

--- a/mage_ai/data_preparation/templates/repo/metadata.yaml
+++ b/mage_ai/data_preparation/templates/repo/metadata.yaml
@@ -25,6 +25,9 @@ spark_config:
   # Master URL to connect to
   # e.g., spark_master: 'spark://host:port', or spark_master: 'yarn'
   spark_master: 'local'
+  # Executor environment variables
+  # e.g., executor_env: {'PYTHONPATH': '/home/path'}
+  executor_env: {}
   # Jar files to be uploaded to the cluster and added to the classpath
   # e.g., spark_jars: ['/home/path/example1.jar']
   spark_jars: []

--- a/mage_ai/data_preparation/templates/repo/metadata.yaml
+++ b/mage_ai/data_preparation/templates/repo/metadata.yaml
@@ -19,6 +19,22 @@ emr_config:
   # You can create a key pair in page https://console.aws.amazon.com/ec2#KeyPairs and download the key file.
   # ec2_key_name: '[ec2_key_pair_name]'
 
+spark_config:
+  # Application name
+  app_name: 'my spark app'
+  # Master URL to connect to
+  # e.g., spark_master: 'spark://host:port', or spark_master: 'yarn'
+  spark_master: 'local'
+  # Jar files to be uploaded to the cluster and added to the classpath
+  # e.g., spark_jars: ['/home/path/example1.jar']
+  spark_jars: []
+  # Path where Spark is installed on worker nodes,
+  # e.g. spark_home: '/usr/lib/spark'
+  spark_home: null
+  # List of key-value pairs to be set in SparkConf
+  # e.g., others: {'spark.executor.memory': '4g', 'spark.executor.cores': '2'}
+  others: {}
+
 notification_config:
   alert_on:
     - trigger_failure


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

Enable custom settings for the Spark session used by PySpark. The behavior for Spark session is summarized below:
```
A custom SparkSession is created based on pipeline-level settings in `metadata.yaml`, and will be re-used for all blocks in the same Mage pipeline.
```
The following behavior is not supported with the current implementation:
```
1. Inside each block, the user creates and destroys a new custom SparkSession instance
2. User may replace the global kwargs['spark'] with a new SparkSession instance any time with a custom created new instance, and keep it till another new instance was created
```

# Tests
<!-- How did you test your change? -->
Manually tested in a local development environment, with the following steps:
1. Initiate a new Mage pipeline with the following command in a terminal:
```
% ./scripts/init.sh demo_project
```
2. Check the `metadata.yaml` generated inside the `demo_project`:
```
% cat demo_project/metadata.yaml
```
3. Make necessary adjustments to the `spark_config` settings in `metadata.yaml`:
```
spark_config:
  # Application name
  app_name: 'my spark app'
  # Master URL to connect to
  # e.g., spark_master: 'spark://host:port', or spark_master: 'yarn'
  spark_master: 'local'
  # Executor environment variables
  # e.g., executor_env: {'PYTHONPATH': '/home/path'}
  executor_env: {}
  # Jar files to be uploaded to the cluster and added to the classpath
  # e.g., spark_jars: ['/home/path/example1.jar']
  spark_jars: []
  # Path where Spark is installed on worker nodes,
  # e.g. spark_home: '/usr/lib/spark'
  spark_home: null
  # List of key-value pairs to be set in SparkConf
  # e.g., others: {'spark.executor.memory': '4g', 'spark.executor.cores': '2'}
  others: {}
``` 
4. Start the Mage application with the following command:
```
% ./scripts/dev.sh demo_project
```
5. Click the Terminal icon on the right side of the Mage UI, and install the required packages and libraries for pyspark:
```
root@488dc9529cf3:/home/src#  apt-get update && \
apt-get install -y --no-install-recommends \
        openjdk-11-jre

root@488dc9529cf3:/home/src#  pip install pyspark
```
6. Stop and restart the Mage application to pick up the newly installed pyspark libraries.
7. Create a new `Standard (batch)` pipeline, and add a new `Data loader` -> `Python` -> `Generic (no template)` block to it.
8. Add the following code to the `load_data` function:
```
@data_loader
def load_data(*args, **kwargs):
    """
    Template code for loading data from any source.

    Returns:
        Anything (e.g. data frame, dictionary, array, int, str, etc.)
    """
    # Specify your data loading logic here

    spark = kwargs.get('spark')
    spark_conf = spark.sparkContext.getConf()
    print('#' * 40)
    print(spark_conf.toDebugString())
    print('#' * 40)
    return {}
```
9. Run the `Data loader` by clicking the Play button on its toolbar. It would generate results similar to the following, which reflects the settings given in the `metadata.yaml` file listed above. 
<img width="1440" alt="Screenshot 2023-05-22 at 11 57 20 PM" src="https://github.com/mage-ai/mage-ai/assets/42320565/c236bdde-1fc7-497e-8488-84febb7fb02f">

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@dy46 @wangxiaoyou1993 