### PR TITLE
[jk] Add dbt block fixes

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -430,6 +430,7 @@ class Block:
             if BlockType.DBT == block.type and BlockLanguage.SQL == block.language:
                 arr = add_blocks_upstream_from_refs(block)
                 upstream_block_uuids += [b.uuid for b in arr]
+                upstream_block_uuids = [*set(upstream_block_uuids)]     # Remove duplicates
                 priority_final = priority if len(upstream_block_uuids) == 0 else None
             else:
                 priority_final = priority

--- a/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
@@ -194,14 +194,21 @@ def add_blocks_upstream_from_refs(
             )
             added_blocks += new_block.upstream_blocks
         else:
-            new_block = block.__class__.create(
+            existing_block = block.pipeline.get_block(
                 uuid,
                 block.type,
-                get_repo_path(),
-                configuration=configuration,
-                language=block.language,
-                pipeline=block.pipeline,
             )
+            if existing_block is None:
+                new_block = block.__class__.create(
+                    uuid,
+                    block.type,
+                    get_repo_path(),
+                    configuration=configuration,
+                    language=block.language,
+                    pipeline=block.pipeline,
+                )
+            else:
+                new_block = existing_block
 
         added_blocks.append(new_block)
         current_upstream_blocks.append(new_block)

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -1003,7 +1003,7 @@ function CodeBlock({
         // @ts-ignore
         setAnyInputFocused(true);
         updateDataProviderConfig({
-          [CONFIG_KEY_LIMIT]: e.target.value,
+          [CONFIG_KEY_LIMIT]: +e.target.value,
         });
         e.preventDefault();
       }}


### PR DESCRIPTION
# Summary (fixed these bugs):
- Running dbt block preview would sometimes not use sample limit amount.
- Existing upstream block would get overwritten when adding a dbt block with a ref to that existing upstream block.
- Duplicate upstream block added when new block contains upstream block ref and upstream block already exists. 

# Tests
Temporarily changed default sample limit to `1` and previewed output without adjusting the sample limit:
![add dbt block 3](https://github.com/mage-ai/mage-ai/assets/78053898/6adff7eb-921d-4326-a791-24edc28d31ab)
