### PR TITLE
[jk] Add commented-out method for changing Monaco Editor CDN if necessary

### DIFF
--- a/mage_ai/frontend/components/CodeEditor/index.tsx
+++ b/mage_ai/frontend/components/CodeEditor/index.tsx
@@ -5,7 +5,18 @@ import React, {
   useState,
 } from 'react';
 import * as ReactDOM from 'react-dom';
-import Editor from '@monaco-editor/react';
+import Editor, { loader } from '@monaco-editor/react';
+
+/*
+ * If https://cdn.jsdelivr.net (the default CDN) is down, uncomment the
+ * loader.config method call below to use a different CDN for loading
+ * the Monaco Editor.
+ */
+// loader.config({
+//   paths: {
+//     vs: 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.33.0/min/vs',
+//   },
+// });
 
 import BlockType, { BlockTypeEnum } from '@interfaces/BlockType';
 import Text from '@oracle/elements/Text';


### PR DESCRIPTION
# Summary
- There was a CDN outage for the jsdeliver.net default CDN that Monaco Editor uses, as reported in this Github issue https://github.com/mage-ai/mage-ai/issues/2776. There no longer appears to be an outage, and upon testing, the Mage editor (which uses Monaco Editor) currently loads fine.
- However, for posterity if a future CDN outage causes an issue, we can uncomment the code from this PR to quickly load the Monaco Editor from a different CDN, but for now, that doesn't seem necessary.

# Tests
Default network request for loading Monaco Editor (cdn.jsdelivr.net):
<img width="1798" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/ec7eed36-3597-4b3a-a4f2-1219a14635ef">

Network request for loading Monaco Editor after uncommenting out call to `loader.config` (cdnjs.cloudflare.com):
<img width="1799" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/964a759b-65bf-46a9-afba-af163d44ca27">

The jsdelivr.net CDN was not down as of 6/19/23 11:51 AM PDT:
<img width="538" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/c06aec97-91fe-42c5-8256-b32e21e980c5">
