### PR TITLE
[hw] Add the support for using MSSQL as the database engine

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-ignore = E121,E126,E712,W503,W504
-exclude = mage_ai/data_preparation/templates,mage_ai/orchestration/db/migrations/versions,mage_ai/orchestration/db/models/schedules.py
+ignore = E121,E126,W503,W504
+exclude = mage_ai/data_preparation/templates,mage_ai/orchestration/db/migrations/versions
 max-line-length = 100

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-ignore = E121,E126,W503,W504
+ignore = E121,E126,E712,W503,W504
 exclude = mage_ai/data_preparation/templates,mage_ai/orchestration/db/migrations/versions
 max-line-length = 100

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 ignore = E121,E126,E712,W503,W504
-exclude = mage_ai/data_preparation/templates,mage_ai/orchestration/db/migrations/versions
+exclude = mage_ai/data_preparation/templates,mage_ai/orchestration/db/migrations/versions,mage_ai/orchestration/db/models/schedules.py
 max-line-length = 100

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -103,6 +103,8 @@ Besides SQLite and PostgreSQL, MSSQL can also be used as the database engine, as
    mcr.microsoft.com/mssql/server:2022-latest
    ```
 
+   More details about the MSSQL docker image are available at [Microsoft SQL Server - Ubuntu based images](https://hub.docker.com/_/microsoft-mssql-server)
+
 3. Launch Mage with `MAGE_DATABASE_CONNECTION_URL` environment variable
 
    ```bash
@@ -111,6 +113,16 @@ Besides SQLite and PostgreSQL, MSSQL can also be used as the database engine, as
    mageai/mageai \
    /app/run_app.sh mage start <project_name>
    ```
+
+   The parameters listed in the MAGE_DATABASE_CONNECTION_URL are explained below:
+
+   * "DRIVER={ODBC Driver 18 for SQL Server}" - a formatted string with a version number matching that of the SQL server
+   * "SERVER=<your_server>" - the name or IP address of the database server
+   * "DATABASE=<your_database>" - the name of the database
+   * "UID=<user>" - the user ID for the database
+   * "PWD=<password>" - the password for the user
+   * "ENCRYPT=yes" - whether to use encryption
+   * "TrustServerCertificate=yes" - whether to trust the server certificate
 
 ---
 

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -57,8 +57,7 @@ docker run -it -p 6789:6789 -v $(pwd):/home/src mageai/mageai \
 
 ### Using PostgreSQL as database
 
-Mage uses SQLite as the default database engine. To use PostgreSQL as
-the database engine, you'll need to run your Docker container slightly differently:
+Mage uses SQLite as the default database engine. To use PostgreSQL as the database engine, you'll need to run your Docker container slightly differently:
 
 1. Create Docker network
 
@@ -66,7 +65,7 @@ the database engine, you'll need to run your Docker container slightly different
    docker network create mage-app
    ```
 
-1. Start PostgreSQL Docker container in a separate window
+2. Start PostgreSQL Docker container in a separate window
 
    ```bash
    docker run --network mage-app --network-alias postgres_db \
@@ -76,13 +75,41 @@ the database engine, you'll need to run your Docker container slightly different
       postgres:13-alpine3.17 postgres
    ```
 
-1. Launch Mage with `MAGE_DATABASE_CONNECTION_URL` environment variable
+3. Launch Mage with `MAGE_DATABASE_CONNECTION_URL` environment variable
 
    ```bash
    docker run --network mage-app -it -p 6789:6789 -v $(pwd):/home/src \
       -e MAGE_DATABASE_CONNECTION_URL=postgresql+psycopg2://<username>:<password>@postgres_db:5432/<database> \
       mageai/mageai \
       /app/run_app.sh mage start another_repo
+   ```
+
+### Using MSSQL as database
+
+Besides SQLite and PostgreSQL, MSSQL can also be used as the database engine, as shown in the following steps using Docker container:
+
+1. Create Docker network
+
+   ```bash
+   docker network create mage-app
+   ```
+
+2. Start MSSQL Docker container in a separate window
+
+   ```bash
+   docker run --network mage-app --network-alias mssql_db \
+   -it -p 1433:1433 -e "ACCEPT_EULA=Y" \
+   -e "MSSQL_SA_PASSWORD=test_Username123" \
+   mcr.microsoft.com/mssql/server:2022-latest
+   ```
+
+3. Launch Mage with `MAGE_DATABASE_CONNECTION_URL` environment variable
+
+   ```bash
+   docker run --network mage-app -it -p 6789:6789 -v $(pwd):/home/src \
+   -e MAGE_DATABASE_CONNECTION_URL="mssql+pyodbc://?odbc_connect=DRIVER={ODBC Driver 18 for SQL Server};SERVER=mssql_db;DATABASE=master;UID=SA;PWD=test_Username123;ENCRYPT=yes;TrustServerCertificate=yes;" \
+   mageai/mageai \
+   /app/run_app.sh mage start another_repo_mssql
    ```
 
 ---

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -81,7 +81,7 @@ Mage uses SQLite as the default database engine. To use PostgreSQL as the databa
    docker run --network mage-app -it -p 6789:6789 -v $(pwd):/home/src \
       -e MAGE_DATABASE_CONNECTION_URL=postgresql+psycopg2://<username>:<password>@postgres_db:5432/<database> \
       mageai/mageai \
-      /app/run_app.sh mage start another_repo
+      /app/run_app.sh mage start <project_name>
    ```
 
 ### Using MSSQL as database
@@ -109,7 +109,7 @@ Besides SQLite and PostgreSQL, MSSQL can also be used as the database engine, as
    docker run --network mage-app -it -p 6789:6789 -v $(pwd):/home/src \
    -e MAGE_DATABASE_CONNECTION_URL="mssql+pyodbc://?odbc_connect=DRIVER={ODBC Driver 18 for SQL Server};SERVER=mssql_db;DATABASE=master;UID=SA;PWD=test_Username123;ENCRYPT=yes;TrustServerCertificate=yes;" \
    mageai/mageai \
-   /app/run_app.sh mage start another_repo_mssql
+   /app/run_app.sh mage start <project_name>
    ```
 
 ---

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -114,13 +114,13 @@ Besides SQLite and PostgreSQL, MSSQL can also be used as the database engine, as
    /app/run_app.sh mage start <project_name>
    ```
 
-   The parameters listed in the MAGE_DATABASE_CONNECTION_URL are explained below:
+   The parameters used in MAGE_DATABASE_CONNECTION_URL are explained below:
 
    * "DRIVER={ODBC Driver 18 for SQL Server}" - a formatted string with a version number matching that of the SQL server
-   * "SERVER=<your_server>" - the name or IP address of the database server
-   * "DATABASE=<your_database>" - the name of the database
-   * "UID=<user>" - the user ID for the database
-   * "PWD=<password>" - the password for the user
+   * "SERVER=database_server" - the name or IP address of the database server
+   * "DATABASE=database" - the name of the database
+   * "UID=user" - the user ID for the database
+   * "PWD=password" - the password for the user
    * "ENCRYPT=yes" - whether to use encryption
    * "TrustServerCertificate=yes" - whether to trust the server certificate
 

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -99,7 +99,7 @@ Besides SQLite and PostgreSQL, MSSQL can also be used as the database engine, as
    ```bash
    docker run --network mage-app --network-alias mssql_db \
    -it -p 1433:1433 -e "ACCEPT_EULA=Y" \
-   -e "MSSQL_SA_PASSWORD=test_Username123" \
+   -e "MSSQL_SA_PASSWORD=test_Password123" \
    mcr.microsoft.com/mssql/server:2022-latest
    ```
 
@@ -107,7 +107,7 @@ Besides SQLite and PostgreSQL, MSSQL can also be used as the database engine, as
 
    ```bash
    docker run --network mage-app -it -p 6789:6789 -v $(pwd):/home/src \
-   -e MAGE_DATABASE_CONNECTION_URL="mssql+pyodbc://?odbc_connect=DRIVER={ODBC Driver 18 for SQL Server};SERVER=mssql_db;DATABASE=master;UID=SA;PWD=test_Username123;ENCRYPT=yes;TrustServerCertificate=yes;" \
+   -e MAGE_DATABASE_CONNECTION_URL="mssql+pyodbc://?odbc_connect=DRIVER={ODBC Driver 18 for SQL Server};SERVER=mssql_db;DATABASE=master;UID=SA;PWD=test_Password123;ENCRYPT=yes;TrustServerCertificate=yes;" \
    mageai/mageai \
    /app/run_app.sh mage start <project_name>
    ```

--- a/docs/production/configuring-production-settings/overview.mdx
+++ b/docs/production/configuring-production-settings/overview.mdx
@@ -29,6 +29,8 @@ In production, you can set the environment variable in the corresponding Terrafo
 #### Postgres
 `export MAGE_DATABASE_CONNECTION_URL=postgresql+psycopg2://user:password@host:port/dbname`
 
+#### MSSQL
+`export MAGE_DATABASE_CONNECTION_URL=mssql+pyodbc://?odbc_connect=DRIVER={ODBC Driver 18 for SQL Server};SERVER=host;DATABASE=dbname;UID=user;PWD=password;ENCRYPT=yes;TrustServerCertificate=yes;`
 
 ### ulimit
 

--- a/docs/production/databases/default.mdx
+++ b/docs/production/databases/default.mdx
@@ -8,3 +8,6 @@ In production, you can set the environment variable in the corresponding Terrafo
 
 ## Postgres
 `export MAGE_DATABASE_CONNECTION_URL=postgresql+psycopg2://user:password@host:port/dbname`
+
+## MSSQL
+`export MAGE_DATABASE_CONNECTION_URL=mssql+pyodbc://?odbc_connect=DRIVER={ODBC Driver 18 for SQL Server};SERVER=host;DATABASE=dbname;UID=user;PWD=password;ENCRYPT=yes;TrustServerCertificate=yes;`

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -314,7 +314,7 @@ class PipelineRun(BaseModel):
                 self.PipelineRunStatus.INITIAL,
                 self.PipelineRunStatus.RUNNING,
             ]),
-            (coalesce(PipelineRun.passed_sla, False) == False),
+            (coalesce(PipelineRun.passed_sla, False) == False),  # noqa: E712
         ).all()
 
     @safe_db_query

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -1,25 +1,26 @@
 import asyncio
 import enum
+import pytz
 import traceback
 import uuid
-from datetime import datetime, timedelta, timezone
-from typing import Dict, List
 
-import pytz
 from croniter import croniter
+from datetime import datetime, timedelta, timezone
 from sqlalchemy import (
-    JSON,
     Boolean,
     Column,
     DateTime,
     Enum,
     ForeignKey,
     Integer,
+    JSON,
     String,
     Table,
 )
 from sqlalchemy.orm import joinedload, relationship, validates
 from sqlalchemy.sql import func
+from sqlalchemy.sql.functions import coalesce
+from typing import Dict, List
 
 from mage_ai.data_preparation.logging.logger_manager_factory import LoggerManagerFactory
 from mage_ai.data_preparation.models.block.utils import (
@@ -313,7 +314,7 @@ class PipelineRun(BaseModel):
                 self.PipelineRunStatus.INITIAL,
                 self.PipelineRunStatus.RUNNING,
             ]),
-            PipelineRun.passed_sla.is_(False),
+            (coalesce(PipelineRun.passed_sla, False) == False),
         ).all()
 
     @safe_db_query


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

Mage currently only supports SQLite and PostgreSQL as backend database engines. This PR contains the code changes and documents to support MSSQL as well.

# Tests
<!-- How did you test your change? -->
Manually tested the setup procedure following the steps described in the added document.

To connect to the MSSQL instance running in the docker container, a tool called `sql-cli` has been used, which could be installed by the following commands
```
% npm install -g sql-cli
```
Using the following command to connect to the local MSSQL instance running in the docker container:
```
% mssql -u sa -p test_Username123
```
To show all the available databases and tables on the server:
```
mssql> sp_databases;
mssql> sp_tables;
```
The mage related tables are generated in the `master` database with `dbo` as the owner:
```
TABLE_QUALIFIER  TABLE_OWNER         TABLE_NAME                                   TABLE_TYPE  REMARKS
---------------  ------------------  -------------------------------------------  ----------  -------
master           dbo                 alembic_version                              TABLE       null   
master           dbo                 backfill                                     TABLE       null   
master           dbo                 block_run                                    TABLE       null   
master           dbo                 event_matcher                                TABLE       null   
master           dbo                 MSreplication_options                        TABLE       null   
master           dbo                 oauth2_access_token                          TABLE       null   
master           dbo                 oauth2_application                           TABLE       null   
master           dbo                 permission                                   TABLE       null   
master           dbo                 pipeline_run                                 TABLE       null   
master           dbo                 pipeline_schedule                            TABLE       null   
master           dbo                 pipeline_schedule_event_matcher_association  TABLE       null   
master           dbo                 role                                         TABLE       null   
master           dbo                 secret                                       TABLE       null   
master           dbo                 spt_fallback_db                              TABLE       null   
master           dbo                 spt_fallback_dev                             TABLE       null   
master           dbo                 spt_fallback_usg                             TABLE       null   
master           dbo                 spt_monitor                                  TABLE       null   
master           dbo                 user                                         TABLE       null   
master           dbo                 user_role                                    TABLE       null
```
To check the pipeline running status:
```
mssql>  select * from pipeline_schedule;

id  created_at                updated_at                name         pipeline_uuid  schedule_type  start_time                schedule_interval  status    variables  sla   token                             settings
--  ------------------------  ------------------------  -----------  -------------  -------------  ------------------------  -----------------  --------  ---------  ----  --------------------------------  --------
1   2023-05-30T07:24:08.560Z  2023-05-30T07:24:23.620Z  dry bush     red_mountain   TIME           2023-05-29T07:24:00.000Z  @once              INACTIVE  null       null  9276da8a88e5492e803116fa9c9a2066  null    
2   2023-05-30T07:32:49.780Z  2023-05-30T07:33:07.643Z  muddy field  red_mountain   TIME           2023-05-29T07:32:00.000Z  @once              INACTIVE  null       null  eee8bd933ae241398b83bae9a88eef96  null    

2 row(s) returned
```

To connect to the MSSQL instance directly from Python code on a Mac OS machine, the following driver installation step is needed ([more details](https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/install-microsoft-odbc-driver-sql-server-macos?view=sql-server-ver16)):
```
% brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
% HOMEBREW_ACCEPT_EULA=Y brew install msodbcsql18 mssql-tools18
```
The installation of the following Python libraries are also needed:
```
mysql-connector-python==8.0.31
sqlalchemy>=1.4.20, <2.0.0
pyodbc==4.0.35
```
An example Python code is given below, which test out the connection with the MSSQL instance running in a docker container on Mac OS:
```
from sqlalchemy import create_engine, exc

# Connection parameters
driver = 'ODBC Driver 18 for SQL Server'
server = 'localhost'
database = 'master'
username = 'SA'
password = 'test_Username123'

connection_string = (
    f'DRIVER={{{driver}}};'
    f'SERVER={server};'
    f'DATABASE={database};'
    f'UID={username};'
    f'PWD={password};'
    'ENCRYPT=yes;'
    'TrustServerCertificate=yes;'
)

conn_str = f"mssql+pyodbc://?odbc_connect={connection_string}"
print(conn_str)

# Create the engine and try to connect
engine = create_engine(conn_str)
try:
    connection = engine.connect()
    print("Connected successfully!")
except exc.SQLAlchemyError as e:
    print("Connection failed:", e)
```

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@dy46 @wangxiaoyou1993 