### PR TITLE
[td] When clicking a file in file browser, select block if in pipeline

### DIFF
--- a/mage_ai/frontend/components/FileBrowser/utils.ts
+++ b/mage_ai/frontend/components/FileBrowser/utils.ts
@@ -217,3 +217,18 @@ export function replacePipelinesFolderWithConfig(
     .concat(filesWithChildren)
     .concat(filesWithoutChildren);
 }
+
+export function getBlockFromFilePath(filePath: string, blocks: BlockType[]) {
+  // data_loaders/[uuid].[extension]
+
+  const nameParts = filePath.split('.');
+  const fileExtension = nameParts[nameParts.length - 1] as FileExtensionEnum;
+  if (CODE_BLOCK_FILE_EXTENSIONS.includes(fileExtension)) {
+    nameParts.pop();
+  }
+
+  const parts = nameParts.join('').split(osPath.sep);
+  const blockUUID = parts.slice(1, parts.length).join('');
+
+  return blocks.find(({ uuid }: BlockType) => uuid === blockUUID);
+}

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -97,6 +97,7 @@ import {
 import { cleanName, randomNameGenerator } from '@utils/string';
 import { displayErrorFromReadResponse, onSuccess } from '@api/utils/response';
 import { equals, find, indexBy, removeAtIndex } from '@utils/array';
+import { getBlockFromFilePath } from '@components/FileBrowser/utils';
 import { getWebSocket } from '@api/utils/url';
 import { goToWithQuery } from '@utils/routing';
 import { isEmptyObject } from '@utils/hash';
@@ -903,11 +904,25 @@ function PipelineDetailPage({
     if (!filePaths.includes(filePathEncoded)) {
       filePaths.push(filePathEncoded);
     }
-    goToWithQuery({
-      file_path: filePathEncoded,
-      'file_paths[]': filePaths,
-    });
+
+
+    const block = getBlockFromFilePath(filePath, blocks);
+
+    if (block) {
+      setSelectedBlock(block);
+      if (blockRefs?.current) {
+        const blockRef = blockRefs.current[`${block.type}s/${block.uuid}.py`];
+        blockRef?.current?.scrollIntoView();
+      }
+    } else {
+      goToWithQuery({
+        file_path: filePathEncoded,
+        'file_paths[]': filePaths,
+      });
+    }
   }, [
+    blockRefs,
+    blocks,
     savePipelineContent,
   ]);
 


### PR DESCRIPTION
# Summary
Instead of opening the file browser and showing the file versions when clicking on a file on the edit pipeline page, select the block and scroll to it if the file exists in the pipeline.