### PR TITLE
Use apt-get when invoking from scripts

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          sudo apt install libkrb5-dev
+          sudo apt-get install libkrb5-dev
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r mage_integrations/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ USER root
 # Download ODBC headers for pyodbc
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
-RUN apt -y update
-RUN ACCEPT_EULA=Y apt -y install msodbcsql18
-RUN apt -y install unixodbc-dev
+RUN apt-get -y update
+RUN ACCEPT_EULA=Y apt-get -y install msodbcsql18
+RUN apt-get -y install unixodbc-dev
 
 # Install NFS dependencies, and pymssql dependencies
-RUN apt -y install nfs-common freetds-dev freetds-bin
+RUN apt-get -y install nfs-common freetds-dev freetds-bin
 
 # Install Mage
 RUN ${PIP} install --upgrade pip
@@ -23,7 +23,7 @@ COPY ./mage_ai/server/constants.py constants.py
 RUN tag=$(tail -n 1 constants.py) && VERSION=$(echo $tag | tr -d "'") && ${PIP} install --no-cache "mage-ai[all]"==$VERSION
 
 # Install R
-RUN apt install -y r-base
+RUN apt-get install -y r-base
 RUN R -e "install.packages('pacman', repos='http://cran.us.r-project.org')"
 RUN R -e "install.packages('renv', repos='http://cran.us.r-project.org')"
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -9,15 +9,15 @@ USER root
 # Download ODBC headers for pyodbc
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
-RUN apt -y update
-RUN ACCEPT_EULA=Y apt -y install msodbcsql18
-RUN apt -y install unixodbc-dev
+RUN apt-get -y update
+RUN ACCEPT_EULA=Y apt-get -y install msodbcsql18
+RUN apt-get -y install unixodbc-dev
 
 # Install NFS dependencies, and pymssql dependencies
-RUN apt -y install curl freetds-dev freetds-bin
+RUN apt-get -y install curl freetds-dev freetds-bin
 
 # Install R
-# RUN apt install -y r-base
+# RUN apt-get install -y r-base
 # RUN R -e "install.packages('pacman', repos='http://cran.us.r-project.org')"
 # RUN R -e "install.packages('renv', repos='http://cran.us.r-project.org')"
 
@@ -44,8 +44,8 @@ RUN jupyter-kernelspec install --user $(pip show sparkmagic | grep Location | cu
 
 # Install node modules used in front-end
 RUN curl -fsSL https://deb.nodesource.com/setup_17.x | bash -
-RUN apt install -y nodejs
-RUN apt install -y npm
+RUN apt-get install -y nodejs
+RUN apt-get install -y npm
 RUN npm install --global yarn
 RUN yarn global add next
 RUN cd /home/src/mage_ai/frontend && yarn install


### PR DESCRIPTION
# Summary
Replace the use of `apt` instead with `apt-get`.

While [apt](https://manpages.ubuntu.com/manpages/xenial/man8/apt.8.html) is newer, it is meant to be a high-level, user-friendly tool, better suited for interactive use. In contrast, [apt-get](https://manpages.ubuntu.com/manpages/xenial/man8/apt-get.8.html) is intended to be the "backend" that multiple other UIs utilize for programmatic control.

This doesn't matter when I tested with Docker Desktop on Mac, but I found that using `apt` was broken when using Docker on Minikube. For example, one dependency that failed was `msodbcsql18`.

# Tests
Updating the Dockerfile and dev.Dockerfile to `apt-get` successfully allowed me to build using Docker on Minikube. I have not tested the 2nd commit, which is for the GitHub Action defined in build_and_test.yml, but it will be easy to detect if it breaks anything upon merge, I assume.

cc: @tommydangerous, @wangxiaoyou1993 