### PR TITLE
fix default filepath in ConfigFileLoader __init__

### DIFF
--- a/mage_ai/io/config.py
+++ b/mage_ai/io/config.py
@@ -431,7 +431,7 @@ class ConfigFileLoader(BaseConfigLoader):
             self.config = config
         else:
             if filepath is None:
-                filepath = get_repo_path() / 'io_config.yaml'
+                filepath = os.path.join(get_repo_path(), 'io_config.yaml')
             self.filepath = Path(filepath)
             self.profile = profile
             with self.filepath.open('r') as fin:


### PR DESCRIPTION
# Summary
Fixes a bug in `ConfigFileUploader`.  
```
    432         else:
    433             if filepath is None:
--> 434                 filepath = get_repo_path() / 'io_config.yaml'
    435             self.filepath = Path(filepath)
    436             self.profile = profile
TypeError: unsupported operand type(s) for /: 'str' and 'str'
```
[Link to slack thread](https://mageai.slack.com/archives/C03HTTWFEKE/p1689202141593109)

# Tests
Ran the code locally and confirmed the unit tests are all still passing.

cc:
@mattppal - Let me know if there's anything else I should include in this request. Thanks!
