### PR TITLE
[xy] Support custom k8s executor job prefix.

### DIFF
--- a/docs/production/configuring-production-settings/compute-resource.mdx
+++ b/docs/production/configuring-production-settings/compute-resource.mdx
@@ -79,6 +79,7 @@ There're two ways to customize the Kubernetes executor config:
 in this project. Example config:
     ```yaml
     k8s_executor_config:
+      job_name_prefix: data-prep
       resource_limits:
         cpu: 1000m
         memory: 2048Mi
@@ -87,14 +88,15 @@ in this project. Example config:
         memory: 1024Mi
       service_account_name: default
     ```
-If you want to use GPU resource in your k8s executor, you can configure the GPU resource in the `k8s_executor_config` like
-```yaml
-k8s_executor_config:
-  resource_limits:
-    gpu-vendor.example/example-gpu: 1 # requesting 1 GPU
-```
-Please make sure the [GPU driver](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/#using-device-plugins)
-is installed and run on your nodes to use the GPUs.
+* The kubernetes job name is in this format: `mage-{job_name_prefix}-block-{block_run_id}`. The default `job_name_prefix` is `data-prep`. You can customize it in the k8s executor config.
+* If you want to use GPU resource in your k8s executor, you can configure the GPU resource in the `k8s_executor_config` like
+  ```yaml
+  k8s_executor_config:
+    resource_limits:
+      gpu-vendor.example/example-gpu: 1 # requesting 1 GPU
+  ```
+  Please make sure the [GPU driver](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/#using-device-plugins)
+  is installed and run on your nodes to use the GPUs.
 
 ### AWS ECS executor
 

--- a/mage_ai/data_preparation/executors/k8s_block_executor.py
+++ b/mage_ai/data_preparation/executors/k8s_block_executor.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 from mage_ai.data_preparation.executors.block_executor import BlockExecutor
+from mage_ai.services.k8s.config import K8sExecutorConfig
 from mage_ai.services.k8s.job_manager import JobManager as K8sJobManager
 from mage_ai.shared.hash import merge_dict
 
@@ -13,6 +14,7 @@ class K8sBlockExecutor(BlockExecutor):
         self.executor_config = self.pipeline.repo_config.k8s_executor_config or dict()
         if self.block.executor_config is not None:
             self.executor_config = merge_dict(self.executor_config, self.block.executor_config)
+        self.executor_config = K8sExecutorConfig.load(config=self.executor_config)
 
     def _execute(
         self,
@@ -20,8 +22,12 @@ class K8sBlockExecutor(BlockExecutor):
         global_vars: Dict = None,
         **kwargs,
     ) -> None:
+        if not self.executor_config.job_name_prefix:
+            job_name_prefix = 'data-prep'
+        else:
+            job_name_prefix = self.executor_config.job_name_prefix
         job_manager = K8sJobManager(
-            job_name=f'mage-data-prep-block-{block_run_id}',
+            job_name=f'mage-{job_name_prefix}-block-{block_run_id}',
             logger=self.logger,
             logging_tags=kwargs.get('tags', dict()),
         )

--- a/mage_ai/services/k8s/config.py
+++ b/mage_ai/services/k8s/config.py
@@ -17,6 +17,7 @@ class K8sResourceConfig(BaseConfig):
 
 @dataclass
 class K8sExecutorConfig(BaseConfig):
+    job_name_prefix: str = None
     resource_limits: Dict = None
     resource_requests: Dict = None
     service_account_name: str = DEFAULT_SERVICE_ACCOUNT_NAME

--- a/mage_ai/services/k8s/job_manager.py
+++ b/mage_ai/services/k8s/job_manager.py
@@ -1,6 +1,6 @@
 import os
 import time
-from typing import Dict
+from typing import Dict, Union
 
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
@@ -52,7 +52,7 @@ class JobManager():
     def run_job(
         self,
         command: str,
-        k8s_config=None,
+        k8s_config: Union[K8sExecutorConfig, Dict] = None,
     ):
         if not self.job_exists():
             if type(k8s_config) is dict:

--- a/mage_ai/services/k8s/job_manager.py
+++ b/mage_ai/services/k8s/job_manager.py
@@ -86,7 +86,7 @@ class JobManager():
         self,
         command: str,
         k8s_config: K8sExecutorConfig = None,
-    ):
+    ) -> client.V1Job:
         # Configureate Pod template container
         mage_server_container_spec = self.pod_config.spec.containers[0]
 
@@ -140,7 +140,7 @@ class JobManager():
             body=job,
             namespace=self.namespace,
         )
-        self._print("Job created. status='%s'" % str(api_response.status))
+        self._print(f"Job created. status='{api_response.status}'")
 
     def delete_job(self):
         try:

--- a/mage_ai/tests/data_preparation/executors/test_k8s_block_executor.py
+++ b/mage_ai/tests/data_preparation/executors/test_k8s_block_executor.py
@@ -1,0 +1,71 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from mage_ai.data_preparation.executors.k8s_block_executor import K8sBlockExecutor
+from mage_ai.services.k8s.config import K8sExecutorConfig
+
+
+class K8sBlockExecutorTestCase(unittest.TestCase):
+    def setUp(self):
+        self.pipeline = MagicMock()
+        self.pipeline.uuid = 'pipeline_uuid'
+        self.pipeline.repo_config = MagicMock()
+        self.pipeline.repo_config.variables_dir = os.path.join(os.getcwd(), 'mage_data')
+        self.block_uuid = 'block-uuid'
+
+        self.logger_manager = MagicMock()
+        self.logger = MagicMock()
+        self.logger_manager.logger = self.logger
+
+        self.executor = K8sBlockExecutor(self.pipeline, self.block_uuid)
+
+        self.executor.logger_manager = self.logger_manager
+        self.executor.logger = self.logger
+
+    @patch('mage_ai.data_preparation.executors.k8s_block_executor.K8sJobManager')
+    def test_execute(self, job_manager_mock):
+        # Mock the necessary objects and methods
+        self.executor._run_commands = MagicMock(return_value='mocked_cmd')
+        job_manager_instance_mock = MagicMock()
+        job_manager_mock.return_value = job_manager_instance_mock
+
+        # Call the method to test
+        self.executor._execute(block_run_id=1, global_vars={'key': 'value'})
+
+        # Assertions
+        self.executor._run_commands.assert_called_once_with(1, {'key': 'value'})
+        job_manager_mock.assert_called_once_with(
+            job_name='mage-data-prep-block-1',
+            logger=self.executor.logger,
+            logging_tags={},
+        )
+        job_manager_instance_mock.run_job.assert_called_once_with(
+            'mocked_cmd',
+            k8s_config=K8sExecutorConfig.load(config={}),
+        )
+
+    @patch('mage_ai.data_preparation.executors.k8s_block_executor.K8sJobManager')
+    def test_execute_with_custom_job_name_prefix(self, job_manager_mock):
+        # Mock the necessary objects and methods
+        self.executor._run_commands = MagicMock(return_value='mocked_cmd')
+        job_manager_instance_mock = MagicMock()
+        job_manager_mock.return_value = job_manager_instance_mock
+
+        # Set a custom job name prefix
+        self.executor.executor_config.job_name_prefix = 'custom-prefix'
+
+        # Call the method to test
+        self.executor._execute(block_run_id=1, global_vars={'key': 'value'})
+
+        # Assertions
+        self.executor._run_commands.assert_called_once_with(1, {'key': 'value'})
+        job_manager_mock.assert_called_once_with(
+            job_name='mage-custom-prefix-block-1',
+            logger=self.executor.logger,
+            logging_tags={},
+        )
+        job_manager_instance_mock.run_job.assert_called_once_with(
+            'mocked_cmd',
+            k8s_config=K8sExecutorConfig.load(config={'job_name_prefix': 'custom-prefix'}),
+        )


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Support custom k8s executor job prefix.

Example k8s executor config:
```yaml
k8s_executor_config:
  job_name_prefix: data-prep
  resource_limits:
    cpu: 1000m
    memory: 2048Mi
  resource_requests:
    cpu: 500m
    memory: 1024Mi
  service_account_name: default
```

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
