### PR TITLE
[td] Include interval datetimes and intervals in block variables

### DIFF
--- a/docs/guides/schedule-pipelines.mdx
+++ b/docs/guides/schedule-pipelines.mdx
@@ -15,3 +15,25 @@ You can schedule your pipeline to run on these intervals:
 - _Streaming pipeline_: coming soon
 Learn more about how to
 [schedule pipelines](/design/data-pipeline-management#create-trigger).
+
+## Extra runtime variables from pipeline run
+
+If your pipeline run belongs to a trigger that is scheduled, then the following extra
+variables are available in your Python block’s keyword arguments (e.g. `kwargs`).
+
+| Key | Description | Example |
+| --- | --- | --- |
+| `interval_start_datetime` | The `datetime` when the pipeline run is scheduled for. | `datetime.datetime(2023, 7, 23, 7, 0, 32, 794553)` |
+| `interval_end_datetime` | The `datetime` when the next pipeline run is scheduled for. | `datetime.datetime(2023, 7, 24, 7, 0, 32, 794553)` |
+| `interval_seconds` | The number of seconds between the current pipeline run and the next pipeline run. | `86400` |
+
+### SQL block
+
+If you’re using a SQL block, here is an example of how you can access these variables:
+
+```sql
+SELECT
+    '{{ interval_start_datetime }}' AS interval_start_datetime
+    , '{{ interval_end_datetime }}' AS interval_end_datetime
+    , '{{ interval_seconds }}' AS interval_seconds
+```

--- a/docs/orchestration/backfills/overview.mdx
+++ b/docs/orchestration/backfills/overview.mdx
@@ -59,3 +59,27 @@ Then the following pipeline runs will be created:
 | 1 | `2023-01-01T00:00:00` | `2023-01-01` | `00` | `0` | `5` |
 | 2 | `2023-01-01T00:00:00` | `2023-01-01` | `00` | `1` | `5` |
 | 3 | `2023-01-01T00:00:00` | `2023-01-01` | `00` | `2` | `5` |
+
+---
+
+## Extra runtime variables from pipeline run
+
+If your pipeline run belongs to a trigger that is scheduled, then the following extra
+variables are available in your Python block’s keyword arguments (e.g. `kwargs`).
+
+| Key | Description | Example |
+| --- | --- | --- |
+| `interval_start_datetime` | The `datetime` when the pipeline run is scheduled for. | `datetime.datetime(2023, 7, 23, 7, 0, 32, 794553)` |
+| `interval_end_datetime` | The `datetime` when the next pipeline run is scheduled for. | `datetime.datetime(2023, 7, 24, 7, 0, 32, 794553)` |
+| `interval_seconds` | The number of seconds between the current pipeline run and the next pipeline run. | `86400` |
+
+### SQL block
+
+If you’re using a SQL block, here is an example of how you can access these variables:
+
+```sql
+SELECT
+    '{{ interval_start_datetime }}' AS interval_start_datetime
+    , '{{ interval_end_datetime }}' AS interval_end_datetime
+    , '{{ interval_seconds }}' AS interval_seconds
+```

--- a/mage_ai/orchestration/backfills/service.py
+++ b/mage_ai/orchestration/backfills/service.py
@@ -33,6 +33,7 @@ def start_backfill(backfill: Backfill) -> List[PipelineRun]:
         execution_date = None
         if 'execution_date' in backfill_run_variables:
             execution_date = dateutil.parser.parse(backfill_run_variables['execution_date'])
+
         pipeline_run = PipelineRun.create(
             backfill_id=backfill.id,
             execution_date=execution_date,
@@ -75,11 +76,35 @@ def __build_variables_list(backfill: Backfill) -> List[Dict]:
         return []
 
     dates = __build_dates(backfill)
-    return [{
-        'ds': execution_date.strftime('%Y-%m-%d'),
-        'execution_date': execution_date.isoformat(),
-        'hr': execution_date.strftime('%H'),
-    } for execution_date in dates]
+    number_of_dates = len(dates)
+
+    arr = []
+
+    for idx, execution_date in enumerate(dates):
+        interval_end_datetime = None
+        interval_seconds = None
+        interval_start_datetime = execution_date
+
+        if idx < number_of_dates - 1:
+            interval_end_datetime = dates[idx + 1]
+            interval_seconds = interval_end_datetime.timestamp() - execution_date.timestamp()
+
+        if interval_end_datetime:
+            interval_end_datetime = interval_end_datetime.isoformat()
+
+        if interval_start_datetime:
+            interval_start_datetime = interval_start_datetime.isoformat()
+
+        arr.append(dict(
+            ds=execution_date.strftime('%Y-%m-%d'),
+            execution_date=execution_date.isoformat(),
+            hr=execution_date.strftime('%H'),
+            interval_end_datetime=interval_end_datetime,
+            interval_seconds=interval_seconds,
+            interval_start_datetime=interval_start_datetime,
+        ))
+
+    return arr
 
 
 def __build_dates(backfill: Backfill) -> List[datetime]:

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -1,8 +1,10 @@
 import asyncio
+import dateutil.parser
 import enum
 import traceback
 import uuid
 from datetime import datetime, timedelta, timezone
+from dateutil.relativedelta import relativedelta
 from typing import Dict, List
 
 import pytz
@@ -467,6 +469,53 @@ class PipelineRun(BaseModel):
         variables['event'] = merge_dict(variables.get('event', {}), event_variables)
         variables['execution_date'] = self.execution_date
         variables['execution_partition'] = self.execution_partition
+
+        interval_end_datetime = variables.get('interval_end_datetime')
+        interval_seconds = variables.get('interval_seconds')
+        interval_start_datetime = variables.get('interval_start_datetime')
+
+        if interval_end_datetime or interval_seconds or interval_start_datetime:
+            if interval_end_datetime:
+                try:
+                    variables['interval_end_datetime'] = dateutil.parser.parse(
+                        interval_end_datetime,
+                    )
+                except Exception as err:
+                    print(f'[ERROR] PipelineRun.get_variables: {err}')
+
+            if interval_start_datetime:
+                try:
+                    variables['interval_start_datetime'] = dateutil.parser.parse(
+                        interval_start_datetime,
+                    )
+                except Exception as err:
+                    print(f'[ERROR] PipelineRun.get_variables: {err}')
+        elif self.execution_date and ScheduleType.TIME == self.pipeline_schedule.schedule_type:
+            interval_end_datetime = None
+            interval_seconds = None
+            interval_start_datetime = self.execution_date
+
+            if ScheduleInterval.DAILY == self.pipeline_schedule.schedule_interval:
+                interval_seconds = 60 * 60 * 24
+            elif ScheduleInterval.HOURLY == self.pipeline_schedule.schedule_interval:
+                interval_seconds = 60 * 60 * 1
+            elif ScheduleInterval.MONTHLY == self.pipeline_schedule.schedule_interval:
+                interval_end_datetime = interval_start_datetime + relativedelta(months=1)
+                interval_seconds = (
+                    interval_end_datetime.timestamp() - interval_start_datetime.timestamp()
+                )
+            elif ScheduleInterval.WEEKLY == self.pipeline_schedule.schedule_interval:
+                interval_seconds = 60 * 60 * 24 * 7
+
+            if interval_seconds and not interval_end_datetime:
+                interval_end_datetime = interval_start_datetime + timedelta(
+                    seconds=interval_seconds,
+                )
+
+            variables['interval_end_datetime'] = interval_end_datetime
+            variables['interval_seconds'] = interval_seconds
+            variables['interval_start_datetime'] = interval_start_datetime
+
         variables.update(extra_variables)
 
         return variables

--- a/mage_ai/server/websocket_server.py
+++ b/mage_ai/server/websocket_server.py
@@ -235,7 +235,7 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
         if 'execution_date' not in global_vars:
             now = datetime.now()
             global_vars['execution_date'] = now
-            global_vars['interval_end_datetime']  = None
+            global_vars['interval_end_datetime'] = None
             global_vars['interval_seconds'] = None
             global_vars['interval_start_datetime'] = now
 

--- a/mage_ai/server/websocket_server.py
+++ b/mage_ai/server/websocket_server.py
@@ -233,7 +233,12 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
             )
         global_vars['env'] = ENV_DEV
         if 'execution_date' not in global_vars:
-            global_vars['execution_date'] = datetime.now()
+            now = datetime.now()
+            global_vars['execution_date'] = now
+            global_vars['interval_end_datetime']  = None
+            global_vars['interval_seconds'] = None
+            global_vars['interval_start_datetime'] = now
+
         global_vars['event'] = dict()
 
         if cancel_pipeline:


### PR DESCRIPTION
# Summary
A block will now have variables of when the pipeline run was schedule for, the datetime of the next scheduled pipeline run, and the number of seconds between.

- https://docs.mage.ai/orchestration/backfills/overview
- https://docs.mage.ai/guides/schedule-pipelines

# Tests
<img width="1334" alt="image" src="https://github.com/mage-ai/mage-ai/assets/1066980/d8d9809e-5dae-4683-9452-7dd66a88c666">
