### PR TITLE
[xy] Support running Mage server and scheduler separately.

### DIFF
--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -9,6 +9,7 @@ from rich import print
 from typer.core import TyperGroup
 
 from mage_ai.cli.utils import parse_runtime_variables
+from mage_ai.shared.constants import InstanceType
 
 
 class OrderCommands(TyperGroup):
@@ -46,7 +47,8 @@ def start(
     port: str = typer.Option('6789', help='specify the port.'),
     manage_instance: str = typer.Option('0', help=''),
     dbt_docs_instance: str = typer.Option('0', help=''),
-    instance_type: str = typer.Option('server_and_scheduler', help='specify the instance type.')
+    instance_type: str = typer.Option(
+        InstanceType.SERVER_AND_SCHEDULER.value, help='specify the instance type.'),
 ):
     """
     Start Mage server and UI.

--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -46,6 +46,7 @@ def start(
     port: str = typer.Option('6789', help='specify the port.'),
     manage_instance: str = typer.Option('0', help=''),
     dbt_docs_instance: str = typer.Option('0', help=''),
+    instance_type: str = typer.Option('server_and_scheduler', help='specify the instance type.')
 ):
     """
     Start Mage server and UI.
@@ -64,6 +65,7 @@ def start(
         project=project_path,
         manage=manage_instance == "1",
         dbt_docs=dbt_docs_instance == "1",
+        instance_type=instance_type,
     )
 
 

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -64,6 +64,7 @@ from mage_ai.settings import (
     SHELL_COMMAND,
     USE_UNIQUE_TERMINAL,
 )
+from mage_ai.shared.constants import InstanceType
 from mage_ai.shared.logger import LoggingLevel
 from mage_ai.shared.utils import is_port_in_use
 from mage_ai.usage_statistics.logger import UsageStatisticLogger
@@ -280,7 +281,7 @@ def start_server(
     project: str = None,
     manage: bool = False,
     dbt_docs: bool = False,
-    instance_type: str = 'server_and_scheduler',
+    instance_type: InstanceType = InstanceType.SERVER_AND_SCHEDULER,
 ):
     host = host if host else None
     port = port if port else DATA_PREP_SERVER_PORT
@@ -310,13 +311,19 @@ def start_server(
                 database_manager.run_migrations()
             except Exception:
                 traceback.print_exc()
-        elif instance_type == 'server_and_scheduler':
+        elif instance_type == InstanceType.SERVER_AND_SCHEDULER:
             # Start a subprocess for scheduler
             scheduler_manager.start_scheduler()
-        elif instance_type == 'scheduler':
+        elif instance_type == InstanceType.SCHEDULER:
             # Start a subprocess for scheduler
             scheduler_manager.start_scheduler(foreground=True)
             run_web_server = False
+        elif instance_type == InstanceType.WEB_SERVER:
+            # run migrations to enable user authentication
+            try:
+                database_manager.run_migrations()
+            except Exception:
+                traceback.print_exc()
 
         if run_web_server:
             if LoggingLevel.is_valid_level(SERVER_VERBOSITY):

--- a/mage_ai/shared/constants.py
+++ b/mage_ai/shared/constants.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 ENV_DEV = 'dev'
 ENV_PROD = 'prod'
 ENV_STAGING = 'staging'
@@ -6,3 +8,9 @@ ENV_TEST = 'test'
 SAMPLE_SIZE = 1000
 
 S3_PREFIX = 's3://'
+
+
+class InstanceType(str, Enum):
+    SERVER_AND_SCHEDULER = 'server_and_scheduler'
+    SCHEDULER = 'scheduler'
+    WEB_SERVER = 'web_server'


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Support running Mage server and scheduler separately.
Run scheduler only
```
mage start project_name --instance-type scheduler
```
Run web server only
```
mage start project_name --instance-type web_server
```
Run both server and scheduler
```
mage start project_name --instance-type server_and_scheduler
```
# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
