### PR TITLE
[td] Fix db init on start

### DIFF
--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -75,10 +75,14 @@ class DBConnection:
 def get_postgresql_schema(url):
     parse_result = urlparse(url)
     if parse_result.scheme == 'postgresql+psycopg2':
-        params = parse_qs(
-            parse_result.query.replace('%%', '%'))['options'][0].replace('-c ', '').split(' ')
-        kvs = dict(p.split('=') for p in params)
-        return kvs.get('search_path')
+        q = parse_qs(
+            parse_result.query.replace('%%', '%')
+        )
+        options = q.get('options')
+        if options and len(options) >= 1:
+            params = options[0].replace('-c ', '').split(' ')
+            kvs = dict(p.split('=') for p in params)
+            return kvs.get('search_path')
 
 
 db_connection = DBConnection()


### PR DESCRIPTION
# Summary
```
mage-ai-server-1  |   File "/home/src/mage_ai/orchestration/db/__init__.py", line 87, in <module>
mage-ai-server-1  |     db_schema = get_postgresql_schema(db_connection_url)
mage-ai-server-1  |   File "/home/src/mage_ai/orchestration/db/__init__.py", line 78, in get_postgresql_schema
mage-ai-server-1  |     params = parse_qs(
mage-ai-server-1  | KeyError: 'options'
```