### PR TITLE
[td] Include runtime variables when executing upstream

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -1553,7 +1553,7 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
                     visited.add(block)
         return list(visited)
 
-    def run_upstream_blocks(self) -> None:
+    def run_upstream_blocks(self, **kwargs) -> None:
         def process_upstream_block(
             block: 'Block',
             root_blocks: List['Block'],
@@ -1568,7 +1568,11 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
             map(lambda x: process_upstream_block(x, root_blocks), upstream_blocks)
         )
 
-        run_blocks_sync(root_blocks, selected_blocks=upstream_block_uuids)
+        run_blocks_sync(
+            root_blocks,
+            selected_blocks=upstream_block_uuids,
+            **kwargs,
+        )
 
     def run_tests(
         self,

--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -265,6 +265,7 @@ from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.data_preparation.repo_manager import get_repo_path
 from mage_ai.orchestration.db import db_connection
 from mage_ai.shared.array import find
+from mage_ai.shared.hash import merge_dict
 import datetime
 import json
 import pandas as pd
@@ -292,15 +293,15 @@ def execute_custom_code():
 {escaped_code}
     \'\'\'
 
-    if run_upstream:
-        block.run_upstream_blocks()
-
-    global_vars = {global_vars} or dict()
+    global_vars = merge_dict({global_vars} or dict(), pipeline.variables or dict())
 
     try:
         global_vars[\'spark\'] = spark
     except Exception:
         pass
+
+    if run_upstream:
+        block.run_upstream_blocks(global_vars=global_vars)
 
     block_output = block.execute_with_callback(
         custom_code=code,


### PR DESCRIPTION
# Summary
Fix runtime and global variables not available in the keyword arguments when executing block with upstream blocks from the edit pipeline page.