### PR TITLE
[jk] Interpolate user-defined variables in dbt command

### DIFF
--- a/docs/dbt/run-single-model.mdx
+++ b/docs/dbt/run-single-model.mdx
@@ -80,3 +80,25 @@ WHERE created_at >= '{{ var("ds") }}'
 
 In the above example, the variable named `ds` is defined as part of the runtime
 variables for the pipeline.
+
+---
+
+## Adding variables when running a YAML dbt block
+
+In addition to interpolating variables described above, you can define variables directly
+in the dbt code block if it is a YAML dbt code block (i.e. not a SQL dbt block) by following
+these steps:
+
+1. In the Pipeline Editor, add a dbt model by selecting on the `All models (w/option exclusion)`
+option from the dropdown when clicking on the `DBT model` button for adding a block.
+2. For the newly added code block, you should see that is `YAML` type indicated in the top left
+corner of the block.
+3. On the same line as your `--select` or `--exclude` syntax, add the `--vars` syntax with the
+variables you want to include. Note: Putting the `--vars` syntax on a separate line may cause
+issues.
+4. Format the variables like a JSON object, so there should be double quotes around the keys and
+string values. Single quotes surrounding the variables object are optional.
+
+Examples of YAML dbt code block content (note the syntax for the variables object):
+`--select demo/models --vars '{"demo_key": "demo_value", "date": 20230101}'`
+`--select demo/models --vars {"demo_key":"demo_value","date":20230101}`

--- a/docs/dbt/run-single-model.mdx
+++ b/docs/dbt/run-single-model.mdx
@@ -98,7 +98,11 @@ variables you want to include. Note: Putting the `--vars` syntax on a separate l
 issues.
 4. Format the variables like a JSON object, so there should be double quotes around the keys and
 string values. Single quotes surrounding the variables object are optional.
+5. You can interpolate global or environment variables using double brackets around the
+variable name. See below for examples.
 
 Examples of YAML dbt code block content (note the syntax for the variables object):
 `--select demo/models --vars '{"demo_key": "demo_value", "date": 20230101}'`
 `--select demo/models --vars {"demo_key":"demo_value","date":20230101}`
+`--select demo/models --vars '{"global_var": {{ test_global_var }}, "env_var": {{ test_env_var }}}'`
+`--select demo/models --vars {"refresh":{{page_refresh}},"env_var":{{env}}}`

--- a/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
@@ -987,6 +987,22 @@ def build_command_line_arguments(
                     vars_end_idx = i + 1
 
             vars_str = ''.join(vars_parts)
+            interpolated_vars = re.findall(r'\{\{(.*?)\}\}', vars_str)
+            for v in interpolated_vars:
+                val = variables.get(v.strip())
+                variable_with_brackets = '{{' + v + '}}'
+                """
+                Replace the variables in the command with the JSON-supported values
+                from the global/environment variables.
+                """
+                if val is not None:
+                    vars_str = vars_str.replace(variable_with_brackets, simplejson.dumps(val))
+                else:
+                    vars_str = vars_str.replace(
+                        variable_with_brackets,
+                        simplejson.dumps(variable_with_brackets),
+                    )
+
             # Remove trailing single quotes to form proper json
             if vars_str.startswith("'") and vars_str.endswith("'"):
                 vars_str = vars_str[1:-1]

--- a/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
@@ -986,8 +986,9 @@ def build_command_line_arguments(
             vars_dict = simplejson.loads(vars_str)
             variables = merge_dict(variables, vars_dict)
             del content_args[vars_start_idx:vars_end_idx]
-        except ValueError as err:
-            print('Error parsing vars argument:', err)
+        except ValueError:
+            # If args do not contain "--vars", continue.
+            pass
 
         args += content_args
 

--- a/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
@@ -967,7 +967,7 @@ def build_command_line_arguments(
         content_args = block.content.split(' ')
         try:
             vars_start_idx = content_args.index('--vars')
-            vars_args = []
+            vars_parts = []
             vars_end_idx = vars_start_idx + 2
             # Include variables if they have spaces in the object
             for i in range(vars_start_idx, len(content_args)):
@@ -983,10 +983,10 @@ def build_command_line_arguments(
                     vars_end_idx = i
                     break
                 elif current_item != ('--vars'):
-                    vars_args.append(content_args[i])
+                    vars_parts.append(content_args[i])
                     vars_end_idx = i + 1
 
-            vars_str = ''.join(vars_args)
+            vars_str = ''.join(vars_parts)
             # Remove trailing single quotes to form proper json
             if vars_str.startswith("'") and vars_str.endswith("'"):
                 vars_str = vars_str[1:-1]

--- a/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
@@ -969,10 +969,17 @@ def build_command_line_arguments(
             vars_start_idx = content_args.index('--vars')
             vars_args = []
             vars_end_idx = vars_start_idx + 2
-            # Include variables if they have spaces in the dictionary
+            # Include variables if they have spaces in the object
             for i in range(vars_start_idx, len(content_args)):
                 current_item = content_args[i]
                 if i > vars_start_idx and current_item.startswith('--'):
+                    """
+                    Stop including parts of the variables object (e.g. {"key": "value"}
+                    is split into ['{"key":', '"value"}']. The variables object can have
+                    many parts.) when next command line arg is reached. If there is not a
+                    next command line argument (such as "--exclude"), then the remaining
+                    items should belong to the variables object.
+                    """
                     vars_end_idx = i
                     break
                 elif current_item != ('--vars'):
@@ -983,6 +990,7 @@ def build_command_line_arguments(
             # Remove trailing single quotes to form proper json
             if vars_str.startswith("'") and vars_str.endswith("'"):
                 vars_str = vars_str[1:-1]
+            # Variables object needs to be formatted as JSON
             vars_dict = simplejson.loads(vars_str)
             variables = merge_dict(variables, vars_dict)
             del content_args[vars_start_idx:vars_end_idx]


### PR DESCRIPTION
# Summary
- Interpolate user-defined variables (i.e. through `--vars`) with the other variables (e.g. env vars and global vars) when running a yaml dbt block.
- Variables must be formatted with json syntax (double-quotes around keys and string values). The variables object can have spaces in it and optionally be surrounded with single quotes.
- Related docs will be located at https://docs.mage.ai/dbt/run-single-model after this PR is merged.

# Tests
Before (spaces not allowed in variables value and they would not be merged with the existing variables in the dbt command):
![image](https://github.com/mage-ai/mage-ai/assets/78053898/331516a1-910f-4d55-bd0a-494d8d9b1844)

After - The variables defined in the block could be seen combined with the other vars in the output (screenshots include differently formatted vars with single quotes and without single quotes):
![image](https://github.com/mage-ai/mage-ai/assets/78053898/2c4ab158-3938-4956-9aaf-59d62f1bf3a1)

![image](https://github.com/mage-ai/mage-ai/assets/78053898/8dee989a-1531-4316-87b8-390ffe11b8d8)

![image](https://github.com/mage-ai/mage-ai/assets/78053898/60966e28-2418-4cde-ba85-b7fe13830974)

![image](https://github.com/mage-ai/mage-ai/assets/78053898/a2dede1b-3213-4c28-89b1-7fe528a9abec)



