### PR TITLE
[xy] Fix file upload.

### DIFF
--- a/mage_ai/data_preparation/models/file.py
+++ b/mage_ai/data_preparation/models/file.py
@@ -1,9 +1,11 @@
+import os
 from datetime import datetime
+from typing import Dict, List, Tuple
+
+import aiofiles
+
 from mage_ai.data_preparation.models.errors import FileExistsError
 from mage_ai.data_preparation.repo_manager import get_repo_path
-from typing import Dict, List, Tuple
-import aiofiles
-import os
 
 FILE_VERSIONS_DIR = '.file_versions'
 BLACKLISTED_DIRS = frozenset([
@@ -183,7 +185,7 @@ class File:
                 self.create_parent_directories(file_path)
 
             write_type = 'wb' if content and type(content) is bytes else 'w'
-            yield file_path, write_type, content
+            yield file_path, write_type
 
     @classmethod
     def write(
@@ -196,7 +198,7 @@ class File:
         file_version_only: bool = False,
         overwrite: bool = True,
     ) -> None:
-        for file_path, write_type, content in self.write_preprocess(
+        for file_path, write_type in self.write_preprocess(
             repo_path,
             dir_path,
             filename,
@@ -205,7 +207,12 @@ class File:
             file_version_only=file_version_only,
             overwrite=overwrite,
         ):
-            with open(file_path, write_type, encoding='utf-8') as f:
+            kwargs = dict(
+                mode=write_type,
+            )
+            if write_type != 'wb':
+                kwargs['encoding'] = 'utf-8'
+            with open(file_path, **kwargs) as f:
                 if content:
                     f.write(content)
         self.validate_content(dir_path, filename, content)
@@ -221,7 +228,7 @@ class File:
         file_version_only: bool = False,
         overwrite: bool = True,
     ) -> None:
-        for file_path, write_type, content in self.write_preprocess(
+        for file_path, write_type in self.write_preprocess(
             repo_path,
             dir_path,
             filename,
@@ -230,7 +237,12 @@ class File:
             file_version_only=file_version_only,
             overwrite=overwrite,
         ):
-            async with aiofiles.open(file_path, mode=write_type, encoding='utf-8') as fp:
+            kwargs = dict(
+                mode=write_type,
+            )
+            if write_type != 'wb':
+                kwargs['encoding'] = 'utf-8'
+            async with aiofiles.open(file_path, **kwargs) as fp:
                 await fp.write(content)
 
     def exists(self) -> bool:


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Fix file upload. If write_type is `wb`, don't set encoding param in the file open method.

```
Traceback (most recent call last): File "/usr/local/lib/python3.10/site-packages/tornado/web.py", line 1704, in _execute result = await result
File "/usr/local/lib/python3.10/site-packages/mage_ai/server/api/v1.py", line 64, in post return await execute_operation(self, resource)
File "/usr/local/lib/python3.10/site-packages/mage_ai/api/views.py", line 66, in execute_operation raise err
File "/usr/local/lib/python3.10/site-packages/mage_ai/api/views.py", line 44, in execute_operation response = await BaseOperation(
File "/usr/local/lib/python3.10/site-packages/mage_ai/api/operations/base.py", line 60, in execute result = await self.__executed_result()
File "/usr/local/lib/python3.10/site-packages/mage_ai/api/operations/base.py", line 138, in __executed_result return await self.__create_or_index()
File "/usr/local/lib/python3.10/site-packages/mage_ai/api/operations/base.py", line 154, in __create_or_index return await self.__resource_class().process_create(
File "/usr/local/lib/python3.10/site-packages/mage_ai/api/resources/BaseResource.py", line 157, in process_create raise err 
File "/usr/local/lib/python3.10/site-packages/mage_ai/api/resources/BaseResource.py", line 141, in process_create res = self.create(payload, user, **merge_dict(kwargs, {
File "/usr/local/lib/python3.10/site-packages/mage_ai/orchestration/db/__init__.py", line 82, in func_with_rollback return func(*args, **kwargs)
File "/usr/local/lib/python3.10/site-packages/mage_ai/api/resources/FileResource.py", line 36, in create file = File.create(
File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/models/file.py", line 66, in create self.write(
File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/models/file.py", line 208, in write with open(file_path, write_type, encoding='utf-8') as f: ValueError: binary mode doesn't take an encoding argument
```

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
