### PR TITLE
[xh]Add OracleDB Destination

### DIFF
--- a/mage_ai/data_integrations/destinations/constants.py
+++ b/mage_ai/data_integrations/destinations/constants.py
@@ -9,6 +9,7 @@ DESTINATIONS = [
         uuid='mssql',
     ),
     dict(name='MySQL'),
+    dict(name='OracleDB'),
     dict(name='PostgreSQL'),
     dict(name='Redshift'),
     dict(name='Snowflake'),

--- a/mage_integrations/mage_integrations/destinations/oracledb/README.md
+++ b/mage_integrations/mage_integrations/destinations/oracledb/README.md
@@ -1,0 +1,17 @@
+# OracleDB
+
+## Config
+
+You must enter the following credentials when configuring Oracle DB destination:
+
+| Key | Description | Sample value
+| --- | --- | --- |
+| `host` | OracleDB host. | `oracledb.example.com` |
+| `port` | OracleDB exported host. | `1521`
+ (default value) |
+| `service` | Listener service runs on the database server listing for client connection. | `xepdb1` |
+| `password` | Password of the user. | `xyz123` |
+| `user` | User name with connection and query access to db. | `xyz123` |
+| `database` | The database you want to create the table and export data. | `xyz123` |
+
+<br />

--- a/mage_integrations/mage_integrations/destinations/oracledb/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/oracledb/__init__.py
@@ -1,0 +1,216 @@
+import re
+from typing import Dict, List
+
+from mage_integrations.connections.oracledb import OracleDB as OracleDBConnection
+from mage_integrations.destinations.constants import (
+    COLUMN_TYPE_OBJECT,
+    UNIQUE_CONFLICT_METHOD_UPDATE,
+)
+from mage_integrations.destinations.oracledb.utils import (
+    build_alter_table_command,
+    build_create_table_command,
+    clean_column_name,
+    convert_column_type,
+)
+from mage_integrations.destinations.sql.base import Destination, main
+from mage_integrations.destinations.sql.utils import (
+    build_insert_command,
+    column_type_mapping,
+)
+
+
+class OracleDB(Destination):
+    @property
+    def host(self) -> str:
+        return self.config['host']
+
+    @property
+    def port(self) -> str:
+        return self.config['port']
+
+    @property
+    def service(self) -> str:
+        return self.config['service']
+
+    @property
+    def user(self) -> str:
+        return self.config['user']
+
+    @property
+    def password(self) -> str:
+        return self.config['password']
+
+    @property
+    def database(self) -> str:
+        return self.config['database']
+
+    def build_connection(self) -> OracleDBConnection:
+        return OracleDBConnection(
+            host=self.host, password=self.password,
+            user=self.user, port=self.port, service=self.service)
+
+    def build_create_schema_commands(
+        self,
+        database_name: str,
+        schema_name: str,
+    ) -> List[str]:
+        # "create schema" in oracle db has nothing to do with schema creation.
+        # While a "schema" is a user ID and a collection of the users tables and indexes.
+        return [
+            'SELECT name FROM v$database',
+        ]
+
+    def test_connection(self) -> None:
+        conn = self.build_connection().build_connection()
+        cursor = conn.cursor()
+        try:
+            cursor.execute("""SELECT name FROM v$database""")
+        except Exception as exc:
+            self.logger.error(f"test_connection exception: {exc}")
+            raise exc
+        return
+
+    def build_create_table_commands(
+        self,
+        schema: Dict,
+        schema_name: str,
+        stream: str,
+        table_name: str,
+        database_name: str = None,
+        unique_constraints: List[str] = None,
+    ) -> List[str]:
+        return [
+            build_create_table_command(
+                column_type_mapping=column_type_mapping(
+                    schema,
+                    convert_column_type,
+                    lambda item_type_converted: 'VARRAY(5)',
+                ),
+                columns=schema['properties'].keys(),
+                full_table_name=f'{table_name}',
+                key_properties=self.key_properties.get(stream),
+                schema=schema,
+                unique_constraints=unique_constraints,
+            ),
+        ]
+
+    def build_alter_table_commands(
+        self,
+        schema: Dict,
+        schema_name: str,
+        stream: str,
+        table_name: str,
+        database_name: str = None,
+        unique_constraints: List[str] = None,
+    ) -> List[str]:
+        results = self.build_connection().load(f"""
+SELECT
+     column_name
+    , data_type
+FROM USER_TAB_COLUMNS
+WHERE TABLE_NAME = '{table_name.upper()}'
+""")
+        current_columns = [r[0].lower() for r in results]
+        schema_columns = schema['properties'].keys()
+        new_columns = [c for c in schema_columns
+                       if clean_column_name(c, handle_leading_underscore=False).lower()
+                       not in current_columns]
+
+        if not new_columns:
+            return []
+        return [
+            build_alter_table_command(
+                column_type_mapping=column_type_mapping(
+                    schema,
+                    convert_column_type,
+                    lambda item_type_converted: 'TEXT',
+                ),
+                columns=new_columns,
+                full_table_name=f'{table_name}',
+            ),
+        ]
+
+    def build_insert_commands(
+        self,
+        records: List[Dict],
+        schema: Dict,
+        schema_name: str,
+        table_name: str,
+        database_name: str = None,
+        unique_conflict_method: str = None,
+        unique_constraints: List[str] = None,
+    ) -> List[str]:
+        columns = list(schema['properties'].keys())
+        insert_columns, insert_values = build_insert_command(
+            column_type_mapping=column_type_mapping(
+                schema,
+                convert_column_type,
+                lambda item_type_converted: 'LONGTEXT',
+            ),
+            columns=columns,
+            records=records,
+            string_parse_func=lambda x, y: x.replace("'", "''").replace('\\', '\\\\')
+            if COLUMN_TYPE_OBJECT == y['type'] else x,
+        )
+        insert_columns = ', '.join([clean_column_name(col) for col in insert_columns])
+        insert_into = f'INTO {table_name} ({insert_columns})'
+        commands = []
+        columns_cleaned = [clean_column_name(col) for col in columns]
+
+        for insert_value in insert_values:
+            if unique_constraints and unique_conflict_method:
+                if UNIQUE_CONFLICT_METHOD_UPDATE == unique_conflict_method:
+                    # Build update command
+                    insert_value_without_left_parenthesis = re.sub(r"^\(", "", insert_value)
+                    insert_value_strip = re.sub(r"\)$", "", insert_value_without_left_parenthesis)
+                    updated_values = insert_value_strip.split(',')
+                    updated_command = ', '.join([f'{col} = {updated_values[idx].strip()}'
+                                                for idx, col in enumerate(columns_cleaned)])
+                    update_command_constraint = ""
+                    for idx, column in enumerate(columns):
+                        if column in unique_constraints:
+                            if len(update_command_constraint) == 0:
+                                update_command_constraint += \
+                                    f'{clean_column_name(column)} = {updated_values[idx]}'
+                            else:
+                                update_command_constraint += \
+                                    f'AND {clean_column_name(column)} = {updated_values[idx]}'
+
+                    insert_command = f'''
+BEGIN
+    INSERT {insert_into} VALUES {insert_value};
+EXCEPTION
+    WHEN DUP_VAL_ON_INDEX
+    THEN
+        UPDATE {table_name}
+        SET {updated_command}
+        WHERE {update_command_constraint};
+    WHEN OTHERS THEN
+        RAISE;
+END;
+'''
+            else:
+                # When there is no unique_constraints
+                insert_command = f'INSERT {insert_into} VALUES {insert_value}'
+            commands.append(insert_command)
+
+        return commands
+
+    def does_table_exist(
+        self,
+        schema_name: str,
+        table_name: str,
+        database_name: str = None,
+    ) -> bool:
+        connection = self.build_connection().build_connection()
+        cursor = connection.cursor()
+        cursor.execute(
+            f'SELECT COUNT(*) FROM user_tables WHERE table_name = \'{table_name.upper()}\'')
+        (number_of_rows,) = cursor.fetchone()
+        if number_of_rows > 0:
+            return True
+        return False
+
+
+if __name__ == '__main__':
+    main(OracleDB)

--- a/mage_integrations/mage_integrations/destinations/oracledb/templates/config.json
+++ b/mage_integrations/mage_integrations/destinations/oracledb/templates/config.json
@@ -1,0 +1,9 @@
+{
+    "host": "",
+    "port": "1521",
+    "service": "",
+    "password": "",
+    "user": "",
+    "database": ""
+}
+

--- a/mage_integrations/mage_integrations/destinations/oracledb/utils.py
+++ b/mage_integrations/mage_integrations/destinations/oracledb/utils.py
@@ -1,0 +1,111 @@
+from typing import Dict, List
+
+import singer
+
+from mage_integrations.destinations.sql.constants import SQL_RESERVED_WORDS
+from mage_integrations.destinations.utils import (
+    clean_column_name as clean_column_name_orig,
+)
+from mage_integrations.sources.constants import (
+    COLUMN_FORMAT_DATETIME,
+    COLUMN_TYPE_BOOLEAN,
+    COLUMN_TYPE_INTEGER,
+    COLUMN_TYPE_NULL,
+    COLUMN_TYPE_NUMBER,
+    COLUMN_TYPE_OBJECT,
+    COLUMN_TYPE_STRING,
+)
+
+LOGGER = singer.get_logger()
+
+
+def clean_column_name(col, lower_case: bool = True, handle_leading_underscore: bool = True):
+    col_new = clean_column_name_orig(col, lower_case=lower_case)
+    if handle_leading_underscore and col_new.startswith('_'):
+        # Oracle does not allow column names to start with an underscore,
+        # so we need to wrap it with quotes.
+        col_new = f'"{col_new}"'
+    if col_new.upper() in (SQL_RESERVED_WORDS):
+        if handle_leading_underscore:
+            col_new = f'"_{col_new}"'
+        else:
+            col_new = f'_{col_new}'
+    return col_new
+
+
+def build_alter_table_command(
+    column_type_mapping: Dict,
+    columns: List[str],
+    full_table_name: str,
+    column_identifier: str = '',
+) -> str:
+    if not columns:
+        return None
+
+    columns_and_types = [
+        f"{column_identifier}{clean_column_name(col)}{column_identifier}" +
+        f" {column_type_mapping[col]['type_converted']}" for col
+        in columns
+    ]
+    # TODO: support add new unique constraints
+    return f"ALTER TABLE {full_table_name} ADD ({', '.join(columns_and_types)})"
+
+
+def build_create_table_command(
+    column_type_mapping: Dict,
+    columns: List[str],
+    full_table_name: str,
+    key_properties: List[str],
+    schema: Dict,
+    unique_constraints: List[str] = None,
+    use_lowercase: bool = True,
+) -> str:
+    columns_and_types = []
+    column_properties = schema['properties']
+
+    for col in columns:
+        column_name = clean_column_name(col, lower_case=use_lowercase)
+        column_type = column_type_mapping[col]['type_converted']
+        if COLUMN_TYPE_INTEGER == column_type_mapping[col]['type']:
+            column_type = 'INTEGER'
+
+        column_props = []
+        if COLUMN_TYPE_NULL not in column_properties.get(col).get('type', []):
+            column_props.append('NOT NULL')
+
+        col_statement = f'{column_name} {column_type}'
+        if len(column_props) >= 1:
+            col_statement = f"{col_statement} {' '.join(column_props)}"
+        columns_and_types.append(col_statement)
+
+    if unique_constraints:
+        unique_constraints = [clean_column_name(col, lower_case=use_lowercase)
+                              for col in unique_constraints]
+        index_name = '_'.join([
+            clean_column_name(full_table_name, lower_case=use_lowercase),
+        ] + unique_constraints)
+        index_name = f'unique{index_name}'[:64]
+        columns_and_types.append(f"CONSTRAINT {index_name} Unique({', '.join(unique_constraints)})")
+
+    if key_properties and len(key_properties) >= 1:
+        col = clean_column_name(key_properties[0], lower_case=use_lowercase)
+        columns_and_types.append(f'PRIMARY KEY ({col})')
+
+    return f"CREATE TABLE {full_table_name} ({', '.join(columns_and_types)})"
+
+
+def convert_column_type(column_type: str, column_settings: Dict, **kwargs) -> str:
+    if COLUMN_TYPE_BOOLEAN == column_type:
+        return 'CHAR(52)'
+    elif COLUMN_TYPE_INTEGER == column_type:
+        return 'NUMBER'
+    elif COLUMN_TYPE_NUMBER == column_type:
+        return 'NUMBER'
+    elif COLUMN_TYPE_OBJECT == column_type:
+        return 'NCLOB'
+    elif COLUMN_TYPE_STRING == column_type:
+        if COLUMN_FORMAT_DATETIME == column_settings.get('format'):
+            # Twice as long as the number of characters in ISO date format
+            return 'CHAR(52)'
+
+    return 'CHAR(255)'

--- a/mage_integrations/mage_integrations/destinations/oracledb/utils.py
+++ b/mage_integrations/mage_integrations/destinations/oracledb/utils.py
@@ -1,7 +1,5 @@
 from typing import Dict, List
 
-import singer
-
 from mage_integrations.destinations.sql.constants import SQL_RESERVED_WORDS
 from mage_integrations.destinations.utils import (
     clean_column_name as clean_column_name_orig,
@@ -15,8 +13,6 @@ from mage_integrations.sources.constants import (
     COLUMN_TYPE_OBJECT,
     COLUMN_TYPE_STRING,
 )
-
-LOGGER = singer.get_logger()
 
 
 def clean_column_name(col, lower_case: bool = True, handle_leading_underscore: bool = True):
@@ -49,6 +45,12 @@ def build_alter_table_command(
     ]
     # TODO: support add new unique constraints
     return f"ALTER TABLE {full_table_name} ADD ({', '.join(columns_and_types)})"
+
+
+def convert_column_to_type(value, column_type) -> str:
+    if column_type == 'NCLOB':
+        return f"to_nclob('{value}')"
+    return f"CAST('{value}' AS {column_type})"
 
 
 def build_create_table_command(

--- a/mage_integrations/mage_integrations/sources/oracledb/__init__.py
+++ b/mage_integrations/mage_integrations/sources/oracledb/__init__.py
@@ -26,6 +26,9 @@ class OracleDB(Source):
     def password(self) -> str:
         return self.config['password']
 
+    def update_column_names(self, columns: List[str]) -> List[str]:
+        return list(map(lambda column: f'"{column}"', columns))
+
     def _limit_query_string(self, limit, offset):
         return f'OFFSET {offset} ROWS FETCH NEXT {limit} ROWS ONLY'
 


### PR DESCRIPTION

# Tests
Tested with S3 source, destination is oracle DB.

Scenarios tested:
1. It can create table and export data.
2. If table already exists, it can export data directly.
3. If table schema is different, it can alter table
4. If insert data with unique keys or not and can update records if duplicated unique key records found with SQL/PL command.

Screenshot of the created table, exported records:
![create table and generate output](https://github.com/mage-ai/mage-ai/assets/5386254/a9db0e7b-b74b-41e4-b872-375557b7ef6b)

Screenshot of the alter table schema:
![alter_table](https://github.com/mage-ai/mage-ai/assets/5386254/4a418d25-29be-447c-8618-4d92ab7152b9)


cc:
@wangxiaoyou1993 @dy46 

