### PR TITLE
[jk] Hide duplicate shortcut items in editor context menu

### DIFF
--- a/mage_ai/frontend/components/CodeEditor/index.style.tsx
+++ b/mage_ai/frontend/components/CodeEditor/index.style.tsx
@@ -1,17 +1,34 @@
 import styled from 'styled-components';
 
 import dark from '@oracle/styles/themes/dark';
+import { FONT_FAMILY_REGULAR } from '@oracle/styles/fonts/primary';
 import { UNIT } from '@oracle/styles/units/spacing';
 
 export const NUMBER_OF_BUFFER_LINES = 2;
 export const SINGLE_LINE_HEIGHT = 21;
 
 export const ContainerStyle = styled.div<{
+  hideDuplicateMenuItems?: boolean;
   padding?: boolean;
 }>`
+  font-family: ${FONT_FAMILY_REGULAR};
+
   ${props => props.padding && `
     padding-top: ${UNIT * 2}px;
     background-color: ${(props.theme.background || dark.background).codeTextarea};
+  `}
+
+  ${props => props.hideDuplicateMenuItems && `
+    /*
+     * The (n + 10) assumes a specific number of items in the block editor context
+     * menu. This includes "Run selected block", "Change All Occurrences", "Cut",
+     * "Copy", "Paste", "Command Palette", and 3 dividers. The 10th item from the
+     * bottom and higher are hidden to avoid duplicate shortcut items in the
+     * context menu.
+     */
+    .monaco-menu li.action-item:nth-last-child(n + 10) {
+      display: none;
+    }
   `}
 `;
 

--- a/mage_ai/frontend/components/CodeEditor/index.tsx
+++ b/mage_ai/frontend/components/CodeEditor/index.tsx
@@ -271,6 +271,10 @@ function CodeEditor({
    * if a block originally had 1 upstream dependency but we add an additional dependency
    * and then try to execute the block via editor shortcut, the code execution only includes
    * the initial single upstream dependency because the shortcut's scope doesn't change.
+   *
+   * We don't need to include shortcutsProp in the dependency array because we only want to
+   * re-add the keyboard shortcuts when the upstream or downstream connections change.
+   * Including shortcutsProp in the dependency array may lead to unnecessary re-renders.
    */
   }, [block?.downstream_blocks, block?.upstream_blocks]);
 
@@ -299,6 +303,7 @@ function CodeEditor({
 
   return (
     <ContainerStyle
+      hideDuplicateMenuItems
       padding={padding}
       style={{
         display: mounted ? null : 'none',
@@ -339,6 +344,7 @@ function CodeEditor({
             alwaysConsumeMouseWheel: false,
             vertical: 'hidden',
           },
+          useShadowDOM: false,
           wordBasedSuggestions: false,
           wordWrap: block?.type === BlockTypeEnum.MARKDOWN ? 'on' : 'off',
         }}


### PR DESCRIPTION
# Summary
- There is a `useEffect` statement in the `mage_ai/frontend/components/CodeEditor/index.tsx` file that re-adds the keyboard shortcut for running a selected block, which was required for fixing an upstream dependency issue (see https://github.com/mage-ai/mage-ai/pull/2246). This resulted in there being duplicates of the shortcut item in the code block editor context menu as user ran a block or updated upstream/downstream connections.
- The Monaco Editor doesn't provide a method for removing or clearing keyboard shortcuts, only adding, so this PR hides the duplicate shortcut items in the context menu.

# Tests
Before (after running the block a few times and removing/adding block connections):
<img width="1291" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/ace1625c-e497-4a0f-9c30-f0bd14ff26ec">

After (after following the same steps and running the block a few times and removing/adding block connections):
<img width="1280" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/34ed5405-4a22-488c-9e0a-3f4ed4751100">
