### PR TITLE
[jk] Fix lost upstream connections when adding block between blocks

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -136,7 +136,7 @@ import { useKeyboardContext } from '@context/Keyboard';
 export const DEFAULT_SQL_CONFIG_KEY_LIMIT = 1000;
 
 type CodeBlockProps = {
-  addNewBlock?: (block: BlockType, downstreamBlocks?: string[]) => Promise<any>;
+  addNewBlock?: (block: BlockType, downstreamBlocks?: BlockType[]) => Promise<any>;
   addNewBlockMenuOpenIdx?: number;
   allBlocks: BlockType[];
   allowCodeBlockShortcuts?: boolean;
@@ -2109,7 +2109,17 @@ function CodeBlock({
                     let content = newBlock.content;
                     let configuration = newBlock.configuration;
                     const upstreamBlocks = getUpstreamBlockUuids(block, newBlock);
-                    const downstreamBlocks = getDownstreamBlockUuids(block, newBlock);
+                    const downstreamBlockUUIDs = getDownstreamBlockUuids(pipeline, block, newBlock);
+                    const downstreamBlocks = downstreamBlockUUIDs.map(uuid => {
+                      const currDownstreamBlock = { ...(blocksMapping[uuid] || {}) };
+                      const upstreamsOfDownstreamBlock = currDownstreamBlock.upstream_blocks;
+                      if (upstreamsOfDownstreamBlock) {
+                        currDownstreamBlock.upstream_blocks = upstreamsOfDownstreamBlock.filter(
+                          upstreamUUID => upstreamUUID !== blockUUID,
+                        );
+                      }
+                      return currDownstreamBlock;
+                    });
 
                     if ([BlockTypeEnum.DATA_LOADER, BlockTypeEnum.TRANSFORMER].includes(blockType)
                       && BlockTypeEnum.SCRATCHPAD === newBlock.type

--- a/mage_ai/frontend/components/CodeBlock/utils.ts
+++ b/mage_ai/frontend/components/CodeBlock/utils.ts
@@ -7,7 +7,7 @@ import BlockType, {
   CONVERTIBLE_BLOCK_TYPES,
   TagEnum,
 } from '@interfaces/BlockType';
-import PipelineType from '@interfaces/PipelineType';
+import PipelineType, { PipelineTypeEnum } from '@interfaces/PipelineType';
 import { FlyoutMenuItemType } from '@oracle/components/FlyoutMenu';
 import { capitalizeRemoveUnderscoreLower, lowercase } from '@utils/string';
 import { goToWithQuery } from '@utils/routing';
@@ -33,12 +33,14 @@ export const getUpstreamBlockUuids = (
 };
 
 export const getDownstreamBlockUuids = (
+  pipeline: PipelineType,
   currentBlock: BlockType,
   newBlock?: BlockRequestPayloadType,
 ): string[] => {
   let downstreamBlocks = [];
 
-  if (!BLOCK_TYPES_WITH_NO_PARENTS.includes(currentBlock?.type)
+  if (pipeline?.type === PipelineTypeEnum.STREAMING
+    && !BLOCK_TYPES_WITH_NO_PARENTS.includes(currentBlock?.type)
     && !BLOCK_TYPES_WITH_NO_PARENTS.includes(newBlock?.type)
   ) {
     downstreamBlocks = downstreamBlocks.concat(currentBlock?.downstream_blocks || []);

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -486,15 +486,16 @@ function PipelineDetail({
           <CodeBlock
             addNewBlock={(
               b: BlockRequestPayloadType,
-              downstreamBlocks?: string[],
+              downstreamBlocks?: BlockType[],
             ) => {
               setTextareaFocused(true);
               const onCreateCallback = (block: BlockType) => {
                 if (downstreamBlocks?.length === 1) {
-                  const downstreamBlockUUID = downstreamBlocks[0];
+                  const downstreamBlockUUID = downstreamBlocks[0]?.uuid;
+                  const upstreamsOfDownstreamBlock = downstreamBlocks[0]?.upstream_blocks || [];
                   updateBlock({
                     block: { uuid: downstreamBlockUUID },
-                    upstreamBlocks: [block.uuid],
+                    upstreamBlocks: [block.uuid, ...upstreamsOfDownstreamBlock],
                   });
                 }
                 setSelectedBlock?.(block);


### PR DESCRIPTION
# Summary
- When adding a new block between blocks, do not include downstream connections for standard pipelines, but include downstream connections for streaming pipelines.

# Tests
- Adding block between blocks on standard pipeline:
![adding transformer to standard](https://github.com/mage-ai/mage-ai/assets/78053898/d3cb4c28-75d4-4136-b9d1-fe8092b7e013)

- Adding block between blocks on streaming pipeline:
![adding transformer to streaming](https://github.com/mage-ai/mage-ai/assets/78053898/de23a083-dcd9-44e8-84e2-7129deb71fdc)
