### PR TITLE
[jk] Decrease variables response size

### DIFF
--- a/mage_ai/api/policies/VariablePolicy.py
+++ b/mage_ai/api/policies/VariablePolicy.py
@@ -55,3 +55,11 @@ VariablePolicy.allow_write([
     constants.CREATE,
     constants.UPDATE,
 ], condition=lambda policy: policy.has_at_least_editor_role_and_notebook_edit_access())
+
+VariablePolicy.allow_query([
+    'global_only',
+], scopes=[
+    OauthScope.CLIENT_PRIVATE,
+], on_action=[
+    constants.LIST,
+], condition=lambda policy: policy.has_at_least_viewer_role())

--- a/mage_ai/api/resources/VariableResource.py
+++ b/mage_ai/api/resources/VariableResource.py
@@ -42,6 +42,10 @@ class VariableResource(GenericResource):
     def collection(self, query, meta, user, **kwargs):
         pipeline_uuid = kwargs['parent_model'].uuid
 
+        global_only = query.get('global_only', [False])
+        if global_only:
+            global_only = global_only[0]
+
         # Get global variables from project's path
         variable_manager = VariableManager(variables_dir=get_variables_dir())
         variables_dict = variable_manager.get_variables_by_pipeline(pipeline_uuid)
@@ -60,18 +64,20 @@ class VariableResource(GenericResource):
                 variables=global_variables,
             )
         ]
-        variables = [
-            dict(
-                block=dict(uuid=uuid),
-                pipeline=dict(uuid=pipeline_uuid),
-                variables=[
-                    get_variable_value(variable_manager, pipeline_uuid, uuid, var) for var in arr
-                    # Not return printed outputs
-                    if var == 'df' or var.startswith('output')
-                  ],
-            )
-            for uuid, arr in variables_dict.items() if uuid != 'global'
-        ] + global_variables_arr
+        variables = global_variables_arr
+        if not global_only:
+            variables = [
+                dict(
+                    block=dict(uuid=uuid),
+                    pipeline=dict(uuid=pipeline_uuid),
+                    variables=[
+                        get_variable_value(variable_manager, pipeline_uuid, uuid, var) for var in arr
+                        # Not return printed outputs
+                        if var == 'df' or var.startswith('output')
+                    ],
+                )
+                for uuid, arr in variables_dict.items() if uuid != 'global'
+            ] + global_variables_arr
 
         return self.build_result_set(
             variables,

--- a/mage_ai/api/resources/VariableResource.py
+++ b/mage_ai/api/resources/VariableResource.py
@@ -71,7 +71,12 @@ class VariableResource(GenericResource):
                     block=dict(uuid=uuid),
                     pipeline=dict(uuid=pipeline_uuid),
                     variables=[
-                        get_variable_value(variable_manager, pipeline_uuid, uuid, var) for var in arr
+                        get_variable_value(
+                            variable_manager,
+                            pipeline_uuid,
+                            uuid,
+                            var,
+                        ) for var in arr
                         # Not return printed outputs
                         if var == 'df' or var.startswith('output')
                     ],

--- a/mage_ai/frontend/components/Sidekick/GlobalVariables/VariableRow.tsx
+++ b/mage_ai/frontend/components/Sidekick/GlobalVariables/VariableRow.tsx
@@ -25,7 +25,7 @@ type VariableRowProps = {
   obfuscate?: boolean;
   pipelineUUID: string;
   variable: VariableType;
-}
+};
 
 function VariableRow({
   copyText: copyTextProp,
@@ -56,7 +56,7 @@ function VariableRow({
           callback: () => {
             setEdit(false);
             fetchVariables();
-          }
+          },
         },
       ),
     },
@@ -64,7 +64,7 @@ function VariableRow({
 
   const handleKeyDown = useCallback((e) => {
     if (e.key === 'Enter') {
-      let updatedValue = variableValue
+      let updatedValue = variableValue;
       try {
         updatedValue = JSON.parse(variableValue);
       } catch {

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -431,7 +431,9 @@ function PipelineDetailPage({
   const {
     data: dataGlobalVariables,
     mutate: fetchVariables,
-  } = api.variables.pipelines.list(pipelineUUID, {}, {
+  } = api.variables.pipelines.list(pipelineUUID, {
+    global_only: true,
+  }, {
     revalidateOnFocus: false,
   });
   const globalVariables = dataGlobalVariables?.variables;

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -60,7 +60,9 @@ function PipelineSchedules({
 
   const {
     data: dataGlobalVariables,
-  } = api.variables.pipelines.list(pipelineUUID, {}, {
+  } = api.variables.pipelines.list(pipelineUUID, {
+    global_only: true,
+  }, {
     revalidateOnFocus: false,
   });
   const globalVariables = dataGlobalVariables?.variables;


### PR DESCRIPTION
# Summary
- Pipeline Editor and Triggers List pages were fetching unnecessary output data in the variables response that could lead to the response payload being many MB in size.
- Add query param to Variables API that only fetches global variables.

# Tests
Using `global_only` query param in `/api/pipelines/[pipeline_uuid]/variables?global_only=true` API request only returned global variables (FE still had necessary data for rendering components):
![image](https://github.com/mage-ai/mage-ai/assets/78053898/e3aba6e7-c7fc-4b5e-ab2e-07733a9ed272)
