### PR TITLE
[xy] Fix retry when using k8s executor

### DIFF
--- a/mage_ai/data_preparation/executors/azure_container_instance_executor.py
+++ b/mage_ai/data_preparation/executors/azure_container_instance_executor.py
@@ -6,6 +6,8 @@ from mage_ai.shared.hash import merge_dict
 
 
 class AzureContainerInstanceExecutor(BlockExecutor):
+    RETRYABLE = False
+
     def __init__(self, pipeline, block_uuid: str, execution_partition: str = None):
         super().__init__(pipeline, block_uuid, execution_partition=execution_partition)
         self.executor_config = self.pipeline.repo_config.azure_container_instance_config or dict()

--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -15,6 +15,10 @@ from mage_ai.shared.utils import clean_name
 
 
 class BlockExecutor:
+    """
+    Executor for a block in a pipeline.
+    """
+
     RETRYABLE = True
 
     def __init__(
@@ -23,6 +27,14 @@ class BlockExecutor:
         block_uuid,
         execution_partition=None
     ):
+        """
+        Initialize the BlockExecutor.
+
+        Args:
+            pipeline: The pipeline object.
+            block_uuid: The UUID of the block.
+            execution_partition: The execution partition of the block.
+        """
         self.pipeline = pipeline
         self.block_uuid = block_uuid
         self.block = self.pipeline.get_block(self.block_uuid, check_template=True)
@@ -54,6 +66,30 @@ class BlockExecutor:
         dynamic_upstream_block_uuids: Union[List[str], None] = None,
         **kwargs,
     ) -> Dict:
+        """
+        Execute the block.
+
+        Args:
+            analyze_outputs: Whether to analyze the outputs of the block.
+            callback_url: The URL for the callback.
+            global_vars: Global variables for the block execution.
+            update_status: Whether to update the status of the block execution.
+            on_complete: Callback function called when the block execution is complete.
+            on_failure: Callback function called when the block execution fails.
+            on_start: Callback function called when the block execution starts.
+            input_from_output: Input from the output of a previous block.
+            verify_output: Whether to verify the output of the block.
+            retry_config: Configuration for retrying the block execution.
+            runtime_arguments: Runtime arguments for the block execution.
+            template_runtime_configuration: Template runtime configuration for the block execution.
+            dynamic_block_index: Index of the dynamic block.
+            dynamic_block_uuid: UUID of the dynamic block.
+            dynamic_upstream_block_uuids: List of UUIDs of the dynamic upstream blocks.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            The result of the block execution.
+        """
         if template_runtime_configuration:
             self.block.template_runtime_configuration = template_runtime_configuration
         try:
@@ -64,7 +100,7 @@ class BlockExecutor:
             self.logger.info(f'Start executing block with {self.__class__.__name__}.', **tags)
             if on_start is not None:
                 on_start(self.block_uuid)
-            pipeline_run = PipelineRun.query.get(kwargs['pipeline_run_id']) \
+            pipeline_run = PipelineRun.query.get(kwargs.get('pipeline_run_id')) \
                 if 'pipeline_run_id' in kwargs else None
 
             conditional_result = self._execute_conditional(
@@ -77,7 +113,7 @@ class BlockExecutor:
             if not conditional_result:
                 self.logger.info(
                     f'Conditional block(s) returned false for {self.block.uuid}. '
-                    'This block run and downstream blocks will set as CONDITION_FAILED.',
+                    'This block run and downstream blocks will be set as CONDITION_FAILED.',
                     **merge_dict(tags, dict(
                         block_type=self.block.type,
                         block_uuid=self.block.uuid,
@@ -203,6 +239,26 @@ class BlockExecutor:
         dynamic_upstream_block_uuids: Union[List[str], None] = None,
         **kwargs,
     ) -> Dict:
+        """
+        Execute the block.
+
+        Args:
+            analyze_outputs: Whether to analyze the outputs of the block.
+            callback_url: The URL for the callback.
+            global_vars: Global variables for the block execution.
+            update_status: Whether to update the status of the block execution.
+            input_from_output: Input from the output of a previous block.
+            logging_tags: Tags for logging.
+            verify_output: Whether to verify the output of the block.
+            runtime_arguments: Runtime arguments for the block execution.
+            dynamic_block_index: Index of the dynamic block.
+            dynamic_block_uuid: UUID of the dynamic block.
+            dynamic_upstream_block_uuids: List of UUIDs of the dynamic upstream blocks.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            The result of the block execution.
+        """
         if logging_tags is None:
             logging_tags = dict()
         result = self.block.execute_sync(
@@ -247,7 +303,20 @@ class BlockExecutor:
         pipeline_run: PipelineRun,
         dynamic_block_index: Union[int, None] = None,
         dynamic_upstream_block_uuids: Union[List[str], None] = None,
-    ):
+    ) -> bool:
+        """
+        Execute the conditional blocks.
+
+        Args:
+            global_vars: Global variables for the block execution.
+            logging_tags: Tags for logging.
+            pipeline_run: The pipeline run object.
+            dynamic_block_index: Index of the dynamic block.
+            dynamic_upstream_block_uuids: List of UUIDs of the dynamic upstream blocks.
+
+        Returns:
+            True if all conditional blocks evaluate to True, False otherwise.
+        """
         result = True
         for conditional_block in self.block.conditional_blocks:
             try:
@@ -263,14 +332,14 @@ class BlockExecutor:
                 )
                 if not block_result:
                     self.logger.info(
-                        f'Conditional block {conditional_block.uuid} evaluated as False ' +
+                        f'Conditional block {conditional_block.uuid} evaluated as False '
                         f'for block {self.block.uuid}',
                         logging_tags,
                     )
                 result = result and block_result
             except Exception as conditional_err:
                 self.logger.exception(
-                    f'Failed to execute conditional block {conditional_block.uuid} ' +
+                    f'Failed to execute conditional block {conditional_block.uuid} '
                     f'for block {self.block.uuid}.',
                     **merge_dict(logging_tags, dict(
                         error=conditional_err,
@@ -289,6 +358,17 @@ class BlockExecutor:
         dynamic_block_index: Union[int, None] = None,
         dynamic_upstream_block_uuids: Union[List[str], None] = None,
     ):
+        """
+        Execute the callback blocks.
+
+        Args:
+            callback: The callback type ('on_success' or 'on_failure').
+            global_vars: Global variables for the block execution.
+            logging_tags: Tags for logging.
+            pipeline_run: The pipeline run object.
+            dynamic_block_index: Index of the dynamic block.
+            dynamic_upstream_block_uuids: List of UUIDs of the dynamic upstream blocks.
+        """
         arr = []
         if self.block.callback_block:
             arr.append(self.block.callback_block)
@@ -311,7 +391,7 @@ class BlockExecutor:
                 )
             except Exception as callback_err:
                 self.logger.exception(
-                    f'Failed to execute {callback} callback block {callback_block.uuid} ' +
+                    f'Failed to execute {callback} callback block {callback_block.uuid} '
                     f'for block {self.block.uuid}.',
                     **merge_dict(logging_tags, dict(
                         error=callback_err,
@@ -324,7 +404,18 @@ class BlockExecutor:
         global_vars: Dict = None,
         **kwargs,
     ) -> List[str]:
-        cmd = f'/app/run_app.sh '\
+        """
+        Run the commands for the block.
+
+        Args:
+            block_run_id: The ID of the block run.
+            global_vars: Global variables for the block execution.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            A list of command arguments.
+        """
+        cmd = f'/app/run_app.sh ' \
               f'mage run {self.pipeline.repo_config.repo_path} {self.pipeline.uuid}'
         options = [
             '--block-uuid',
@@ -401,6 +492,15 @@ class BlockExecutor:
         )
 
     def _build_tags(self, **kwargs):
+        """
+        Build tags for logging.
+
+        Args:
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            The built tags.
+        """
         default_tags = dict(
             block_type=self.block.type,
             block_uuid=self.block_uuid,

--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -97,7 +97,7 @@ class BlockExecutor:
                 if retry_config is None:
                     if self.RETRYABLE:
                         retry_config = merge_dict(
-                            self.pipeline.retry_config or dict(),
+                            self.pipeline.repo_config.retry_config or dict(),
                             self.block.retry_config or dict(),
                         )
                     else:

--- a/mage_ai/data_preparation/executors/ecs_block_executor.py
+++ b/mage_ai/data_preparation/executors/ecs_block_executor.py
@@ -6,6 +6,8 @@ from mage_ai.shared.hash import merge_dict
 
 
 class EcsBlockExecutor(BlockExecutor):
+    RETRYABLE = False
+
     def __init__(self, pipeline, block_uuid: str, execution_partition: str = None):
         super().__init__(pipeline, block_uuid, execution_partition=execution_partition)
         self.executor_config = self.pipeline.repo_config.ecs_config or dict()

--- a/mage_ai/data_preparation/executors/gcp_cloud_run_block_executor.py
+++ b/mage_ai/data_preparation/executors/gcp_cloud_run_block_executor.py
@@ -7,6 +7,8 @@ from mage_ai.shared.hash import merge_dict
 
 
 class GcpCloudRunBlockExecutor(BlockExecutor):
+    RETRYABLE = False
+
     def __init__(self, pipeline, block_uuid: str, execution_partition: str = None):
         super().__init__(pipeline, block_uuid, execution_partition=execution_partition)
         self.executor_config = self.pipeline.repo_config.gcp_cloud_run_config or dict()

--- a/mage_ai/data_preparation/executors/k8s_block_executor.py
+++ b/mage_ai/data_preparation/executors/k8s_block_executor.py
@@ -1,10 +1,13 @@
+from typing import Dict
+
 from mage_ai.data_preparation.executors.block_executor import BlockExecutor
 from mage_ai.services.k8s.job_manager import JobManager as K8sJobManager
 from mage_ai.shared.hash import merge_dict
-from typing import Dict
 
 
 class K8sBlockExecutor(BlockExecutor):
+    RETRYABLE = False
+
     def __init__(self, pipeline, block_uuid: str, execution_partition: str = None):
         super().__init__(pipeline, block_uuid, execution_partition=execution_partition)
         self.executor_config = self.pipeline.repo_config.k8s_executor_config or dict()

--- a/mage_ai/tests/data_preparation/executors/test_block_executor.py
+++ b/mage_ai/tests/data_preparation/executors/test_block_executor.py
@@ -204,3 +204,50 @@ class BlockExecutorTest(TestCase):
             logging_tags={},
             pipeline_run=None,
         )
+
+    def test_execute_callback(self):
+        self.block.callback_blocks = [MagicMock(), MagicMock()]
+        self.block.callback_block = MagicMock()
+
+        self.block_executor._execute_callback(
+            callback='on_success',
+            global_vars={},
+            logging_tags={},
+            pipeline_run=None,
+            dynamic_block_index=None,
+            dynamic_upstream_block_uuids=None,
+        )
+
+        self.block.callback_block.execute_callback.assert_called_once_with(
+            'on_success',
+            dynamic_block_index=None,
+            dynamic_upstream_block_uuids=None,
+            execution_partition=self.execution_partition,
+            global_vars={},
+            logger=self.logger,
+            logging_tags={},
+            parent_block=self.block,
+            pipeline_run=None,
+        )
+        self.block.callback_blocks[0].execute_callback.assert_called_once_with(
+            'on_success',
+            dynamic_block_index=None,
+            dynamic_upstream_block_uuids=None,
+            execution_partition=self.execution_partition,
+            global_vars={},
+            logger=self.logger,
+            logging_tags={},
+            parent_block=self.block,
+            pipeline_run=None,
+        )
+        self.block.callback_blocks[1].execute_callback.assert_called_once_with(
+            'on_success',
+            dynamic_block_index=None,
+            dynamic_upstream_block_uuids=None,
+            execution_partition=self.execution_partition,
+            global_vars={},
+            logger=self.logger,
+            logging_tags={},
+            parent_block=self.block,
+            pipeline_run=None,
+        )

--- a/mage_ai/tests/data_preparation/executors/test_block_executor.py
+++ b/mage_ai/tests/data_preparation/executors/test_block_executor.py
@@ -161,8 +161,7 @@ class BlockExecutorTest(TestCase):
         )
 
         self.assertFalse(result)
-        self.block.conditional_blocks[0].execute_conditional.assert_called_once_with(
-            self.block,
+        expected_kwargs = dict(
             dynamic_block_index=None,
             dynamic_upstream_block_uuids=None,
             execution_partition=self.execution_partition,
@@ -171,15 +170,13 @@ class BlockExecutorTest(TestCase):
             logging_tags={},
             pipeline_run=None,
         )
+        self.block.conditional_blocks[0].execute_conditional.assert_called_once_with(
+            self.block,
+            **expected_kwargs,
+        )
         self.block.conditional_blocks[1].execute_conditional.assert_called_once_with(
             self.block,
-            dynamic_block_index=None,
-            dynamic_upstream_block_uuids=None,
-            execution_partition=self.execution_partition,
-            global_vars={},
-            logger=self.logger,
-            logging_tags={},
-            pipeline_run=None,
+            **expected_kwargs,
         )
 
     def test_execute_conditional_exception(self):
@@ -220,8 +217,7 @@ class BlockExecutorTest(TestCase):
             dynamic_upstream_block_uuids=None,
         )
 
-        self.block.callback_block.execute_callback.assert_called_once_with(
-            'on_success',
+        expected_kwargs = dict(
             dynamic_block_index=None,
             dynamic_upstream_block_uuids=None,
             execution_partition=self.execution_partition,
@@ -230,26 +226,17 @@ class BlockExecutorTest(TestCase):
             logging_tags={},
             parent_block=self.block,
             pipeline_run=None,
+        )
+
+        self.block.callback_block.execute_callback.assert_called_once_with(
+            'on_success',
+            **expected_kwargs,
         )
         self.block.callback_blocks[0].execute_callback.assert_called_once_with(
             'on_success',
-            dynamic_block_index=None,
-            dynamic_upstream_block_uuids=None,
-            execution_partition=self.execution_partition,
-            global_vars={},
-            logger=self.logger,
-            logging_tags={},
-            parent_block=self.block,
-            pipeline_run=None,
+            **expected_kwargs,
         )
         self.block.callback_blocks[1].execute_callback.assert_called_once_with(
             'on_success',
-            dynamic_block_index=None,
-            dynamic_upstream_block_uuids=None,
-            execution_partition=self.execution_partition,
-            global_vars={},
-            logger=self.logger,
-            logging_tags={},
-            parent_block=self.block,
-            pipeline_run=None,
+            **expected_kwargs,
         )

--- a/mage_ai/tests/data_preparation/executors/test_block_executor.py
+++ b/mage_ai/tests/data_preparation/executors/test_block_executor.py
@@ -1,0 +1,206 @@
+from unittest.mock import MagicMock
+
+from mage_ai.data_preparation.executors.block_executor import BlockExecutor
+from mage_ai.data_preparation.models.block import Block
+from mage_ai.data_preparation.models.constants import BlockType
+from mage_ai.tests.base_test import TestCase
+
+
+class BlockExecutorTest(TestCase):
+    def setUp(self):
+        self.pipeline = MagicMock()
+        self.pipeline.uuid = 'pipeline_uuid'
+        self.pipeline.repo_config = MagicMock()
+        self.block_uuid = 'block_uuid'
+        self.execution_partition = 'partition'
+        self.logger_manager = MagicMock()
+        self.logger = MagicMock()
+        self.block = MagicMock(spec=Block)
+        self.block.type = BlockType.DBT
+
+        self.pipeline.get_block.return_value = self.block
+        self.pipeline.repo_config.retry_config = {'retries': 3, 'delay': 1}
+
+        self.logger_manager.logger = self.logger
+        self.logger_manager.output_logs_to_destination = MagicMock()
+
+        self.block.uuid = self.block_uuid
+        self.block.template_runtime_configuration = None
+        self.block.conditional_blocks = []
+        self.block.callback_block = None
+        self.block.callback_blocks = []
+
+        self.block_executor = BlockExecutor(
+            self.pipeline,
+            self.block_uuid,
+            self.execution_partition,
+        )
+        self.block_executor.logger_manager = self.logger_manager
+        self.block_executor.logger = self.logger
+        self.block_executor.block = self.block
+
+    def test_execute(self):
+        analyze_outputs = False
+        callback_url = 'http://example.com/callback'
+        global_vars = {'var1': 'value1'}
+        update_status = True
+
+        def on_complete(block_uuid):
+            pass
+
+        def on_failure(block_uuid, error):
+            pass
+
+        def on_start(block_uuid):
+            pass
+
+        input_from_output = {'input': 'output'}
+        verify_output = True
+        retry_config = {'retries': 5, 'delay': 2}
+        runtime_arguments = {'arg1': 'value1'}
+        template_runtime_configuration = {'config': 'value'}
+        dynamic_block_index = 1
+        dynamic_block_uuid = 'dynamic_block_uuid'
+        dynamic_upstream_block_uuids = ['upstream_block1', 'upstream_block2']
+
+        self.block_executor._execute_conditional = MagicMock(return_value=True)
+        self.block_executor._execute = MagicMock(return_value={'result': 'success'})
+        # self.block.run_tests = MagicMock()
+        self.block_executor._execute_callback = MagicMock()
+
+        result = self.block_executor.execute(
+            analyze_outputs=analyze_outputs,
+            callback_url=callback_url,
+            global_vars=global_vars,
+            update_status=update_status,
+            on_complete=on_complete,
+            on_failure=on_failure,
+            on_start=on_start,
+            input_from_output=input_from_output,
+            verify_output=verify_output,
+            retry_config=retry_config,
+            runtime_arguments=runtime_arguments,
+            template_runtime_configuration=template_runtime_configuration,
+            dynamic_block_index=dynamic_block_index,
+            dynamic_block_uuid=dynamic_block_uuid,
+            dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
+        )
+
+        self.assertEqual(result, {'result': 'success'})
+        self.pipeline.get_block.assert_called_once_with(self.block_uuid, check_template=True)
+        self.assertEqual(self.block.template_runtime_configuration, template_runtime_configuration)
+        self.block_executor._execute_conditional.assert_called_once_with(
+            dynamic_block_index=dynamic_block_index,
+            dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
+            global_vars=global_vars,
+            logging_tags={
+                'block_type': BlockType.DBT,
+                'block_uuid': self.block_uuid,
+                'pipeline_uuid': self.pipeline.uuid,
+            },
+            pipeline_run=None,
+        )
+        self.block_executor._execute.assert_called_once_with(
+            analyze_outputs=analyze_outputs,
+            callback_url=callback_url,
+            global_vars=global_vars,
+            update_status=update_status,
+            input_from_output=input_from_output,
+            logging_tags={
+                'block_type': BlockType.DBT,
+                'block_uuid': self.block_uuid,
+                'pipeline_uuid': self.pipeline.uuid,
+            },
+            verify_output=verify_output,
+            runtime_arguments=runtime_arguments,
+            template_runtime_configuration=template_runtime_configuration,
+            dynamic_block_index=dynamic_block_index,
+            dynamic_block_uuid=dynamic_block_uuid,
+            dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
+        )
+        # self.block.run_tests.assert_called_once_with(
+        #     execution_partition=self.execution_partition,
+        #     global_vars=global_vars,
+        #     logger=self.logger,
+        #     logging_tags={
+        #         'block_type': BlockType.DBT,
+        #         'block_uuid': self.block_uuid,
+        #         'pipeline_uuid': self.pipeline.uuid,
+        #     },
+        #     update_tests=False,
+        #     dynamic_block_uuid=dynamic_block_uuid,
+        # )
+        self.block_executor._execute_callback.assert_called_with(
+            'on_success',
+            dynamic_block_index=dynamic_block_index,
+            dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
+            global_vars=global_vars,
+            logging_tags={
+                'block_type': BlockType.DBT,
+                'block_uuid': self.block_uuid,
+                'pipeline_uuid': self.pipeline.uuid,
+            },
+            pipeline_run=None,
+        )
+        self.logger_manager.output_logs_to_destination.assert_called_once()
+
+    def test_execute_conditional(self):
+        self.block.conditional_blocks = [MagicMock(), MagicMock()]
+
+        self.block.conditional_blocks[0].execute_conditional.return_value = True
+        self.block.conditional_blocks[1].execute_conditional.return_value = False
+
+        result = self.block_executor._execute_conditional(
+            dynamic_block_index=None,
+            dynamic_upstream_block_uuids=None,
+            global_vars={},
+            logging_tags={},
+            pipeline_run=None,
+        )
+
+        self.assertFalse(result)
+        self.block.conditional_blocks[0].execute_conditional.assert_called_once_with(
+            self.block,
+            dynamic_block_index=None,
+            dynamic_upstream_block_uuids=None,
+            execution_partition=self.execution_partition,
+            global_vars={},
+            logger=self.logger,
+            logging_tags={},
+            pipeline_run=None,
+        )
+        self.block.conditional_blocks[1].execute_conditional.assert_called_once_with(
+            self.block,
+            dynamic_block_index=None,
+            dynamic_upstream_block_uuids=None,
+            execution_partition=self.execution_partition,
+            global_vars={},
+            logger=self.logger,
+            logging_tags={},
+            pipeline_run=None,
+        )
+
+    def test_execute_conditional_exception(self):
+        self.block.conditional_blocks = [MagicMock()]
+
+        self.block.conditional_blocks[0].execute_conditional.side_effect = Exception('Error')
+
+        result = self.block_executor._execute_conditional(
+            dynamic_block_index=None,
+            dynamic_upstream_block_uuids=None,
+            global_vars={},
+            logging_tags={},
+            pipeline_run=None,
+        )
+
+        self.assertFalse(result)
+        self.block.conditional_blocks[0].execute_conditional.assert_called_once_with(
+            self.block,
+            dynamic_block_index=None,
+            dynamic_upstream_block_uuids=None,
+            execution_partition=self.execution_partition,
+            global_vars={},
+            logger=self.logger,
+            logging_tags={},
+            pipeline_run=None,
+        )

--- a/mage_ai/tests/data_preparation/executors/test_block_executor.py
+++ b/mage_ai/tests/data_preparation/executors/test_block_executor.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import MagicMock
 
 from mage_ai.data_preparation.executors.block_executor import BlockExecutor
@@ -20,6 +21,7 @@ class BlockExecutorTest(TestCase):
 
         self.pipeline.get_block.return_value = self.block
         self.pipeline.repo_config.retry_config = {'retries': 3, 'delay': 1}
+        self.pipeline.repo_config.variables_dir = os.path.join(os.getcwd(), 'mage_data')
 
         self.logger_manager.logger = self.logger
         self.logger_manager.output_logs_to_destination = MagicMock()


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Fix retry when using k8s executor
* Only retry in BlockExecutor inside the k8s pod
* Fetch retry config from repo_config and block config when it's None

# Tests
<!-- How did you test your change? -->
tested on local k8s cluster

cc:
<!-- Optionally mention someone to let them know about this pull request -->
