### PR TITLE
[hw] Support PostgreSQL schema based on the connection URL

### DIFF
--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -84,6 +84,15 @@ Mage uses SQLite as the default database engine. To use PostgreSQL as the databa
       /app/run_app.sh mage start [project_name]
    ```
 
+To use a specific schema in the PostgreSQL database, the connection string could contain the schema name as a parameter:
+
+   ```bash
+   docker run --network mage-app -it -p 6789:6789 -v $(pwd):/home/src \
+      -e MAGE_DATABASE_CONNECTION_URL="postgresql+psycopg2://<username>:<password>@postgres_db:5432/<database>?options=-c%%20search_path%%3D<schema_name>" \
+      mageai/mageai \
+      /app/run_app.sh mage start [project_name]
+   ```
+
 ### Using MySQL as database
 
 Mage uses SQLite as the default database engine. To use MySQL as the database engine, you'll need to run your Docker container slightly differently:

--- a/docs/production/configuring-production-settings/overview.mdx
+++ b/docs/production/configuring-production-settings/overview.mdx
@@ -29,6 +29,10 @@ In production, you can set the environment variable in the corresponding Terrafo
 #### PostgreSQL
 `export MAGE_DATABASE_CONNECTION_URL=postgresql+psycopg2://user:password@host:port/dbname`
 
+To use a specific `schema_name` in PostgreSQL:
+
+`export MAGE_DATABASE_CONNECTION_URL="postgresql+psycopg2://user:password@host:port/dbname?options=-c%%20search_path%%3Dschema_name"`
+
 #### MySQL
 `export MAGE_DATABASE_CONNECTION_URL=mysql+mysqlconnector://user:password@host:port/dbname`
 

--- a/docs/production/databases/default.mdx
+++ b/docs/production/databases/default.mdx
@@ -9,6 +9,10 @@ In production, you can set the environment variable in the corresponding Terrafo
 ## PostgreSQL
 `export MAGE_DATABASE_CONNECTION_URL=postgresql+psycopg2://user:password@host:port/dbname`
 
+To use a specific `schema_name` in PostgreSQL:
+
+`export MAGE_DATABASE_CONNECTION_URL="postgresql+psycopg2://user:password@host:port/dbname?options=-c%%20search_path%%3Dschema_name"`
+
 ## MySQL
 `export MAGE_DATABASE_CONNECTION_URL=mysql+mysqlconnector://user:password@host:port/dbname`
 

--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -75,7 +75,9 @@ class DBConnection:
 def get_postgresql_schema(url):
     parse_result = urlparse(url)
     if parse_result.scheme == 'postgresql+psycopg2':
-        return parse_qs(parse_result.query)['options'][0].split('=')[1]
+        params = parse_qs(parse_result.query.replace('%%', '%'))['options'][0].replace('-c ', '').split(' ')
+        kvs = dict(p.split('=') for p in params)
+        return kvs.get('search_path')
 
 
 db_connection = DBConnection()

--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -89,7 +89,7 @@ if db_connection_url.startswith('postgresql'):
         db_connection.close_session()
         print(f'Set the default PostgreSQL schema to {db_schema}')
     else:
-        print('No schema found in PostgreSQL connection URL: use default "public" schema')
+        print('No schema in PostgreSQL connection URL: use the default "public" schema')
 
 
 def safe_db_query(func):

--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -75,7 +75,8 @@ class DBConnection:
 def get_postgresql_schema(url):
     parse_result = urlparse(url)
     if parse_result.scheme == 'postgresql+psycopg2':
-        params = parse_qs(parse_result.query.replace('%%', '%'))['options'][0].replace('-c ', '').split(' ')
+        params = parse_qs(
+            parse_result.query.replace('%%', '%'))['options'][0].replace('-c ', '').split(' ')
         kvs = dict(p.split('=') for p in params)
         return kvs.get('search_path')
 

--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -4,6 +4,7 @@ import os
 import sqlalchemy
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
+from urllib.parse import parse_qs, urlparse
 
 from mage_ai.data_preparation.repo_manager import get_variables_dir
 from mage_ai.orchestration.constants import (
@@ -71,7 +72,24 @@ class DBConnection:
         self.session = None
 
 
+def get_postgresql_schema(url):
+    parse_result = urlparse(url)
+    if parse_result.scheme == 'postgresql+psycopg2':
+        return parse_qs(parse_result.query)['options'][0].split('=')[1]
+
+
 db_connection = DBConnection()
+
+if db_connection_url.startswith('postgresql'):
+    db_schema = get_postgresql_schema(db_connection_url)
+    if db_schema:
+        db_connection.start_session()
+        db_connection.session.execute(f'CREATE SCHEMA IF NOT EXISTS {db_schema};')
+        db_connection.session.commit()
+        db_connection.close_session()
+        print(f'Set the default PostgreSQL schema to {db_schema}')
+    else:
+        print('No schema found in PostgreSQL connection URL: use default "public" schema')
 
 
 def safe_db_query(func):


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

Add the schema creation step to support running multiple Mage instances with the same PostgreSQL databases, but in different schemas. The PostgreSQL connection URL should have the `options` parameter passed in through a special query string format:

```
export MAGE_DATABASE_CONNECTION_URL=postgresql+psycopg2://user:password@host:port/dbname?options=-c%%20search_path%%3Dschema_name'
```
where `schema_name` needs to be changed to the schema name specific to the Mage instance.

For example,
```
export DATABASE_CONNECTION_URL='postgresql+psycopg2://test_username:test_password@postgres_db:5432/test_database?options=-c%%20search_path%%3Dtest_schema_8'
```

# Tests
<!-- How did you test your change? -->
Manually tested with a local development environment, with the following steps:
1. Build the Mage docker image:
```
./scripts/init.sh test_project_1
```
2. Start the PostgreSQL docker instance:
```
docker run --network mage-ai_default --network-alias postgres_db \
   -it -p 5432:5432 -v pgdata:/var/lib/postgresql/data \
   -e POSTGRES_USER=test_username -e POSTGRES_PASSWORD=test_password \
   -e POSTGRES_DB=test_database -e PG_DATA=/var/lib/postgresql/data/pgdata \
   postgres:13-alpine3.17 postgres
``` 
3. Set the environment variable in the terminal for Mage:
```
export DATABASE_CONNECTION_URL='postgresql+psycopg2://test_username:test_password@postgres_db:5432/test_database?options=-c%%20search_path%%3Dtest_schema_3'
```
4. Start the Mage docker image:
```
./scripts/dev.sh test_project_1
```
5. Start the PostgreSQL console:
```
psql -h localhost -p 5432 -d test_database -U test_username -W
```
6. Check the created Mage schema and database in `psql` console: 
```
test_database=# \dt test_schema_3.*
                                  List of relations
    Schema     |                    Name                     | Type  |     Owner     
---------------+---------------------------------------------+-------+---------------
 test_schema_3 | alembic_version                             | table | test_username
 test_schema_3 | backfill                                    | table | test_username
 test_schema_3 | block_run                                   | table | test_username
 test_schema_3 | event_matcher                               | table | test_username
 test_schema_3 | oauth2_access_token                         | table | test_username
 test_schema_3 | oauth2_application                          | table | test_username
 test_schema_3 | permission                                  | table | test_username
 test_schema_3 | pipeline_run                                | table | test_username
 test_schema_3 | pipeline_schedule                           | table | test_username
 test_schema_3 | pipeline_schedule_event_matcher_association | table | test_username
 test_schema_3 | role                                        | table | test_username
 test_schema_3 | secret                                      | table | test_username
 test_schema_3 | user                                        | table | test_username
 test_schema_3 | user_role                                   | table | test_username
(14 rows)
```
cc:
<!-- Optionally mention someone to let them know about this pull request -->
@dy46 @wangxiaoyou1993