### PR TITLE
[dy] Update snowflake to use VARCHAR

### DIFF
--- a/mage_ai/io/mysql.py
+++ b/mage_ai/io/mysql.py
@@ -119,7 +119,7 @@ class MySQL(BaseSQL):
         elif dtype == PandasTypes.DATE:
             return 'DATE'
         elif dtype == PandasTypes.STRING:
-            return 'CHAR(255)'
+            return 'TEXT'
         elif dtype == PandasTypes.CATEGORICAL:
             return 'TEXT'
         elif dtype == PandasTypes.BYTES:

--- a/mage_ai/io/sql.py
+++ b/mage_ai/io/sql.py
@@ -1,15 +1,17 @@
+import warnings
 from io import StringIO
-from mage_ai.io.base import BaseSQLConnection, ExportWritePolicy, QUERY_ROW_LIMIT
+from typing import IO, Any, Dict, List, Mapping, Union
+
+from pandas import DataFrame, Series, read_sql
+
+from mage_ai.io.base import QUERY_ROW_LIMIT, BaseSQLConnection, ExportWritePolicy
 from mage_ai.io.config import BaseConfigLoader
 from mage_ai.io.export_utils import (
+    PandasTypes,
     clean_df_for_export,
     gen_table_creation_query,
     infer_dtypes,
-    PandasTypes,
 )
-from pandas import DataFrame, read_sql, Series
-from typing import Any, Dict, IO, List, Mapping, Union
-import warnings
 
 
 class BaseSQL(BaseSQLConnection):

--- a/mage_integrations/mage_integrations/destinations/snowflake/utils.py
+++ b/mage_integrations/mage_integrations/destinations/snowflake/utils.py
@@ -39,5 +39,7 @@ def convert_column_type(column_type: str, column_settings: Dict, **kwargs) -> st
     elif COLUMN_TYPE_STRING == column_type \
             and COLUMN_FORMAT_DATETIME == column_settings.get('format'):
         return 'TIMESTAMP_TZ'
+    elif COLUMN_TYPE_STRING == column_type:
+        return 'VARCHAR'
 
     return convert_column_type_og(column_type, column_settings)


### PR DESCRIPTION
# Summary

Update snowflake to cast strings as `VARCHAR` instead of `VARCHAR(255)`. Also update the `mysql` io loader to use `TEXT` for strings so they don't get cut off at 255 characters.
<!-- Brief summary of what your code does -->

# Tests

tested locally
<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
