### PR TITLE
[mp] simplify GCP terraform docs to use cloud run

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -378,7 +378,6 @@
                 "production/deploying-to-cloud/gcp/setup",
                 "production/deploying-to-cloud/gcp/resources",
                 "production/deploying-to-cloud/gcp/gcp-artifact-registry"
-
               ]
             },
             {

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -376,7 +376,9 @@
               "group": "GCP",
               "pages": [
                 "production/deploying-to-cloud/gcp/setup",
-                "production/deploying-to-cloud/gcp/resources"
+                "production/deploying-to-cloud/gcp/resources",
+                "production/deploying-to-cloud/gcp/gcp-artifact-registry"
+
               ]
             },
             {

--- a/docs/production/deploying-to-cloud/gcp/gcp-artifact-registry.mdx
+++ b/docs/production/deploying-to-cloud/gcp/gcp-artifact-registry.mdx
@@ -1,0 +1,84 @@
+---
+title: "Push Docker Image to GCP Artifact Registry"
+---
+
+While you may pull an image directly from Docker Hub, here are our legacy instructions for pushing a Docker image to GCP Artifact Registry:
+
+1.  Create a repository on
+    [GCP Artifact Registry](https://console.cloud.google.com/artifacts) by
+    clicking the **`+ CREATE REPOSITORY`** button.
+
+    - Fill in the **Name**
+    - Choose Docker as the **Format**
+    - Choose any **Location type**
+    - Choose any **Encryption**
+    - Click **`CREATE`**
+
+2.  Click on the newly created repository (e.g. `mage-docker`).
+3. Near the top of the page, click the link **`SETUP INSTRUCTIONS`** or read these
+    [instructions](https://cloud.google.com/artifact-registry/docs/docker/authentication)
+    to set up authentication for Docker.
+
+    - Run the following command in your terminal:
+
+        ```bash
+        gcloud auth configure-docker [region]-docker.pkg.dev
+        ```
+
+    - An example command could look like this:
+
+        ```bash
+        gcloud auth configure-docker us-west2-docker.pkg.dev
+        ```
+
+4. Pull the Mage Docker image:
+
+    ```bash
+    docker pull mageai/mageai:latest
+    ```
+
+    - If your local workstation is using macOS and a silicon chip (e.g. M1, M2,
+    etc), then run this command instead:
+
+        ```bash
+        docker pull --platform linux/amd64 mageai/mageai:latest
+        ```
+
+5.  Tag the pulled Mage docker image or use a previously tagged Docker image you
+    built when following this [CI/CD guide](/production/ci-cd):
+
+    - Sample commands if using vanilla Mage Docker image:
+
+        ```bash
+        docker tag mageai/mageai:latest [region]-docker.pkg.dev/[project_id]/[repository]/mageai:latest
+        ```
+
+        - An example command could look like this:
+
+            ```bash
+            docker tag mageai/mageai:latest us-west2-docker.pkg.dev/materia-284023/mage-docker/mageai:latest
+            ```
+
+    - Sample commands if using previously tagged a custom Docker image using the tag `mageprod:latest`:
+
+        ```bash
+        docker tag mageprod:latest [region]-docker.pkg.dev/[project_id]/[repository]/mageai:latest
+        ```
+
+        - An example command could look like this if you previously tagged your custom Docker image with the tag `mageprod:latest`:
+
+            ```bash
+            docker tag mageprod:latest us-west2-docker.pkg.dev/materia-284023/mage-docker/mageai:latest
+            ```
+
+6.  Push the local Docker image to GCP Artifact Registry:
+
+    ```bash
+    docker push [region]-docker.pkg.dev/[project_id]/[repository]/mageai:latest
+    ```
+
+    - An example command could look like this:
+
+        ```bash
+        docker push us-west2-docker.pkg.dev/materia-284023/mage-docker/mageai:latest
+        ```

--- a/docs/production/deploying-to-cloud/gcp/setup.mdx
+++ b/docs/production/deploying-to-cloud/gcp/setup.mdx
@@ -89,7 +89,7 @@ variable "project_id" {
 }
 ```
 
-**Mage Image (REQUIRED)**
+**Docker Image (REQUIRED)**
 
 Google Cloud Run supports pulling Docker images directly from Docker Hub. To use the latest Mage image (default):
 

--- a/docs/production/deploying-to-cloud/gcp/setup.mdx
+++ b/docs/production/deploying-to-cloud/gcp/setup.mdx
@@ -89,6 +89,20 @@ variable "project_id" {
 }
 ```
 
+**Mage Image (REQUIRED)**
+
+Google Cloud Run supports pulling Docker images directly from Docker Hub. To use the latest Mage image (default):
+
+```js
+variable "docker_image" {
+  type        = string
+  description = "The docker image to deploy to Cloud Run."
+  default     = "docker.io/mageai/mageai:latest"
+}
+```
+
+Simply change the tag to adjust the version of Mage you want to deploy. If you need to build your own image, you can push it to Docker Hub or follow our guide to use [GCP Artifact Registry](/production/deploying-to-cloud/gcp/gcp-artifact-registry).
+
 **Application Name**
 
 In the file
@@ -294,9 +308,7 @@ Other variables defined in
 [./gcp/variables.tf](https://github.com/mage-ai/mage-ai-terraform-templates/blob/master/gcp/variables.tf)
 can also be customized to your needs.
 
----
-
-## 5. Deploy
+## 4. Deploy
 
 1. Change directory into scripts folder:
    ```bash

--- a/docs/production/deploying-to-cloud/gcp/setup.mdx
+++ b/docs/production/deploying-to-cloud/gcp/setup.mdx
@@ -97,7 +97,7 @@ Google Cloud Run supports pulling Docker images directly from Docker Hub. To use
 variable "docker_image" {
   type        = string
   description = "The docker image to deploy to Cloud Run."
-  default     = "docker.io/mageai/mageai:latest"
+  default     = "mageai/mageai:latest"
 }
 ```
 

--- a/docs/production/deploying-to-cloud/gcp/setup.mdx
+++ b/docs/production/deploying-to-cloud/gcp/setup.mdx
@@ -72,96 +72,7 @@ gcloud init
 gcloud auth application-default login
 ```
 
-## 3. Push Docker image to GCP Artifact Registry
-
-GCP doesn’t support using Docker images from Docker Hub. We’ll need to pull the
-Mage Docker image, tag it, and push it to
-[GCP Artifact Registry](https://cloud.google.com/artifact-registry).
-
-Here are the steps we’ll take:
-
-1.  Create a repository on
-    [GCP Artifact Registry](https://console.cloud.google.com/artifacts) by
-    clicking the **`+ CREATE REPOSITORY`** button.
-
-    - Fill in the **Name**
-    - Choose Docker as the **Format**
-    - Choose any **Location type**
-    - Choose any **Encryption**
-    - Click **`CREATE`**
-
-2.  Click on the newly created repository (e.g. `mage-docker`).
-3. Near the top of the page, click the link **`SETUP INSTRUCTIONS`** or read these
-    [instructions](https://cloud.google.com/artifact-registry/docs/docker/authentication)
-    to set up authentication for Docker.
-
-    - Run the following command in your terminal:
-
-        ```bash
-        gcloud auth configure-docker [region]-docker.pkg.dev
-        ```
-
-    - An example command could look like this:
-
-        ```bash
-        gcloud auth configure-docker us-west2-docker.pkg.dev
-        ```
-
-4. Pull the Mage Docker image:
-
-    ```bash
-    docker pull mageai/mageai:latest
-    ```
-
-    - If your local workstation is using macOS and a silicon chip (e.g. M1, M2,
-    etc), then run this command instead:
-
-        ```bash
-        docker pull --platform linux/amd64 mageai/mageai:latest
-        ```
-
-5.  Tag the pulled Mage docker image or use a previously tagged Docker image you
-    built when following this [CI/CD guide](/production/ci-cd):
-
-    - Sample commands if using vanilla Mage Docker image:
-
-        ```bash
-        docker tag mageai/mageai:latest [region]-docker.pkg.dev/[project_id]/[repository]/mageai:latest
-        ```
-
-        - An example command could look like this:
-
-            ```bash
-            docker tag mageai/mageai:latest us-west2-docker.pkg.dev/materia-284023/mage-docker/mageai:latest
-            ```
-
-    - Sample commands if using previously tagged a custom Docker image using the tag `mageprod:latest`:
-
-        ```bash
-        docker tag mageprod:latest [region]-docker.pkg.dev/[project_id]/[repository]/mageai:latest
-        ```
-
-        - An example command could look like this if you previously tagged your custom Docker image with the tag `mageprod:latest`:
-
-            ```bash
-            docker tag mageprod:latest us-west2-docker.pkg.dev/materia-284023/mage-docker/mageai:latest
-            ```
-
-6.  Push the local Docker image to GCP Artifact Registry:
-
-    ```bash
-    docker push [region]-docker.pkg.dev/[project_id]/[repository]/mageai:latest
-    ```
-
-    - An example command could look like this:
-
-        ```bash
-        docker push us-west2-docker.pkg.dev/materia-284023/mage-docker/mageai:latest
-        ```
-
----
-
-## 4. Customize Terraform settings
+## 3. Customize Terraform settings
 
 **Project ID (REQUIRED)**
 
@@ -175,24 +86,6 @@ variable "project_id" {
   type        = string
   description = "The name of the project"
   default     = "unique-gcp-project-id"
-}
-```
-
-**Docker image (REQUIRED)**
-
-In the repository you created in GCP Artifact Repository, you’ll see a list of
-Docker images. Click on an image name, then copy the full path to the image
-(e.g. `us-west2-docker.pkg.dev/materia-284023/mage-docker/mageai`).
-
-In the file
-[./gcp/variables.tf](https://github.com/mage-ai/mage-ai-terraform-templates/blob/master/gcp/variables.tf),
-you can change the `default` value under `docker_image`:
-
-```js
-variable "docker_image" {
-  type        = string
-  description = "The Docker image url in the Artifact Registry repository to be deployed to Cloud Run"
-  default     = "us-west2-docker.pkg.dev/materia-284023/mage-docker/mageai"
 }
 ```
 


### PR DESCRIPTION
# Summary

Google Cloud Run now supports running Docker images from Docker Hub directly. This resolves the issue mentioned in https://github.com/mage-ai/mage-ai/issues/3033 and drastically simplifies steps to configure Mage on GCP. 

An updated Terraform template PR is available [here](https://github.com/mage-ai/mage-ai-terraform-templates/pull/39).

# Tests

Followed instructions to spin up Mage instance via Terraform.
