### PR TITLE
[xh]Update documentation generation as async

### DIFF
--- a/mage_ai/ai/gen_doc_for_pipeline.py
+++ b/mage_ai/ai/gen_doc_for_pipeline.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import typer
 
 from mage_ai.ai.llm_pipeline_wizard import LLMPipelineWizard
@@ -33,11 +35,11 @@ def generate_block_documentation(project_path: str = PROJECT_NAME_DEFAULT,
 def generate_pipeline_documentation(project_path: str = PROJECT_NAME_DEFAULT,
                                     pipeline_uuid: str = PROJECT_NAME_DEFAULT,
                                     print_block_doc: bool = PRINT_BLOCK_DOC_DEFAULT):
-    print(LLMPipelineWizard().generate_pipeline_documentation(
+    print(asyncio.run(LLMPipelineWizard().async_generate_pipeline_documentation(
         pipeline_uuid,
         print_block_doc=print_block_doc,
         project_path=project_path,
-    )['pipeline_doc'])
+    ))['pipeline_doc'])
 
 
 if __name__ == '__main__':

--- a/mage_ai/ai/generator.py
+++ b/mage_ai/ai/generator.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Dict
 
 from mage_ai.ai.constants import LLMUseCase
@@ -19,8 +20,8 @@ class Generator:
         elif use_case == LLMUseCase.GENERATE_DOC_FOR_PIPELINE:
             from mage_ai.ai.llm_pipeline_wizard import LLMPipelineWizard
 
-            return LLMPipelineWizard().generate_pipeline_documentation(
+            return asyncio.run(LLMPipelineWizard().async_generate_pipeline_documentation(
                 pipeline_uuid,
-            )
+            ))
 
         raise Exception(f'Use case {use_case} is not supported yet.')

--- a/mage_ai/ai/llm_pipeline_wizard.py
+++ b/mage_ai/ai/llm_pipeline_wizard.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from langchain.chains import LLMChain
 from langchain.llms import OpenAI
 from langchain.prompts import PromptTemplate
@@ -43,7 +45,7 @@ class LLMPipelineWizard:
     def __init__(self):
         self.llm = OpenAI(temperature=0)
 
-    def __llm_generate_documentation(
+    async def __async_llm_generate_documentation(
         self,
         block_content: str,
         file_type: str,
@@ -61,27 +63,27 @@ class LLMPipelineWizard:
             template=template,
         )
         chain = LLMChain(llm=self.llm, prompt=prompt_template)
-        return chain.run(block_content=block_content,
-                         file_type=file_type,
-                         purpose=purpose,
-                         add_on_prompt=add_on_prompt)
+        return await chain.arun(block_content=block_content,
+                                file_type=file_type,
+                                purpose=purpose,
+                                add_on_prompt=add_on_prompt)
 
-    def generate_pipeline_documentation(
+    async def async_generate_pipeline_documentation(
         self,
         pipeline_uuid: str,
         project_path: str = None,
         print_block_doc: bool = False,
-    ) -> str:
+    ) -> dict:
         pipeline = Pipeline.get(
             uuid=pipeline_uuid,
             repo_path=project_path or get_repo_path(),
         )
-        block_docs = []
-
+        async_block_docs = []
         for block in pipeline.blocks_by_uuid.values():
             if block.type in NON_PIPELINE_EXECUTABLE_BLOCK_TYPES:
                 continue
-            block_docs.append(self.generate_block_documentation(block))
+            async_block_docs.append(self.__async_generate_block_documentation(block))
+        block_docs = await asyncio.gather(*async_block_docs)
         block_docs_content = '\n'.join(block_docs)
         if print_block_doc:
             print(block_docs_content)
@@ -102,9 +104,10 @@ class LLMPipelineWizard:
     ) -> str:
         pipeline = Pipeline.get(uuid=pipeline_uuid,
                                 repo_path=project_path or get_repo_path())
-        return self.generate_block_documentation(pipeline.get_block(block_uuid))
+        return asyncio.run(
+            self.__async_generate_block_documentation(pipeline.get_block(block_uuid)))
 
-    def generate_block_documentation(
+    async def __async_generate_block_documentation(
         self,
         block: Block,
     ) -> str:
@@ -112,11 +115,10 @@ class LLMPipelineWizard:
         if block.type == BlockType.TRANSFORMER:
             add_on_prompt = "Focus on the customized business logic in execute_transformer_action \
                              function."
-        block_doc = self.__llm_generate_documentation(
+        return await self.__async_llm_generate_documentation(
                     block.content,
                     BLOCK_LANGUAGE_TO_FILE_TYPE_VARIABLE[block.language],
                     BLOCK_TYPE_TO_PURPOSE_VARIABLE.get(block.type, ""),
                     PROMPT_FOR_BLOCK,
                     add_on_prompt
                 )
-        return block_doc


### PR DESCRIPTION
# Summary
Update llm block generation function to by async. In this way, it takes less time to generate documentation for pipeline.

# Tests
Commands:
`python mage_ai/ai/gen_doc_for_pipeline.py generate-pipeline-documentation documentation documentation_standard_pipeline_test_1 --print-block-doc`

`python mage_ai/ai/gen_doc_for_pipeline.py generate-block-documentation documentation documentation_standard_pipeline_test_1 polished_fire`

cc:
@wangxiaoyou1993 
