### PR TITLE
[td] Use UTF-8 encoding when logging output from dbt blocks

### DIFF
--- a/mage_ai/data_preparation/models/block/dbt/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/__init__.py
@@ -231,6 +231,7 @@ class DBTBlock(Block):
                 proc = subprocess.Popen(
                     cmds,
                     bufsize=1,
+                    encoding='utf-8',
                     preexec_fn=os.setsid,  # os.setsid doesn't work on Windows
                     stdout=stdout,
                     universal_newlines=True,


### PR DESCRIPTION
# Summary
Fix this error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/mage_ai/shared/retry.py", line 34, in retry_func
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/executors/block_executor.py", line 109, in __execute_with_retry
    return self._execute(
  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/executors/block_executor.py", line 200, in _execute
    result = self.block.execute_sync(
  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/models/block/__init__.py", line 840, in execute_sync
    raise err
  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/models/block/__init__.py", line 779, in execute_sync
    output = self.execute_block(
  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/models/block/__init__.py", line 1013, in execute_block
    outputs = self._execute_block(
  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/models/block/dbt/__init__.py", line 225, in _execute_block
    for line in proc.stdout:
  File "/usr/local/lib/python3.10/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xea in position 4033: invalid continuation byte
```