### PR TITLE
[jk] Check for file_path in config for dbt pipelines

### DIFF
--- a/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
@@ -1130,11 +1130,11 @@ def run_dbt_tests(
     logger: Logger = None,
     logging_tags: Dict = dict(),
 ) -> None:
-    attributes_dict = parse_attributes(block)
-    snapshot = attributes_dict['snapshot']
-
-    if snapshot:
-        return
+    if block.configuration.get('file_path') is not None:
+        attributes_dict = parse_attributes(block)
+        snapshot = attributes_dict['snapshot']
+        if snapshot:
+            return
 
     if logger is not None:
         stdout = StreamToLogger(logger, logging_tags=logging_tags)


### PR DESCRIPTION
# Summary
- Check for `file_path` before calling `parse_attributes` method to avoid KeyError.

# Tests
- Confirmed pipeline with dbt yaml block loads successfully.

cc:
@wangxiaoyou1993 @tommydangerous 
