### PR TITLE
[xy] Support customizing the timeout seconds in gcp cloud run config.

### DIFF
--- a/docs/production/configuring-production-settings/compute-resource.mdx
+++ b/docs/production/configuring-production-settings/compute-resource.mdx
@@ -130,6 +130,8 @@ How to configure pipeline to use GCP cloud run executor:
 ```yaml
 gcp_cloud_run_config:
   path_to_credentials_json_file: "/path/to/credentials_json_file"
+  project_id: project_id
+  timeout_seconds: 600
 ```
 
 2. Update the `executor_type` of block to `gcp_cloud_run` in pipeline's metadata.yaml:

--- a/mage_ai/services/gcp/cloud_run/cloud_run.py
+++ b/mage_ai/services/gcp/cloud_run/cloud_run.py
@@ -6,6 +6,7 @@ from google.api.launch_stage_pb2 import LaunchStage
 from google.api_core.exceptions import AlreadyExists
 from google.cloud import run_v2
 from google.oauth2 import service_account
+from google.protobuf.duration_pb2 import Duration
 
 from mage_ai.server.logger import Logger
 from mage_ai.services.gcp.cloud_run.config import CloudRunConfig
@@ -56,7 +57,8 @@ def run_job(command: str, job_id: str, cloud_run_config: CloudRunConfig) -> Dict
             service_account=service_template.service_account,
             execution_environment=service_template.execution_environment,
             encryption_key=service_template.encryption_key,
-            vpc_access=service_template.vpc_access
+            timeout=Duration(seconds=cloud_run_config.timeout_seconds),
+            vpc_access=service_template.vpc_access,
         )
     )
     job = run_v2.Job(

--- a/mage_ai/services/gcp/cloud_run/config.py
+++ b/mage_ai/services/gcp/cloud_run/config.py
@@ -8,3 +8,4 @@ class CloudRunConfig(BaseConfig):
     project_id: str
     path_to_credentials_json_file: str = None
     region: str = 'us-west2'
+    timeout_seconds: int = 600


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Support customizing the timeout seconds in gcp cloud run config.



# Tests
<!-- How did you test your change? -->
tested on gcp
<img width="421" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/779a7c19-3c9d-43e1-9da7-7a45cbca8b36">
<img width="389" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/65670328-7b36-4482-91f9-b5bf3aadf4cd">

cc:
<!-- Optionally mention someone to let them know about this pull request -->
