### PR TITLE
[xy] Fix copy output in streaming pipeline.

### DIFF
--- a/mage_ai/data_preparation/executors/streaming_pipeline_executor.py
+++ b/mage_ai/data_preparation/executors/streaming_pipeline_executor.py
@@ -119,13 +119,26 @@ class StreamingPipelineExecutor(PipelineExecutor):
                 ),
             )
 
+        def __deepcopy(data):
+            if data is None:
+                return data
+            if type(data) is list:
+                data_copy = []
+                for item in data:
+                    data_copy.append(__deepcopy(item))
+                return data_copy
+            try:
+                return copy.deepcopy(data)
+            except Exception:
+                return copy.copy(data)
+
         def handle_batch_events_recursively(curr_block, outputs_by_block: Dict, **kwargs):
             curr_block_output = outputs_by_block[curr_block.uuid]
             for downstream_block in curr_block.downstream_blocks:
                 if downstream_block.type == BlockType.TRANSFORMER:
                     execute_block_kwargs = dict(
                         global_vars=kwargs,
-                        input_args=[copy.deepcopy(curr_block_output)],
+                        input_args=[__deepcopy(curr_block_output)],
                         logger=self.logger,
                     )
                     if build_block_output_stdout:
@@ -137,7 +150,7 @@ class StreamingPipelineExecutor(PipelineExecutor):
                     )['output']
                 elif downstream_block.type == BlockType.DATA_EXPORTER:
                     sinks_by_uuid[downstream_block.uuid].batch_write(
-                        copy.deepcopy(curr_block_output))
+                        __deepcopy(curr_block_output))
                 if downstream_block.downstream_blocks:
                     handle_batch_events_recursively(
                         downstream_block,


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Fix copy output in streaming pipeline. Catch deepcopy error and fallback to copy method.

`TypeError: cannot pickle '_thread.lock' object in the deepcopy from the handle_batch_events_recursively`

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
