### PR TITLE
[jk] Allow slashes in block_uuid when downloading block output

### DIFF
--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -162,7 +162,7 @@ def make_app():
         # Download block output
         (
             r'/api/pipelines/(?P<pipeline_uuid>\w+)/block_outputs/'
-            r'(?P<block_uuid>[\w\%2f\.]+)/downloads',
+            r'(?P<block_uuid>[\w\%2f\.(/.*)?]+)/downloads',
             ApiDownloadHandler,
         ),
 


### PR DESCRIPTION
# Summary
- The regex for the block output download endpoint would not capture block_uuids with slashes in them, so this fixes that.

# Tests
- Added a nested block with a `/` in the block_uuid and successfully downloaded block output.
![downlaod nested block output](https://github.com/mage-ai/mage-ai/assets/78053898/f627b7ae-c2f8-48bb-84a1-e06ed128643e)

