### PR TITLE
[td] Add interval_start_datetime_previous for the previous run’s interval_start_datetime

### DIFF
--- a/docs/guides/schedule-pipelines.mdx
+++ b/docs/guides/schedule-pipelines.mdx
@@ -23,9 +23,10 @@ variables are available in your Python block’s keyword arguments (e.g. `kwargs
 
 | Key | Description | Example |
 | --- | --- | --- |
-| `interval_start_datetime` | The `datetime` when the pipeline run is scheduled for. | `datetime.datetime(2023, 7, 23, 7, 0, 32, 794553)` |
-| `interval_end_datetime` | The `datetime` when the next pipeline run is scheduled for. | `datetime.datetime(2023, 7, 24, 7, 0, 32, 794553)` |
+| `interval_start_datetime` | The `datetime` when the pipeline run is scheduled for. | `datetime.datetime(2023, 7, 23, 7, 0, 0, 0)` |
+| `interval_end_datetime` | The `datetime` when the next pipeline run is scheduled for. | `datetime.datetime(2023, 7, 24, 7, 0, 0, 0)` |
 | `interval_seconds` | The number of seconds between the current pipeline run and the next pipeline run. | `86400` |
+| `interval_start_datetime_previous` | The `datetime` when the previous pipeline run was scheduled for. | `datetime.datetime(2023, 7, 22, 7, 0, 0, 0)` |
 
 ### SQL block
 
@@ -36,4 +37,5 @@ SELECT
     '{{ interval_start_datetime }}' AS interval_start_datetime
     , '{{ interval_end_datetime }}' AS interval_end_datetime
     , '{{ interval_seconds }}' AS interval_seconds
+    , '{{ interval_start_datetime_previous }}' AS interval_start_datetime_previous
 ```

--- a/docs/orchestration/backfills/overview.mdx
+++ b/docs/orchestration/backfills/overview.mdx
@@ -69,9 +69,10 @@ variables are available in your Python block’s keyword arguments (e.g. `kwargs
 
 | Key | Description | Example |
 | --- | --- | --- |
-| `interval_start_datetime` | The `datetime` when the pipeline run is scheduled for. | `datetime.datetime(2023, 7, 23, 7, 0, 32, 794553)` |
-| `interval_end_datetime` | The `datetime` when the next pipeline run is scheduled for. | `datetime.datetime(2023, 7, 24, 7, 0, 32, 794553)` |
+| `interval_start_datetime` | The `datetime` when the pipeline run is scheduled for. | `datetime.datetime(2023, 7, 23, 7, 0, 0, 0)` |
+| `interval_end_datetime` | The `datetime` when the next pipeline run is scheduled for. | `datetime.datetime(2023, 7, 24, 7, 0, 0, 0)` |
 | `interval_seconds` | The number of seconds between the current pipeline run and the next pipeline run. | `86400` |
+| `interval_start_datetime_previous` | The `datetime` when the previous pipeline run was scheduled for. | `datetime.datetime(2023, 7, 22, 7, 0, 0, 0)` |
 
 ### SQL block
 
@@ -82,4 +83,5 @@ SELECT
     '{{ interval_start_datetime }}' AS interval_start_datetime
     , '{{ interval_end_datetime }}' AS interval_end_datetime
     , '{{ interval_seconds }}' AS interval_seconds
+    , '{{ interval_start_datetime_previous }}' AS interval_start_datetime_previous
 ```

--- a/mage_ai/orchestration/backfills/service.py
+++ b/mage_ai/orchestration/backfills/service.py
@@ -84,16 +84,34 @@ def __build_variables_list(backfill: Backfill) -> List[Dict]:
         interval_end_datetime = None
         interval_seconds = None
         interval_start_datetime = execution_date
+        interval_start_datetime_previous = None
 
         if idx < number_of_dates - 1:
             interval_end_datetime = dates[idx + 1]
-            interval_seconds = interval_end_datetime.timestamp() - execution_date.timestamp()
+            interval_seconds = (
+                interval_end_datetime.timestamp() - interval_start_datetime.timestamp()
+            )
+        elif idx >= 1 and idx == number_of_dates - 1:
+            # Last date
+            interval_start_datetime_previous = dates[idx - 1]
+            interval_seconds = (
+                interval_start_datetime.timestamp() - interval_start_datetime_previous.timestamp()
+            )
+            interval_end_datetime = interval_start_datetime + timedelta(seconds=interval_seconds)
+
+        if not interval_start_datetime_previous and (interval_seconds and interval_start_datetime):
+            interval_start_datetime_previous = interval_start_datetime - timedelta(
+                seconds=interval_seconds,
+            )
 
         if interval_end_datetime:
             interval_end_datetime = interval_end_datetime.isoformat()
 
         if interval_start_datetime:
             interval_start_datetime = interval_start_datetime.isoformat()
+
+        if interval_start_datetime_previous:
+            interval_start_datetime_previous = interval_start_datetime_previous.isoformat()
 
         arr.append(dict(
             ds=execution_date.strftime('%Y-%m-%d'),
@@ -102,6 +120,7 @@ def __build_variables_list(backfill: Backfill) -> List[Dict]:
             interval_end_datetime=interval_end_datetime,
             interval_seconds=interval_seconds,
             interval_start_datetime=interval_start_datetime,
+            interval_start_datetime_previous=interval_start_datetime_previous,
         ))
 
     return arr

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -473,8 +473,12 @@ class PipelineRun(BaseModel):
         interval_end_datetime = variables.get('interval_end_datetime')
         interval_seconds = variables.get('interval_seconds')
         interval_start_datetime = variables.get('interval_start_datetime')
+        interval_start_datetime_previous = variables.get('interval_start_datetime_previous')
 
-        if interval_end_datetime or interval_seconds or interval_start_datetime:
+        if interval_end_datetime or \
+                interval_seconds or \
+                interval_start_datetime or \
+                interval_start_datetime_previous:
             if interval_end_datetime:
                 try:
                     variables['interval_end_datetime'] = dateutil.parser.parse(
@@ -490,10 +494,19 @@ class PipelineRun(BaseModel):
                     )
                 except Exception as err:
                     print(f'[ERROR] PipelineRun.get_variables: {err}')
+
+            if interval_start_datetime_previous:
+                try:
+                    variables['interval_start_datetime_previous'] = dateutil.parser.parse(
+                        interval_start_datetime_previous,
+                    )
+                except Exception as err:
+                    print(f'[ERROR] PipelineRun.get_variables: {err}')
         elif self.execution_date and ScheduleType.TIME == self.pipeline_schedule.schedule_type:
             interval_end_datetime = None
             interval_seconds = None
             interval_start_datetime = self.execution_date
+            interval_start_datetime_previous = None
 
             if ScheduleInterval.DAILY == self.pipeline_schedule.schedule_interval:
                 interval_seconds = 60 * 60 * 24
@@ -512,9 +525,15 @@ class PipelineRun(BaseModel):
                     seconds=interval_seconds,
                 )
 
+            if interval_seconds and interval_start_datetime:
+                interval_start_datetime_previous = interval_start_datetime - timedelta(
+                    seconds=interval_seconds,
+                )
+
             variables['interval_end_datetime'] = interval_end_datetime
             variables['interval_seconds'] = interval_seconds
             variables['interval_start_datetime'] = interval_start_datetime
+            variables['interval_start_datetime_previous'] = interval_start_datetime_previous
 
         variables.update(extra_variables)
 

--- a/mage_ai/server/websocket_server.py
+++ b/mage_ai/server/websocket_server.py
@@ -238,6 +238,7 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
             global_vars['interval_end_datetime'] = None
             global_vars['interval_seconds'] = None
             global_vars['interval_start_datetime'] = now
+            global_vars['interval_start_datetime_previous'] = None
 
         global_vars['event'] = dict()
 


### PR DESCRIPTION
# Summary
Include the previous run’s `interval_start_datetime` as the keyword argument `interval_start_datetime_previous`.

# Tests
<img width="632" alt="image" src="https://github.com/mage-ai/mage-ai/assets/1066980/e6c91864-2867-4a3b-a653-936fa9f72f4d">

<img width="609" alt="image" src="https://github.com/mage-ai/mage-ai/assets/1066980/520e7874-face-4dbc-b9d3-1f973640d189">
