### PR TITLE
Couchbase: Add Certificate Authentication

### DIFF
--- a/mage_integrations/mage_integrations/connections/couchbase/__init__.py
+++ b/mage_integrations/mage_integrations/connections/couchbase/__init__.py
@@ -1,4 +1,4 @@
-from couchbase.auth import PasswordAuthenticator
+from couchbase.auth import CertificateAuthenticator, PasswordAuthenticator
 from couchbase.cluster import Cluster
 from couchbase.options import ClusterOptions
 from mage_integrations.connections.base import Connection
@@ -10,18 +10,42 @@ class Couchbase(Connection):
         bucket: str,
         scope: str,
         connection_string: str,
-        password: str,
-        username: str,
+        password: Optional[str],
+        username: Optional[str],
+        cert_path: Optional[str],
+        trust_store_path: Optional[str],
+        key_path: Optional[str]
     ):
         super().__init__()
+
+        if password is not None:
+            assert username is not None
+            assert cert_path is None
+            assert trust_store_path is None
+            assert key_path is None
+        else:
+            assert username is None
+            assert cert_path is not None
+            assert trust_store_path is not None
+            assert key_path is not None
+
+
         self.bucket = bucket
         self.scope = scope
         self.connection_string = connection_string
         self.password = password
         self.username = username
+        self.cert_path = cert_path
+        self.trust_store_path = trust_store_path
+        self.key_path = key_path
 
     def get_bucket(self):
-        auth = PasswordAuthenticator(self.username, self.password)
+        if self.username is not None:
+            auth = PasswordAuthenticator(self.username, self.password)
+        else:
+            auth_dict = dict(cert_path=self.cert_path, trust_store_path=self.trust_store_path, key_path=self.key_path)
+            auth = CertificateAuthenticator(auth_dict)
+
         cluster = Cluster(self.connection_string, ClusterOptions(auth))
         return cluster.bucket(self.bucket)
 

--- a/mage_integrations/mage_integrations/sources/couchbase/README.md
+++ b/mage_integrations/mage_integrations/sources/couchbase/README.md
@@ -13,6 +13,9 @@ You must enter the following credentials when configuring this source:
 | `connection_string` | Connection string for your Couchbase database. For more information see [here](https://docs.couchbase.com/kotlin-sdk/current/howtos/connecting.html#connection-string-scheme). | `couchbase://my_instance.cloud.couchbase.com` |
 | `username` | Name of the user that will access the database (must have permissions to read from specified bucket and scope) | `username` |
 | `password` | Password for the user to access the database.  | `password` |
+| `cert_path` | Path to the certificate trust store public key accessible to the SDK.  | `cert_path` |
+| `trust_store_path` | Path to the certificate trust store public key on the server.  | `trust_store_path` |
+| `key_path` | Path to the private key accessible to the SDK.  | `key_path` |
 | `bucket` | Name of Couchbase bucket that contains your data | `my_bucket` |
 | `scope` | Name of Couchbase scope that contains your data. Only collections within this scope will be available in Mage. | `my_scope` |
 | `strategy` | (Optional) See below for more info. | `infer` |

--- a/mage_integrations/mage_integrations/sources/couchbase/__init__.py
+++ b/mage_integrations/mage_integrations/sources/couchbase/__init__.py
@@ -32,7 +32,10 @@ class Couchbase(Source):
             scope=self.config['scope'],
             connection_string=self.config['connection_string'],
             password=self.config['password'],
-            username=self.config['username']
+            username=self.config['username'],
+            cert_path=self.config['cert_path'],
+            trust_store_path=self.config['trust_store_path'],
+            key_path=self.config['key_path'],
         )
 
     def discover(self, streams: List[str] = None) -> Catalog:
@@ -42,21 +45,21 @@ class Couchbase(Source):
         catalog_entries = []
         for stream_id in collection_names:
             properties = dict()
-            
+
             infer_query = f"""
 INFER `{stream_id}`
 WITH {{"sample_size": 1000, "similarity_metric": 0.4, "dictionary_threshold": 3}}
             """
 
             infer_result = connection.load(infer_query)[0]
-            
+
             def get_infer_result_doc_count(result):
                 props = result.get('properties', {})
                 doc_count = props.get('#docs', 0)
                 if type(doc_count) is list:
                     doc_count = sum(doc_count)
                 return doc_count
-            
+
             strategy = self.config.get('strategy')
             if strategy == SchemaStrategy.INFER or \
                     (strategy is None and len(infer_result) == 1):
@@ -96,7 +99,7 @@ WITH {{"sample_size": 1000, "similarity_metric": 0.4, "dictionary_threshold": 3}
         column_type = dtype
         if dtype == 'missing':
             column_type = COLUMN_TYPE_STRING
-        
+
         return column_type
 
     def _build_comparison_statement(

--- a/mage_integrations/mage_integrations/sources/couchbase/templates/config.json
+++ b/mage_integrations/mage_integrations/sources/couchbase/templates/config.json
@@ -3,5 +3,8 @@
   "username": "",
   "password": "",
   "bucket": "",
-  "scope": ""
+  "scope": "",
+  "cert_path": "",
+  "trust_store_path": "",
+  "key_path": ""
 }


### PR DESCRIPTION
Fixes https://github.com/mage-ai/mage-ai/issues/2796

# Summary

Couchbase's Python API supports credential authentication [here](https://docs.couchbase.com/python-sdk/current/howtos/sdk-authentication.html). This modifies the Couchbase template in Mage to allow for credential authentication in place of username and passwords.

This should allow organizations managing Couchbase Server using VPNs to use the connector. 

# Tests

Code review. I'm not sure how to test this. 

cc:

@thomaschung408 
@wangxiaoyou1993 
