### PR TITLE
[dy] Import block function from file for test execution

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -1163,10 +1163,10 @@ class Block:
                     )
                     module = importlib.util.module_from_spec(spec)
                     spec.loader.exec_module(module)
+                    block_function_updated = getattr(module, block_function.__name__)
                     self.module = module
                 except Exception:
                     print('Error initializing block module.')
-                block_function_updated = getattr(self.module, block_function.__name__)
 
         sig = signature(block_function)
         has_kwargs = any([p.kind == p.VAR_KEYWORD for p in sig.parameters.values()])

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -279,6 +279,7 @@ class Block:
         # Replicate block
         self.replicated_block = replicated_block
 
+        # Module for the block functions. Will be set when the block is executed from a notebook.
         self.module = None
 
     @property

--- a/mage_ai/data_preparation/models/block/integration/__init__.py
+++ b/mage_ai/data_preparation/models/block/integration/__init__.py
@@ -19,11 +19,11 @@ class IntegrationBlock(Block):
         self,
         outputs_from_input_vars,
         execution_partition: str = None,
+        from_notebook: bool = False,
+        global_vars: Dict = None,
         input_vars: List = None,
         logger: Logger = None,
         logging_tags: Dict = None,
-        global_vars: Dict = None,
-        test_execution: bool = False,
         input_from_output: Dict = None,
         runtime_arguments: Dict = None,
         **kwargs,
@@ -214,8 +214,8 @@ class IntegrationBlock(Block):
                                 df = self.execute_block_function(
                                     block_function,
                                     input_vars,
-                                    input_kwargs,
-                                    test_execution,
+                                    global_vars=input_kwargs,
+                                    from_notebook=from_notebook,
                                 )
                                 if df_sample is None:
                                     df_sample = df

--- a/mage_ai/data_preparation/models/block/integration/__init__.py
+++ b/mage_ai/data_preparation/models/block/integration/__init__.py
@@ -1,10 +1,10 @@
 import json
 import os
+import subprocess
 from logging import Logger
 from typing import Dict, List
 
 import pandas as pd
-from jupyter_server import subprocess
 
 from mage_ai.data_integrations.logger.utils import print_log_from_line
 from mage_ai.data_integrations.utils.config import build_config, get_catalog_by_stream
@@ -21,7 +21,7 @@ class IntegrationBlock(Block):
         execution_partition: str = None,
         input_vars: List = None,
         logger: Logger = None,
-        logging_tags: Dict = dict(),
+        logging_tags: Dict = None,
         global_vars: Dict = None,
         test_execution: bool = False,
         input_from_output: Dict = None,
@@ -29,6 +29,9 @@ class IntegrationBlock(Block):
         **kwargs,
     ) -> List:
         from mage_integrations.sources.constants import BATCH_FETCH_LIMIT
+
+        if logging_tags is None:
+            logging_tags = dict()
 
         index = self.template_runtime_configuration.get('index', None)
         is_last_block_run = self.template_runtime_configuration.get('is_last_block_run', False)

--- a/mage_ai/data_preparation/models/block/sql/__init__.py
+++ b/mage_ai/data_preparation/models/block/sql/__init__.py
@@ -40,10 +40,10 @@ def execute_sql_code(
     dynamic_block_index: int = None,
     dynamic_upstream_block_uuids: List[str] = None,
     execution_partition: str = None,
+    from_notebook: bool = False,
     global_vars: Dict = None,
     config_file_loader: Any = None,
     configuration: Dict = None,
-    test_execution: bool = False,
 ) -> List[Any]:
     configuration = configuration if configuration else block.configuration
     use_raw_sql = configuration.get('use_raw_sql')
@@ -67,7 +67,7 @@ def execute_sql_code(
     should_query = block.type in PREVIEWABLE_BLOCK_TYPES
 
     limit = int(configuration.get('limit') or QUERY_ROW_LIMIT)
-    if test_execution:
+    if from_notebook:
         limit = min(limit, QUERY_ROW_LIMIT)
     else:
         limit = QUERY_ROW_LIMIT
@@ -589,6 +589,7 @@ class SQLBlock(Block):
         dynamic_upstream_block_uuids: List[str] = None,
         custom_code: str = None,
         execution_partition: str = None,
+        from_notebook: bool = False,
         global_vars: Dict = None,
         **kwargs,
     ) -> List:
@@ -603,6 +604,6 @@ class SQLBlock(Block):
             dynamic_block_index=dynamic_block_index,
             dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
             execution_partition=execution_partition,
+            from_notebook=from_notebook,
             global_vars=global_vars,
-            test_execution=kwargs.get('test_execution'),
         )

--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -309,17 +309,17 @@ def execute_custom_code():
 
     block_output = block.execute_with_callback(
         custom_code=code,
+        from_notebook=True,
         global_vars=global_vars,
         output_messages_to_logs={output_messages_to_logs},
         run_settings=json.loads('{run_settings_json}'),
-        test_execution=True,
         update_status={update_status},
     )
     if {run_tests}:
         block.run_tests(
             custom_code=code,
-            global_vars=global_vars,
             from_notebook=True,
+            global_vars=global_vars,
             update_tests=False,
         )
     output = block_output['output'] or []

--- a/mage_ai/tests/data_preparation/models/test_block.py
+++ b/mage_ai/tests/data_preparation/models/test_block.py
@@ -324,7 +324,7 @@ def sensor(*args):
     return df is not None
             ''')
         asyncio.run(block1.execute())
-        output = block2.execute_sync(test_execution=True)
+        output = block2.execute_sync(from_notebook=True)
         self.assertEqual(output['output'][0], True)
 
     @patch('builtins.print')


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

Updated how python blocks are executed when run from the notebook. Instead of running the block function directly from the file, we will import the block function and then execute it so that the error logging is more readable. 

I also changed the `test_execution` parameter to `from_notebook` to be consistent across the Block functions.

# Tests

tested locally with different blocks

examples:

![Screenshot 2023-07-28 at 11 57 58 AM](https://github.com/mage-ai/mage-ai/assets/14357209/16bf41e9-10bb-4039-934c-ec9efb6f63d2)
![Screenshot 2023-07-28 at 11 57 47 AM](https://github.com/mage-ai/mage-ai/assets/14357209/b4278af8-54b7-4e47-aff2-2a11c4af4645)


<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
