### PR TITLE
Gracefully shut down Mage server upon SIGTERM

### DIFF
--- a/mage_ai/orchestration/triggers/loop_time_trigger.py
+++ b/mage_ai/orchestration/triggers/loop_time_trigger.py
@@ -1,13 +1,15 @@
-from mage_ai.orchestration.triggers.time_trigger import TimeTrigger
+import asyncio
 import time
+
+from mage_ai.orchestration.triggers.time_trigger import TimeTrigger
 
 
 class LoopTimeTrigger(TimeTrigger):
-    def start(self) -> None:
-        while True:
+    async def start(self) -> None:
+        task = asyncio.current_task()
+        while not task.done():
             self.last_run_time = int(time.time())
             self.run()
             current_time = int(time.time())
             sleep_time = self.trigger_interval - (current_time - self.last_run_time)
-            if sleep_time > 0:
-                time.sleep(sleep_time)
+            await asyncio.sleep(sleep_time)

--- a/mage_ai/server/scheduler_manager.py
+++ b/mage_ai/server/scheduler_manager.py
@@ -1,3 +1,4 @@
+import asyncio
 import multiprocessing
 import time
 import traceback
@@ -35,7 +36,9 @@ def run_scheduler():
     except Exception:
         traceback.print_exc()
     try:
-        LoopTimeTrigger().start()
+        asyncio.run(LoopTimeTrigger().start())
+    except asyncio.CancelledError:
+        pass
     except Exception as e:
         traceback.print_exc()
         raise e

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import os
+import signal
 import traceback
 import webbrowser
 from time import sleep
@@ -218,7 +219,7 @@ async def main(
             )
         port += 1
 
-    app.listen(
+    server = app.listen(
         port,
         address=host if host != 'localhost' else None,
     )
@@ -307,13 +308,22 @@ async def main(
     )
     periodic_callback.start()
 
-    get_messages(
-        lambda content: WebSocketServer.send_message(
-            parse_output_message(content),
-        ),
-    )
+    loop = asyncio.get_event_loop()
+    loop.add_signal_handler(signal.SIGTERM, loop.create_task, stop_server())
 
-    await asyncio.Event().wait()
+    try:
+        asyncio.run(get_messages(
+            lambda content: WebSocketServer.send_message(
+                parse_output_message(content),
+            ),
+        ))
+    except asyncio.CancelledError:
+        pass
+
+    periodic_callback.stop()
+    server.stop()
+    await server.close_all_connections()
+    scheduler_manager.stop_scheduler()
 
 
 def start_server(
@@ -381,13 +391,25 @@ def start_server(
             enable_pretty_logging()
 
             # Start web server
-            asyncio.run(
-                main(
-                    host=host,
-                    port=port,
-                    project=project,
+            try:
+                asyncio.run(
+                    main(
+                        host=host,
+                        port=port,
+                        project=project,
+                    )
                 )
-            )
+            except asyncio.CancelledError:
+                print('Server has shut down')
+
+
+async def stop_server():
+    current_task = asyncio.current_task()
+    other_tasks = [t for t in asyncio.all_tasks() if t is not current_task]
+    for task in other_tasks:
+        if not task.done():
+            task.cancel()
+    await asyncio.gather(*other_tasks, return_exceptions=True)
 
 
 if __name__ == '__main__':

--- a/mage_ai/server/subscriber.py
+++ b/mage_ai/server/subscriber.py
@@ -1,14 +1,17 @@
+import asyncio
 from datetime import datetime
+
 from mage_ai.server.active_kernel import get_active_kernel_client
 from mage_ai.server.logger import Logger
 
 logger = Logger().new_server_logger(__name__)
 
 
-def get_messages(callback=None):
+async def get_messages(callback=None):
     now = datetime.utcnow()
+    task = asyncio.current_task()
 
-    while True:
+    while not task.done():
         try:
             client = get_active_kernel_client()
             message = client.get_iopub_msg(timeout=1)
@@ -18,6 +21,7 @@ def get_messages(callback=None):
                     callback(message)
                 else:
                     logger.warn(f'[{now}] No callback for message: {message}')
+            await asyncio.sleep(0)
         except Exception as e:
             if str(e):
                 logger.error(f'[{now}] Error: {e}', )


### PR DESCRIPTION
# Summary
This allows the server to shut down gracefully soon after the container is stopped instead of timing out and killing in-progress requests.

A graceful shut down is when the server stops accepting new requests, while continuing to process existing requests until they complete (or canceled, if necessary). This is helpful for rolling restarts such as for version upgrades. I believe this feature is low priority, but it does allow Mage to be more robust in the future.

# Tests
The timeout appears to be 10 seconds using Docker Compose using scripts/dev.sh. The time to stop the container was ~10.2 seconds, but this code change reduces it to ~0.8 seconds on my computer. The process previously exited with code 137 (error), but now exits with code 0 (success).

I am still new to all the server features that this code stops or exits, and I haven't tested common use cases, such as starting a long running pipeline and then trying a shut down, but you are welcome to use this contribution in whatever form you find useful.

cc: @tommydangerous @wangxiaoyou1993 