### PR TITLE
[jk] Display error when fetching data providers

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -268,9 +268,6 @@ function PipelineDetailPage({
     pipelineLastSavedState,
     showStalePipelineMessageModal,
   ]);
-  useEffect(() => {
-    displayErrorFromReadResponse(data, setPipelineErrors);
-  }, [data]);
 
   const qUrl = queryFromUrl();
   const {
@@ -417,6 +414,14 @@ function PipelineDetailPage({
     revalidateOnFocus: false,
   });
   const dataProviders: DataProviderType[] = dataDataProviders?.data_providers;
+
+  useEffect(() => {
+    let dataWithPotentialError = data;
+    if (!data?.hasOwnProperty('error') && dataDataProviders?.hasOwnProperty('error')) {
+      dataWithPotentialError = dataDataProviders;
+    }
+    displayErrorFromReadResponse(dataWithPotentialError, setPipelineErrors);
+  }, [data, dataDataProviders]);
 
   // Variables
   const {


### PR DESCRIPTION
# Summary
- If user has a syntax error in their `io_config.yaml` file, it may cause an error when fetching the data providers and profiles for SQL blocks. This PR will parse the error from the data provider response and display it in the UI.

# Tests
![image](https://github.com/mage-ai/mage-ai/assets/78053898/d5c9eb6b-6417-4319-bd8f-e9ece64e7351)
