### PR TITLE
[jk] Add "Updated at" column to Pipelines list page

### DIFF
--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -847,6 +847,7 @@ function PipelineListPage() {
                   </Text>,
                   <Text
                     key={`pipeline_updated_at_${idx}`}
+                    title={updatedAt}
                   >
                     {updatedAt ? updatedAt.slice(0, -3) : <>&#8212;</>}
                   </Text>,

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -654,7 +654,7 @@ function PipelineListPage() {
             maxHeight={`calc(100vh - ${HEADER_HEIGHT + 74}px)`}
           >
             <Table
-              columnFlex={[null, null, null, 2, null, 1, null, null, null]}
+              columnFlex={[null, null, null, 2, null, null, 1, null, null, null]}
               columns={[
                 {
                   label: () => '',
@@ -671,6 +671,9 @@ function PipelineListPage() {
                 },
                 {
                   uuid: capitalize(PipelineGroupingEnum.TYPE),
+                },
+                {
+                  uuid: 'Updated at',
                 },
                 {
                   uuid: 'Tags',
@@ -762,6 +765,7 @@ function PipelineListPage() {
                   schedules,
                   tags,
                   type,
+                  updated_at: updatedAt,
                   uuid,
                 } = pipeline;
                 const blocksCount = blocks.filter(({ type }) => BlockTypeEnum.SCRATCHPAD !== type).length;
@@ -840,6 +844,11 @@ function PipelineListPage() {
                     key={`pipeline_type_${idx}`}
                   >
                     {PIPELINE_TYPE_LABEL_MAPPING[type]}
+                  </Text>,
+                  <Text
+                    key={`pipeline_updated_at_${idx}`}
+                  >
+                    {updatedAt ? updatedAt.slice(0, -3) : <>&#8212;</>}
                   </Text>,
                   tagsEl,
                   <Text


### PR DESCRIPTION
# Summary
- See title. Hovering over `Updated at` value shows the timestamp with seconds.

# Tests
![image](https://github.com/mage-ai/mage-ai/assets/78053898/a49b0025-4383-449f-a804-19b87d4bd513)
