### PR TITLE
[jk] Clarify input for dbt profile target if a default target is not configured

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -124,9 +124,9 @@ import {
 } from './utils';
 import { capitalize, pluralize } from '@utils/string';
 import { executeCode } from '@components/CodeEditor/keyboard_shortcuts/shortcuts';
+import { find, indexBy } from '@utils/array';
 import { get, set } from '@storage/localStorage';
 import { getModelName } from '@utils/models/dbt';
-import { indexBy } from '@utils/array';
 import { initializeContentAndMessages } from '@components/PipelineDetail/utils';
 import { onError, onSuccess } from '@api/utils/response';
 import { onlyKeysPresent } from '@utils/hooks/keyboardShortcuts/utils';
@@ -359,6 +359,11 @@ function CodeBlock({
   const dbtProfileTarget = useMemo(() => dataProviderConfig[CONFIG_KEY_DBT_PROFILE_TARGET], [
     dataProviderConfig,
   ]);
+  const dbtProfileTargetSelectPlaceholder = dbtProjectName
+    ? (dbtProfileData?.target
+      ? find(dbtProfileTargets, (target: string) => target === dbtProfileData.target)
+      : 'Select target')
+    : 'Select project first';
 
   const [manuallyEnterTarget, setManuallyEnterTarget] = useState<boolean>(dbtProfileTarget &&
     !dbtProfileTargets?.includes(dbtProfileTarget),
@@ -1403,7 +1408,6 @@ function CodeBlock({
                             setAnyInputFocused(false);
                           }, 300)}
                           onChange={(e) => {
-                            // @ts-ignore
                             updateDataProviderConfig({
                               [CONFIG_KEY_DBT_PROFILE_TARGET]: '',
                               [CONFIG_KEY_DBT_PROJECT_NAME]: e.target.value,
@@ -1449,7 +1453,6 @@ function CodeBlock({
                             setAnyInputFocused(false);
                           }, 300)}
                           onChange={(e) => {
-                            // @ts-ignore
                             updateDataProviderConfig({
                               [CONFIG_KEY_DBT_PROFILE_TARGET]: e.target.value,
                             });
@@ -1459,12 +1462,7 @@ function CodeBlock({
                           onFocus={() => {
                             setAnyInputFocused(true);
                           }}
-                          placeholder={dbtProjectName
-                            ? isSQLBlock
-                              ? dbtProfileData?.target
-                              : null
-                            : 'Select project first'
-                          }
+                          placeholder={dbtProfileTargetSelectPlaceholder}
                           small
                           value={dbtProfileTarget || ''}
                         >
@@ -1484,7 +1482,6 @@ function CodeBlock({
                             setAnyInputFocused(false);
                           }, 300)}
                           onChange={(e) => {
-                            // @ts-ignore
                             updateDataProviderConfig({
                               [CONFIG_KEY_DBT_PROFILE_TARGET]: e.target.value,
                             });
@@ -1495,9 +1492,7 @@ function CodeBlock({
                             setAnyInputFocused(true);
                           }}
                           placeholder={dbtProjectName
-                            ? isSQLBlock
-                              ? dbtProfileData?.target
-                              : null
+                            ? (dbtProfileData?.target || 'Enter target')
                             : 'Select project first'
                           }
                           small
@@ -1539,6 +1534,11 @@ function CodeBlock({
                               onClick={(e) => {
                                 pauseEvent(e);
                                 setManuallyEnterTarget(!manuallyEnterTarget);
+                                if (manuallyEnterTarget) {
+                                  updateDataProviderConfig({
+                                    [CONFIG_KEY_DBT_PROFILE_TARGET]: null,
+                                  });
+                                }
                               }}
                             />
                             <span>&nbsp;</span>


### PR DESCRIPTION
# Summary
- If the default `target` was not set in the `profiles.yml` file for a dbt project, the target input in the UI was a bit confusing since it was unclear that users were required to enter or select a target. If user did not select a target and no default target was set, an error would occur.

# Tests
If default dbt target is set in `profiles.yml` file ([sample config](https://docs.getdbt.com/docs/core/connect-data-platform/profiles.yml)), then user does not need to select target when adding a new dbt block:
![WITH default target in dbt profile](https://github.com/mage-ai/mage-ai/assets/78053898/bbe56c4a-58f9-447a-9e29-bf255a4349b0)

If default dbt target is NOT set in `profiles.yml`, then the target input will now say "Select target" or "Enter target" instead of displaying a dbt target that is not actually selected:
![no default target in dbt profile](https://github.com/mage-ai/mage-ai/assets/78053898/bd1df4cb-2c14-4e82-bf7b-c6170e03943f)

Github issue: #3046
