### PR TITLE
fix: add missing rules for k8s Role

### DIFF
--- a/kube/app.yaml
+++ b/kube/app.yaml
@@ -13,8 +13,14 @@ rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["create", "delete", "get"]
 - apiGroups: ["batch", "extensions"]
   resources: ["jobs", "jobs/status"]
+  verbs: ["create", "delete", "get"]
+- apiGroups: ["apps"]
+  resources: ["statefulsets"]
   verbs: ["create", "delete", "get"]
 
 ---


### PR DESCRIPTION
# Summary
When working with [Workspace management](https://docs.mage.ai/developing-in-the-cloud/workspaces/overview), the Helm chart generated role misses a few rules, which led to this:

![image](https://github.com/mage-ai/mage-ai/assets/35741485/cabe702c-62a9-4571-962e-e0f3af17c347)

Adding these rules grants enough authorization for the service account to manage the resources it needs.

# Tests
I've tested in my current toy deployment.