### PR TITLE
[hw] Fix the issue with database setting when running ClickHouse in SQL blocks

### DIFF
--- a/mage_ai/data_preparation/models/block/sql/__init__.py
+++ b/mage_ai/data_preparation/models/block/sql/__init__.py
@@ -169,7 +169,7 @@ def execute_sql_code(
         query_string = interpolate_vars(
             query_string, global_vars=global_vars)
 
-        database = database or 'default'
+        database = database or loader.default_database()
 
         if use_raw_sql:
             return execute_raw_sql(

--- a/mage_ai/data_preparation/models/block/sql/clickhouse.py
+++ b/mage_ai/data_preparation/models/block/sql/clickhouse.py
@@ -17,6 +17,8 @@ def create_upstream_block_tables(
     dynamic_block_index: int = None,
     dynamic_upstream_block_uuids: List[str] = None,
 ):
+    configuration = configuration if configuration else block.configuration
+    database = configuration.get('data_provider_database') or loader.default_database()
     create_upstream_block_tables_orig(
         loader,
         block,
@@ -33,6 +35,7 @@ def create_upstream_block_tables(
         query=query,
         dynamic_block_index=dynamic_block_index,
         dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
+        database=database,
     )
 
 

--- a/mage_ai/data_preparation/models/block/sql/utils/shared.py
+++ b/mage_ai/data_preparation/models/block/sql/utils/shared.py
@@ -373,29 +373,19 @@ def create_upstream_block_tables(
             print(f'\n\nExporting data from upstream block {upstream_block.uuid} '
                   f'to {full_table_name}.')
 
+            kwargs = dict(
+                table_name=table_name,
+                schema_name=schema,
+                cascade_on_drop=cascade_on_drop,
+                drop_table_on_replace=True,
+                if_exists='replace',
+                index=False,
+                verbose=False,
+            )
             if database:
-                loader.export(
-                    df,
-                    table_name=table_name,
-                    database=database,
-                    schema_name=schema,
-                    cascade_on_drop=cascade_on_drop,
-                    drop_table_on_replace=True,
-                    if_exists='replace',
-                    index=False,
-                    verbose=False,
-                )
-            else:
-                loader.export(
-                    df,
-                    table_name=table_name,
-                    schema_name=schema,
-                    cascade_on_drop=cascade_on_drop,
-                    drop_table_on_replace=True,
-                    if_exists='replace',
-                    index=False,
-                    verbose=False,
-                )
+                kwargs['database'] = database
+
+            loader.export(df, **kwargs)
 
 
 def extract_and_replace_text_between_strings(

--- a/mage_ai/data_preparation/models/block/sql/utils/shared.py
+++ b/mage_ai/data_preparation/models/block/sql/utils/shared.py
@@ -295,6 +295,7 @@ def create_upstream_block_tables(
     schema_name: str = None,
     dynamic_block_index: int = None,
     dynamic_upstream_block_uuids: List[str] = None,
+    database: str = None,
 ):
     if cache_keys is None:
         cache_keys = []
@@ -372,16 +373,29 @@ def create_upstream_block_tables(
             print(f'\n\nExporting data from upstream block {upstream_block.uuid} '
                   f'to {full_table_name}.')
 
-            loader.export(
-                df,
-                table_name=table_name,
-                schema_name=schema,
-                cascade_on_drop=cascade_on_drop,
-                drop_table_on_replace=True,
-                if_exists='replace',
-                index=False,
-                verbose=False,
-            )
+            if database:
+                loader.export(
+                    df,
+                    table_name=table_name,
+                    database=database,
+                    schema_name=schema,
+                    cascade_on_drop=cascade_on_drop,
+                    drop_table_on_replace=True,
+                    if_exists='replace',
+                    index=False,
+                    verbose=False,
+                )
+            else:
+                loader.export(
+                    df,
+                    table_name=table_name,
+                    schema_name=schema,
+                    cascade_on_drop=cascade_on_drop,
+                    drop_table_on_replace=True,
+                    if_exists='replace',
+                    index=False,
+                    verbose=False,
+                )
 
 
 def extract_and_replace_text_between_strings(

--- a/mage_ai/io/clickhouse.py
+++ b/mage_ai/io/clickhouse.py
@@ -26,6 +26,7 @@ class ClickHouse(BaseSQLDatabase):
         if kwargs.get('verbose') is not None:
             kwargs.pop('verbose')
         super().__init__(verbose=kwargs.get('verbose', True))
+        self.database = kwargs.get('database', 'default')
         with self.printer.print_msg('Connecting to ClickHouse'):
             self.client = clickhouse_connect.get_client(**kwargs)
 
@@ -50,6 +51,9 @@ class ClickHouse(BaseSQLDatabase):
             port=config[ConfigKey.CLICKHOUSE_PORT],
             username=config[ConfigKey.CLICKHOUSE_USERNAME],
         )
+
+    def default_database(self) -> str:
+        return self.database
 
     def execute(self, command_string: str, **kwargs) -> None:
         """
@@ -208,7 +212,7 @@ class ClickHouse(BaseSQLDatabase):
         elif type(df) is list:
             df = DataFrame(df)
 
-        def __process(database: Union[str, None]):
+        def __process():
 
             df_existing = self.client.query_df(f"""
 EXISTS TABLE {database}.{table_name}
@@ -258,6 +262,6 @@ INSERT INTO {database}.{table_name}
         if verbose:
             with self.printer.print_msg(
                     f'Exporting data to table \'{database}.{table_name}\''):
-                __process(database=database)
+                __process()
         else:
-            __process(database=database)
+            __process()

--- a/mage_ai/io/clickhouse.py
+++ b/mage_ai/io/clickhouse.py
@@ -161,7 +161,7 @@ class ClickHouse(BaseSQLDatabase):
         self,
         df: DataFrame,
         table_name: str,
-        database: str = 'default',
+        database: str,
     ):
         dtypes = infer_dtypes(df)
         db_dtypes = {
@@ -180,7 +180,7 @@ class ClickHouse(BaseSQLDatabase):
         self,
         df: DataFrame,
         table_name: str,
-        database: str = 'default',
+        database: str,
         if_exists: str = 'append',
         index: bool = False,
         query_string: Union[str, None] = None,
@@ -225,7 +225,7 @@ EXISTS TABLE {database}.{table_name}
                 if ExportWritePolicy.FAIL == if_exists:
                     raise ValueError(
                         f'Table \'{table_name}\' already'
-                        ' exists in database {database}.',
+                        f' exists in database {database}.',
                     )
                 elif ExportWritePolicy.REPLACE == if_exists:
                     self.client.command(


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

Storing ClickHouse data to a custom database caused exceptions, as described in https://github.com/mage-ai/mage-ai/issues/2988

# Tests
<!-- How did you test your change? -->
Manually tested in a local development environment, with the following custom ClickHouse settings:
```
  # Clickhouse
  CLICKHOUSE_DATABASE: helloworld
  CLICKHOUSE_HOST: host.docker.internal
  CLICKHOUSE_INTERFACE: http
  CLICKHOUSE_PASSWORD: null
  CLICKHOUSE_PORT: 8123
  CLICKHOUSE_USERNAME: null
```
The data generated from the previous `Data loader` block was from the following code:
```
@data_loader
def load_data(*args, **kwargs):
    """
    Template code for loading data from any source.

    Returns:
        Anything (e.g. data frame, dictionary, array, int, str, etc.)
    """
    import pandas as pd
    # Specify your data loading logic here
    return pd.DataFrame({'num_legs': [2, 4, 8, 0],
                    'num_wings': [2, 0, 0, 0],
                    'num_specimen_seen': [10, 2, 1, 8]},
                    index=['falcon', 'dog', 'spider', 'fish']
                    )
```
The data has been successfully stored to the newly sepecified custon database `helloworld`, as shown in the following screenshot:
<img width="1110" alt="Screenshot 2023-07-17 at 9 58 02 PM" src="https://github.com/mage-ai/mage-ai/assets/42320565/de0027cf-9f0f-45f9-a700-e39e2391b0b9">

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@dy46 @wangxiaoyou1993 