### PR TITLE
[dy] Batch git sync in pipeline_scheduler

### DIFF
--- a/mage_ai/api/resources/CustomTemplateResource.py
+++ b/mage_ai/api/resources/CustomTemplateResource.py
@@ -1,4 +1,5 @@
 import urllib.parse
+
 from mage_ai.api.errors import ApiError
 from mage_ai.api.resources.GenericResource import GenericResource
 from mage_ai.cache.block_action_object import BlockActionObjectCache

--- a/mage_ai/api/resources/SearchResultResource.py
+++ b/mage_ai/api/resources/SearchResultResource.py
@@ -1,12 +1,17 @@
+from typing import Dict
+
 from mage_ai.api.resources.GenericResource import GenericResource
 from mage_ai.cache.block_action_object.constants import (
     OBJECT_TYPE_BLOCK_FILE,
     OBJECT_TYPE_CUSTOM_BLOCK_TEMPLATE,
     OBJECT_TYPE_MAGE_TEMPLATE,
 )
-from mage_ai.data_preparation.models.constants import BlockLanguage, BlockType, PipelineType
+from mage_ai.data_preparation.models.constants import (
+    BlockLanguage,
+    BlockType,
+    PipelineType,
+)
 from mage_ai.services.search.constants import SEARCH_TYPE_BLOCK_ACTION_OBJECTS
-from typing import Dict
 
 
 def filter_results(result: Dict) -> bool:

--- a/mage_ai/api/resources/VariableResource.py
+++ b/mage_ai/api/resources/VariableResource.py
@@ -1,6 +1,7 @@
+from typing import Dict
+
 from mage_ai.api.errors import ApiError
 from mage_ai.api.resources.GenericResource import GenericResource
-from mage_ai.orchestration.db import safe_db_query
 from mage_ai.data_preparation.models.variable import VariableType
 from mage_ai.data_preparation.repo_manager import get_variables_dir
 from mage_ai.data_preparation.variable_manager import (
@@ -9,7 +10,7 @@ from mage_ai.data_preparation.variable_manager import (
     get_global_variables,
     set_global_variable,
 )
-from typing import Dict
+from mage_ai.orchestration.db import safe_db_query
 
 
 def get_variable_value(

--- a/mage_ai/data_preparation/sync/git_sync.py
+++ b/mage_ai/data_preparation/sync/git_sync.py
@@ -1,4 +1,7 @@
+from typing import Union
+
 from mage_ai.data_preparation.git import Git
+from mage_ai.data_preparation.preferences import get_preferences
 from mage_ai.data_preparation.sync import GitConfig
 from mage_ai.data_preparation.sync.base_sync import BaseSync
 from mage_ai.shared.logger import VerboseFunctionExec
@@ -20,3 +23,12 @@ class GitSync(BaseSync):
             verbose=True,
         ):
             self.git_manager.clone()
+
+
+def get_sync_config() -> Union[GitConfig, None]:
+    sync_config = None
+    preferences = get_preferences()
+
+    if preferences.sync_config:
+        sync_config = GitConfig.load(config=preferences.sync_config)
+    return sync_config

--- a/mage_ai/data_preparation/sync/git_sync.py
+++ b/mage_ai/data_preparation/sync/git_sync.py
@@ -8,10 +8,10 @@ from mage_ai.shared.logger import VerboseFunctionExec
 
 
 class GitSync(BaseSync):
-    def __init__(self, sync_config: GitConfig):
+    def __init__(self, sync_config: GitConfig, setup_repo: bool = True):
         self.branch = sync_config.branch or 'main'
         self.remote_repo_link = sync_config.remote_repo_link
-        self.git_manager = Git(sync_config, setup_repo=True)
+        self.git_manager = Git(sync_config, setup_repo=setup_repo)
 
     def sync_data(self):
         self.git_manager.reset(self.branch)

--- a/mage_ai/orchestration/monitor/monitor_stats.py
+++ b/mage_ai/orchestration/monitor/monitor_stats.py
@@ -1,10 +1,12 @@
-from datetime import datetime, timedelta
-from mage_ai.shared.hash import group_by, merge_dict
-from mage_ai.orchestration.db.models.schedules import BlockRun, PipelineRun
-from sqlalchemy.orm import joinedload
-from typing import Callable, Dict, List, Union
-import dateutil.parser
 import enum
+from datetime import datetime, timedelta
+from typing import Callable, Dict, List, Union
+
+import dateutil.parser
+from sqlalchemy.orm import joinedload
+
+from mage_ai.orchestration.db.models.schedules import BlockRun, PipelineRun
+from mage_ai.shared.hash import group_by, merge_dict
 
 NO_PIPELINE_SCHEDULE_ID = 'no_pipeline_schedule_id'
 NO_PIPELINE_SCHEDULE_NAME = 'no_pipeline_schedule_name'

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -29,13 +29,8 @@ from mage_ai.data_preparation.models.triggers import (
     get_triggers_by_pipeline,
 )
 from mage_ai.data_preparation.repo_manager import get_repo_config
-<<<<<<< HEAD
-from mage_ai.data_preparation.sync import GitConfig
-from mage_ai.data_preparation.sync.git_sync import GitSync
-from mage_ai.orchestration.concurrency import ConcurrencyConfig
-=======
 from mage_ai.data_preparation.sync.git_sync import get_sync_config
->>>>>>> 2dfe5f334 ([dy] Update for other trigger types)
+from mage_ai.orchestration.concurrency import ConcurrencyConfig
 from mage_ai.orchestration.db import db_connection, safe_db_query
 from mage_ai.orchestration.db.models.schedules import (
     Backfill,

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -124,7 +124,7 @@ class PipelineScheduler:
         if self.pipeline_run.status == PipelineRun.PipelineRunStatus.RUNNING:
             return True
 
-        tags = self.__build_tags()
+        tags = self.build_tags()
 
         is_integration = PipelineType.INTEGRATION == self.pipeline.type
 

--- a/mage_ai/orchestration/utils/git.py
+++ b/mage_ai/orchestration/utils/git.py
@@ -1,0 +1,58 @@
+from typing import Dict
+
+from mage_ai.data_preparation.logging.logger import DictLogger
+from mage_ai.data_preparation.preferences import get_preferences
+from mage_ai.data_preparation.sync import GitConfig
+from mage_ai.data_preparation.sync.git_sync import GitSync
+from mage_ai.orchestration.utils.distributed_lock import DistributedLock
+
+
+def run_git_sync(lock: DistributedLock = None, sync_config: GitConfig = None) -> Dict:
+    if sync_config is None:
+        preferences = get_preferences()
+        if preferences.sync_config:
+            sync_config = GitConfig.load(config=preferences.sync_config)
+
+    result = dict()
+    git_sync_lock_key = 'git_sync'
+    if not lock or lock.try_acquire_lock(git_sync_lock_key):
+        try:
+            GitSync(sync_config).sync_data()
+            result = dict(
+                status='success',
+                remote_repo_link=sync_config.remote_repo_link,
+                branch=sync_config.branch,
+            )
+        except Exception as err:
+            result = dict(
+                status='failed',
+                error=str(err),
+                remote_repo_link=sync_config.remote_repo_link,
+                branch=sync_config.branch,
+            )
+        if lock:
+            lock.release_lock(git_sync_lock_key)
+
+    return result
+
+
+def log_git_sync(result: Dict, logger: DictLogger, tags: Dict = None) -> None:
+    if result is None:
+        return
+
+    if tags is None:
+        tags = dict()
+    git_sync_status = result.get('status')
+    if git_sync_status == 'success':
+        logger.info(
+            'Successfully synced data from git repo: '
+            f'{result.get("remote_repo_link")}, branch: {result.get("branch")}',
+            **tags,
+        )
+    elif git_sync_status == 'failed':
+        logger.warning(
+            f'Failed to sync data from git repo: {result.get("remote_repo_link")}'
+            f', branch: {result.get("branch")} with error: ' +
+            str(result.get("error")),
+            **tags,
+        )


### PR DESCRIPTION
# Summary

Currently, git syncs are run every time a pipeline run is started. However, it is possible for many pipeline runs to get created at the same time which could start a large number of git syncs which can cause problems. I changed the logic in the `pipeline_scheduler` to only perform 1 git sync for all active pipeline schedules.

This can be an issue for event and api triggers as well, but I'll fix that in the future since it's a more difficult problem to solve.
<!-- Brief summary of what your code does -->

# Tests

tested locally
<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
