### PR TITLE
[td] Update tree node when block status changes

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -47,7 +47,6 @@ import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
 import FlyoutMenuWrapper from '@oracle/components/FlyoutMenu/FlyoutMenuWrapper';
 import KernelOutputType, {
-  DataTypeEnum,
   ExecutionStateEnum,
 } from '@interfaces/KernelOutputType';
 import LabelWithValueClicker from '@oracle/components/LabelWithValueClicker';
@@ -119,7 +118,9 @@ import {
   buildBorderProps,
   buildConvertBlockMenuItems,
   getDownstreamBlockUuids,
+  getMessagesWithType,
   getUpstreamBlockUuids,
+  hasErrorOrOutput,
 } from './utils';
 import { capitalize, pluralize } from '@utils/string';
 import { executeCode } from '@components/CodeEditor/keyboard_shortcuts/shortcuts';
@@ -540,20 +541,14 @@ function CodeBlock({
     mainContainerRef,
   ]);
 
-  const messagesWithType = useMemo(() => {
-    if (errorMessages?.length >= 0) {
-      return errorMessages.map((errorMessage: string) => ({
-        data: errorMessage,
-        execution_state: ExecutionStateEnum.IDLE,
-        type: DataTypeEnum.TEXT_PLAIN,
-      }));
-    }
-    return messages.filter((kernelOutput: KernelOutputType) => kernelOutput?.type);
-  }, [
+  const messagesWithType = useMemo(() => getMessagesWithType(messages, errorMessages), [
     errorMessages,
     messages,
   ]);
-  const hasError = !!messagesWithType.find(({ error }) => error);
+  const {
+    hasError,
+    hasOutput,
+  } = hasErrorOrOutput(messagesWithType);
 
   const color = getColorsForBlockType(
     blockType,
@@ -589,7 +584,6 @@ function CodeBlock({
     selected,
   ]);
 
-  const hasOutput = messagesWithType.length >= 1;
   const onClickSelectBlock = useCallback(() => {
     if (!selected) {
       setAnyInputFocused?.(false);

--- a/mage_ai/frontend/components/CodeBlock/utils.ts
+++ b/mage_ai/frontend/components/CodeBlock/utils.ts
@@ -7,6 +7,10 @@ import BlockType, {
   CONVERTIBLE_BLOCK_TYPES,
   TagEnum,
 } from '@interfaces/BlockType';
+import KernelOutputType, {
+  DataTypeEnum,
+  ExecutionStateEnum,
+} from '@interfaces/KernelOutputType';
 import PipelineType, { PipelineTypeEnum } from '@interfaces/PipelineType';
 import { FlyoutMenuItemType } from '@oracle/components/FlyoutMenu';
 import { capitalizeRemoveUnderscoreLower, lowercase } from '@utils/string';
@@ -416,5 +420,33 @@ export function buildBorderProps({
       selected,
     },
     tags: buildTags(block),
+  };
+}
+
+export function getMessagesWithType(
+  messages: KernelOutputType[],
+  errorMessages?: string[] = null,
+): KernelOutputType[] {
+  if (errorMessages && errorMessages?.length >= 0) {
+    return errorMessages.map((errorMessage: string) => ({
+      data: errorMessage,
+      execution_state: ExecutionStateEnum.IDLE,
+      type: DataTypeEnum.TEXT_PLAIN,
+    }));
+  }
+
+  return messages.filter((kernelOutput: KernelOutputType) => kernelOutput?.type);
+}
+
+export function hasErrorOrOutput(messagesWithType: KernelOutputType[]): {
+  hasError: boolean;
+  hasOutput: boolean;
+} {
+  const hasError = !!messagesWithType.find(({ error }) => error);
+  const hasOutput = messagesWithType.length >= 1;
+
+  return {
+    hasError,
+    hasOutput,
   };
 }

--- a/mage_ai/frontend/components/CodeBlock/utils.ts
+++ b/mage_ai/frontend/components/CodeBlock/utils.ts
@@ -425,7 +425,7 @@ export function buildBorderProps({
 
 export function getMessagesWithType(
   messages: KernelOutputType[],
-  errorMessages?: string[] = null,
+  errorMessages: string[] = null,
 ): KernelOutputType[] {
   if (errorMessages && errorMessages?.length >= 0) {
     return errorMessages.map((errorMessage: string) => ({

--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -118,7 +118,7 @@ export type DependencyGraphProps = {
   fetchPipeline?: () => void;
   height: number;
   heightOffset?: number;
-  messages: {
+  messages?: {
     [uuid: string]: KernelOutputType[];
   };
   noStatus?: boolean;

--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -20,12 +20,12 @@ import BlockType, {
 } from '@interfaces/BlockType';
 import FlexContainer from '@oracle/components/FlexContainer';
 import GraphNode from './GraphNode';
+import KernelOutputType  from '@interfaces/KernelOutputType';
 import KeyboardShortcutButton from '@oracle/elements/Button/KeyboardShortcutButton';
 import PipelineType, { PipelineTypeEnum } from '@interfaces/PipelineType';
 import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
 import api from '@api';
-
 import {
   EdgeType,
   NodeType,
@@ -45,6 +45,10 @@ import {
 import { find, indexBy, removeAtIndex } from '@utils/array';
 import { getBlockRunBlockUUID } from '@utils/models/blockRun';
 import { getColorsForBlockType } from '@components/CodeBlock/index.style';
+import {
+  getMessagesWithType,
+  hasErrorOrOutput,
+} from '@components/CodeBlock/utils';
 import { getModelAttributes } from '@utils/models/dbt';
 import { isActivePort } from './utils';
 import { onSuccess } from '@api/utils/response';
@@ -114,6 +118,9 @@ export type DependencyGraphProps = {
   fetchPipeline?: () => void;
   height: number;
   heightOffset?: number;
+  messages: {
+    [uuid: string]: KernelOutputType[];
+  };
   noStatus?: boolean;
   onClickNode?: (opts: {
     block?: BlockType;
@@ -142,6 +149,7 @@ function DependencyGraph({
   fetchPipeline,
   height,
   heightOffset = UNIT * 10,
+  messages,
   noStatus,
   onClickNode,
   pannable = true,
@@ -493,16 +501,24 @@ function DependencyGraph({
         runtime,
       };
     } else {
+      const messagesWithType = getMessagesWithType(messages?.[block.uuid] || []);
+      const {
+        hasError,
+        hasOutput,
+      } = hasErrorOrOutput(messagesWithType);
+
+      const isInProgress = runningBlocksMapping[block.uuid];
+
       return {
-        hasFailed: StatusTypeEnum.FAILED === block.status,
-        isInProgress: runningBlocksMapping[block.uuid],
-        isQueued: runningBlocksMapping[block.uuid]
-          && runningBlocks[0]?.uuid !== block.uuid,
-        isSuccessful: StatusTypeEnum.EXECUTED === block.status,
+        hasFailed: !isInProgress && (hasError || StatusTypeEnum.FAILED === block.status),
+        isInProgress,
+        isQueued: isInProgress && runningBlocks[0]?.uuid !== block.uuid,
+        isSuccessful: !isInProgress && ((!hasError && hasOutput) || StatusTypeEnum.EXECUTED === block.status),
       };
     }
   }, [
     blockStatus,
+    messages,
     noStatus,
     runningBlocks,
     runningBlocksMapping,

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -263,7 +263,7 @@ function Sidekick({
     secrets,
   ]);
 
-  const extensionsAndAddonsProps = {
+  const extensionsAndAddonsProps = useMemo(() => ({
     addNewBlockAtIndex,
     autocompleteItems,
     blockRefs,
@@ -288,7 +288,147 @@ function Sidekick({
     setSelectedBlock,
     setTextareaFocused,
     textareaFocused,
-  };
+  }), [
+    addNewBlockAtIndex,
+    autocompleteItems,
+    blockRefs,
+    blocks,
+    blocksInNotebook,
+    deleteBlock,
+    fetchFileTree,
+    fetchPipeline,
+    interruptKernel,
+    messages,
+    onChangeCallbackBlock,
+    onChangeCodeBlock,
+    onSelectBlockFile,
+    pipeline,
+    runBlock,
+    runningBlocks,
+    savePipelineContent,
+    selectedBlock,
+    setAnyInputFocused,
+    setErrors,
+    setHiddenBlocks,
+    setSelectedBlock,
+    setTextareaFocused,
+    textareaFocused,
+  ]);
+
+  const dataMemo = useMemo(() => columns.length > 0 && (
+    <DataTable
+      columnHeaderHeight={
+        (isEmptyObject(columnTypes)
+          && isEmptyObject(insightsByFeatureUUID)
+          && isEmptyObject(insightsOverview))
+        ? 0
+        : TABLE_COLUMN_HEADER_HEIGHT
+      }
+      columns={columns}
+      height={heightWindow - heightOffset - ASIDE_SUBHEADER_HEIGHT}
+      noBorderBottom
+      noBorderLeft
+      noBorderRight
+      noBorderTop
+      renderColumnHeader={renderColumnHeader}
+      rows={rows}
+      width={afterWidth}
+    />
+  ), [
+    afterWidth,
+    columnTypes,
+    columns,
+    heightOffset,
+    heightWindow,
+    insightsByFeatureUUID,
+    insightsOverview,
+    renderColumnHeader,
+    rows,
+  ]);
+
+  const chartsMemo = useMemo(() => widgets.length > 0 && (
+    <Charts
+      autocompleteItems={autocompleteItems}
+      blockRefs={blockRefs}
+      blocks={blocks}
+      chartRefs={chartRefs}
+      deleteWidget={deleteWidget}
+      fetchFileTree={fetchFileTree}
+      fetchPipeline={fetchPipeline}
+      messages={messages}
+      onChangeChartBlock={onChangeChartBlock}
+      pipeline={pipeline}
+      runBlock={runBlock}
+      runningBlocks={runningBlocks}
+      savePipelineContent={savePipelineContent}
+      selectedBlock={selectedBlock}
+      setAnyInputFocused={setAnyInputFocused}
+      setErrors={setErrors}
+      setSelectedBlock={setSelectedBlock}
+      setTextareaFocused={setTextareaFocused}
+      textareaFocused={textareaFocused}
+      updateWidget={updateWidget}
+      widgets={widgets}
+      width={afterWidth}
+    />
+  ), [
+    afterWidth,
+    autocompleteItems,
+    blockRefs,
+    blocks,
+    chartRefs,
+    deleteWidget,
+    fetchFileTree,
+    fetchPipeline,
+    messages,
+    onChangeChartBlock,
+    pipeline,
+    runBlock,
+    runningBlocks,
+    savePipelineContent,
+    selectedBlock,
+    setAnyInputFocused,
+    setErrors,
+    setSelectedBlock,
+    setTextareaFocused,
+    textareaFocused,
+    updateWidget,
+    widgets,
+  ]);
+
+  const terminalMemo = useMemo(() => (
+    <div
+      style={{
+        height: '100%',
+        position: 'relative',
+        width: afterWidth,
+      }}
+    >
+      <Terminal
+        lastMessage={lastTerminalMessage}
+        onFocus={() => setSelectedBlock(null)}
+        sendMessage={sendTerminalMessage}
+        width={afterWidth}
+      />
+    </div>
+  ), [
+    afterWidth,
+    lastTerminalMessage,
+    sendTerminalMessage,
+    setSelectedBlock,
+  ]);
+
+  const extensionsMemo = useMemo(() => (
+    <Extensions
+      {...extensionsAndAddonsProps}
+    />
+  ), [extensionsAndAddonsProps]);
+
+  const addonMemo = useMemo(() => (
+    <AddonBlocks
+      {...extensionsAndAddonsProps}
+    />
+  ), [extensionsAndAddonsProps]);
 
   return (
     <>
@@ -343,6 +483,7 @@ function Sidekick({
                 enablePorts={!isIntegration}
                 fetchPipeline={fetchPipeline}
                 height={heightWindow - heightOffset - finalOutputHeight}
+                messages={messages}
                 // @ts-ignore
                 onClickNode={({ block: { uuid } }) => setHiddenBlocks((prev) => {
                   const hidden = !!prev?.[uuid];
@@ -381,28 +522,13 @@ function Sidekick({
             </>
           </ApiReloader>
         }
-        {activeView === ViewKeyEnum.DATA && columns.length > 0 && (
-          <DataTable
-            columnHeaderHeight={
-              (isEmptyObject(columnTypes)
-                && isEmptyObject(insightsByFeatureUUID)
-                && isEmptyObject(insightsOverview))
-              ? 0
-              : TABLE_COLUMN_HEADER_HEIGHT
-            }
-            columns={columns}
-            height={heightWindow - heightOffset - ASIDE_SUBHEADER_HEIGHT}
-            noBorderBottom
-            noBorderLeft
-            noBorderRight
-            noBorderTop
-            renderColumnHeader={renderColumnHeader}
-            rows={rows}
-            width={afterWidth}
-          />
-        )}
+
+        {activeView === ViewKeyEnum.DATA && dataMemo}
+
         {ViewKeyEnum.SECRETS === activeView && secretsMemo}
+
         {ViewKeyEnum.VARIABLES === activeView && globalVariablesMemo}
+
         {ViewKeyEnum.FILE_VERSIONS === activeView && (
           <ApiReloader uuid={`FileVersions/${selectedFilePath
               ? decodeURIComponent(selectedFilePath)
@@ -443,30 +569,7 @@ function Sidekick({
 
         {ViewKeyEnum.CHARTS === activeView && (widgets.length > 0
           ?
-            <Charts
-              autocompleteItems={autocompleteItems}
-              blockRefs={blockRefs}
-              blocks={blocks}
-              chartRefs={chartRefs}
-              deleteWidget={deleteWidget}
-              fetchFileTree={fetchFileTree}
-              fetchPipeline={fetchPipeline}
-              messages={messages}
-              onChangeChartBlock={onChangeChartBlock}
-              pipeline={pipeline}
-              runBlock={runBlock}
-              runningBlocks={runningBlocks}
-              savePipelineContent={savePipelineContent}
-              selectedBlock={selectedBlock}
-              setAnyInputFocused={setAnyInputFocused}
-              setErrors={setErrors}
-              setSelectedBlock={setSelectedBlock}
-              setTextareaFocused={setTextareaFocused}
-              textareaFocused={textareaFocused}
-              updateWidget={updateWidget}
-              widgets={widgets}
-              width={afterWidth}
-            />
+            chartsMemo
           :
             <FlexContainer
               alignItems="center"
@@ -492,34 +595,11 @@ function Sidekick({
             </FlexContainer>
         )}
 
-        {ViewKeyEnum.TERMINAL === activeView && (
-          <div
-            style={{
-              height: '100%',
-              position: 'relative',
-              width: afterWidth,
-            }}
-          >
-            <Terminal
-              lastMessage={lastTerminalMessage}
-              onFocus={() => setSelectedBlock(null)}
-              sendMessage={sendTerminalMessage}
-              width={afterWidth}
-            />
-          </div>
-        )}
+        {ViewKeyEnum.TERMINAL === activeView && terminalMemo}
 
-        {ViewKeyEnum.EXTENSIONS === activeView && (
-          <Extensions
-            {...extensionsAndAddonsProps}
-          />
-        )}
+        {ViewKeyEnum.EXTENSIONS === activeView && extensionsMemo}
 
-        {ViewKeyEnum.ADDON_BLOCKS === activeView && (
-          <AddonBlocks
-            {...extensionsAndAddonsProps}
-          />
-        )}
+        {ViewKeyEnum.ADDON_BLOCKS === activeView && addonMemo}
       </SidekickContainerStyle>
     </>
   );

--- a/mage_ai/frontend/interfaces/KernelOutputType.ts
+++ b/mage_ai/frontend/interfaces/KernelOutputType.ts
@@ -35,9 +35,9 @@ export default interface KernelOutputType {
   metadata?: {
     [key: string]: string;
   };
-  msg_id: string;
-  msg_type: MsgType;
-  pipeline_uuid: string;
+  msg_id?: string;
+  msg_type?: MsgType;
+  pipeline_uuid?: string;
   type: DataTypeEnum;
-  uuid: string;
+  uuid?: string;
 }


### PR DESCRIPTION
# Summary
When in the edit pipeline page, after an individual block executes and fails, when executing that block again and it succeeds, the block’s status (e.g. checkmark, red cross, etc) in the tree UI doesn’t update to reflect the success status of the block.