### PR TITLE
[jk] Include runs without associated triggers in pipeline run count

### DIFF
--- a/mage_ai/frontend/components/Dashboard/VerticalNavigation.tsx
+++ b/mage_ai/frontend/components/Dashboard/VerticalNavigation.tsx
@@ -61,7 +61,7 @@ const DEFAULT_NAV_ITEMS = [
       {
         Icon: Schedule,
         id: 'pipeline-runs',
-        label: () => 'Pipelines runs',
+        label: () => 'Pipeline runs',
         linkProps: {
           href: '/pipeline-runs',
         },

--- a/mage_ai/frontend/components/PipelineRun/shared/utils.ts
+++ b/mage_ai/frontend/components/PipelineRun/shared/utils.ts
@@ -130,7 +130,9 @@ export const getAllPipelineRunDataGrouped = (
             const currentNumUngrouped = currentStatsUngrouped?.[status]
               ? currentStatsUngrouped[status]
               : 0;
-            updatedStatsUngrouped[status] = currentNumUngrouped + num;
+            updatedStatsUngrouped[status] = updatedStatsUngrouped?.[status]
+              ? updatedStatsUngrouped[status] + num
+              : currentNumUngrouped + num;
 
             if (runStatusesToDisplaySet.has(status)) {
               totalPipelineRunCountByPipelineType[pipelineType][status] =

--- a/mage_ai/orchestration/monitor/monitor_stats.py
+++ b/mage_ai/orchestration/monitor/monitor_stats.py
@@ -70,10 +70,11 @@ class MonitorStats:
                 continue
             if p.pipeline_schedule_id not in stats_by_schedule_id:
                 if p.pipeline_schedule_id is None:
-                    stats_by_schedule_id[NO_PIPELINE_SCHEDULE_ID] = dict(
-                        name=NO_PIPELINE_SCHEDULE_NAME,
-                        data=dict(),
-                    )
+                    if NO_PIPELINE_SCHEDULE_ID not in stats_by_schedule_id:
+                        stats_by_schedule_id[NO_PIPELINE_SCHEDULE_ID] = dict(
+                            name=NO_PIPELINE_SCHEDULE_NAME,
+                            data=dict(),
+                        )
                 else:
                     stats_by_schedule_id[p.pipeline_schedule_id] = dict(
                         name=p.pipeline_schedule_name,

--- a/mage_ai/orchestration/monitor/monitor_stats.py
+++ b/mage_ai/orchestration/monitor/monitor_stats.py
@@ -7,6 +7,9 @@ import dateutil.parser
 import enum
 
 
+NO_PIPELINE_SCHEDULE_ID = 'no_pipeline_schedule_id'
+NO_PIPELINE_SCHEDULE_NAME = 'no_pipeline_schedule_name'
+
 class MonitorStatsType(str, enum.Enum):
     PIPELINE_RUN_COUNT = 'pipeline_run_count'
     PIPELINE_RUN_TIME = 'pipeline_run_time'
@@ -63,15 +66,23 @@ class MonitorStats:
         stats_by_schedule_id = dict()
         pipeline_type_by_pipeline_uuid = dict()
         for p in pipeline_runs:
-            if p.pipeline_schedule is None:
+            if p.pipeline_schedule is None and not group_by_pipeline_type:
                 continue
             if p.pipeline_schedule_id not in stats_by_schedule_id:
-                stats_by_schedule_id[p.pipeline_schedule_id] = dict(
-                    name=p.pipeline_schedule_name,
-                    data=dict(),
-                )
+                if p.pipeline_schedule_id is None:
+                    stats_by_schedule_id[NO_PIPELINE_SCHEDULE_ID] = dict(
+                        name=NO_PIPELINE_SCHEDULE_NAME,
+                        data=dict(),
+                    )
+                else:
+                    stats_by_schedule_id[p.pipeline_schedule_id] = dict(
+                        name=p.pipeline_schedule_name,
+                        data=dict(),
+                    )
             created_at_formatted = p.created_at.strftime('%Y-%m-%d')
-            data = stats_by_schedule_id[p.pipeline_schedule_id]['data']
+            data = stats_by_schedule_id[p.pipeline_schedule_id]['data'] \
+                if p.pipeline_schedule_id is not None \
+                else stats_by_schedule_id[NO_PIPELINE_SCHEDULE_ID]['data']
             if created_at_formatted not in data:
                 data[created_at_formatted] = dict()
             if group_by_pipeline_type:

--- a/mage_ai/orchestration/monitor/monitor_stats.py
+++ b/mage_ai/orchestration/monitor/monitor_stats.py
@@ -80,9 +80,7 @@ class MonitorStats:
                     data=dict(),
                 )
             created_at_formatted = p.created_at.strftime('%Y-%m-%d')
-            data = stats_by_schedule_id[p.pipeline_schedule_id]['data'] \
-                if p.pipeline_schedule_id is not None \
-                else stats_by_schedule_id[NO_PIPELINE_SCHEDULE_ID]['data']
+            data = stats_by_schedule_id[pipeline_schedule_id]['data']
             if created_at_formatted not in data:
                 data[created_at_formatted] = dict()
             if group_by_pipeline_type:

--- a/mage_ai/orchestration/monitor/monitor_stats.py
+++ b/mage_ai/orchestration/monitor/monitor_stats.py
@@ -68,18 +68,17 @@ class MonitorStats:
         for p in pipeline_runs:
             if p.pipeline_schedule is None and not group_by_pipeline_type:
                 continue
-            if p.pipeline_schedule_id not in stats_by_schedule_id:
-                if p.pipeline_schedule_id is None:
-                    if NO_PIPELINE_SCHEDULE_ID not in stats_by_schedule_id:
-                        stats_by_schedule_id[NO_PIPELINE_SCHEDULE_ID] = dict(
-                            name=NO_PIPELINE_SCHEDULE_NAME,
-                            data=dict(),
-                        )
-                else:
-                    stats_by_schedule_id[p.pipeline_schedule_id] = dict(
-                        name=p.pipeline_schedule_name,
-                        data=dict(),
-                    )
+            if p.pipeline_schedule_id is None:
+                pipeline_schedule_id = NO_PIPELINE_SCHEDULE_ID
+                pipeline_schedule_name = NO_PIPELINE_SCHEDULE_NAME
+            else:
+                pipeline_schedule_id = p.pipeline_schedule_id
+                pipeline_schedule_name = p.pipeline_schedule_name
+            if pipeline_schedule_id not in stats_by_schedule_id:
+                stats_by_schedule_id[pipeline_schedule_id] = dict(
+                    name=pipeline_schedule_name,
+                    data=dict(),
+                )
             created_at_formatted = p.created_at.strftime('%Y-%m-%d')
             data = stats_by_schedule_id[p.pipeline_schedule_id]['data'] \
                 if p.pipeline_schedule_id is not None \

--- a/mage_ai/orchestration/monitor/monitor_stats.py
+++ b/mage_ai/orchestration/monitor/monitor_stats.py
@@ -6,9 +6,9 @@ from typing import Callable, Dict, List, Union
 import dateutil.parser
 import enum
 
-
 NO_PIPELINE_SCHEDULE_ID = 'no_pipeline_schedule_id'
 NO_PIPELINE_SCHEDULE_NAME = 'no_pipeline_schedule_name'
+
 
 class MonitorStatsType(str, enum.Enum):
     PIPELINE_RUN_COUNT = 'pipeline_run_count'


### PR DESCRIPTION
# Summary
- Account for pipeline runs without associated triggers (e.g. if the trigger was deleted) on the Overview page stats.

# Tests
Before (runs without associated triggers not factored in counts):
<img width="2056" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/00d53774-b3c3-4ca0-9d13-1d273752ed4d">

After (Overall pipeline run counts include runs without associated triggers in the metric summary as well as bar chart):
<img width="2056" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/a9700249-a2fa-4237-b0b6-961d54af0e9f">

