### PR TITLE
[xy] Create dynamic block runs in block executor.

### DIFF
--- a/mage_ai/data_preparation/executors/azure_container_instance_executor.py
+++ b/mage_ai/data_preparation/executors/azure_container_instance_executor.py
@@ -20,7 +20,11 @@ class AzureContainerInstanceExecutor(BlockExecutor):
         global_vars: Dict = None,
         **kwargs,
     ) -> None:
-        cmd = self._run_commands(block_run_id, global_vars, **kwargs)
+        cmd = self._run_commands(
+            block_run_id=block_run_id,
+            global_vars=global_vars,
+            **kwargs,
+        )
         container_instance.run_job(
             ' '.join(cmd),
             f'mage-data-prep-block-{block_run_id}',

--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -119,9 +119,14 @@ class BlockExecutor:
             pipeline_run = PipelineRun.query.get(pipeline_run_id) if pipeline_run_id else None
             block_run = BlockRun.query.get(block_run_id) if block_run_id else None
 
-            block_run_data = block_run.metrics or {}
-            dynamic_block_index = block_run_data.get('dynamic_block_index', None)
-            dynamic_upstream_block_uuids = block_run_data.get('dynamic_upstream_block_uuids', None)
+            if block_run:
+                block_run_data = block_run.metrics or {}
+                dynamic_block_index = block_run_data.get('dynamic_block_index', None)
+                dynamic_upstream_block_uuids = block_run_data.get(
+                    'dynamic_upstream_block_uuids', None)
+            else:
+                dynamic_block_index = None
+                dynamic_upstream_block_uuids = None
 
             # If there are upstream blocks that were dynamically created, and if any of them are
             # configured to reduce their output, we must update the dynamic_upstream_block_uuids to

--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -235,6 +235,7 @@ class BlockExecutor:
                         update_status=update_status,
                         input_from_output=input_from_output,
                         logging_tags=tags,
+                        pipeline_run_id=pipeline_run_id,
                         verify_output=verify_output,
                         runtime_arguments=runtime_arguments,
                         template_runtime_configuration=template_runtime_configuration,

--- a/mage_ai/data_preparation/executors/ecs_block_executor.py
+++ b/mage_ai/data_preparation/executors/ecs_block_executor.py
@@ -20,5 +20,9 @@ class EcsBlockExecutor(BlockExecutor):
         global_vars: Dict = None,
         **kwargs,
     ) -> None:
-        cmd = self._run_commands(block_run_id, global_vars, **kwargs)
+        cmd = self._run_commands(
+            block_run_id=block_run_id,
+            global_vars=global_vars,
+            **kwargs,
+        )
         ecs.run_task(' '.join(cmd), ecs_config=self.executor_config)

--- a/mage_ai/data_preparation/executors/gcp_cloud_run_block_executor.py
+++ b/mage_ai/data_preparation/executors/gcp_cloud_run_block_executor.py
@@ -25,7 +25,11 @@ class GcpCloudRunBlockExecutor(BlockExecutor):
         global_vars: Dict = None,
         **kwargs,
     ) -> None:
-        cmd = self._run_commands(block_run_id, global_vars, **kwargs)
+        cmd = self._run_commands(
+            block_run_id=block_run_id,
+            global_vars=global_vars,
+            **kwargs,
+        )
         cloud_run.run_job(
             ' '.join(cmd),
             f'mage-data-prep-block-{block_run_id}',

--- a/mage_ai/data_preparation/executors/k8s_block_executor.py
+++ b/mage_ai/data_preparation/executors/k8s_block_executor.py
@@ -31,7 +31,11 @@ class K8sBlockExecutor(BlockExecutor):
             logger=self.logger,
             logging_tags=kwargs.get('tags', dict()),
         )
-        cmd = self._run_commands(block_run_id, global_vars, **kwargs)
+        cmd = self._run_commands(
+            block_run_id=block_run_id,
+            global_vars=global_vars,
+            **kwargs
+        )
         job_manager.run_job(
             cmd,
             k8s_config=self.executor_config,

--- a/mage_ai/data_preparation/models/block/utils.py
+++ b/mage_ai/data_preparation/models/block/utils.py
@@ -57,6 +57,7 @@ def create_block_run_from_dynamic_child(
     pipeline_run,
     block_metadata: Dict,
     index: int,
+    skip_if_exists: bool = True,
     upstream_block_uuid: str = None,
 ):
     """
@@ -81,7 +82,11 @@ def create_block_run_from_dynamic_child(
         index,
         upstream_block_uuid=upstream_block_uuid,
     )
-    block_run = pipeline_run.create_block_run(block_uuid, metrics=metadata)
+    block_run = pipeline_run.create_block_run(
+        block_uuid,
+        metrics=metadata,
+        skip_if_exists=skip_if_exists,
+    )
 
     return block_run
 

--- a/mage_ai/tests/data_preparation/executors/test_block_executor.py
+++ b/mage_ai/tests/data_preparation/executors/test_block_executor.py
@@ -61,9 +61,6 @@ class BlockExecutorTest(TestCase):
         retry_config = {'retries': 5, 'delay': 2}
         runtime_arguments = {'arg1': 'value1'}
         template_runtime_configuration = {'config': 'value'}
-        dynamic_block_index = 1
-        dynamic_block_uuid = 'dynamic_block_uuid'
-        dynamic_upstream_block_uuids = ['upstream_block1', 'upstream_block2']
 
         self.block_executor._execute_conditional = MagicMock(return_value=True)
         self.block_executor._execute = MagicMock(return_value={'result': 'success'})
@@ -83,17 +80,14 @@ class BlockExecutorTest(TestCase):
             retry_config=retry_config,
             runtime_arguments=runtime_arguments,
             template_runtime_configuration=template_runtime_configuration,
-            dynamic_block_index=dynamic_block_index,
-            dynamic_block_uuid=dynamic_block_uuid,
-            dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
         )
 
         self.assertEqual(result, {'result': 'success'})
         self.pipeline.get_block.assert_called_once_with(self.block_uuid, check_template=True)
         self.assertEqual(self.block.template_runtime_configuration, template_runtime_configuration)
         self.block_executor._execute_conditional.assert_called_once_with(
-            dynamic_block_index=dynamic_block_index,
-            dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
+            dynamic_block_index=None,
+            dynamic_upstream_block_uuids=None,
             global_vars=global_vars,
             logging_tags={
                 'block_type': BlockType.DBT,
@@ -104,21 +98,23 @@ class BlockExecutorTest(TestCase):
         )
         self.block_executor._execute.assert_called_once_with(
             analyze_outputs=analyze_outputs,
+            block_run_id=None,
             callback_url=callback_url,
             global_vars=global_vars,
-            update_status=update_status,
             input_from_output=input_from_output,
             logging_tags={
                 'block_type': BlockType.DBT,
                 'block_uuid': self.block_uuid,
                 'pipeline_uuid': self.pipeline.uuid,
             },
+            pipeline_run_id=None,
+            update_status=update_status,
             verify_output=verify_output,
             runtime_arguments=runtime_arguments,
             template_runtime_configuration=template_runtime_configuration,
-            dynamic_block_index=dynamic_block_index,
-            dynamic_block_uuid=dynamic_block_uuid,
-            dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
+            dynamic_block_index=None,
+            dynamic_block_uuid=None,
+            dynamic_upstream_block_uuids=None,
         )
         # self.block.run_tests.assert_called_once_with(
         #     execution_partition=self.execution_partition,
@@ -134,8 +130,8 @@ class BlockExecutorTest(TestCase):
         # )
         self.block_executor._execute_callback.assert_called_with(
             'on_success',
-            dynamic_block_index=dynamic_block_index,
-            dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
+            dynamic_block_index=None,
+            dynamic_upstream_block_uuids=None,
             global_vars=global_vars,
             logging_tags={
                 'block_type': BlockType.DBT,

--- a/mage_ai/tests/data_preparation/executors/test_k8s_block_executor.py
+++ b/mage_ai/tests/data_preparation/executors/test_k8s_block_executor.py
@@ -34,7 +34,10 @@ class K8sBlockExecutorTestCase(unittest.TestCase):
         self.executor._execute(block_run_id=1, global_vars={'key': 'value'})
 
         # Assertions
-        self.executor._run_commands.assert_called_once_with(1, {'key': 'value'})
+        self.executor._run_commands.assert_called_once_with(
+            block_run_id=1,
+            global_vars={'key': 'value'},
+        )
         job_manager_mock.assert_called_once_with(
             job_name='mage-data-prep-block-1',
             logger=self.executor.logger,
@@ -59,7 +62,10 @@ class K8sBlockExecutorTestCase(unittest.TestCase):
         self.executor._execute(block_run_id=1, global_vars={'key': 'value'})
 
         # Assertions
-        self.executor._run_commands.assert_called_once_with(1, {'key': 'value'})
+        self.executor._run_commands.assert_called_once_with(
+            block_run_id=1,
+            global_vars={'key': 'value'},
+        )
         job_manager_mock.assert_called_once_with(
             job_name='mage-custom-prefix-block-1',
             logger=self.executor.logger,


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Fix running dynamic blocks in k8s/gcp_cloud_run/ecs/azure_container_instance executors
* Create dynamic child block runs in block executor after block execution completes.
* Move dynamic_upstream_block_uuids generation logic into block executor

# Tests
<!-- How did you test your change? -->
tested locally
cc:
<!-- Optionally mention someone to let them know about this pull request -->
