### PR TITLE
Gjvv fix mssql

### DIFF
--- a/mage_ai/io/mssql.py
+++ b/mage_ai/io/mssql.py
@@ -65,6 +65,16 @@ class MSSQL(BaseSQL):
             )
             self._ctx = pyodbc.connect(connection_string)
 
+    def build_create_schema_command(
+        self,
+        schema_name: str
+    ) -> str:
+        return '\n'.join([
+                'IF NOT EXISTS (',
+                f'SELECT * FROM information_schema.schemata WHERE schema_name = \'{schema_name}\')',
+                f'BEGIN EXEC(\'CREATE SCHEMA {schema_name}\') END'
+            ])
+
     def build_create_table_as_command(
         self,
         table_name: str,
@@ -79,7 +89,7 @@ class MSSQL(BaseSQL):
         with self.conn.cursor() as cur:
             cur.execute('\n'.join([
                 'SELECT TOP 1 * FROM information_schema.tables ',
-                f'WHERE table_name = \'{table_name}\'',
+                f'WHERE table_schema = \'{schema_name}\' AND table_name = \'{table_name}\'',
             ]))
             return len(cur.fetchall()) >= 1
 

--- a/mage_ai/io/sql.py
+++ b/mage_ai/io/sql.py
@@ -39,6 +39,12 @@ class BaseSQL(BaseSQLConnection):
         """
         raise Exception('Subclasses must override this method.')
 
+    def build_create_schema_command(
+        self,
+        schema_name: str
+    ) -> str:
+        return f'CREATE SCHEMA IF NOT EXISTS {schema_name};'
+
     def build_create_table_command(
         self,
         dtypes: Mapping[str, str],
@@ -256,7 +262,8 @@ class BaseSQL(BaseSQLConnection):
 
             with self.conn.cursor() as cur:
                 if schema_name:
-                    cur.execute(f'CREATE SCHEMA IF NOT EXISTS {schema_name};')
+                    query = self.build_create_schema_command(schema_name)
+                    cur.execute(query)
 
                 should_create_table = not table_exists
 


### PR DESCRIPTION
# Summary
The command CREATE SCHEMA IF NOT EXISTS is not supported by MSSQL. Provided a default command in BaseSQL -> build_create_schema_command, and an overridden implementation in MSSQL -> build_create_schema_command containing compatible syntax.

# Tests
Called `build_create_schema_command('my_schema')` in REPL and executed returned string on Azure Sql database.

cc:
<!-- Optionally mention someone to let them know about this pull request -->
