### PR TITLE
[jk] Snowflake sql block defaults

### DIFF
--- a/docs/integrations/databases/Snowflake.mdx
+++ b/docs/integrations/databases/Snowflake.mdx
@@ -19,6 +19,8 @@ default:
   SNOWFLAKE_PASSWORD: ...
   SNOWFLAKE_ACCOUNT: ...
   SNOWFLAKE_DEFAULT_WH: ...
+  SNOWFLAKE_DEFAULT_DB: ...
+  SNOWFLAKE_DEFAULT_SCHEMA: ...
   SNOWFLAKE_ROLE: ...
 ```
 
@@ -32,12 +34,26 @@ default:
 4. Under the `Data provider` dropdown, select `Snowflake`.
 5. Under the `Profile` dropdown, select `default` (or the profile you added
    credentials underneath).
-6. Next to the `Database` label, enter the database name you want this block to
+6. In the `Database` input in the block header, enter the database name you want this block to
    save data to.
-7. Next to the `Save to schema` label, enter the schema name you want this block
+7. In the `Schema` input in the block header, enter the schema name you want this block
    to save data to.
 8. Under the `Write policy` dropdown, select `Replace` or `Append` (please see
    [SQL blocks guide](/guides/sql-blocks)
    for more information on write policies).
 9. Enter in this test query: `SELECT 1`.
 10. Run the block.
+
+## Methods for configuring database and schema
+
+You only need to include the database and schema config in one of these 3 places, in
+order of priority (so if all 3 are included, #1 takes priority, then #2, then #3):
+1. Inlude the db and schema directly in the query (e.g.
+`select * from [database_name].[schema_name].[table_name];`)
+2. Include the db and schema in the SQL code block header inputs, as mentioned in Steps
+6 and 7 of the "Using SQL block" section above.
+3. Include the default db and schema in the `io_config.yaml` file using these fields:
+```
+SNOWFLAKE_DEFAULT_DB: YOUR_DB_NAME
+SNOWFLAKE_DEFAULT_SCHEMA: YOUR_SCHEMA_NAME
+```

--- a/docs/integrations/databases/Snowflake.mdx
+++ b/docs/integrations/databases/Snowflake.mdx
@@ -49,7 +49,8 @@ default:
 You only need to include the database and schema config in one of these 3 places, in
 order of priority (so if all 3 are included, #1 takes priority, then #2, then #3):
 1. Inlude the db and schema directly in the query (e.g.
-`select * from [database_name].[schema_name].[table_name];`)
+`select * from [database_name].[schema_name].[table_name];`). This is supported
+when NOT using the "raw sql" query option.
 2. Include the db and schema in the SQL code block header inputs, as mentioned in Steps
 6 and 7 of the "Using SQL block" section above.
 3. Include the default db and schema in the `io_config.yaml` file using these fields:

--- a/mage_ai/data_preparation/models/block/sql/__init__.py
+++ b/mage_ai/data_preparation/models/block/sql/__init__.py
@@ -421,11 +421,12 @@ def execute_sql_code(
     elif DataSource.SNOWFLAKE.value == data_provider:
         from mage_ai.io.snowflake import Snowflake
 
-        table_name_parts = table_name_parts_from_query(query)
-        if table_name_parts is not None:
-            db_from_query, schema_from_query, _ = table_name_parts
-            database = db_from_query or database
-            schema = schema_from_query or schema
+        if not use_raw_sql:
+            table_name_parts = table_name_parts_from_query(query)
+            if table_name_parts is not None:
+                db_from_query, schema_from_query, _ = table_name_parts
+                database = db_from_query or database
+                schema = schema_from_query or schema
 
         table_name = table_name.upper() if table_name else table_name
 

--- a/mage_ai/data_preparation/models/block/sql/__init__.py
+++ b/mage_ai/data_preparation/models/block/sql/__init__.py
@@ -14,6 +14,7 @@ from mage_ai.data_preparation.models.block.sql import (
 from mage_ai.data_preparation.models.block.sql.utils.shared import (
     has_create_or_insert_statement,
     interpolate_vars,
+    table_name_parts_from_query,
 )
 from mage_ai.data_preparation.models.constants import BlockType
 from mage_ai.data_preparation.repo_manager import get_repo_path
@@ -419,6 +420,12 @@ def execute_sql_code(
                         ]
     elif DataSource.SNOWFLAKE.value == data_provider:
         from mage_ai.io.snowflake import Snowflake
+
+        table_name_parts = table_name_parts_from_query(query)
+        if table_name_parts is not None:
+            db_from_query, schema_from_query, _ = table_name_parts
+            database = db_from_query or database
+            schema = schema_from_query or schema
 
         table_name = table_name.upper() if table_name else table_name
 

--- a/mage_ai/data_preparation/models/block/sql/utils/shared.py
+++ b/mage_ai/data_preparation/models/block/sql/utils/shared.py
@@ -1,6 +1,6 @@
 import re
 from os import path
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List, Tuple, Union
 
 from jinja2 import Template
 from pandas import DataFrame
@@ -259,8 +259,13 @@ def table_name_parts(
 
 def table_name_parts_from_query(
     query: str,
-) -> Tuple[str, str, str]:
-    match = re.search(r'[^.+]from[\s](.+)\.(.+)\.(.+)', query, re.IGNORECASE)
+) -> Union[Tuple[str, str, str], None]:
+    """
+    This method is intended to parse the database, query, and table name from a SELECT
+    query, such as "select * from demo_db.demo_schema.demo_table;". The regex may need
+    to be updated if using non-SELECT queries.
+    """
+    match = re.search(r'[^.+]from[\s](\S+)\.(\S+)\.(\S+[^;\s]+)', query, re.IGNORECASE)
     if match is None:
         return None
     else:

--- a/mage_ai/data_preparation/models/block/sql/utils/shared.py
+++ b/mage_ai/data_preparation/models/block/sql/utils/shared.py
@@ -257,6 +257,17 @@ def table_name_parts(
     return database, schema, table
 
 
+def table_name_parts_from_query(
+    query: str,
+) -> Tuple[str, str, str]:
+    match = re.search(r'[^.+]from[\s](.+)\.(.+)\.(.+)', query, re.IGNORECASE)
+    if match is None:
+        return None
+    else:
+        database, schema, table = match.groups()
+        return database, schema, table
+
+
 def build_dynamic_table_name(table_name: str, dynamic_block_index: int = None) -> str:
     if dynamic_block_index is None:
         return table_name

--- a/mage_ai/frontend/components/Logs/Table/index.style.ts
+++ b/mage_ai/frontend/components/Logs/Table/index.style.ts
@@ -17,6 +17,7 @@ export const TableContainer = styled.div`
 export const TableHeadStyle = styled.div`
   display: flex;
   align-items: center;
+  overflow: hidden;
 
   ${props => `
     border-bottom: 1px solid ${(props.theme || dark).borders.medium2};

--- a/mage_ai/frontend/components/Logs/Table/index.tsx
+++ b/mage_ai/frontend/components/Logs/Table/index.tsx
@@ -222,7 +222,7 @@ function LogsTable({
             key={`${col}_${idx}`}
             style={{
               height: UNIT * 4,
-              width: col.width || null,
+              minWidth: col.width || null,
             }}
           >
             {col.uuid !== '_' &&

--- a/mage_ai/io/snowflake.py
+++ b/mage_ai/io/snowflake.py
@@ -264,6 +264,7 @@ class Snowflake(BaseSQLConnection):
 
                 if query_string:
                     cur.execute(f'USE DATABASE {database}', timeout=self.timeout)
+                    cur.execute(f'USE SCHEMA {schema}', timeout=self.timeout)
 
                     if should_create_table:
                         cur.execute(f"""

--- a/mage_ai/tests/data_preparation/models/block/test_sql.py
+++ b/mage_ai/tests/data_preparation/models/block/test_sql.py
@@ -1,4 +1,5 @@
 from mage_ai.data_preparation.models.block.sql import split_query_string
+from mage_ai.data_preparation.models.block.sql.utils.shared import table_name_parts_from_query
 from mage_ai.tests.base_test import TestCase
 
 
@@ -40,3 +41,18 @@ SELECT 5 AS id;
 
         self.assertEqual(queries[2], """INSERT INTO schema_2.table_v2 SELECT 3 AS id UNION ALL
 SELECT 5 AS id""")
+
+    def test_table_name_parts_from_query(self):
+        query1 = 'select * from demo_db1.demo_schema1.demo_table1'
+        query2 = 'SELECT * FROM demo_db2.demo_schema2.demo_table2;'
+        query3 = 'select * from demo_db3.demo_schema3.demo_table3 where "id"=1;'
+        query4 = 'SELECT * from demo_table4'
+        result1 = table_name_parts_from_query(query1)
+        result2 = table_name_parts_from_query(query2)
+        result3 = table_name_parts_from_query(query3)
+        result4 = table_name_parts_from_query(query4)
+
+        self.assertEqual(result1, ('demo_db1', 'demo_schema1', 'demo_table1'))
+        self.assertEqual(result2, ('demo_db2', 'demo_schema2', 'demo_table2'))
+        self.assertEqual(result3, ('demo_db3', 'demo_schema3', 'demo_table3'))
+        self.assertEqual(result4, None)


### PR DESCRIPTION
# Summary
- Allow more flexibility in Snowflake sql block queries. Users only need to include the database and schema config in one of these 3 places, in order of priority (so if all 3 are included, `#1` takes priority, then `#2`, then `#3`):
1. Users can include the db and schema directly in the query (e.g. `select * from demo_db.mage_dev2.jk_demo_table;`)
2. Users can include the db and schema in the SQL code block header inputs. For example:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/0a18ce31-e0be-468e-ac1c-717bfed99d63)
3. Users can include the default db and schema in the `io_config.yaml using these fields:
```
SNOWFLAKE_DEFAULT_DB: DEMO_DB
SNOWFLAKE_DEFAULT_SCHEMA: MAGE_DEV2
``` 
# Tests
![snowflake query](https://github.com/mage-ai/mage-ai/assets/78053898/b8fe4ae2-dd2f-41f4-96c9-52c8c6083f59)
- Also confirmed snowflake queries were successful with the priorities in the scenarios above.
