### PR TITLE
[hw] Update doc on creating destination table in ClickHouse data exporter

### DIFF
--- a/docs/integrations/databases/ClickHouse.mdx
+++ b/docs/integrations/databases/ClickHouse.mdx
@@ -19,6 +19,7 @@ title: "ClickHouse"
 ```yaml
 version: 0.1.1
 default:
+  # ClickHouse
   CLICKHOUSE_DATABASE: ...
   CLICKHOUSE_HOST: ...
   CLICKHOUSE_INTERFACE: http
@@ -75,3 +76,14 @@ def load_data_from_clickhouse(**kwargs) -> DataFrame:
 ```
 
 5. Run the block.
+
+---
+
+## Destination table for Data Exporter
+
+For a `Data Exporter` with ClickHouse, if the destination table does not exist and
+the `Write policy` option is set to `Replace`, a table with `Engine = Memory` and an
+inferred schema with some default field types would be created, which might not be
+optimum for many use cases. As creating a table could involve [a lot of details](https://clickhouse.com/docs/en/sql-reference/statements/create/table),
+it is highly recommended that the destination table be created first on ClickHouse
+before loading data to the table.

--- a/docs/integrations/databases/ClickHouse.mdx
+++ b/docs/integrations/databases/ClickHouse.mdx
@@ -82,7 +82,7 @@ def load_data_from_clickhouse(**kwargs) -> DataFrame:
 ## Destination table in Data Exporter
 
 If the destination table does not exist and the `Write policy` is set
-to `Replace`, `data exporter` will automatically create a table in ClickHouse
+to `Replace`, `data exporter` will automatically create a table in `ClickHouse`
 with `Engine = Memory` and a default schema inferred from the data.
 However, this may not be optimal for various use cases. Since [table creation](https://clickhouse.com/docs/en/sql-reference/statements/create/table)
 in `ClickHouse` can involve numerous details, it is strongly advised to

--- a/docs/integrations/databases/ClickHouse.mdx
+++ b/docs/integrations/databases/ClickHouse.mdx
@@ -79,11 +79,12 @@ def load_data_from_clickhouse(**kwargs) -> DataFrame:
 
 ---
 
-## Destination table for Data Exporter
+## Destination table in Data Exporter
 
-For a `Data Exporter` with ClickHouse, if the destination table does not exist and
-the `Write policy` option is set to `Replace`, a table with `Engine = Memory` and an
-inferred schema with some default field types would be created, which might not be
-optimum for many use cases. As creating a table could involve [a lot of details](https://clickhouse.com/docs/en/sql-reference/statements/create/table),
-it is highly recommended that the destination table be created first on ClickHouse
-before loading data to the table.
+If the destination table does not exist and the `Write policy` is set
+to `Replace`, `data exporter` will automatically create a table in ClickHouse
+with `Engine = Memory` and a default schema inferred from the data.
+However, this may not be optimal for various use cases. Since [table creation](https://clickhouse.com/docs/en/sql-reference/statements/create/table)
+in `ClickHouse` can involve numerous details, it is strongly advised to
+create the destination table manually before loading data to ensure it
+meets specific requirements.


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

Manually creating destination table is strong recommended for ClickHouse when using `Data Exporter` due to the complexity involved when defining a table.

# Tests
<!-- How did you test your change? -->
CI
cc:
<!-- Optionally mention someone to let them know about this pull request -->
@dy46 @wangxiaoyou1993 