### PR TITLE
[dy] Remove data integration config from logs

### DIFF
--- a/mage_ai/data_integrations/logger/utils.py
+++ b/mage_ai/data_integrations/logger/utils.py
@@ -1,6 +1,5 @@
 import json
 import re
-from collections.abc import Iterable
 from datetime import datetime
 from typing import Dict
 
@@ -91,7 +90,7 @@ def print_log_from_line(
 
 def print_logs_from_output(
     output: str,
-    filter_values: Iterable = None,
+    config: Dict = None,
     logger=None,
     logging_tags: Dict = None,
     tags: Dict = None,
@@ -99,7 +98,7 @@ def print_logs_from_output(
     for line in output.split('\n'):
         print_log_from_line(
             line,
-            filter_values=filter_values,
+            config=config,
             logger=logger,
             logging_tags=logging_tags,
             tags=tags,

--- a/mage_ai/data_integrations/logger/utils.py
+++ b/mage_ai/data_integrations/logger/utils.py
@@ -5,12 +5,12 @@ from datetime import datetime
 from typing import Dict
 
 from mage_ai.shared.hash import merge_dict
-from mage_ai.shared.security import filter_out_values
+from mage_ai.shared.security import filter_out_config_values
 
 
 def print_log_from_line(
     line: str,
-    filter_values: Iterable = None,
+    config: Dict = None,
     logger=None,
     logging_tags: Dict = None,
     tags: Dict = None,
@@ -61,7 +61,7 @@ def print_log_from_line(
                     updated_tags = tags1
                     try:
                         updated_tags.update(data2)
-                        message = filter_out_values(message, filter_values)
+                        message = filter_out_config_values(message, config)
                         logger.info(
                             message,
                             **merge_dict(
@@ -80,11 +80,11 @@ def print_log_from_line(
                 else:
                     message = 'Exception raised, please check logs for more details.'
 
-                message = filter_out_values(message, filter_values)
+                message = filter_out_config_values(message, config)
                 raise Exception(message)
 
         if log_to_print:
-            print(filter_out_values(log_to_print, filter_values))
+            print(filter_out_config_values(log_to_print, config))
     except json.decoder.JSONDecodeError:
         pass
 

--- a/mage_ai/data_integrations/logger/utils.py
+++ b/mage_ai/data_integrations/logger/utils.py
@@ -1,15 +1,19 @@
-from datetime import datetime
-from mage_ai.shared.hash import merge_dict
-from typing import Dict
 import json
 import re
+from collections.abc import Iterable
+from datetime import datetime
+from typing import Dict
+
+from mage_ai.shared.hash import merge_dict
+from mage_ai.shared.security import filter_out_values
 
 
 def print_log_from_line(
     line: str,
+    filter_values: Iterable = None,
     logger=None,
-    logging_tags: Dict = dict(),
-    tags: Dict = {},
+    logging_tags: Dict = None,
+    tags: Dict = None,
 ):
     from mage_integrations.utils.logger.constants import (
         LOG_LEVEL_ERROR,
@@ -17,73 +21,85 @@ def print_log_from_line(
         TYPE_LOG,
     )
 
+    if logging_tags is None:
+        logging_tags = dict()
+    if tags is None:
+        tags = {}
+
+    log_to_print = None
     try:
         data = json.loads(line)
 
         if type(data) is not dict:
             if type(data) is list and len(data) >= 1:
-                print(json.dumps(data))
-            return
+                log_to_print = json.dumps(data)
+        else:
+            message = data.get('message')
+            tags1 = data.get('tags')
 
-        message = data.get('message')
-        tags1 = data.get('tags')
+            if 'timestamp' in data:
+                message = datetime.fromtimestamp(data['timestamp']).strftime('%Y-%m-%dT%H:%M:%S') \
+                            + ' ' + str(message)
 
-        if 'timestamp' in data:
-            message = datetime.fromtimestamp(data['timestamp']).strftime('%Y-%m-%dT%H:%M:%S') \
-                        + ' ' + str(message)
+            if message and (
+                re.match(
+                    '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2} Unable to parse:',
+                    message,
+                ) or
+                re.match('Unable to parse:', message)
+            ):
+                return
 
-        if message and (
-            re.match(
-                '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2} Unable to parse:',
-                message,
-            ) or
-            re.match('Unable to parse:', message)
-        ):
-            return
+            if TYPE_LOG == data.get('type'):
+                if logger:
+                    data2 = data.copy()
+                    if 'message' in data2:
+                        del data2['message']
+                    if 'tags' in data2:
+                        del data2['tags']
 
-        if TYPE_LOG == data.get('type'):
-            if logger:
-                data2 = data.copy()
-                if 'message' in data2:
-                    del data2['message']
-                if 'tags' in data2:
-                    del data2['tags']
-
-                updated_tags = tags1
-                try:
-                    updated_tags.update(data2)
-                    logger.info(
-                        message,
-                        **merge_dict(
-                            logging_tags,
-                            dict(tags=merge_dict(tags, updated_tags)),
+                    updated_tags = tags1
+                    try:
+                        updated_tags.update(data2)
+                        message = filter_out_values(message, filter_values)
+                        logger.info(
+                            message,
+                            **merge_dict(
+                                logging_tags,
+                                dict(tags=merge_dict(tags, updated_tags)),
+                            )
                         )
-                    )
-                except Exception:
-                    pass
-            else:
-                print(json.dumps(data))
-        if data.get('level') in [LOG_LEVEL_ERROR, LOG_LEVEL_EXCEPTION]:
-            if message:
-                if tags1:
-                    message = f'{message} {json.dumps(tags1)}'
-            else:
-                message = 'Exception raised, please check logs for more details.'
+                    except Exception:
+                        pass
+                else:
+                    log_to_print = json.dumps(data)
+            if data.get('level') in [LOG_LEVEL_ERROR, LOG_LEVEL_EXCEPTION]:
+                if message:
+                    if tags1:
+                        message = f'{message} {json.dumps(tags1)}'
+                else:
+                    message = 'Exception raised, please check logs for more details.'
 
-            raise Exception(message)
+                message = filter_out_values(message, filter_values)
+                raise Exception(message)
+
+        if log_to_print:
+            print(filter_out_values(log_to_print, filter_values))
     except json.decoder.JSONDecodeError:
         pass
 
 
 def print_logs_from_output(
     output: str,
+    filter_values: Iterable = None,
     logger=None,
-    logging_tags: Dict = dict(),
-    tags: Dict = {},
+    logging_tags: Dict = None,
+    tags: Dict = None,
 ):
     for line in output.split('\n'):
         print_log_from_line(
             line,
+            filter_values=filter_values,
             logger=logger,
             logging_tags=logging_tags,
             tags=tags,

--- a/mage_ai/data_integrations/utils/config.py
+++ b/mage_ai/data_integrations/utils/config.py
@@ -1,14 +1,16 @@
+import json
+from typing import Dict, List, Tuple
+
+import simplejson
+import yaml
 from jinja2 import Template
+
+from mage_ai.data_integrations.utils.parsers import NoDatesSafeLoader
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.data_preparation.shared.utils import get_template_vars
-from mage_ai.data_integrations.utils.parsers import NoDatesSafeLoader
 from mage_ai.shared.dates import n_days_ago
 from mage_ai.shared.hash import merge_dict
 from mage_ai.shared.parsers import encode_complex
-from typing import Dict, List
-import json
-import simplejson
-import yaml
 
 KEY_PATTERNS = '_patterns'
 PATTERN_KEY_DESTINATION_TABLE = 'destination_table'
@@ -96,11 +98,11 @@ def build_catalog_json(
     )
 
 
-def build_config_json(
+def build_config(
     absolute_file_path: str,
     variables: Dict,
     override: Dict = None,
-) -> str:
+) -> Tuple[Dict, str]:
     config = interpolate_variables_for_block_settings(
         absolute_file_path,
         variables,
@@ -109,7 +111,7 @@ def build_config_json(
     if override:
         config.update(override)
 
-    return simplejson.dumps(
+    return config, simplejson.dumps(
         config,
         default=encode_complex,
         ignore_nan=True,

--- a/mage_ai/data_integrations/utils/parsers.py
+++ b/mage_ai/data_integrations/utils/parsers.py
@@ -1,14 +1,12 @@
 import json
-from collections.abc import Iterable
+from typing import Dict
 
 import yaml
 
-from mage_ai.shared.security import filter_out_values
+from mage_ai.shared.security import filter_out_config_values
 
 
-def parse_logs_and_json(input_string: str, filter_values: Iterable = None) -> str:
-    if filter_values is None:
-        filter_values = []
+def parse_logs_and_json(input_string: str, config: Dict = None) -> str:
     logs = []
     lines = []
 
@@ -25,7 +23,7 @@ def parse_logs_and_json(input_string: str, filter_values: Iterable = None) -> st
             lines.append(line)
 
     for log in logs:
-        print(filter_out_values(log, filter_values))
+        print(filter_out_config_values(log, config))
 
     return ''.join(lines)
 

--- a/mage_ai/data_integrations/utils/parsers.py
+++ b/mage_ai/data_integrations/utils/parsers.py
@@ -1,8 +1,14 @@
 import json
+from collections.abc import Iterable
+
 import yaml
 
+from mage_ai.shared.security import filter_out_values
 
-def parse_logs_and_json(input_string: str) -> str:
+
+def parse_logs_and_json(input_string: str, filter_values: Iterable = None) -> str:
+    if filter_values is None:
+        filter_values = []
     logs = []
     lines = []
 
@@ -19,7 +25,7 @@ def parse_logs_and_json(input_string: str) -> str:
             lines.append(line)
 
     for log in logs:
-        print(log)
+        print(filter_out_values(log, filter_values))
 
     return ''.join(lines)
 

--- a/mage_ai/data_preparation/models/block/integration/__init__.py
+++ b/mage_ai/data_preparation/models/block/integration/__init__.py
@@ -11,7 +11,7 @@ from mage_ai.data_integrations.utils.config import build_config, get_catalog_by_
 from mage_ai.data_preparation.models.block import PYTHON_COMMAND, Block
 from mage_ai.data_preparation.models.constants import BlockType
 from mage_ai.shared.hash import merge_dict
-from mage_ai.shared.security import filter_out_values
+from mage_ai.shared.security import filter_out_config_values
 
 
 class IntegrationBlock(Block):
@@ -119,10 +119,10 @@ class IntegrationBlock(Block):
                 proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
                 for line in proc.stdout:
-                    f.write(filter_out_values(line.decode(), config.values())),
+                    f.write(filter_out_config_values(line.decode(), config)),
                     print_log_from_line(
                         line,
-                        filter_values=config.values(),
+                        config=config,
                         logger=logger,
                         logging_tags=logging_tags,
                         tags=tags,
@@ -136,7 +136,7 @@ class IntegrationBlock(Block):
                 cmd = proc.args if isinstance(proc.args, str) else str(proc.args)
                 raise subprocess.CalledProcessError(
                     proc.returncode,
-                    filter_out_values(cmd, config.values()),
+                    filter_out_config_values(cmd, config),
                 )
 
             file_size = os.path.getsize(source_output_file_path)
@@ -309,7 +309,7 @@ class IntegrationBlock(Block):
             for line in proc.stdout:
                 print_log_from_line(
                     line,
-                    filter_values=config.values(),
+                    config=config,
                     logger=logger,
                     logging_tags=logging_tags,
                     tags=tags,
@@ -320,7 +320,7 @@ class IntegrationBlock(Block):
                 cmd = proc.args if isinstance(proc.args, str) else str(proc.args)
                 raise subprocess.CalledProcessError(
                     proc.returncode,
-                    filter_out_values(cmd, config.values()),
+                    filter_out_config_values(cmd, config),
                 )
 
             outputs.append(proc)

--- a/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
+++ b/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
@@ -2,6 +2,7 @@ import importlib
 import json
 import os
 import subprocess
+from collections.abc import Iterable
 from typing import Any, Dict, List
 
 import pandas as pd
@@ -10,7 +11,7 @@ import yaml
 
 from mage_ai.data_integrations.logger.utils import print_logs_from_output
 from mage_ai.data_integrations.utils.config import (
-    build_config_json,
+    build_config,
     get_catalog,
     interpolate_variables,
 )
@@ -23,6 +24,7 @@ from mage_ai.data_preparation.variable_manager import get_global_variables
 from mage_ai.shared.array import find
 from mage_ai.shared.hash import dig
 from mage_ai.shared.parsers import encode_complex, extract_json_objects
+from mage_ai.shared.security import filter_out_values
 from mage_ai.shared.utils import clean_name
 
 PYTHON = 'python3'
@@ -179,6 +181,7 @@ class IntegrationPipeline(Pipeline):
         elif BlockType.DATA_EXPORTER == block_type:
             file_path = self.destination_file_path
 
+        config_interpolated = interpolate_variables(config, self.__global_variables())
         try:
             if file_path:
                 run_args = [
@@ -186,7 +189,7 @@ class IntegrationPipeline(Pipeline):
                     file_path,
                     '--config_json',
                     simplejson.dumps(
-                        interpolate_variables(config, self.__global_variables()),
+                        config_interpolated,
                         default=encode_complex,
                         ignore_nan=True,
                     ),
@@ -200,8 +203,8 @@ class IntegrationPipeline(Pipeline):
                     timeout=10,
                 )
                 proc.check_returncode()
-        except subprocess.CalledProcessError as e:
-            stderr = e.stderr.decode('utf-8').split('\n')
+        except subprocess.CalledProcessError as err:
+            stderr = err.stderr.decode('utf-8').split('\n')
 
             json_object = {}
             error = ''
@@ -214,7 +217,7 @@ class IntegrationPipeline(Pipeline):
                         error = line
                 elif not error and line.startswith('CRITICAL'):
                     error = line
-            raise Exception(error)
+            raise Exception(filter_out_values(error, config_interpolated.values()))
 
     def preview_data(self, block_type: BlockType, streams: List[str] = None) -> List[str]:
         from mage_integrations.utils.logger.constants import TYPE_SAMPLE_DATA
@@ -226,6 +229,10 @@ class IntegrationPipeline(Pipeline):
             file_path = self.destination_file_path
 
         streams_updated = set()
+        config, config_json = build_config(
+            self.data_loader.file_path,
+            self.__global_variables(),
+        )
         try:
             streams = streams if streams else \
                 list(map(lambda s: s['tap_stream_id'], self.streams()))
@@ -234,7 +241,7 @@ class IntegrationPipeline(Pipeline):
                     PYTHON,
                     file_path,
                     '--config_json',
-                    build_config_json(self.data_loader.file_path, self.__global_variables()),
+                    config_json,
                     '--load_sample_data',
                     '--log_to_stdout',
                     '1',
@@ -252,7 +259,7 @@ class IntegrationPipeline(Pipeline):
                 proc.check_returncode()
 
                 output = proc.stdout.decode()
-                print_logs_from_output(output)
+                print_logs_from_output(output, filter_values=config.values())
 
                 pipeline = Pipeline(self.uuid)
                 block = pipeline.get_block(self.data_loader.uuid)
@@ -279,7 +286,7 @@ class IntegrationPipeline(Pipeline):
             stderr = e.stderr.decode('utf-8').split('\n')
 
             json_object = {}
-            error = None
+            error = ''
             for line in stderr:
                 if line.startswith('ERROR'):
                     try:
@@ -287,6 +294,7 @@ class IntegrationPipeline(Pipeline):
                         error = dig(json_object, 'tags.error')
                     except Exception:
                         error = line
+            error = filter_out_values(error, config.values())
             if not error:
                 raise Exception('The sample data was not able to be loaded. Please check if the ' +
                                 'stream still exists. If it does not, click the "View and select ' +
@@ -303,12 +311,16 @@ class IntegrationPipeline(Pipeline):
                 tap_stream_id = stream_data['tap_stream_id']
                 destination_table = stream_data.get('destination_table', tap_stream_id)
 
-                try:
-                    run_args = [
+                config, config_json = build_config(
+                    self.data_loader.file_path,
+                    self.__global_variables(),
+                )
+                arr += self.__run_in_subprocess(
+                    [
                         PYTHON,
                         self.source_file_path,
                         '--config_json',
-                        build_config_json(self.data_loader.file_path, self.__global_variables()),
+                        config_json,
                         '--settings',
                         self.settings_file_path,
                         '--state',
@@ -319,62 +331,67 @@ class IntegrationPipeline(Pipeline):
                         '--selected_streams_json',
                         json.dumps([tap_stream_id]),
                         '--count_records',
-                    ]
-
-                    proc = subprocess.run(run_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                    proc.check_returncode()
-
-                    arr += json.loads(parse_logs_and_json(proc.stdout.decode()))
-                except subprocess.CalledProcessError as e:
-                    message = e.stderr.decode('utf-8')
-                    raise Exception(message)
+                    ],
+                    filter_values=config.values(),
+                )
 
         return arr
 
     def discover(self, streams: List[str] = None) -> Dict:
         if self.source_file_path and self.data_loader.file_path:
-            try:
-                run_args = [
-                    PYTHON,
-                    self.source_file_path,
-                    '--config_json',
-                    build_config_json(self.data_loader.file_path, self.__global_variables()),
-                    '--discover',
+            config, config_json = build_config(
+                self.data_loader.file_path,
+                self.__global_variables(),
+            )
+            run_args = [
+                PYTHON,
+                self.source_file_path,
+                '--config_json',
+                config_json,
+                '--discover',
+            ]
+            if streams:
+                run_args += [
+                    '--selected_streams_json',
+                    json.dumps(streams),
                 ]
-                if streams:
-                    run_args += [
-                        '--selected_streams_json',
-                        json.dumps(streams),
-                    ]
-
-                proc = subprocess.run(run_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                proc.check_returncode()
-
-                return json.loads(parse_logs_and_json(proc.stdout.decode()))
-
-            except subprocess.CalledProcessError as e:
-                message = e.stderr.decode('utf-8')
-                raise Exception(message)
+            return self.__run_in_subprocess(
+                run_args,
+                filter_values=config.values(),
+            )
 
     def discover_streams(self) -> List[str]:
         if self.source_file_path and self.data_loader.file_path:
-            try:
-                run_args = [
+            config, config_json = build_config(
+                self.data_loader.file_path,
+                self.__global_variables(),
+            )
+            return self.__run_in_subprocess(
+                [
                     PYTHON,
                     self.source_file_path,
                     '--config_json',
-                    build_config_json(self.data_loader.file_path, self.__global_variables()),
+                    config_json,
                     '--discover',
                     '--discover_streams',
-                ]
+                ],
+                filter_values=config.values(),
+            )
 
-                proc = subprocess.run(run_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                proc.check_returncode()
+    def __run_in_subprocess(self, run_args: List[str], filter_values: Iterable = None) -> str:
+        try:
+            proc = subprocess.run(run_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            proc.check_returncode()
 
-                return json.loads(parse_logs_and_json(proc.stdout.decode()))
-            except subprocess.CalledProcessError as e:
-                message = e.stderr.decode('utf-8')
-                raise Exception(message)
+            return json.loads(
+                parse_logs_and_json(
+                    proc.stdout.decode(),
+                    filter_values=filter_values,
+                )
+            )
+        except subprocess.CalledProcessError as e:
+            message = e.stderr.decode('utf-8')
+            raise Exception(filter_out_values(message, filter_values))
 
     def streams(self, variables: Dict = None) -> List[Dict]:
         if variables is None:

--- a/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
+++ b/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
@@ -314,24 +314,26 @@ class IntegrationPipeline(Pipeline):
                     self.data_loader.file_path,
                     self.__global_variables(),
                 )
-                arr += self.__run_in_subprocess(
-                    [
-                        PYTHON,
-                        self.source_file_path,
-                        '--config_json',
-                        config_json,
-                        '--settings',
-                        self.settings_file_path,
-                        '--state',
-                        self.source_state_file_path(
-                            destination_table=destination_table,
-                            stream=tap_stream_id,
-                        ),
-                        '--selected_streams_json',
-                        json.dumps([tap_stream_id]),
-                        '--count_records',
-                    ],
-                    config=config,
+                arr += json.loads(
+                    self.__run_in_subprocess(
+                        [
+                            PYTHON,
+                            self.source_file_path,
+                            '--config_json',
+                            config_json,
+                            '--settings',
+                            self.settings_file_path,
+                            '--state',
+                            self.source_state_file_path(
+                                destination_table=destination_table,
+                                stream=tap_stream_id,
+                            ),
+                            '--selected_streams_json',
+                            json.dumps([tap_stream_id]),
+                            '--count_records',
+                        ],
+                        config=config,
+                    )
                 )
 
         return arr
@@ -354,9 +356,11 @@ class IntegrationPipeline(Pipeline):
                     '--selected_streams_json',
                     json.dumps(streams),
                 ]
-            return self.__run_in_subprocess(
-                run_args,
-                config=config,
+            return json.loads(
+                self.__run_in_subprocess(
+                    run_args,
+                    config=config,
+                )
             )
 
     def discover_streams(self) -> List[str]:
@@ -365,16 +369,18 @@ class IntegrationPipeline(Pipeline):
                 self.data_loader.file_path,
                 self.__global_variables(),
             )
-            return self.__run_in_subprocess(
-                [
-                    PYTHON,
-                    self.source_file_path,
-                    '--config_json',
-                    config_json,
-                    '--discover',
-                    '--discover_streams',
-                ],
-                config=config,
+            return json.loads(
+                self.__run_in_subprocess(
+                    [
+                        PYTHON,
+                        self.source_file_path,
+                        '--config_json',
+                        config_json,
+                        '--discover',
+                        '--discover_streams',
+                    ],
+                    config=config,
+                )
             )
 
     def __run_in_subprocess(self, run_args: List[str], config: Dict = None) -> str:
@@ -382,11 +388,9 @@ class IntegrationPipeline(Pipeline):
             proc = subprocess.run(run_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             proc.check_returncode()
 
-            return json.loads(
-                parse_logs_and_json(
-                    proc.stdout.decode(),
-                    config=config,
-                )
+            return parse_logs_and_json(
+                proc.stdout.decode(),
+                config=config,
             )
         except subprocess.CalledProcessError as e:
             message = e.stderr.decode('utf-8')

--- a/mage_ai/shared/security.py
+++ b/mage_ai/shared/security.py
@@ -23,9 +23,17 @@ def filter_out_env_var_values(value: str) -> str:
 def filter_out_config_values(log: str, config: Dict) -> str:
     """
     Used for integration pipeline logging security. Filters out values from
-    the passed in config.
+    the passed in config if the config value is a string and is over
+    MIN_SECRET_LENGTH characters long.
+
+    Args:
+        log (str): The log to filter.
+        config (Dict[str, any]): The config to get filter values from.
+
+    Returns:
+        str: Log with config values filtered out.
     """
-    if config is None:
+    if not log or not config:
         return log
     values = config.values()
     secret_values = [v for v in values if isinstance(v, str) and len(v) >= MIN_SECRET_LENGTH]
@@ -33,7 +41,7 @@ def filter_out_config_values(log: str, config: Dict) -> str:
 
 
 def filter_out_values(log: str, values: List[str]) -> str:
-    if not values:
+    if not log or not values:
         return log
     values.sort(key=len, reverse=True)
     log_clean = log

--- a/mage_ai/shared/security.py
+++ b/mage_ai/shared/security.py
@@ -21,6 +21,10 @@ def filter_out_env_var_values(value: str) -> str:
 
 
 def filter_out_config_values(log: str, config: Dict) -> str:
+    """
+    Used for integration pipeline logging security. Filters out values from
+    the passed in config.
+    """
     if config is None:
         return log
     values = config.values()

--- a/mage_ai/shared/security.py
+++ b/mage_ai/shared/security.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Iterable
 
 MIN_SECRET_ENV_VAR_LENGTH = 8
 WHITELISTED_ENV_VARS = set([
@@ -16,9 +17,16 @@ def filter_out_env_var_values(value: str):
     env_var_values = [v for v in env_var_values
                       if v and len(v) >= MIN_SECRET_ENV_VAR_LENGTH
                       and v not in whitelisted_env_var_values]
-    env_var_values.sort(key=len, reverse=True)
-    value_clean = value
-    for env_var_value in env_var_values:
-        replace_value = '*' * len(env_var_value)
-        value_clean = value_clean.replace(env_var_value, replace_value)
-    return value_clean
+    return filter_out_values(value, env_var_values)
+
+
+def filter_out_values(log: str, values: Iterable):
+    if not values:
+        return log
+    values = [v for v in values if isinstance(v, str)]
+    values.sort(key=len, reverse=True)
+    log_clean = log
+    for value in values:
+        replace_value = '*' * len(value)
+        log_clean = log_clean.replace(value, replace_value)
+    return log_clean


### PR DESCRIPTION
# Summary

I added filtering to data integration logging to hide string source/destination config values. 

At some point we should make the data integration logging more organized since we log things in a lot of places.
<!-- Brief summary of what your code does -->

# Tests

tested locally
<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
