### PR TITLE
[td] Execute incomplete upstream blocks from another block

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -1659,7 +1659,7 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
                     visited.add(block)
         return list(visited)
 
-    def run_upstream_blocks(self, **kwargs) -> None:
+    def run_upstream_blocks(self, incomplete_only: bool = False, **kwargs) -> None:
         def process_upstream_block(
             block: 'Block',
             root_blocks: List['Block'],
@@ -1668,10 +1668,13 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
                 root_blocks.append(block)
             return block.uuid
 
-        upstream_blocks = self.get_all_upstream_blocks()
+        upstream_blocks = list(filter(
+            lambda x: not incomplete_only or BlockStatus.EXECUTED != x.status,
+            self.get_all_upstream_blocks(),
+        ))
         root_blocks = []
         upstream_block_uuids = list(
-            map(lambda x: process_upstream_block(x, root_blocks), upstream_blocks)
+            map(lambda x: process_upstream_block(x, root_blocks), upstream_blocks),
         )
 
         run_blocks_sync(

--- a/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
@@ -68,6 +68,7 @@ type CommandButtonsProps = {
     code?: string;
     disableReset?: boolean;
     runDownstream?: boolean;
+    runIncompleteUpstream?: boolean;
     runSettings?: {
       run_model?: boolean;
     };

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -172,6 +172,7 @@ type CodeBlockProps = {
     block: BlockType;
     code: string;
     runDownstream?: boolean;
+    runIncompleteUpstream?: boolean;
     runSettings?: {
       run_model?: boolean;
     };
@@ -426,6 +427,7 @@ function CodeBlock({
     code?: string;
     disableReset?: boolean;
     runDownstream?: boolean;
+    runIncompleteUpstream?: boolean;
     runSettings?: {
       run_model?: boolean;
     };
@@ -437,6 +439,7 @@ function CodeBlock({
       code,
       disableReset,
       runDownstream,
+      runIncompleteUpstream,
       runSettings,
       runUpstream,
       runTests: runTestsInit,
@@ -462,6 +465,7 @@ function CodeBlock({
       block: blockPayload,
       code: code || content,
       runDownstream: runDownstream || hasDownstreamWidgets,
+      runIncompleteUpstream: runIncompleteUpstream || false,
       runSettings,
       runTests: runTests || false,
       runUpstream: runUpstream || false,

--- a/mage_ai/frontend/components/CodeBlock/utils.ts
+++ b/mage_ai/frontend/components/CodeBlock/utils.ts
@@ -90,6 +90,7 @@ export const getMoreActionsItems = (
   block: BlockType,
   runBlock: (payload: {
     block: BlockType;
+    runIncompleteUpstream?: boolean;
     runSettings?: {
       build_model?: boolean;
       run_model?: boolean;
@@ -142,13 +143,22 @@ export const getMoreActionsItems = (
     BlockTypeEnum.EXTENSION,
     BlockTypeEnum.MARKDOWN,
   ].includes(blockType)) {
-    items.push({
-      label: () => isDBT
-        ? 'Execute and run upstream blocks'
-        : 'Execute with upstream blocks',
-      onClick: () => runBlock({ block, runUpstream: true }),
-      uuid: 'execute_upstream',
-    });
+    items.push(...[
+      {
+        label: () => isDBT
+          ? 'Execute and run all upstream blocks'
+          : 'Execute with all upstream blocks',
+        onClick: () => runBlock({ block, runUpstream: true }),
+        uuid: 'execute_upstream',
+      },
+      {
+        label: () => isDBT
+          ? 'Execute and run incomplete upstream blocks'
+          : 'Execute with incomplete upstream blocks',
+        onClick: () => runBlock({ block, runIncompleteUpstream: true }),
+        uuid: 'execute_incomplete_upstream',
+      },
+    ]);
 
     if (!isDBT) {
       items.push({

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1728,6 +1728,7 @@ function PipelineDetailPage({
     code: string;
     ignoreAlreadyRunning?: boolean;
     runDownstream?: boolean;
+    runIncompleteUpstream?: boolean;
     runSettings?: {
       run_model?: boolean;
     };
@@ -1739,9 +1740,10 @@ function PipelineDetailPage({
       code,
       ignoreAlreadyRunning,
       runDownstream = false,
+      runIncompleteUpstream = false,
       runSettings = {},
-      runUpstream = false,
       runTests = false,
+      runUpstream,
     } = payload;
 
     const {
@@ -1762,6 +1764,7 @@ function PipelineDetailPage({
         output_messages_to_logs: !!get(localStorageBlockOutputLogsKey),
         pipeline_uuid: pipeline?.uuid,
         run_downstream: runDownstream, // This will only run downstream blocks that are charts/widgets
+        run_incomplete_upstream: runIncompleteUpstream,
         run_settings: runSettings,
         run_tests: runTests,
         run_upstream: runUpstream,

--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -227,6 +227,7 @@ def add_execution_code(
     output_messages_to_logs: bool = False,
     pipeline_config: Dict = None,
     repo_config: Dict = None,
+    run_incomplete_upstream: bool = False,
     run_settings: Dict = None,
     run_tests: bool = False,
     run_upstream: bool = False,
@@ -251,6 +252,7 @@ def add_execution_code(
             block_type == BlockType.SENSOR and not is_pyspark_code(code)
         ):
             magic_header = '%%local'
+            run_incomplete_upstream = False
             run_upstream = False
         else:
             if block_type in [BlockType.DATA_LOADER, BlockType.TRANSFORMER]:
@@ -277,6 +279,7 @@ db_connection.start_session()
 
 def execute_custom_code():
     block_uuid=\'{block_uuid}\'
+    run_incomplete_upstream={str(run_incomplete_upstream)}
     run_upstream={str(run_upstream)}
     pipeline = Pipeline(
         uuid=\'{pipeline_uuid}\',
@@ -301,8 +304,8 @@ def execute_custom_code():
     except Exception:
         pass
 
-    if run_upstream:
-        block.run_upstream_blocks(global_vars=global_vars)
+    if run_incomplete_upstream or run_upstream:
+        block.run_upstream_blocks(global_vars=global_vars, incomplete_only=run_incomplete_upstream)
 
     block_output = block.execute_with_callback(
         custom_code=code,

--- a/mage_ai/server/websocket_server.py
+++ b/mage_ai/server/websocket_server.py
@@ -352,6 +352,7 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
         extension_uuid = message.get('extension_uuid')
         output_messages_to_logs = message.get('output_messages_to_logs', False)
         run_downstream = message.get('run_downstream')
+        run_incomplete_upstream = message.get('run_incomplete_upstream')
         run_settings = message.get('run_settings')
         run_tests = message.get('run_tests')
         run_upstream = message.get('run_upstream')
@@ -410,6 +411,7 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
                     output_messages_to_logs=output_messages_to_logs,
                     pipeline_config=pipeline.get_config_from_yaml(),
                     repo_config=get_repo_config().to_dict(remote=remote_execution),
+                    run_incomplete_upstream=run_incomplete_upstream,
                     run_settings=run_settings,
                     run_tests=run_tests,
                     run_upstream=run_upstream,


### PR DESCRIPTION
# Summary
When running a block in the notebook, provide an option to only run the upstream blocks that haven’t been executed successfully.

# Tests
<img width="448" alt="image" src="https://github.com/mage-ai/mage-ai/assets/1066980/12085c84-d2d2-4d0d-8be9-335ce9c5deda">
