### PR TITLE
[hw] Define a new TABLE_CONFIG_KEY to replace the hard-coded 'table' constant

### DIFF
--- a/mage_integrations/mage_integrations/destinations/bigquery/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/bigquery/__init__.py
@@ -290,7 +290,7 @@ WHERE table_id = '{table_name}'
 
         database_name = self.config.get(self.DATABASE_CONFIG_KEY)
         schema_name = self.config.get(self.SCHEMA_CONFIG_KEY)
-        table_name = self.config.get('table')
+        table_name = self.config.get(self.TABLE_CONFIG_KEY)
 
         full_table_name = f'{database_name}.{schema_name}.{table_name}'
         table_name_delete = f'_delete_{table_name}'
@@ -390,7 +390,7 @@ WHERE table_id = '{table_name}'
         except Exception as err:
             database_name = self.config.get(self.DATABASE_CONFIG_KEY)
             schema_name = self.config.get(self.SCHEMA_CONFIG_KEY)
-            table_name = self.config.get('table')
+            table_name = self.config.get(self.TABLE_CONFIG_KEY)
 
             if self.attempted_create_table:
                 connection.execute([
@@ -424,7 +424,7 @@ WHERE table_id = '{table_name}'
 
         database_name = self.config.get(self.DATABASE_CONFIG_KEY)
         schema_name = self.config.get(self.SCHEMA_CONFIG_KEY)
-        table_name = self.config.get('table')
+        table_name = self.config.get(self.TABLE_CONFIG_KEY)
 
         schema = self.schemas[stream]
         unique_constraints = self.unique_constraints.get(stream)

--- a/mage_integrations/mage_integrations/destinations/sql/base.py
+++ b/mage_integrations/mage_integrations/destinations/sql/base.py
@@ -16,6 +16,7 @@ import sys
 class Destination(BaseDestination):
     DATABASE_CONFIG_KEY = 'database'
     SCHEMA_CONFIG_KEY = 'schema'
+    TABLE_CONFIG_KEY = 'table'
 
     BATCH_SIZE = 1000
 
@@ -32,7 +33,7 @@ class Destination(BaseDestination):
     def export_batch_data(self, record_data: List[Dict], stream: str) -> None:
         database_name = self.config.get(self.DATABASE_CONFIG_KEY)
         schema_name = self.config.get(self.SCHEMA_CONFIG_KEY)
-        table_name = self.config.get('table')
+        table_name = self.config.get(self.TABLE_CONFIG_KEY)
 
         tags = dict(
             database_name=database_name,
@@ -88,7 +89,7 @@ class Destination(BaseDestination):
     ) -> List[str]:
         database_name = self.config.get(self.DATABASE_CONFIG_KEY)
         schema_name = self.config.get(self.SCHEMA_CONFIG_KEY)
-        table_name = self.config.get('table')
+        table_name = self.config.get(self.TABLE_CONFIG_KEY)
 
         schema = self.schemas[stream]
         unique_constraints = self.unique_constraints.get(stream)
@@ -183,7 +184,7 @@ class Destination(BaseDestination):
     ):
         database_name = self.config.get(self.DATABASE_CONFIG_KEY)
         schema_name = self.config.get(self.SCHEMA_CONFIG_KEY)
-        table_name = self.config.get('table')
+        table_name = self.config.get(self.TABLE_CONFIG_KEY)
 
         schema = self.schemas[stream]
         unique_constraints = self.unique_constraints.get(stream)

--- a/mage_integrations/mage_integrations/destinations/trino/connectors/base.py
+++ b/mage_integrations/mage_integrations/destinations/trino/connectors/base.py
@@ -236,7 +236,7 @@ DESCRIBE {schema_name}.{table_name}
 
         database_name = self.config.get(self.DATABASE_CONFIG_KEY)
         schema_name = self.config.get(self.SCHEMA_CONFIG_KEY)
-        table_name = self.config.get('table')
+        table_name = self.config.get(self.TABLE_CONFIG_KEY)
 
         schema = self.schemas[stream]
         unique_constraints = self.unique_constraints.get(stream)


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

Introduce a new constant `TABLE_CONFIG_KEY` to be consistent with `DATABASE_CONFIG_KEY` and `SCHEMA_CONFIG_KEY`, to avoid using the hard-coded `table` string.

# Tests
<!-- How did you test your change? -->
CI
cc:
<!-- Optionally mention someone to let them know about this pull request -->
@dy46 @wangxiaoyou1993 