### PR TITLE
[jk] Clear pipeline list filters when clicking Defaults

### DIFF
--- a/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
@@ -28,6 +28,7 @@ import { SHARED_BUTTON_PROPS } from '@components/shared/AddButton';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { getNestedTruthyValuesCount } from '@utils/hash';
 import { isViewer } from '@utils/session';
+import { setFilters } from '@storage/pipelines';
 
 type ToolbarProps = {
   addButtonProps?: {
@@ -189,7 +190,10 @@ function Toolbar({
         }
       }}
       onClickOutside={closeFilterButtonMenu}
-      onSecondaryClick={() => router.push('/pipelines')}
+      onSecondaryClick={() => {
+        setFilters({});
+        router.push('/pipelines');
+      }}
       open={filterButtonMenuOpen}
       options={filterOptionsEnabledMapping}
       parentRef={filterButtonMenuRef}


### PR DESCRIPTION
# Summary
- See title. Previously, clicking the `Defaults` button would not clear the pipeline filters and persist it.

# Tests
![clear pipeline filters](https://github.com/mage-ai/mage-ai/assets/78053898/6c7615e8-bcc2-4305-b7a7-b8296e03466d)
