### PR TITLE
[td] Fix generic resource

### DIFF
--- a/mage_ai/api/resources/GenericResource.py
+++ b/mage_ai/api/resources/GenericResource.py
@@ -4,5 +4,7 @@ from mage_ai.api.resources.BaseResource import BaseResource
 class GenericResource(BaseResource):
     def __getattr__(self, name):
         def _missing(*args, **kwargs):
-            return self.model.get(name)
+            if type(self.model) is dict:
+                return self.model.get(name)
+            return self.model
         return _missing()

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -957,7 +957,8 @@ class Block:
         with redirect_stdout(stdout):
             global_vars_copy = global_vars.copy()
             for kwargs_var in kwargs_vars:
-                global_vars_copy.update(kwargs_var)
+                if kwargs_var:
+                    global_vars_copy.update(kwargs_var)
 
             outputs = self._execute_block(
                 outputs_from_input_vars,


### PR DESCRIPTION
# Summary
- If generic resource model isn’t a dictionary, don’t use `get` function.
- Fix kwargs none