### PR TITLE
[xy] Allow setting service account name for k8s executor.

### DIFF
--- a/docs/production/configuring-production-settings/compute-resource.mdx
+++ b/docs/production/configuring-production-settings/compute-resource.mdx
@@ -57,7 +57,7 @@ blocks:
 ```
 By default, Mage uses `default` as the Kubernetes namespace. You can customize the namespace by setting the `KUBE_NAMESPACE` environment variable.
 
-There're two ways to customize the compute resource for Kubernetes executor:
+There're two ways to customize the Kubernetes executor config:
 
 1. Add the `executor_config` at block level in pipeline's metadata.yaml file. Example config:
     ```yaml
@@ -85,6 +85,7 @@ in this project. Example config:
       resource_requests:
         cpu: 500m
         memory: 1024Mi
+      service_account_name: default
     ```
 If you want to use GPU resource in your k8s executor, you can configure the GPU resource in the `k8s_executor_config` like
 ```yaml

--- a/mage_ai/services/k8s/config.py
+++ b/mage_ai/services/k8s/config.py
@@ -1,8 +1,11 @@
 from dataclasses import dataclass
-from mage_ai.shared.config import BaseConfig
 from typing import Dict
+
+from mage_ai.shared.config import BaseConfig
+
 # import traceback
 
+DEFAULT_SERVICE_ACCOUNT_NAME = 'default'
 ECS_CONTAINER_METADATA_URI_VAR = 'ECS_CONTAINER_METADATA_URI_V4'
 
 
@@ -16,6 +19,7 @@ class K8sResourceConfig(BaseConfig):
 class K8sExecutorConfig(BaseConfig):
     resource_limits: Dict = None
     resource_requests: Dict = None
+    service_account_name: str = DEFAULT_SERVICE_ACCOUNT_NAME
 
     @classmethod
     def load(self, config_path: str = None, config: Dict = None):

--- a/mage_ai/services/k8s/job_manager.py
+++ b/mage_ai/services/k8s/job_manager.py
@@ -112,15 +112,17 @@ class JobManager():
             **container_kwargs,
         )
         # Create and configurate a spec section
+        pod_spec = dict(
+            containers=[container],
+            image_pull_secrets=self.pod_config.spec.image_pull_secrets,
+            restart_policy='Never',
+            volumes=self.pod_config.spec.volumes,
+        )
+        if k8s_config and k8s_config.service_account_name:
+            pod_spec['service_account_name'] = k8s_config.service_account_name
         template = client.V1PodTemplateSpec(
             metadata=client.V1ObjectMeta(labels={'name': self.job_name}),
-            spec=client.V1PodSpec(
-                containers=[container],
-                image_pull_secrets=self.pod_config.spec.image_pull_secrets,
-                restart_policy='Never',
-                service_account_name=k8s_config.service_account_name,
-                volumes=self.pod_config.spec.volumes,
-            ),
+            spec=client.V1PodSpec(**pod_spec),
         )
         # Create the specification of deployment
         spec = client.V1JobSpec(template=template, backoff_limit=0)

--- a/mage_ai/services/k8s/job_manager.py
+++ b/mage_ai/services/k8s/job_manager.py
@@ -1,5 +1,6 @@
 import os
 import time
+from typing import Dict
 
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
@@ -15,7 +16,7 @@ class JobManager():
         job_name: str = 'mage-job',
         namespace: str = DEFAULT_NAMESPACE,
         logger=None,
-        logging_tags=dict(),
+        logging_tags: Dict = None,
     ):
         self.job_name = job_name
         self.namespace = namespace
@@ -114,9 +115,10 @@ class JobManager():
         template = client.V1PodTemplateSpec(
             metadata=client.V1ObjectMeta(labels={'name': self.job_name}),
             spec=client.V1PodSpec(
-                restart_policy='Never',
                 containers=[container],
                 image_pull_secrets=self.pod_config.spec.image_pull_secrets,
+                restart_policy='Never',
+                service_account_name=k8s_config.service_account_name,
                 volumes=self.pod_config.spec.volumes,
             ),
         )


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Allow setting service account name for k8s executor.

Example k8s executor config:
```yaml
k8s_executor_config:
  resource_limits:
    cpu: 1000m
    memory: 2048Mi
  resource_requests:
    cpu: 500m
    memory: 1024Mi
  service_account_name: custom_service_account_name
```

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
