### PR TITLE
[td] Encode URI component for file path on files page

### DIFF
--- a/mage_ai/frontend/components/Files/index.tsx
+++ b/mage_ai/frontend/components/Files/index.tsx
@@ -277,7 +277,7 @@ function FilesPageComponent() {
         <FileEditor
           active={selectedFilePath === filePath}
           disableRefreshWarning
-          filePath={filePath}
+          filePath={filePath ? encodeURIComponent(filePath) : null}
           hideHeaderButtons
           onContentChange={(content: string) => setContentByFilePath({
             [filePath]: content,


### PR DESCRIPTION
# Summary
The file content could not be fetched because we weren’t encoding the file path.