### PR TITLE
[xy] Not require key file for bigquery source and destination.

### DIFF
--- a/mage_integrations/mage_integrations/connections/bigquery/__init__.py
+++ b/mage_integrations/mage_integrations/connections/bigquery/__init__.py
@@ -1,9 +1,10 @@
+from typing import List, Tuple
+
 from google.cloud.bigquery import Client, dbapi
 from google.oauth2 import service_account
+
 from mage_integrations.connections.sql.base import Connection
 from mage_integrations.connections.utils.google import CredentialsInfoType
-from mage_integrations.connections.utils.sql import clean_query
-from typing import List, Tuple
 
 
 class BigQuery(Connection):
@@ -23,11 +24,10 @@ class BigQuery(Connection):
         self.location = location
 
         if self.credentials_info is None:
-            if self.path_to_credentials_json_file is None:
-                raise Exception('No valid credentials provided.')
-            self.credentials_info = service_account.Credentials.from_service_account_file(
-                self.path_to_credentials_json_file,
-            )
+            if self.path_to_credentials_json_file is not None:
+                self.credentials_info = service_account.Credentials.from_service_account_file(
+                    self.path_to_credentials_json_file,
+                )
         self.client = Client(credentials=self.credentials_info, location=self.location)
 
     def build_connection(self):

--- a/mage_integrations/mage_integrations/connections/bigquery/__init__.py
+++ b/mage_integrations/mage_integrations/connections/bigquery/__init__.py
@@ -15,19 +15,15 @@ class BigQuery(Connection):
         location: str = None,
         **kwargs,
     ):
-        if not credentials_info and not path_to_credentials_json_file:
-            raise Exception('BigQuery connection requires credentials_info '
-                            'or path_to_credentials_json_file.')
         super().__init__(**kwargs)
         self.credentials_info = credentials_info
         self.path_to_credentials_json_file = path_to_credentials_json_file
         self.location = location
 
-        if self.credentials_info is None:
-            if self.path_to_credentials_json_file is not None:
-                self.credentials_info = service_account.Credentials.from_service_account_file(
-                    self.path_to_credentials_json_file,
-                )
+        if self.credentials_info is None and self.path_to_credentials_json_file is not None:
+            self.credentials_info = service_account.Credentials.from_service_account_file(
+                self.path_to_credentials_json_file,
+            )
         self.client = Client(credentials=self.credentials_info, location=self.location)
 
     def build_connection(self):

--- a/mage_integrations/mage_integrations/destinations/bigquery/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/bigquery/__init__.py
@@ -66,7 +66,7 @@ class BigQuery(Destination):
 
     def build_connection(self) -> BigQueryConnection:
         return BigQueryConnection(
-            path_to_credentials_json_file=self.config['path_to_credentials_json_file'],
+            path_to_credentials_json_file=self.config.get('path_to_credentials_json_file'),
             location=self.config.get('location'),
         )
 

--- a/mage_integrations/mage_integrations/sources/bigquery/__init__.py
+++ b/mage_integrations/mage_integrations/sources/bigquery/__init__.py
@@ -1,7 +1,8 @@
+from typing import List
+
 from mage_integrations.connections.bigquery import BigQuery as BigQueryConnection
 from mage_integrations.sources.base import main
 from mage_integrations.sources.sql.base import Source
-from typing import List
 
 
 class BigQuery(Source):
@@ -12,7 +13,7 @@ class BigQuery(Source):
 
     def build_connection(self) -> BigQueryConnection:
         return BigQueryConnection(
-            path_to_credentials_json_file=self.config['path_to_credentials_json_file'],
+            path_to_credentials_json_file=self.config.get('path_to_credentials_json_file'),
         )
 
     def build_discover_query(self, streams: List[str] = None) -> str:


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Not require key file for bigquery source and destination. When Mage is deployed on GCP, it can use the service account to authenticate.

# Tests
<!-- How did you test your change? -->
tested on gcp

cc:
<!-- Optionally mention someone to let them know about this pull request -->
