### PR TITLE
[xh]Generate block template based on block description

### DIFF
--- a/mage_ai/ai/constants.py
+++ b/mage_ai/ai/constants.py
@@ -5,3 +5,4 @@ class LLMUseCase(str, Enum):
     GENERATE_COMMENT_FOR_BLOCK = 'generate_comment_for_block'
     GENERATE_DOC_FOR_BLOCK = 'generate_doc_for_block'
     GENERATE_DOC_FOR_PIPELINE = 'generate_doc_for_pipeline'
+    GENERATE_BLOCK_WITH_DESCRIPTION = 'generate_block_with_description'

--- a/mage_ai/ai/generator.py
+++ b/mage_ai/ai/generator.py
@@ -27,7 +27,7 @@ class Generator:
         elif use_case == LLMUseCase.GENERATE_BLOCK_WITH_DESCRIPTION:
             from mage_ai.ai.llm_pipeline_wizard import LLMPipelineWizard
 
-            return LLMPipelineWizard().generate_block_with_description(
+            return await LLMPipelineWizard().async_generate_block_with_description(
                 request.get('block_description'),
             )
 

--- a/mage_ai/ai/generator.py
+++ b/mage_ai/ai/generator.py
@@ -24,5 +24,11 @@ class Generator:
             return await LLMPipelineWizard().async_generate_pipeline_documentation(
                 pipeline_uuid,
             )
+        elif use_case == LLMUseCase.GENERATE_BLOCK_WITH_DESCRIPTION:
+            from mage_ai.ai.llm_pipeline_wizard import LLMPipelineWizard
+
+            return LLMPipelineWizard().generate_block_with_description(
+                request.get('block_description'),
+            )
 
         raise Exception(f'Use case {use_case} is not supported yet.')

--- a/mage_ai/ai/generator_cmds.py
+++ b/mage_ai/ai/generator_cmds.py
@@ -44,7 +44,7 @@ def generate_pipeline_documentation(project_path: str = PROJECT_NAME_DEFAULT,
 
 @app.command()
 def generate_block_with_description(block_description: str):
-    print(LLMPipelineWizard().generate_block_with_description(block_description))
+    print(asyncio.run(LLMPipelineWizard().async_generate_block_with_description(block_description)))
 
 
 if __name__ == '__main__':

--- a/mage_ai/ai/generator_cmds.py
+++ b/mage_ai/ai/generator_cmds.py
@@ -42,5 +42,10 @@ def generate_pipeline_documentation(project_path: str = PROJECT_NAME_DEFAULT,
     ))['pipeline_doc'])
 
 
+@app.command()
+def generate_block_with_description(block_description: str):
+    print(LLMPipelineWizard().generate_block_with_description(block_description))
+
+
 if __name__ == '__main__':
     app()

--- a/mage_ai/ai/llm_pipeline_wizard.py
+++ b/mage_ai/ai/llm_pipeline_wizard.py
@@ -1,17 +1,26 @@
 import asyncio
+import json
 
+import openai
 from langchain.chains import LLMChain
 from langchain.llms import OpenAI
 from langchain.prompts import PromptTemplate
 
+from mage_ai.data_cleaner.transformer_actions.constants import ActionType, Axis
 from mage_ai.data_preparation.models.block import Block
 from mage_ai.data_preparation.models.constants import (
     NON_PIPELINE_EXECUTABLE_BLOCK_TYPES,
     BlockLanguage,
     BlockType,
+    PipelineType,
 )
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.data_preparation.repo_manager import get_repo_path
+from mage_ai.data_preparation.templates.template import fetch_template_source
+from mage_ai.io.base import DataSource
+from mage_ai.server.logger import Logger
+
+logger = Logger().new_server_logger(__name__)
 
 BLOCK_LANGUAGE_TO_FILE_TYPE_VARIABLE = {
     BlockLanguage.MARKDOWN: 'markdown script',
@@ -39,6 +48,50 @@ Write a detailed summarization of the data pipeline based on the content provide
 ```{block_content}```
 """
 TRANSFORMERS_FOLDER = 'transformers'
+CLASSIFICATION_FUNCTION_NAME = "classify_description"
+TEMPLATE_CLASSIFICATION_FUNCTION = [
+            {
+                "name": CLASSIFICATION_FUNCTION_NAME,
+                "description": "Classify the code description provided into following properties.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        BlockType.__name__: {
+                            "type": "string",
+                            "description": "Type of the code block. It either "
+                                           "loads data from a source, export data to a source "
+                                           "or transform data from one format to another.",
+                            "enum": ["data_exporter", "data_loader", "transformer"]
+                        },
+                        BlockLanguage.__name__: {
+                            "type": "string",
+                            "description": "Programming language of the code block.",
+                            "enum": [type.name.lower() for type in BlockLanguage]
+                        },
+                        PipelineType.__name__: {
+                            "type": "string",
+                            "description": "Type of pipeline description to build.",
+                            "enum": [type.name.lower() for type in PipelineType]
+                        },
+                        ActionType.__name__: {
+                            "type": "string",
+                            "description": f"If {BlockType.__name__} is transformer, "
+                                           f"{ActionType.__name__} specifies what kind "
+                                           "of action the code performs.",
+                            "enum": [type.name.lower() for type in ActionType]
+                        },
+                        DataSource.__name__: {
+                            "type": "string",
+                            "description": f"If {BlockType.__name__} is data_loader or "
+                                           f"data_exporter, {DataSource.__name__} field specify "
+                                           "where the data loads from or exports to.",
+                            "enum": [type.name.lower() for type in DataSource]
+                        },
+                    },
+                    "required": [BlockType.__name__, BlockLanguage.__name__, PipelineType.__name__],
+                },
+            }
+        ]
 
 
 class LLMPipelineWizard:
@@ -67,6 +120,49 @@ class LLMPipelineWizard:
                                 file_type=file_type,
                                 purpose=purpose,
                                 add_on_prompt=add_on_prompt)
+
+    def __load_template_params(self, function_args: json):
+        block_type = BlockType(function_args[BlockType.__name__].lower())
+        block_language = BlockLanguage(
+                            function_args.get(BlockLanguage.__name__, "python").lower())
+        pipeline_type = PipelineType(function_args.get(PipelineType.__name__, "python").lower())
+        config = {}
+        config['action_type'] = function_args.get(ActionType.__name__, None)
+        if config['action_type']:
+            if config['action_type'] in [
+                ActionType.FILTER,
+                ActionType.DROP_DUPLICATE,
+                ActionType.REMOVE,
+                ActionType.SORT
+            ]:
+                config['axis'] = Axis.ROW
+            else:
+                config['axis'] = Axis.COLUMN
+        config['data_source'] = function_args.get(DataSource.__name__, None)
+        return block_type, block_language, pipeline_type, config
+
+    def generate_block_with_description(self, block_description: str) -> str:
+        messages = [{"role": "user", "content": block_description}]
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo-0613",
+            messages=messages,
+            functions=TEMPLATE_CLASSIFICATION_FUNCTION,
+            function_call={"name": CLASSIFICATION_FUNCTION_NAME},  # explicitly set function call
+        )
+        response_message = response["choices"][0]["message"]
+        if response_message.get("function_call"):
+            function_args = json.loads(response_message["function_call"]["arguments"])
+            block_type, block_language, pipeline_type, config = self.__load_template_params(
+                function_args)
+            return fetch_template_source(
+                block_type=block_type,
+                config=config,
+                language=block_language,
+                pipeline_type=pipeline_type,
+            )
+        else:
+            logger.error("Failed to interpret the description as a block template.")
+            return None
 
     async def async_generate_pipeline_documentation(
         self,

--- a/mage_ai/ai/llm_pipeline_wizard.py
+++ b/mage_ai/ai/llm_pipeline_wizard.py
@@ -50,48 +50,48 @@ Write a detailed summarization of the data pipeline based on the content provide
 TRANSFORMERS_FOLDER = 'transformers'
 CLASSIFICATION_FUNCTION_NAME = "classify_description"
 TEMPLATE_CLASSIFICATION_FUNCTION = [
-            {
-                "name": CLASSIFICATION_FUNCTION_NAME,
-                "description": "Classify the code description provided into following properties.",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        BlockType.__name__: {
-                            "type": "string",
-                            "description": "Type of the code block. It either "
-                                           "loads data from a source, export data to a source "
-                                           "or transform data from one format to another.",
-                            "enum": ["data_exporter", "data_loader", "transformer"]
-                        },
-                        BlockLanguage.__name__: {
-                            "type": "string",
-                            "description": "Programming language of the code block.",
-                            "enum": [type.name.lower() for type in BlockLanguage]
-                        },
-                        PipelineType.__name__: {
-                            "type": "string",
-                            "description": "Type of pipeline description to build.",
-                            "enum": [type.name.lower() for type in PipelineType]
-                        },
-                        ActionType.__name__: {
-                            "type": "string",
-                            "description": f"If {BlockType.__name__} is transformer, "
-                                           f"{ActionType.__name__} specifies what kind "
-                                           "of action the code performs.",
-                            "enum": [type.name.lower() for type in ActionType]
-                        },
-                        DataSource.__name__: {
-                            "type": "string",
-                            "description": f"If {BlockType.__name__} is data_loader or "
-                                           f"data_exporter, {DataSource.__name__} field specify "
-                                           "where the data loads from or exports to.",
-                            "enum": [type.name.lower() for type in DataSource]
-                        },
-                    },
-                    "required": [BlockType.__name__, BlockLanguage.__name__, PipelineType.__name__],
+    {
+        "name": CLASSIFICATION_FUNCTION_NAME,
+        "description": "Classify the code description provided into following properties.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                BlockType.__name__: {
+                    "type": "string",
+                    "description": "Type of the code block. It either "
+                                   "loads data from a source, export data to a source "
+                                   "or transform data from one format to another.",
+                    "enum": ["data_exporter", "data_loader", "transformer"]
                 },
-            }
-        ]
+                BlockLanguage.__name__: {
+                    "type": "string",
+                    "description": "Programming language of the code block.",
+                    "enum": [type.name.lower() for type in BlockLanguage]
+                },
+                PipelineType.__name__: {
+                    "type": "string",
+                    "description": "Type of pipeline description to build.",
+                    "enum": [type.name.lower() for type in PipelineType]
+                },
+                ActionType.__name__: {
+                    "type": "string",
+                    "description": f"If {BlockType.__name__} is transformer, "
+                                   f"{ActionType.__name__} specifies what kind "
+                                   "of action the code performs.",
+                    "enum": [type.name.lower() for type in ActionType]
+                },
+                DataSource.__name__: {
+                    "type": "string",
+                    "description": f"If {BlockType.__name__} is data_loader or "
+                                   f"data_exporter, {DataSource.__name__} field specify "
+                                   "where the data loads from or exports to.",
+                    "enum": [type.name.lower() for type in DataSource]
+                },
+            },
+            "required": [BlockType.__name__, BlockLanguage.__name__, PipelineType.__name__],
+        },
+    }
+]
 
 
 class LLMPipelineWizard:
@@ -141,9 +141,9 @@ class LLMPipelineWizard:
         config['data_source'] = function_args.get(DataSource.__name__, None)
         return block_type, block_language, pipeline_type, config
 
-    def generate_block_with_description(self, block_description: str) -> str:
+    async def async_generate_block_with_description(self, block_description: str) -> str:
         messages = [{"role": "user", "content": block_description}]
-        response = openai.ChatCompletion.create(
+        response = await openai.ChatCompletion.acreate(
             model="gpt-3.5-turbo-0613",
             messages=messages,
             functions=TEMPLATE_CLASSIFICATION_FUNCTION,


### PR DESCRIPTION
# Summary
Use latest openai function call API: https://platform.openai.com/docs/guides/gpt/function-calling to classify the block description with different block attributes.
Then pass the attributes to `fetch_template_source` function to return the block template.

# Tests
Recorded my evaluation in this spreadsheet: https://docs.google.com/spreadsheets/d/1vp0UB6EqM3vnY4f0hYV0nB36X7ngiRIVZZU4FFcybH0/edit#gid=0
Feel free to try more and add the samples into the spreadsheet. Eventually we can use the data in spreadsheet as integration test/verification for this feature iteration.

<img width="974" alt="image" src="https://github.com/mage-ai/mage-ai/assets/5386254/7e38634a-cec5-4383-85b3-ea8d445bf697">


cc:
@wangxiaoyou1993 
