### PR TITLE
[jk] Allow JWT_SECRET to be modified via env var

### DIFF
--- a/mage_ai/authentication/oauth2.py
+++ b/mage_ai/authentication/oauth2.py
@@ -2,10 +2,11 @@ from datetime import datetime, timedelta
 from mage_ai.orchestration.db.models.oauth import Oauth2AccessToken, Oauth2Application, User
 from typing import Dict
 import jwt
+import os
 import secrets
 
 JWT_ALGORITHM = 'HS256'
-JWT_SECRET = 'materia'
+JWT_SECRET = os.getenv('JWT_SECRET', 'materia')
 
 
 def generate_access_token(user: User, application: Oauth2Application = None) -> Oauth2AccessToken:

--- a/mage_ai/frontend/api/utils/AuthToken.ts
+++ b/mage_ai/frontend/api/utils/AuthToken.ts
@@ -72,7 +72,7 @@ export default class AuthToken {
         await redirectToUrl('/sign-in');
       }
     } catch {
-      console.log('Sign out error.')
+      console.log('Sign out error.');
     }
   }
 


### PR DESCRIPTION
# Summary
- The `JWT_SECRET` for encoding and decoding access tokens is currently hardcoded, so PR allows users to update it through an environment variable.

# Tests
- Built Docker container using different `JWT_SECRET` and confirmed the value of `JWT_SECRET` had changed.
