### PR TITLE
[jk]  Update error messaging for testing connection and loading sample data

### DIFF
--- a/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
+++ b/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
@@ -286,9 +286,9 @@ class IntegrationPipeline(Pipeline):
                     except Exception:
                         error = line
             if not error:
-                raise Exception('The sample data was not able to be loaded. Please check \
-                                if the stream still exists. If it does not, click the "View and \
-                                select streams" button and confirm the valid streams.')
+                raise Exception('The sample data was not able to be loaded. Please check ' +
+                                'if the stream still exists. If it does not, click the "View and ' +
+                                'select streams" button and confirm the valid streams.')
             raise Exception(error)
 
     def count_records(self) -> List[Dict]:

--- a/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
+++ b/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
@@ -212,6 +212,8 @@ class IntegrationPipeline(Pipeline):
                         error = dig(json_object, 'tags.error')
                     except Exception:
                         error = line
+                elif not error and line.startswith('CRITICAL'):
+                    error = line
             raise Exception(error)
 
     def preview_data(self, block_type: BlockType, streams: List[str] = None) -> List[str]:

--- a/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
+++ b/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
@@ -286,9 +286,11 @@ class IntegrationPipeline(Pipeline):
                     except Exception:
                         error = line
             if not error:
-                raise Exception('The sample data was not able to be loaded. Please check ' +
-                                'if the stream still exists. If it does not, click the "View and ' +
-                                'select streams" button and confirm the valid streams.')
+                raise Exception('The sample data was not able to be loaded. Please check if the ' +
+                                'stream still exists. If it does not, click the "View and select ' +
+                                'streams" button and confirm the valid streams. If it does, ' +
+                                'loading sample data for this source may not currently ' +
+                                'be supported.')
             raise Exception(error)
 
     def count_records(self) -> List[Dict]:

--- a/mage_integrations/mage_integrations/sources/base.py
+++ b/mage_integrations/mage_integrations/sources/base.py
@@ -601,9 +601,11 @@ class Source:
 
     def test_connection(self) -> None:
         """
-        Test connection with source
+        Test connection with source.
+        Subclasses must implement the test_connection method.
         """
-        raise Exception('Subclasses must implement the test_connection method.')
+        raise Exception('Testing the connection is not currently supported for this source. ' +
+                        'You can request it as a feature by creating a new Github issue.')
 
     def count_records(
         self,

--- a/mage_integrations/mage_integrations/sources/base.py
+++ b/mage_integrations/mage_integrations/sources/base.py
@@ -632,8 +632,10 @@ class Source:
             bookmarks (Dict): Bookmarks for the stream id.
             query (Dict): query
             start_date (datetime): start_date
+
+        Subclasses must implement the load_data method.
         """
-        raise Exception('Subclasses must implement the load_data method.')
+        raise Exception('Loading sample data is not currently supported for this source.')
 
     def get_forced_replication_method(self, stream_id: str) -> str:
         """

--- a/mage_integrations/mage_integrations/sources/chargebee/__init__.py
+++ b/mage_integrations/mage_integrations/sources/chargebee/__init__.py
@@ -72,9 +72,6 @@ class Chargebee(Source):
             for stream in available_streams
         }
 
-    def test_connection(self):
-        pass
-
 
 if __name__ == '__main__':
     main(Chargebee)

--- a/mage_integrations/mage_integrations/sources/commercetools/__init__.py
+++ b/mage_integrations/mage_integrations/sources/commercetools/__init__.py
@@ -35,9 +35,6 @@ class Commercetools(Source):
     def get_valid_replication_keys(self, stream_id: str) -> List[str]:
         return STREAMS[stream_id].KEY_PROPERTIES
 
-    def test_connection(self):
-        pass
-
 
 if __name__ == '__main__':
     main(Commercetools)

--- a/mage_integrations/mage_integrations/sources/datadog/__init__.py
+++ b/mage_integrations/mage_integrations/sources/datadog/__init__.py
@@ -1,5 +1,4 @@
 from mage_integrations.sources.base import Source, main
-from mage_integrations.sources.catalog import Catalog
 from mage_integrations.sources.datadog.client import DatadogClient
 from mage_integrations.sources.datadog.streams import (
     AuditLogs,
@@ -50,9 +49,6 @@ class Datadog(Source):
         bookmark_properties = self._get_bookmark_properties_for_stream(stream)
         to_date = query.get('_execution_date')
         return stream_obj.load_data(bookmarks, bookmark_properties, to_date)
-    
-    def test_connection(self):
-        pass
 
 
 if __name__ == '__main__':

--- a/mage_integrations/mage_integrations/sources/freshdesk/__init__.py
+++ b/mage_integrations/mage_integrations/sources/freshdesk/__init__.py
@@ -20,9 +20,6 @@ class Freshdesk(Source):
         update_state(self.state)
         do_sync(catalog.to_dict())
 
-    def test_connection(self):
-        pass
-
 
 if __name__ == '__main__':
     main(Freshdesk, schemas_folder='tap_freshdesk/schemas')

--- a/mage_integrations/mage_integrations/sources/front/__init__.py
+++ b/mage_integrations/mage_integrations/sources/front/__init__.py
@@ -35,9 +35,6 @@ class Front(Source):
     def get_valid_replication_keys(self, stream_id: str) -> List[str]:
         return STREAMS[stream_id].KEY_PROPERTIES
 
-    def test_connection(self):
-        pass
-
 
 if __name__ == '__main__':
     main(Front)

--- a/mage_integrations/mage_integrations/sources/hubspot/__init__.py
+++ b/mage_integrations/mage_integrations/sources/hubspot/__init__.py
@@ -36,9 +36,6 @@ class Hubspot(Source):
     def get_valid_replication_keys(self, stream_id: str) -> List[str]:
         return BOOKMARK_PROPERTIES_BY_STREAM_NAME.get(stream_id, ['N/A'])
 
-    def test_connection(self):
-        pass
-
 
 if __name__ == '__main__':
     main(Hubspot, schemas_folder='tap_hubspot/schemas')

--- a/mage_integrations/mage_integrations/sources/intercom/__init__.py
+++ b/mage_integrations/mage_integrations/sources/intercom/__init__.py
@@ -49,9 +49,6 @@ class Intercom(Source):
     def get_valid_replication_keys(self, stream_id):
         return STREAMS[stream_id].valid_replication_keys
 
-    def test_connection(self):
-        pass
-
 
 if __name__ == '__main__':
     main(Intercom)

--- a/mage_integrations/mage_integrations/sources/monday/__init__.py
+++ b/mage_integrations/mage_integrations/sources/monday/__init__.py
@@ -34,9 +34,6 @@ class Monday(Source):
     def get_valid_replication_keys(self, stream_id: str) -> List[str]:
         return STREAMS[stream_id].replication_key
 
-    def test_connection(self):
-        pass
-
 
 if __name__ == '__main__':
     main(Monday)

--- a/mage_integrations/mage_integrations/sources/pipedrive/__init__.py
+++ b/mage_integrations/mage_integrations/sources/pipedrive/__init__.py
@@ -33,9 +33,6 @@ class Pipedrive(Source):
                                      self.state)
         pipedrive_tap.do_sync(catalog)
 
-    def test_connection(self):
-        pass
-
 
 if __name__ == '__main__':
     main(Pipedrive, schemas_folder='tap_pipedrive/schemas')

--- a/mage_integrations/mage_integrations/sources/postmark/__init__.py
+++ b/mage_integrations/mage_integrations/sources/postmark/__init__.py
@@ -33,9 +33,6 @@ class Postmark(Source):
     def get_valid_replication_keys(self, stream_id: str) -> List[str]:
         return ['date']
 
-    def test_connection(self):
-        pass
-
 
 if __name__ == '__main__':
     main(Postmark, schemas_folder='tap_postmark/schemas')

--- a/mage_integrations/mage_integrations/sources/stripe/__init__.py
+++ b/mage_integrations/mage_integrations/sources/stripe/__init__.py
@@ -1153,9 +1153,6 @@ class Stripe(Source):
     def test_connection(self) -> None:
         configure_stripe_client()
 
-    def load_data(self, **kwargs):
-        pass
-
 
 @utils.handle_top_exception(LOGGER)
 def main():


### PR DESCRIPTION
# Summary
Improve visibility into non-functioning "test connection" and "load sample data" features for integration pipelines:
- Show unsupported error is "Test connection" is not implemented for an integration source.
- Update error messaging for "Load sample data" to let user know that it may not be supported for the currently selected integration source.

# Tests
Testing connection when `test_connection` method not implemented (tested on all sources where the `test_connection` method was removed):
<img width="1432" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/d5b1f9f0-faca-49d2-af0f-0951fafa8eb4">

Load sample data error (a bit verbose but if the `load_data` method is not implemented, a clear exception message is not provided otherwise):
<img width="1441" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/cad04d18-39e5-47c9-aeee-cdf858f595a6">


cc:
<!-- Optionally mention someone to let them know about this pull request -->
