### PR TITLE
[td] Fix block settings not updating after saving

### DIFF
--- a/mage_ai/api/policies/BlockPolicy.py
+++ b/mage_ai/api/policies/BlockPolicy.py
@@ -48,6 +48,7 @@ BlockPolicy.allow_read([
     'bookmarks',
     'content',
     'outputs',
+    'pipelines',
 ] + BlockPresenter.default_attributes, scopes=[
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[


### PR DESCRIPTION
# Summary
The block settings aren’t updating because of a policy issue.