### PR TITLE
[hw] Fix an issue with setAll parameter passing

### DIFF
--- a/mage_ai/services/spark/spark.py
+++ b/mage_ai/services/spark/spark.py
@@ -61,14 +61,13 @@ def get_spark_session(spark_config: SparkConfig):
             if spark_config.spark_home:
                 conf.setSparkHome(spark_config.spark_home)
             if spark_config.executor_env:
-                list_kv_pairs = []
-                for key, value in spark_config.executor_env.items():
-                    list_kv_pairs.append((key, value))
-                conf.setExecutorEnv(key=None, value=None, pairs=list_kv_pairs)
+                env_kv_pairs = list(spark_config.executor_env.items())
+                conf.setExecutorEnv(key=None, value=None, pairs=env_kv_pairs)
             if spark_config.spark_jars:
                 conf.set('spark.jars', ','.join(spark_config.spark_jars))
             if spark_config.others:
-                conf.setAll(spark_config.others)
+                others_kv_pairs = list(spark_config.others.items())
+                conf.setAll(others_kv_pairs)
 
             return SparkSession.builder.config(conf=conf).getOrCreate()
     else:


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

There was a bug related to `setAll`: the parameter needs to be a list of key-value tuples.

# Tests
<!-- How did you test your change? -->
Tested in a local enviornment.
cc:
<!-- Optionally mention someone to let them know about this pull request -->
@dy46 @wangxiaoyou1993 