### PR TITLE
[jk] Add /files route to backend server and fix TypeError in FileEditor

### DIFF
--- a/mage_ai/frontend/components/FileEditor/index.tsx
+++ b/mage_ai/frontend/components/FileEditor/index.tsx
@@ -184,7 +184,13 @@ function FileEditor({
 
   const regex = useMemo(() => buildFileExtensionRegExp(), []);
 
-  const fileExtension = useMemo(() => file?.path.match(regex)[0]?.split('.')[1], [regex, file]);
+  const fileExtension = useMemo(() => (
+    file?.path?.match(regex) === null
+      ? FileExtensionEnum.TXT
+      : file?.path?.match(regex)[0]?.split('.')[1]
+  ),
+    [regex, file],
+  );
 
   const codeEditorEl = useMemo(() => {
     if (file?.path) {

--- a/mage_ai/frontend/components/FileEditor/index.tsx
+++ b/mage_ai/frontend/components/FileEditor/index.tsx
@@ -187,7 +187,7 @@ function FileEditor({
   const fileExtension = useMemo(() => (
     file?.path?.match(regex) === null
       ? FileExtensionEnum.TXT
-      : file?.path?.match(regex)[0]?.split('.')[1]
+      : file?.path?.match(regex)?.[0]?.split('.')[1]
   ),
     [regex, file],
   );

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -118,6 +118,7 @@ def make_app():
 
     routes = [
         (r'/', MainPageHandler),
+        (r'/files', MainPageHandler),
         (r'/overview', MainPageHandler),
         (r'/pipelines', MainPageHandler),
         (r'/pipelines/(.*)', MainPageHandler),


### PR DESCRIPTION
# Summary
- Add `/files` route so that it is accessible from frontend production build.
- Resolve TypeError related to unmatched regex in FileEditor.

# Tests
- Confirmed TypeError no longer appeared locally after adding default file extension and optional chaining.
- Can access `/files` route directly from url (previously would throw 404 error):
![files route](https://github.com/mage-ai/mage-ai/assets/78053898/66890cb8-0227-40ae-ae79-00eec2341551)
