### PR TITLE
[xy] Lock typing extension version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ sqlalchemy>=1.4.20, <2.0.0
 terminado==0.17.1
 tornado==6.1
 typer[all]==0.7.0
+typing-extensions==4.5.0
 
 # extras
 aws-secretsmanager-caching==1.1.1.5


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Lock typing extension version to fix error `TypeError: Instance and class checks can only be used with @runtime protocols`

# Tests
<!-- How did you test your change? -->
CI

cc:
<!-- Optionally mention someone to let them know about this pull request -->
