### PR TITLE
automate release note generation

### DIFF
--- a/.github/releases.yml
+++ b/.github/releases.yml
@@ -1,0 +1,16 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - documentation
+  categories:
+    - title: 🎉 Exciting New Features 
+      labels:
+        - enhancement
+    - title: 🐛 Bug Fix & Polish
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
# Summary

**Note**: this is very much a WIP and will still require human eyes/edits 😀

Via [this](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) doc, we can semi-automate release note generation. This should simplify the process for building release notes while maintaining a human element.

The workflow can look like GitHub automated release notes -> edit -> share. A bonus is that releases can now automatically include shout outs for first time contributors, e.g. 

```
- @ethanbrown3 made their first contribution in https://github.com/mage-ai/mage-ai/pull/2976
- @erictse made their first contribution in https://github.com/mage-ai/mage-ai/pull/2977
```

cc:
@wangxiaoyou1993 
@thomaschung408 
