### PR TITLE
[td] Save pipelines list filters and group bys

### DIFF
--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -160,9 +160,11 @@ function PipelineListPage() {
           v2 = [v2];
         }
 
-        v2.forEach((v3) => {
-          f[k][v3] = true;
-        });
+        if (v2 && Array.isArray(v2)) {
+          v2?.forEach((v3) => {
+            f[k][v3] = true;
+          });
+        }
       });
 
       setFilters(f);

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -42,8 +42,15 @@ import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { capitalize, capitalizeRemoveUnderscoreLower } from '@utils/string';
 import { displayErrorFromReadResponse, onSuccess } from '@api/utils/response';
 import { filterQuery, queryFromUrl } from '@utils/url';
+import {
+  getFilters,
+  getGroupBys,
+  setFilters,
+  setGroupBys,
+} from '@storage/pipelines';
 import { getNewPipelineButtonMenuItems } from '@components/Dashboard/utils';
 import { goToWithQuery } from '@utils/routing';
+import { isEmptyObject } from '@utils/hash';
 import { pauseEvent } from '@utils/events';
 import { sortByKey } from '@utils/array';
 import { useModal } from '@context/Modal';
@@ -75,7 +82,6 @@ function PipelineListPage() {
     PipelineQueryEnum.TAG,
     PipelineQueryEnum.TYPE,
   ]);
-  const groupByQuery = q?.[PipelineQueryEnum.GROUP];
   const { data, mutate: fetchPipelines } = api.pipelines.list({
     ...query,
     include_schedules: 1,
@@ -96,6 +102,81 @@ function PipelineListPage() {
 
   const { data: dataProjects, mutate: fetchProjects } = api.projects.list();
   const project: ProjectType = useMemo(() => dataProjects?.projects?.[0], [dataProjects]);
+
+  const groupByQuery = q?.[PipelineQueryEnum.GROUP];
+
+  useEffect(() => {
+    let queryFinal = {};
+
+    if (groupByQuery) {
+      setGroupBys({
+        [groupByQuery]: true,
+      });
+    } else {
+      let val;
+      const groupBys = getGroupBys();
+      if (groupBys) {
+        Object.entries(groupBys).forEach(([k, v]) => {
+          if (!val && v) {
+            val = k;
+          }
+        });
+      }
+
+      if (val) {
+        queryFinal[PipelineQueryEnum.GROUP] = val;
+      }
+    }
+
+    if (isEmptyObject(query)) {
+      const filtersQuery = {};
+      const f = getFilters();
+
+      if (f) {
+        Object.entries(f).forEach(([k, v]) => {
+          filtersQuery[k] = [];
+
+          Object.entries(v).forEach(([k2, v2]) => {
+            if (v2) {
+              filtersQuery[k].push(k2);
+            }
+          });
+        });
+      }
+
+      if (!isEmptyObject(filtersQuery)) {
+        queryFinal = {
+          ...queryFinal,
+          ...filtersQuery,
+        };
+      }
+    } else {
+      const f = {};
+      Object.entries(query).forEach(([k, v]) => {
+        f[k] = {};
+
+        let v2 = v;
+        if (!Array.isArray(v2)) {
+          v2 = [v2];
+        }
+
+        v2.forEach((v3) => {
+          f[k][v3] = true;
+        });
+      });
+
+      setFilters(f);
+    }
+
+    if (!isEmptyObject(queryFinal)) {
+      goToWithQuery(queryFinal, {
+        pushHistory: true,
+      });
+    }
+  }, [
+    groupByQuery,
+    query,
+  ]);
 
   useEffect(() => {
     displayErrorFromReadResponse(data, setErrors);

--- a/mage_ai/frontend/storage/pipelines.ts
+++ b/mage_ai/frontend/storage/pipelines.ts
@@ -1,0 +1,34 @@
+import { get, set } from './localStorage';
+
+const LOCAL_STORAGE_KEY_PIPELINE_LIST_FILTERS = 'pipeline_list_filters';
+const LOCAL_STORAGE_KEY_PIPELINE_LIST_GROUP_BYS = 'pipeline_list_group_bys';
+
+type FilterType = {
+  [filterKey: string]: {
+    [value: string]: boolean;
+  };
+};
+
+type GroupByType = {
+  [groupByKey: string]: boolean;
+};
+
+export function getFilters() {
+  return get(LOCAL_STORAGE_KEY_PIPELINE_LIST_FILTERS, {});
+}
+
+export function setFilters(filters: FilterType) {
+  set(LOCAL_STORAGE_KEY_PIPELINE_LIST_FILTERS, filters);
+
+  return filters;
+}
+
+export function getGroupBys() {
+  return get(LOCAL_STORAGE_KEY_PIPELINE_LIST_GROUP_BYS, {});
+}
+
+export function setGroupBys(groupBys: GroupByType) {
+  set(LOCAL_STORAGE_KEY_PIPELINE_LIST_GROUP_BYS, groupBys);
+
+  return groupBys;
+}


### PR DESCRIPTION
# Summary
When filtering or grouping the pipelines on the pipelines list page, preserve those settings so that when a user comes back to that page, those filters and group bys persist.

# Tests
![2023-07-23 00 40 48](https://github.com/mage-ai/mage-ai/assets/1066980/3d86d4ac-255b-4894-8a5f-45c10b7c68c8)
