### PR TITLE
{orchestration] check_status method bug fix to look at pipelines ran between specific time period

### DIFF
--- a/docs/design/blocks/sensor.mdx
+++ b/docs/design/blocks/sensor.mdx
@@ -28,6 +28,7 @@ def check_condition(*args, **kwargs) -> bool:
         'pipeline_uuid',
         kwargs['execution_date'],
         block_uuid='block_uuid',
+        hours=24,
     )
 ```
 
@@ -37,6 +38,10 @@ checking whether or not it’s finished running successfully.
 The `block_uuid` positional argument is optional. If you add a value for the `block_uuid`
 positional argument, then the sensor will check the status of the block in that pipeline.
 Only when that specific block is finished running successfully, then the sensor will be complete.
+
+The 'hours' positional argument is optional. If you add a value for the 'hours' positional argument,
+then the sensor will check the status of the pipeline for that many hours in past from execution_date.
+The default value is 24 hours.
 
 Sensors can also have upstream block dependencies. The output of the upstream blocks will be passed
 into the sensor in the `args` parameter like in other Mage block types.

--- a/docs/design/core-abstractions.mdx
+++ b/docs/design/core-abstractions.mdx
@@ -206,7 +206,9 @@ def check_condition(**kwargs) -> bool:
 <Note>
   This example is using a helper function called `check_status` that handles the
   logic for retrieving the status of a pipeline run for `transform_users` on the
-  current execution date.
+  current execution date. You can opetionally pass block uuid and hours 
+  parameters to `check_status` to check the status of a block run or within a
+  interval of time.
 </Note>
 
 ## Data product

--- a/docs/development/blocks/sensors/templates.mdx
+++ b/docs/development/blocks/sensors/templates.mdx
@@ -21,6 +21,7 @@ def check_condition(**kwargs) -> bool:
         'pipeline_uuid',
         kwargs['execution_date'],
         block_uuid='block_uuid',  # optional if you want the sensor to wait on a specific block
+        hours=24,  # optional if you want to check for a specific number of hours. Default is 24
     )
 ```
 

--- a/mage_ai/data_preparation/templates/sensors/default.py
+++ b/mage_ai/data_preparation/templates/sensors/default.py
@@ -13,4 +13,5 @@ def check_condition(*args, **kwargs) -> bool:
         'pipeline_uuid',
         kwargs['execution_date'],
         block_uuid='block_uuid',  # optional if you want the sensor to wait on a specific block
+        hours=24,  # optional if you want to check for a specific time window. Default is 24 hours.
     )

--- a/mage_ai/orchestration/run_status_checker.py
+++ b/mage_ai/orchestration/run_status_checker.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta, timezone
 
 from mage_ai.data_preparation.models.pipeline import Pipeline
-from mage_ai.data_preparation.models.triggers import ScheduleInterval
 from mage_ai.orchestration.db.models.schedules import (
     BlockRun,
     PipelineRun,

--- a/mage_ai/orchestration/run_status_checker.py
+++ b/mage_ai/orchestration/run_status_checker.py
@@ -24,7 +24,7 @@ def check_status(
     pipeline_uuid: str,
     execution_date: datetime,
     block_uuid: str = None,
-    hours:int = 24,
+    hours: int = 24,
 ) -> bool:
     __validate_pipeline_and_block(pipeline_uuid, block_uuid)
 

--- a/mage_ai/orchestration/run_status_checker.py
+++ b/mage_ai/orchestration/run_status_checker.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.data_preparation.models.triggers import ScheduleInterval
@@ -25,25 +25,23 @@ def check_status(
     pipeline_uuid: str,
     execution_date: datetime,
     block_uuid: str = None,
+    hours:int = 24,
 ) -> bool:
     __validate_pipeline_and_block(pipeline_uuid, block_uuid)
 
+    execution_date = execution_date.replace(tzinfo=timezone.utc)
     pipeline_run = (
         PipelineRun
         .query
         .join(PipelineRun.pipeline_schedule)
         .filter(PipelineSchedule.pipeline_uuid == pipeline_uuid)
-        .filter(PipelineRun.execution_date >= execution_date - timedelta(days=1))
+        .filter(PipelineRun.execution_date >= execution_date - timedelta(hours=hours))
+        .filter(PipelineRun.execution_date <= execution_date)
         .order_by(PipelineRun.execution_date.desc())
         .first()
     )
 
     if pipeline_run is None:
-        return False
-
-    if pipeline_run.execution_date != execution_date and \
-        pipeline_run.pipeline_schedule.schedule_interval != \
-            ScheduleInterval.ONCE:
         return False
 
     pipeline_run.refresh()


### PR DESCRIPTION
# Summary
There was a bug with check_status method in orchestration while compared exact execution_datetime with pipeline run datetime which is not the purpose of the method. Rather it should check if pipeline was ran within a specific time period. Hence included another parameter hours. Now the method checks if pipeline had a successful run between execution_date - hours and execution_date

# Tests
Tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
