### PR TITLE
[td] Turn on output to logs when running a single block in the notebook

### DIFF
--- a/docs/production/observability/logging.mdx
+++ b/docs/production/observability/logging.mdx
@@ -55,4 +55,22 @@ logging_config:
     prefix: <prefix path>
 ```
 
-### More destinations coming...
+<br />
+
+*More destinations coming...*
+
+<br />
+
+---
+
+## Edit pipeline logging
+
+When you’re editing a pipeline (e.g. `/pipelines/[uuid]/edit`), you can execute the code for an
+individual block and see the output. Any `print` statements in the block of code is displayed
+in the block’s output.
+
+However, you can redirect those `print` statements to output to logs.
+
+To toggle this feature, go to the pipeline settings page (e.g. `/pipelines/[uuid]/settings`)
+and check the box labeled
+<b>When running a block while editing a pipeline, output the block messages to the logs</b>.

--- a/mage_ai/api/resources/LogResource.py
+++ b/mage_ai/api/resources/LogResource.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Dict, List
 from sqlalchemy.orm import aliased
 

--- a/mage_ai/data_preparation/models/block/constants.py
+++ b/mage_ai/data_preparation/models/block/constants.py
@@ -29,3 +29,5 @@ TAG_REDUCE_OUTPUT = 'reduce_output'
 TAG_REPLICA = 'replica'
 
 TAG_DBT_SNAPSHOT = 'snapshot'
+
+LOG_PARTITION_EDIT_PIPELINE = 'edit_pipeline'

--- a/mage_ai/frontend/components/PipelineDetail/Settings/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Settings/index.tsx
@@ -11,8 +11,15 @@ import FlexContainer from '@oracle/components/FlexContainer';
 import PipelineType from '@interfaces/PipelineType';
 import Spacing from '@oracle/elements/Spacing';
 import TextInput from '@oracle/elements/Inputs/TextInput';
-import { LOCAL_STORAGE_KEY_PIPELINE_EDIT_HIDDEN_BLOCKS } from '@storage/constants';
-import { PADDING_UNITS } from '@oracle/styles/units/spacing';
+import {
+  LOCAL_STORAGE_KEY_PIPELINE_EDIT_BLOCK_OUTPUT_LOGS,
+  LOCAL_STORAGE_KEY_PIPELINE_EDIT_HIDDEN_BLOCKS,
+} from '@storage/constants';
+import {
+  PADDING_UNITS,
+  UNITS_BETWEEN_ITEMS_IN_SECTIONS,
+  UNITS_BETWEEN_SECTIONS,
+} from '@oracle/styles/units/spacing';
 import { get, set } from '@storage/localStorage';
 import { isJsonString } from '@utils/string';
 
@@ -38,6 +45,10 @@ function PipelineSettings({
     [uuid: string]: boolean;
   }>({});
 
+  const localStorageBlockOutputLogsKey =
+    `${LOCAL_STORAGE_KEY_PIPELINE_EDIT_BLOCK_OUTPUT_LOGS}_${pipelineUUID}`;
+  const [blockOutputLogs, setBlockOutputLogsState] = useState<boolean>(false);
+
   const setHiddenBlocks = useCallback((callback) => {
     setHiddenBlocksState((prev) => {
       const data = callback(prev);
@@ -50,6 +61,18 @@ function PipelineSettings({
     setHiddenBlocksState,
   ]);
 
+  const setBlockOutputLogs = useCallback((callback) => {
+    setBlockOutputLogsState((prev) => {
+      const data = callback(prev);
+      set(localStorageBlockOutputLogsKey, data);
+
+      return data;
+    });
+  }, [
+    localStorageBlockOutputLogsKey,
+    setBlockOutputLogsState,
+  ]);
+
   useEffect(() => {
     const hiddenBlocksInitString = get(localStorageHiddenBlocksKey);
     if (hiddenBlocksInitString && isJsonString(hiddenBlocksInitString)) {
@@ -58,6 +81,16 @@ function PipelineSettings({
   }, [
     localStorageHiddenBlocksKey,
     setHiddenBlocksState,
+  ]);
+
+  useEffect(() => {
+    const initValue = get(localStorageBlockOutputLogsKey);
+    if (initValue) {
+      setBlockOutputLogsState(initValue);
+    }
+  }, [
+    localStorageBlockOutputLogsKey,
+    setBlockOutputLogsState,
   ]);
 
   const allBlocksHidden = useMemo(() => {
@@ -82,7 +115,7 @@ function PipelineSettings({
         value={newPipelineName}
       />
 
-      <Spacing mt={5}>
+      <Spacing mt={UNITS_BETWEEN_SECTIONS}>
         <FlexContainer>
           <Button
             disabled={newPipelineName === pipeline?.name}
@@ -98,7 +131,7 @@ function PipelineSettings({
         </FlexContainer>
       </Spacing>
 
-      <Spacing mt={5}>
+      <Spacing mt={UNITS_BETWEEN_SECTIONS}>
         <Checkbox
           checked={allBlocksHidden && !noBlocks}
           disabled={noBlocks}
@@ -113,6 +146,15 @@ function PipelineSettings({
               [uuid]: true,
             }), {});
           })}
+        />
+      </Spacing>
+
+      <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
+        <Checkbox
+          checked={blockOutputLogs}
+          label="When running a block while editing a pipeline, output the block messages to the logs"
+          // @ts-ignore
+          onClick={() => setBlockOutputLogs(prev => !prev)}
         />
       </Spacing>
     </Spacing>

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -66,6 +66,7 @@ import { INTERNAL_OUTPUT_REGEX } from '@utils/models/output';
 import {
   LOCAL_STORAGE_KEY_AUTOMATICALLY_NAME_BLOCKS,
   LOCAL_STORAGE_KEY_PIPELINE_EDIT_BEFORE_TAB_SELECTED,
+  LOCAL_STORAGE_KEY_PIPELINE_EDIT_BLOCK_OUTPUT_LOGS,
   LOCAL_STORAGE_KEY_PIPELINE_EDIT_HIDDEN_BLOCKS,
 } from '@storage/constants';
 import {
@@ -1751,10 +1752,14 @@ function PipelineDetailPage({
     const isAlreadyRunning = runningBlocks.find(({ uuid: uuid2 }) => uuid === uuid2);
 
     if (!isAlreadyRunning || ignoreAlreadyRunning) {
+      const localStorageBlockOutputLogsKey =
+        `${LOCAL_STORAGE_KEY_PIPELINE_EDIT_BLOCK_OUTPUT_LOGS}_${pipeline?.uuid}`;
+
       sendMessage(JSON.stringify({
         ...sharedWebsocketData,
         code,
         extension_uuid: extensionUUID,
+        output_messages_to_logs: !!get(localStorageBlockOutputLogsKey),
         pipeline_uuid: pipeline?.uuid,
         run_downstream: runDownstream, // This will only run downstream blocks that are charts/widgets
         run_settings: runSettings,

--- a/mage_ai/frontend/storage/constants.ts
+++ b/mage_ai/frontend/storage/constants.ts
@@ -5,3 +5,6 @@ export const LOCAL_STORAGE_KEY_PIPELINE_EDIT_BEFORE_TAB_SELECTED =
 
 export const LOCAL_STORAGE_KEY_PIPELINE_EDIT_HIDDEN_BLOCKS =
   'pipeline_edit_hidden_blocks';
+
+export const LOCAL_STORAGE_KEY_PIPELINE_EDIT_BLOCK_OUTPUT_LOGS =
+  'pipeline_edit_block_output_logs';

--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -224,6 +224,7 @@ def add_execution_code(
     block_type: BlockType = None,
     extension_uuid: str = None,
     kernel_name: str = None,
+    output_messages_to_logs: bool = False,
     pipeline_config: Dict = None,
     repo_config: Dict = None,
     run_settings: Dict = None,
@@ -306,6 +307,7 @@ def execute_custom_code():
     block_output = block.execute_with_callback(
         custom_code=code,
         global_vars=global_vars,
+        output_messages_to_logs={output_messages_to_logs},
         run_settings=json.loads('{run_settings_json}'),
         test_execution=True,
         update_status={update_status},

--- a/mage_ai/server/websocket_server.py
+++ b/mage_ai/server/websocket_server.py
@@ -350,6 +350,7 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
         block_uuid = message.get('uuid')
         custom_code = message.get('code')
         extension_uuid = message.get('extension_uuid')
+        output_messages_to_logs = message.get('output_messages_to_logs', False)
         run_downstream = message.get('run_downstream')
         run_settings = message.get('run_settings')
         run_tests = message.get('run_tests')
@@ -406,6 +407,7 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
                     block_type=block_type,
                     extension_uuid=extension_uuid,
                     kernel_name=kernel_name,
+                    output_messages_to_logs=output_messages_to_logs,
                     pipeline_config=pipeline.get_config_from_yaml(),
                     repo_config=get_repo_config().to_dict(remote=remote_execution),
                     run_settings=run_settings,


### PR DESCRIPTION
# Summary
Optionally enable the notebook to output block execution messages to logs when running a block on the edit pipeline page.

# Tests
<img width="731" alt="image" src="https://github.com/mage-ai/mage-ai/assets/1066980/5b36a7cf-65f2-488d-a02b-03b262553995">

<img width="1151" alt="image" src="https://github.com/mage-ai/mage-ai/assets/1066980/f0b30ac3-e2af-45fc-bf4e-539d0d443ffb">