### PR TITLE
[jk] Check for too many open files error whenever calling displayErrorFromReadResponse util method

### DIFF
--- a/mage_ai/frontend/api/utils/response.ts
+++ b/mage_ai/frontend/api/utils/response.ts
@@ -153,10 +153,20 @@ export function displayErrorFromReadResponse(
     onClick?: () => void;
   }[],
 ) {
+  let linksFinal = links;
+  if (data?.error?.exception?.includes('Too many open files')) {
+    const tooManyOpenFilesErrLink = [
+      {
+        href: 'https://docs.mage.ai/production/configuring-production-settings/overview#ulimit',
+        label: 'Refer to the docs for troubleshooting this error.',
+      },
+    ];
+    linksFinal = links.concat(tooManyOpenFilesErrLink);
+  }
   if (data?.error) {
     setErrors?.({
       errors: parseErrorFromResponse(data),
-      links,
+      links: linksFinal,
       response: data,
     });
   } else {

--- a/mage_ai/frontend/api/utils/response.ts
+++ b/mage_ai/frontend/api/utils/response.ts
@@ -153,7 +153,7 @@ export function displayErrorFromReadResponse(
     onClick?: () => void;
   }[],
 ) {
-  let linksFinal = links;
+  let linksFinal = links || [];
   if (data?.error?.exception?.includes('Too many open files')) {
     const tooManyOpenFilesErrLink = [
       {
@@ -161,7 +161,7 @@ export function displayErrorFromReadResponse(
         label: 'Refer to the docs for troubleshooting this error.',
       },
     ];
-    linksFinal = links.concat(tooManyOpenFilesErrLink);
+    linksFinal = linksFinal.concat(tooManyOpenFilesErrLink);
   }
   if (data?.error) {
     setErrors?.({

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -90,17 +90,7 @@ function PipelineListPage() {
   const project: ProjectType = useMemo(() => dataProjects?.projects?.[0], [dataProjects]);
 
   useEffect(() => {
-    if (data?.error?.exception?.includes('Too many open files')) {
-      const links = [
-        {
-          href: 'https://docs.mage.ai/production/configuring-production-settings/overview#ulimit',
-          label: 'Refer to the docs for troubleshooting this error.',
-        },
-      ];
-      displayErrorFromReadResponse(data, setErrors, links);
-    } else {
-      displayErrorFromReadResponse(data, setErrors);
-    }
+    displayErrorFromReadResponse(data, setErrors);
   }, [data]);
 
   const useCreatePipelineMutation = (onSuccessCallback) => useMutation(


### PR DESCRIPTION
# Summary
- The "Too many open files" error may occur on other pages outside of the Pipelines Dashboard, so this PR will guide users to the docs for resolving it in other pages of the Mage app.

# Tests
- Before, the link to the docs in the error popup only appeared on the Pipelines Dashboard.

Pipeline Editor:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/7d0c88a4-7236-44e4-a91b-e7884f8ddf0a)

Triggers Page:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/0a1354b2-abf1-4afb-beb6-fa08f0d8d879)
 
