### PR TITLE
[jk] Do not make block outputs API request if after panel hidden

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -513,11 +513,12 @@ function PipelineDetailPage({
     data: blockOutputData,
     mutate: fetchSampleData,
   } = api.block_outputs.detail(
-    selectedOutputBlock?.type !== BlockTypeEnum.SCRATCHPAD
+    (!afterHidden && selectedOutputBlock?.type !== BlockTypeEnum.SCRATCHPAD
       && selectedOutputBlock?.type !== BlockTypeEnum.CHART
-      && selectedOutputBlock?.uuid
-      && encodeURIComponent(selectedOutputBlock?.uuid),
-    { pipeline_uuid: !afterHidden && pipelineUUID },
+      && selectedOutputBlock?.uuid)
+      ? encodeURIComponent(selectedOutputBlock?.uuid)
+      : null,
+    { pipeline_uuid: pipelineUUID },
   );
   const blockSampleData = useMemo(() => blockOutputData?.block_output, [blockOutputData]);
   const sampleData: SampleDataType = useMemo(() => {
@@ -534,7 +535,7 @@ function PipelineDetailPage({
     data: blockAnalysis,
     mutate: fetchAnalysis,
   } = api.blocks.pipelines.analyses.detail(
-    !afterHidden && pipelineUUID,
+    !afterHidden ? pipelineUUID : null,
     selectedOutputBlock?.type !== BlockTypeEnum.SCRATCHPAD
       && selectedOutputBlock?.type !== BlockTypeEnum.CHART
       && selectedOutputBlock?.uuid


### PR DESCRIPTION
# Summary
- Fix logic for making API requests for block outputs or analyses that were throwing errors due to invalid pipeline_uuids.

# Tests
- Local
