### PR TITLE
adding MinIO support for S3 in Data integrations pipeline

### DIFF
--- a/mage_integrations/mage_integrations/destinations/amazon_s3/README.md
+++ b/mage_integrations/mage_integrations/destinations/amazon_s3/README.md
@@ -17,5 +17,6 @@ You must enter the following credentials when configuring this source:
 | `file_type` | The type of S3 files. Supported file type values: `parquet`, `csv`. | `parquet` or `csv` |
 | `object_key_path` | The path of the location where you have files. Don’t include the `s3`, the bucket name, or the table name in this path value.  | `users/ds/20221225` |
 | `date_partition_format` | (Optional) The datetime format of the partition. If it's null, files will not be saved into paratitions. | `null`, `%Y%m%d`, `%Y%m%dT%H` |
+| `aws_endpoint` | (Optional) Allow for MinIO support | `https://play.min.io` |
 
 <br />

--- a/mage_integrations/mage_integrations/destinations/amazon_s3/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/amazon_s3/__init__.py
@@ -1,14 +1,16 @@
-from botocore.config import Config
-from mage_integrations.destinations.base import Destination
-from mage_integrations.destinations.utils import update_record_with_internal_columns
+import argparse
+import os
+import sys
 from datetime import datetime, timezone
 from io import BytesIO
 from typing import Dict, List
-import argparse
+
 import boto3
-import os
 import pandas as pd
-import sys
+from botocore.config import Config
+
+from mage_integrations.destinations.base import Destination
+from mage_integrations.destinations.utils import update_record_with_internal_columns
 
 
 class AmazonS3(Destination):
@@ -28,6 +30,10 @@ class AmazonS3(Destination):
     def region(self) -> str:
         return self.config.get('aws_region', 'us-west-2')
 
+    @property
+    def endpoint(self) -> str:
+        return self.config.get("aws_endpoint")
+
     def build_client(self):
         config = Config(
            retries={
@@ -42,6 +48,7 @@ class AmazonS3(Destination):
             aws_secret_access_key=self.config.get('aws_secret_access_key'),
             config=config,
             region_name=self.region,
+            endpoint_url=self.endpoint,
         )
 
     def export_batch_data(self, record_data: List[Dict], stream: str) -> None:

--- a/mage_integrations/mage_integrations/sources/amazon_s3/README.md
+++ b/mage_integrations/mage_integrations/sources/amazon_s3/README.md
@@ -20,5 +20,6 @@ You must enter the following credentials when configuring this source:
 | `search_pattern` | Search files with the regular expression syntax. | `test_table\\/.*\\.csv` |
 | `single_stream_in_prefix` | If `true`, then this source will treat all files in the prefix as part of the same stream. | `false` (default value) |
 | `table_configs` | A list of table configs to configure multiple streams. Each table config must have three keys: `prefix`, `search_pattern` and `table_name`| `[{"prefix": "users/", "search_pattern": "test_table\\/.*\\.csv", "table_name": "test_table"}]` |
+| `aws_endpoint` | (Optional) Allow for MinIO support | `https://play.min.io` |
 
 <br />


### PR DESCRIPTION
# Summary
Adding MinIO support for both Source and Destination blocks
Added docs example

# Tests
Tested using https://play.min.io buckets, by transfering parquet files.
Pipeline Logs:
![Screenshot from 2023-06-30 07-07-56](https://github.com/mage-ai/mage-ai/assets/14100959/856b7faa-4bf4-4301-985e-8001e3c815cf)
![Screenshot from 2023-06-30 07-08-04](https://github.com/mage-ai/mage-ai/assets/14100959/930e4abe-7ffe-4fd4-ba33-c27536571d3c)


cc:
@wangxiaoyou1993 
