### PR TITLE
[xy] Personalize notification messages

### DIFF
--- a/mage_ai/orchestration/notification/config.py
+++ b/mage_ai/orchestration/notification/config.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import List
+
 from mage_ai.services.email.config import EmailConfig
 from mage_ai.services.google_chat.config import GoogleChatConfig
+from mage_ai.services.opsgenie.config import OpsgenieConfig
 from mage_ai.services.slack.config import SlackConfig
 from mage_ai.services.teams.config import TeamsConfig
-from mage_ai.services.opsgenie.config import OpsgenieConfig
 from mage_ai.shared.config import BaseConfig
-from typing import Dict, List
-import traceback
 
 
 class AlertOn(str, Enum):
@@ -23,6 +23,20 @@ DEFAULT_ALERT_ON = [
 
 
 @dataclass
+class MessageTemplate(BaseConfig):
+    title: str = None
+    summary: str = None
+    details: str = None
+
+
+@dataclass
+class MessageTemplates(BaseConfig):
+    success: MessageTemplate = None
+    failure: MessageTemplate = None
+    passed_sla: MessageTemplate = None
+
+
+@dataclass
 class NotificationConfig(BaseConfig):
     alert_on: List[AlertOn] = field(default_factory=lambda: DEFAULT_ALERT_ON)
     email_config: EmailConfig = None
@@ -30,53 +44,4 @@ class NotificationConfig(BaseConfig):
     opsgenie_config: OpsgenieConfig = None
     slack_config: SlackConfig = None
     teams_config: TeamsConfig = None
-
-    @classmethod
-    def load(self, config_path: str = None, config: Dict = None):
-        notification_config = super().load(config_path=config_path, config=config)
-        if notification_config.slack_config is not None and \
-                type(notification_config.slack_config) is dict:
-            try:
-                notification_config.slack_config = SlackConfig.load(
-                    config=notification_config.slack_config,
-                )
-            except Exception:
-                traceback.print_exc()
-                notification_config.slack_config = None
-        if notification_config.teams_config is not None and \
-                type(notification_config.teams_config) is dict:
-            try:
-                notification_config.teams_config = TeamsConfig.load(
-                    config=notification_config.teams_config,
-                )
-            except Exception:
-                traceback.print_exc()
-                notification_config.teams_config = None
-        if notification_config.google_chat_config is not None and \
-                type(notification_config.google_chat_config) is dict:
-            try:
-                notification_config.google_chat_config = GoogleChatConfig.load(
-                    config=notification_config.google_chat_config,
-                )
-            except Exception:
-                traceback.print_exc()
-                notification_config.google_chat_config = None
-        if notification_config.email_config is not None and \
-                type(notification_config.email_config) is dict:
-            try:
-                notification_config.email_config = EmailConfig.load(
-                    config=notification_config.email_config,
-                )
-            except Exception:
-                traceback.print_exc()
-                notification_config.email_config = None
-        if notification_config.opsgenie_config is not None and \
-                type(notification_config.opsgenie_config) is dict:
-            try:
-                notification_config.opsgenie_config = OpsgenieConfig.load(
-                    config=notification_config.opsgenie_config,
-                )
-            except Exception:
-                traceback.print_exc()
-                notification_config.opsgenie_config = None
-        return notification_config
+    message_templates: MessageTemplates = None

--- a/mage_ai/orchestration/notification/sender.py
+++ b/mage_ai/orchestration/notification/sender.py
@@ -6,7 +6,7 @@ from mage_ai.services.google_chat.google_chat import send_google_chat_message
 from mage_ai.services.opsgenie.opsgenie import send_opsgenie_alert
 from mage_ai.services.slack.slack import send_slack_message
 from mage_ai.services.teams.teams import send_teams_message
-from mage_ai.settings import MAGE_PUBLIC_HOST
+from mage_ai.settings import DEFAULT_LOCALHOST_URL, MAGE_PUBLIC_HOST
 
 
 class NotificationSender:
@@ -60,7 +60,7 @@ class NotificationSender:
                 f'at execution time `{pipeline_run.execution_date}`.'
             )
             email_content = f'{message}\n'
-            if os.getenv('ENV') != 'production':
+            if os.getenv('ENV') != 'production' or MAGE_PUBLIC_HOST != DEFAULT_LOCALHOST_URL:
                 email_content += f'Open {self.__pipeline_run_url(pipeline, pipeline_run)} '\
                                   'to check pipeline run results and logs.'
             self.send(
@@ -83,7 +83,7 @@ class NotificationSender:
                 f'at execution time `{pipeline_run.execution_date}`.'
             )
             email_content = f'{message}\n'
-            if os.getenv('ENV') != 'production' or MAGE_PUBLIC_HOST != 'http://localhost:6789':
+            if os.getenv('ENV') != 'production' or MAGE_PUBLIC_HOST != DEFAULT_LOCALHOST_URL:
                 """
                 Include the URL for the following cases
                 1. Dev environment: Use the default localhost as host in URL
@@ -106,7 +106,7 @@ class NotificationSender:
                 f'at execution time `{pipeline_run.execution_date}`.'
             )
             email_content = f'{message}\n'
-            if os.getenv('ENV') != 'production':
+            if os.getenv('ENV') != 'production' or MAGE_PUBLIC_HOST != DEFAULT_LOCALHOST_URL:
                 email_content += f'Open {self.__pipeline_run_url(pipeline, pipeline_run)} '\
                                   'to check pipeline run results and logs.'
             self.send(
@@ -117,5 +117,5 @@ class NotificationSender:
 
     @staticmethod
     def __pipeline_run_url(pipeline, pipeline_run):
-        return f'{MAGE_PUBLIC_HOST}/pipelines/{pipeline.uuid}/triggers/'\
-               f'{pipeline_run.pipeline_schedule_id}'
+        return f'{MAGE_PUBLIC_HOST}/pipelines/{pipeline.uuid}/runs/'\
+               f'{pipeline_run.id}'

--- a/mage_ai/orchestration/notification/sender.py
+++ b/mage_ai/orchestration/notification/sender.py
@@ -1,12 +1,42 @@
 import os
 
-from mage_ai.orchestration.notification.config import AlertOn, NotificationConfig
+from jinja2 import Template
+
+from mage_ai.orchestration.notification.config import (
+    AlertOn,
+    MessageTemplate,
+    NotificationConfig,
+)
 from mage_ai.services.email.email import send_email
 from mage_ai.services.google_chat.google_chat import send_google_chat_message
 from mage_ai.services.opsgenie.opsgenie import send_opsgenie_alert
 from mage_ai.services.slack.slack import send_slack_message
 from mage_ai.services.teams.teams import send_teams_message
 from mage_ai.settings import DEFAULT_LOCALHOST_URL, MAGE_PUBLIC_HOST
+
+DEFAULT_MESSAGES = dict(
+    success=dict(
+        title='Successfully ran Pipeline {{pipeline_uuid}}',
+        summary=(
+            'Successfully ran Pipeline `{{pipeline_uuid}}` with Trigger {{pipeline_schedule_id}} '
+            '`{{pipeline_schedule_name}}` at execution time `{{execution_time}}`.'
+        ),
+    ),
+    failure=dict(
+        title='Failed to run Mage pipeline {{pipeline_uuid}}',
+        summary=(
+            'Failed to run Pipeline `{{pipeline_uuid}}` with Trigger {{pipeline_schedule_id}} '
+            '`{{pipeline_schedule_name}}` at execution time `{{execution_time}}`.'
+        ),
+    ),
+    passed_sla=dict(
+        title='SLA passed for Mage pipeline {{pipeline_uuid}}',
+        summary=(
+            'SLA passed for pipeline `{{pipeline_uuid}}` with Trigger {{pipeline_schedule_id}} '
+            '`{{pipeline_schedule_name}}` at execution time `{{execution_time}}`.'
+        ),
+    ),
+)
 
 
 class NotificationSender:
@@ -53,67 +83,102 @@ class NotificationSender:
 
     def send_pipeline_run_success_message(self, pipeline, pipeline_run) -> None:
         if AlertOn.PIPELINE_RUN_SUCCESS in self.config.alert_on:
-            message = (
-                f'Successfully ran Pipeline `{pipeline.uuid}` '
-                f'with Trigger {pipeline_run.pipeline_schedule.id} '
-                f'`{pipeline_run.pipeline_schedule.name}` '
-                f'at execution time `{pipeline_run.execution_date}`.'
-            )
-            email_content = f'{message}\n'
-            if os.getenv('ENV') != 'production' or MAGE_PUBLIC_HOST != DEFAULT_LOCALHOST_URL:
-                email_content += f'Open {self.__pipeline_run_url(pipeline, pipeline_run)} '\
-                                  'to check pipeline run results and logs.'
-            self.send(
-                title=f'Successfully ran Pipeline {pipeline.uuid}',
-                summary=message,
-                details=email_content,
+            default_message = DEFAULT_MESSAGES['success']
+            if self.config.message_templates:
+                message_template = self.config.message_templates.success
+            else:
+                message_template = None
+            self.__send_pipeline_run_message(
+                default_message,
+                pipeline,
+                pipeline_run,
+                message_template=message_template,
             )
 
     def send_pipeline_run_failure_message(
         self,
         pipeline,
         pipeline_run,
-        message: str = None,
+        summary: str = None,
     ) -> None:
         if AlertOn.PIPELINE_RUN_FAILURE in self.config.alert_on:
-            message = message or (
-                f'Failed to run Pipeline `{pipeline.uuid}` '
-                f'with Trigger {pipeline_run.pipeline_schedule.id} '
-                f'`{pipeline_run.pipeline_schedule.name}` '
-                f'at execution time `{pipeline_run.execution_date}`.'
-            )
-            email_content = f'{message}\n'
-            if os.getenv('ENV') != 'production' or MAGE_PUBLIC_HOST != DEFAULT_LOCALHOST_URL:
-                """
-                Include the URL for the following cases
-                1. Dev environment: Use the default localhost as host in URL
-                2. Production environment: If MAGE_PUBLIC_HOST is set, use it as host.
-                """
-                email_content += f'Open {self.__pipeline_run_url(pipeline, pipeline_run)} '\
-                                 'to check pipeline run results and logs.'
-            self.send(
-                title=f'Failed to run Mage pipeline {pipeline.uuid}',
-                summary=message,
-                details=email_content,
+            default_message = DEFAULT_MESSAGES['failure']
+            if self.config.message_templates:
+                message_template = self.config.message_templates.failure
+            else:
+                message_template = None
+            self.__send_pipeline_run_message(
+                default_message,
+                pipeline,
+                pipeline_run,
+                message_template=message_template,
+                summary=summary,
             )
 
     def send_pipeline_run_sla_passed_message(self, pipeline, pipeline_run) -> None:
         if AlertOn.PIPELINE_RUN_PASSED_SLA in self.config.alert_on:
-            message = (
-                f'SLA passed for pipeline `{pipeline.uuid}` '
-                f'with Trigger {pipeline_run.pipeline_schedule.id} '
-                f'`{pipeline_run.pipeline_schedule.name}` '
-                f'at execution time `{pipeline_run.execution_date}`.'
+            default_message = DEFAULT_MESSAGES['passed_sla']
+            if self.config.message_templates:
+                message_template = self.config.message_templates.passed_sla
+            else:
+                message_template = None
+            self.__send_pipeline_run_message(
+                default_message,
+                pipeline,
+                pipeline_run,
+                message_template=message_template,
             )
-            email_content = f'{message}\n'
-            if os.getenv('ENV') != 'production' or MAGE_PUBLIC_HOST != DEFAULT_LOCALHOST_URL:
-                email_content += f'Open {self.__pipeline_run_url(pipeline, pipeline_run)} '\
-                                  'to check pipeline run results and logs.'
-            self.send(
-                title=f'SLA passed for Mage pipeline {pipeline.uuid}',
-                summary=message,
-                details=email_content,
-            )
+
+    def __send_pipeline_run_message(
+        self,
+        default_message,
+        pipeline,
+        pipeline_run,
+        message_template: MessageTemplate = None,
+        summary: str = None,
+    ):
+        default_title = default_message['title']
+        default_summary = default_message['summary']
+        default_details = f'{default_summary}\n'
+        if os.getenv('ENV') != 'production' or MAGE_PUBLIC_HOST != DEFAULT_LOCALHOST_URL:
+            """
+            Include the URL for the following cases
+            1. Dev environment: Use the default localhost as host in URL
+            2. Production environment: If MAGE_PUBLIC_HOST is set, use it as host.
+            """
+            default_details += f'Open {self.__pipeline_run_url(pipeline, pipeline_run)} '\
+                               'to check pipeline run results and logs.'
+        print('default_title', default_title)
+        print('default_summary', default_summary)
+        print('default_details', default_details)
+
+        title = None
+        details = None
+        if message_template is not None:
+            if message_template.title is not None:
+                title = message_template.title
+            if summary is None and message_template.summary is not None:
+                summary = message_template.summary
+            if message_template.details is not None:
+                details = message_template.details
+
+        self.send(
+            title=self.__interpolate_vars(title or default_title, pipeline, pipeline_run),
+            summary=self.__interpolate_vars(summary or default_summary, pipeline, pipeline_run),
+            details=self.__interpolate_vars(details or default_details, pipeline, pipeline_run),
+        )
+
+    def __interpolate_vars(self, text: str, pipeline, pipeline_run):
+        print(f'interpolate {text}')
+        if text is None or pipeline is None or pipeline_run is None:
+            return text
+        return Template(text).render(
+            execution_time=pipeline_run.execution_date,
+            pipeline_run_url=self.__pipeline_run_url(pipeline, pipeline_run),
+            pipeline_schedule_id=pipeline_run.pipeline_schedule.id,
+            pipeline_schedule_name=pipeline_run.pipeline_schedule.name,
+            pipeline_uuid=pipeline.uuid,
+        )
 
     @staticmethod
     def __pipeline_run_url(pipeline, pipeline_run):

--- a/mage_ai/orchestration/notification/sender.py
+++ b/mage_ai/orchestration/notification/sender.py
@@ -148,9 +148,6 @@ class NotificationSender:
             """
             default_details += f'Open {self.__pipeline_run_url(pipeline, pipeline_run)} '\
                                'to check pipeline run results and logs.'
-        print('default_title', default_title)
-        print('default_summary', default_summary)
-        print('default_details', default_details)
 
         title = None
         details = None
@@ -169,7 +166,6 @@ class NotificationSender:
         )
 
     def __interpolate_vars(self, text: str, pipeline, pipeline_run):
-        print(f'interpolate {text}')
         if text is None or pipeline is None or pipeline_run is None:
             return text
         return Template(text).render(

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -304,7 +304,7 @@ class PipelineScheduler:
         self.notification_sender.send_pipeline_run_failure_message(
             pipeline=self.pipeline,
             pipeline_run=self.pipeline_run,
-            message=msg,
+            summary=msg,
         )
 
         if PipelineType.INTEGRATION == self.pipeline.type:

--- a/mage_ai/settings/__init__.py
+++ b/mage_ai/settings/__init__.py
@@ -1,6 +1,5 @@
 import os
 
-
 DEBUG = os.getenv('DEBUG', False)
 HIDE_ENV_VAR_VALUES = int(os.getenv('HIDE_ENV_VAR_VALUES', 1) or 1) == 1
 QUERY_API_KEY = 'api_key'
@@ -46,4 +45,5 @@ USE_UNIQUE_TERMINAL = os.getenv('USE_UNIQUE_TERMINAL', None)
 SENTRY_DSN = os.getenv('SENTRY_DSN', None)
 SENTRY_TRACES_SAMPLE_RATE = os.getenv('SENTRY_TRACES_SAMPLE_RATE', 1.0)
 
-MAGE_PUBLIC_HOST = os.getenv('MAGE_PUBLIC_HOST') or 'http://localhost:6789'
+DEFAULT_LOCALHOST_URL = 'http://localhost:6789'
+MAGE_PUBLIC_HOST = os.getenv('MAGE_PUBLIC_HOST') or DEFAULT_LOCALHOST_URL

--- a/mage_ai/tests/factory.py
+++ b/mage_ai/tests/factory.py
@@ -1,15 +1,14 @@
 from datetime import datetime
+from typing import Dict, Union
+
 from faker import Faker
+
 from mage_ai.authentication.passwords import create_bcrypt_hash, generate_salt
 from mage_ai.data_preparation.models.block import Block
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.orchestration.db.models.oauth import User
-from mage_ai.orchestration.db.models.schedules import (
-    PipelineRun,
-    PipelineSchedule,
-)
+from mage_ai.orchestration.db.models.schedules import PipelineRun, PipelineSchedule
 from mage_ai.shared.hash import merge_dict
-from typing import Dict, Union
 
 faker = Faker()
 
@@ -69,10 +68,13 @@ def create_pipeline_run_with_schedule(
     pipeline_uuid: str,
     execution_date: datetime = None,
     pipeline_schedule_id: int = None,
-    pipeline_schedule_settings: Dict = dict(),
+    pipeline_schedule_settings: Dict = None,
 ):
+    if pipeline_schedule_settings is None:
+        pipeline_schedule_settings = dict()
     if pipeline_schedule_id is None:
         pipeline_schedule = PipelineSchedule.create(
+            name=f'{pipeline_uuid}_trigger',
             pipeline_uuid=pipeline_uuid,
             settings=pipeline_schedule_settings,
         )

--- a/mage_ai/tests/orchestration/notification/constants.py
+++ b/mage_ai/tests/orchestration/notification/constants.py
@@ -22,6 +22,22 @@ SLACK_NOTIFICATION_CONFIG = dict(
     )
 )
 
+SLACK_NOTIFICATION_CONFIG_WITH_CUSTOM_TEMPLATE = dict(
+    alert_on=[
+        'trigger_failure',
+        'trigger_success',
+    ],
+    slack_config=dict(
+        webhook_url='test_webhook_url',
+    ),
+    message_templates=dict(
+        failure=dict(
+            details='Failed to execute pipeline {pipeline_run_url}. '
+                    'Pipeline uuid: {pipeline_uuid}. Trigger name: {pipeline_schedule_name}.',
+        )
+    )
+)
+
 GOOGLE_CHAT_NOTIFICATION_CONFIG = dict(
     alert_on=[
         'trigger_failure',

--- a/mage_ai/tests/orchestration/notification/test_sender.py
+++ b/mage_ai/tests/orchestration/notification/test_sender.py
@@ -8,6 +8,7 @@ from mage_ai.tests.orchestration.notification.constants import (
     EMAIL_NOTIFICATION_CONFIG,
     OPSGENIE_NOTIFICATION_CONFIG,
     SLACK_NOTIFICATION_CONFIG,
+    SLACK_NOTIFICATION_CONFIG_WITH_CUSTOM_TEMPLATE,
     TEAMS_NOTIFICATION_CONFIG,
     TEAMS_NOTIFICATION_CONFIG_NO_ALERT_ON,
 )
@@ -36,8 +37,8 @@ class NotificationSenderTests(DBTestCase):
             f'at execution time `{pipeline_run.execution_date}`.'
         )
         email_content += (
-            '\nOpen http://localhost:6789/pipelines/test_pipeline/triggers/'
-            f'{pipeline_run.pipeline_schedule.id} to check pipeline run results and logs.'
+            '\nOpen http://localhost:6789/pipelines/test_pipeline/runs/'
+            f'{pipeline_run.id} to check pipeline run results and logs.'
         )
         mock_send_email.assert_called_once_with(
             notification_config.email_config,
@@ -58,8 +59,31 @@ class NotificationSenderTests(DBTestCase):
             f'with Trigger {pipeline_run.pipeline_schedule.id} '
             f'`{pipeline_run.pipeline_schedule.name}` '
             f'at execution time `{pipeline_run.execution_date}`.\n'
-            f'Open http://localhost:6789/pipelines/test_pipeline/triggers/'
-            f'{pipeline_run.pipeline_schedule.id} to check pipeline run results and logs.'
+            f'Open http://localhost:6789/pipelines/test_pipeline/runs/'
+            f'{pipeline_run.id} to check pipeline run results and logs.'
+        )
+        mock_send_slack.assert_called_once_with(
+            notification_config.slack_config,
+            message,
+        )
+
+    @patch('mage_ai.orchestration.notification.sender.send_slack_message')
+    @patch('mage_ai.orchestration.notification.sender.send_email')
+    def test_send_pipeline_run_failure_message_with_custom_template(
+        self,
+        mock_send_email,
+        mock_send_slack,
+    ):
+        notification_config = NotificationConfig.load(
+            config=SLACK_NOTIFICATION_CONFIG_WITH_CUSTOM_TEMPLATE)
+        sender = NotificationSender(config=notification_config)
+        pipeline_run = self.__class__.pipeline_run
+        sender.send_pipeline_run_failure_message(self.__class__.pipeline, pipeline_run)
+        self.assertEqual(mock_send_email.call_count, 0)
+        message = (
+            'Failed to execute pipeline http://localhost:6789/pipelines/test_pipeline/runs/'
+            f'{pipeline_run.id}. Pipeline uuid: test_pipeline. '
+            f'Trigger name: {pipeline_run.pipeline_schedule.name}.'
         )
         mock_send_slack.assert_called_once_with(
             notification_config.slack_config,


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
This PR makes the following changes
* Personalize notification messages
* Update the url to pipeline run url instead of trigger url in the default message
* Update the BaseConfig to support parsing nested dataclass

Example config in project's metadata.yaml
```
notification_config:
  slack_config:
    webhook_url: "{{ env_var('MAGE_SLACK_WEBHOOK_URL') }}"
  message_templates:
    failure:
      details: >
        Failure to execute pipeline {pipeline_run_url}.
        Pipeline uuid: {pipeline_uuid}. Trigger name: {pipeline_schedule_name}.
        Test custom message."
```

# Tests
<!-- How did you test your change? -->
added unit test
tested locally
<img width="608" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/8a7a1b80-4b0b-41d1-898d-c3ab225b6131">


cc:
<!-- Optionally mention someone to let them know about this pull request -->
