### PR TITLE
[jk] Default error log to Errors tab when opening log detail

### DIFF
--- a/mage_ai/frontend/components/DependencyGraph/BlockNode/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/BlockNode/index.tsx
@@ -205,7 +205,7 @@ function BlockNode({
             </Flex>
           </Flex>
 
-          <Spacing mr={HEADER_SPACING_HORIZONTAL_UNITS} />
+          <Spacing mr="15px" />
 
           <StatusStyle title={tooltipText}>
             {!hideStatus && (

--- a/mage_ai/frontend/components/Logs/Detail/index.tsx
+++ b/mage_ai/frontend/components/Logs/Detail/index.tsx
@@ -27,19 +27,22 @@ const KEYS_TO_SKIP = [
   'error_stack',
   'error_stacktrace',
 ];
-const TAB_DETAILS = { uuid: 'Details' };
-const TAB_ERRORS = { uuid: 'Errors' };
+export const TAB_DETAILS = { uuid: 'Details' };
+export const TAB_ERRORS = { uuid: 'Errors' };
 
 type LogDetailProps = {
   log: LogType;
   onClose: () => void;
+  selectedTab: TabType;
+  setSelectedTab: (tab: TabType) => void;
 };
 
 function LogDetail({
   log,
   onClose,
+  selectedTab,
+  setSelectedTab,
 }: LogDetailProps) {
-  const [selectedTab, setSelectedTab] = useState<TabType>(TAB_DETAILS);
   const [showFullLogMessage, setShowFullLogMessage] = useState<boolean>(false);
   const {
     data,
@@ -94,8 +97,6 @@ function LogDetail({
     );
   }, [
     error,
-    errorStack,
-    errorStackTrace,
     selectedTab,
     setSelectedTab,
   ]);

--- a/mage_ai/frontend/components/Logs/Table/index.tsx
+++ b/mage_ai/frontend/components/Logs/Table/index.tsx
@@ -17,7 +17,9 @@ import { ChevronRight } from '@oracle/icons';
 import { FilterQueryType } from '@components/Logs/Filter';
 import { HEADER_HEIGHT } from '@components/shared/Header/index.style';
 import { LogLevelIndicatorStyle } from '@components/Logs/index.style';
+import { TAB_DETAILS, TAB_ERRORS } from '@components/Logs/Detail';
 import { TableContainer, TableHeadStyle, TableRowStyle } from './index.style';
+import { TabType } from '@oracle/components/Tabs/ButtonTabs';
 import { ThemeType } from '@oracle/styles/themes/constants';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { WIDTH_OF_SINGLE_CHARACTER_MONOSPACE } from '@components/DataTable';
@@ -31,6 +33,7 @@ export const LOG_UUID_PARAM = 'log_uuid';
 type LogsTableProps = {
   blocksByUUID: { [keyof: string]: BlockType };
   logs: LogType[];
+  onRowClick?: (tab?: TabType) => void;
   pipeline: PipelineType;
   query: FilterQueryType;
   setSelectedLog: (log: LogType) => void;
@@ -40,6 +43,7 @@ type LogsTableProps = {
 function LogsTable({
   blocksByUUID,
   logs,
+  onRowClick,
   pipeline,
   query,
   setSelectedLog,
@@ -92,7 +96,6 @@ function LogsTable({
     const {
       blocksByUUID,
       logs,
-      pipeline,
       themeContext,
     } = data;
     const { content, data: logData, name } = logs[index];
@@ -183,6 +186,12 @@ function LogsTable({
             logUUID = null;
           }
 
+          if (log.data?.error) {
+            onRowClick?.(TAB_ERRORS);
+          } else {
+            onRowClick?.(TAB_DETAILS);
+          }
+
           goToWithQuery({ [LOG_UUID_PARAM]: logUUID });
           setSelectedLog(logUUID ? log : null);
         }}
@@ -240,7 +249,13 @@ function LogsTable({
         </Flex>
       </TableRowStyle>
     );
-  }, [blockUUIDColWidth, isIntegration, query, setSelectedLog]);
+  }, [
+    blockUUIDColWidth,
+    isIntegration,
+    onRowClick,
+    query,
+    setSelectedLog,
+  ]);
 
   return (
     <TableContainer>

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -14,7 +14,7 @@ import Divider from '@oracle/elements/Divider';
 import ErrorsType from '@interfaces/ErrorsType';
 import Filter, { FilterQueryType } from '@components/Logs/Filter';
 import KeyboardShortcutButton from '@oracle/elements/Button/KeyboardShortcutButton';
-import LogDetail from '@components/Logs/Detail';
+import LogDetail, { TAB_DETAILS } from '@components/Logs/Detail';
 import LogType, { LogRangeEnum } from '@interfaces/LogType';
 import PipelineDetailPage from '@components/PipelineDetailPage';
 import PipelineType, { PipelineTypeEnum } from '@interfaces/PipelineType';
@@ -34,11 +34,12 @@ import {
 } from '@components/Logs/Toolbar/constants';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
+import { TabType } from '@oracle/components/Tabs/ButtonTabs';
 import { calculateStartTimestamp } from '@utils/number';
 import { find, indexBy, sortByKey } from '@utils/array';
-import { initializeLogs } from '@utils/models/log';
 import { goToWithQuery } from '@utils/routing';
 import { ignoreKeys, isEqual } from '@utils/hash';
+import { initializeLogs } from '@utils/models/log';
 import { numberWithCommas } from '@utils/string';
 import { queryFromUrl } from '@utils/url';
 
@@ -63,6 +64,7 @@ function PipelineLogsPage({
   const [selectedRange, setSelectedRange] = useState<LogRangeEnum>(null);
   const [scrollToBottom, setScrollToBottom] = useState(false);
   const [errors, setErrors] = useState<ErrorsType>(null);
+  const [selectedTab, setSelectedTab] = useState<TabType>(TAB_DETAILS);
 
   const { data: dataPipeline } = api.pipelines.detail(pipelineUUID, {
     includes_content: false,
@@ -292,6 +294,7 @@ function PipelineLogsPage({
     <LogsTable
       blocksByUUID={blocksByUUID}
       logs={logsFiltered}
+      onRowClick={setSelectedTab}
       pipeline={pipeline}
       query={query}
       setSelectedLog={setSelectedLog}
@@ -308,6 +311,8 @@ function PipelineLogsPage({
             goToWithQuery({ [LOG_UUID_PARAM]: null });
             setSelectedLog(null);
           }}
+          selectedTab={selectedTab}
+          setSelectedTab={setSelectedTab}
         />
       )}
       afterHidden={!selectedLog}


### PR DESCRIPTION
# Summary
- When user clicks on a log row from the Logs table, default to opening the Errors tab in the Log Detail instead of the Details tab if the log is an error log.

# Tests
![open error log](https://github.com/mage-ai/mage-ai/assets/78053898/1d13dd60-0b4a-425b-b18d-020164d157b9)
