### PR TITLE
[td] Added UI for landing times

### DIFF
--- a/mage_ai/api/policies/PipelineSchedulePolicy.py
+++ b/mage_ai/api/policies/PipelineSchedulePolicy.py
@@ -47,6 +47,7 @@ PipelineSchedulePolicy.allow_read(PipelineSchedulePresenter.default_attributes +
 
 PipelineSchedulePolicy.allow_read(PipelineSchedulePresenter.default_attributes + [
     'event_matchers',
+    'runtime_average',
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[

--- a/mage_ai/api/presenters/PipelineSchedulePresenter.py
+++ b/mage_ai/api/presenters/PipelineSchedulePresenter.py
@@ -21,18 +21,23 @@ class PipelineSchedulePresenter(BasePresenter):
     ]
 
     async def present(self, **kwargs):
-        if constants.LIST == kwargs['format']:
+        display_format = kwargs['format']
+        data = self.model.to_dict()
+
+        if constants.LIST == display_format:
             return self.model.to_dict(include_attributes=[
                 'event_matchers',
                 'last_pipeline_run_status',
                 'pipeline_runs_count',
             ])
-        elif kwargs['format'] in [constants.DETAIL, constants.UPDATE]:
+        elif display_format in [constants.DETAIL, constants.UPDATE]:
             return self.model.to_dict(include_attributes=[
                 'event_matchers',
             ])
+        elif 'with_runtime_average' == display_format:
+            data['runtime_average'] = self.model.runtime_average()
 
-        return self.model.to_dict()
+        return data
 
 
 PipelineSchedulePresenter.register_format(
@@ -49,5 +54,13 @@ PipelineSchedulePresenter.register_formats([
     constants.UPDATE,
 ], PipelineSchedulePresenter.default_attributes + [
         'event_matchers',
+    ],
+)
+
+
+PipelineSchedulePresenter.register_formats([
+    'with_runtime_average',
+], PipelineSchedulePresenter.default_attributes + [
+        'runtime_average',
     ],
 )

--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -46,6 +46,7 @@ import {
   CalendarDate,
   Code,
   Schedule,
+  Switch,
   Trash,
 } from '@oracle/icons';
 import { BlockTypeEnum } from '@interfaces/BlockType';
@@ -151,7 +152,7 @@ function Edit({
   }, [settingsInit]);
 
   const [date, setDate] = useState<Date>(null);
-  const [time, setTime] = useState<TimeType>({ hour: '00', minute: '00', second: '00' });
+  const [time, setTime] = useState<TimeType>({ hour: '00', minute: '00' });
   const [landingTimeData, setLandingTimeData] = useState<{
     dayOfMonth?: number;
     dayOfWeek?: number;
@@ -311,7 +312,7 @@ function Edit({
       ScheduleIntervalEnum.HOURLY,
       ScheduleIntervalEnum.MONTHLY,
       ScheduleIntervalEnum.WEEKLY,
-    ].includes(scheduleInterval),
+    ].includes(scheduleInterval as ScheduleIntervalEnum),
     [
       scheduleInterval,
       scheduleType,
@@ -512,7 +513,7 @@ function Edit({
       ScheduleIntervalEnum.DAILY,
       ScheduleIntervalEnum.MONTHLY,
       ScheduleIntervalEnum.WEEKLY,
-    ].includes(scheduleInterval)) {
+    ].includes(scheduleInterval as ScheduleIntervalEnum)) {
       inputs.unshift(
         <Spacing key="Hour" mr={1}>
           <Spacing mb={1}>
@@ -706,7 +707,7 @@ function Edit({
           alignItems="center"
           key="frequency"
         >
-          <Schedule default size={1.5 * UNIT} />
+          <Switch default size={1.5 * UNIT} />
           <Spacing mr={1} />
           <Text default>
             Enable landing time
@@ -748,10 +749,10 @@ function Edit({
           alignItems="center"
           key="runtime_average"
         >
-          <CalendarDate default size={1.5 * UNIT} />
+          <Schedule default size={1.5 * UNIT} />
           <Spacing mr={1} />
           <Text default>
-            Runtime average
+            Average runtime
           </Text>
         </FlexContainer>,
         <FlexContainer

--- a/mage_ai/frontend/interfaces/PipelineScheduleType.ts
+++ b/mage_ai/frontend/interfaces/PipelineScheduleType.ts
@@ -66,6 +66,7 @@ export default interface PipelineScheduleType {
   name?: string;
   pipeline_runs_count?: number;
   pipeline_uuid?: string;
+  runtime_average?: float;
   schedule_interval?: string;
   schedule_type?: ScheduleTypeEnum;
   settings?: PipelineScheduleSettingsType;

--- a/mage_ai/frontend/interfaces/PipelineScheduleType.ts
+++ b/mage_ai/frontend/interfaces/PipelineScheduleType.ts
@@ -40,8 +40,9 @@ export enum SortQueryParamEnum {
 }
 
 export interface PipelineScheduleSettingsType {
-  skip_if_previous_running?: boolean;
   allow_blocks_to_fail?: boolean;
+  landing_time_enabled?: boolean;
+  skip_if_previous_running?: boolean;
 }
 
 export const SORT_QUERY_TO_COLUMN_NAME_MAPPING = {
@@ -66,7 +67,7 @@ export default interface PipelineScheduleType {
   name?: string;
   pipeline_runs_count?: number;
   pipeline_uuid?: string;
-  runtime_average?: float;
+  runtime_average?: number;
   schedule_interval?: string;
   schedule_type?: ScheduleTypeEnum;
   settings?: PipelineScheduleSettingsType;

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/[...slug].tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/[...slug].tsx
@@ -18,6 +18,7 @@ function TriggerDetailPage({
   pipelineUUID,
   subpath,
 }: TriggerDetailPageProps) {
+  const isEdit = PAGE_NAME_EDIT === subpath;
   const [errors, setErrors] = useState<ErrorsType>(null);
 
   const {
@@ -30,7 +31,9 @@ function TriggerDetailPage({
   const {
     data: pipelineScheduleData,
     mutate: fetchPipelineSchedule,
-  } = api.pipeline_schedules.detail(pipelineScheduleId);
+  } = api.pipeline_schedules.detail(pipelineScheduleId, {
+    _format: isEdit ? 'with_runtime_average' : null,
+  });
   const pipelineSchedule = pipelineScheduleData?.pipeline_schedule;
 
   const { data: dataPipeline } = api.pipelines.detail(pipelineUUID, {
@@ -44,7 +47,7 @@ function TriggerDetailPage({
     uuid: pipelineUUID,
   };
 
-  if (PAGE_NAME_EDIT === subpath) {
+  if (isEdit) {
     return (
       <TriggerEdit
         errors={errors}

--- a/mage_ai/frontend/utils/string.ts
+++ b/mage_ai/frontend/utils/string.ts
@@ -254,6 +254,10 @@ export function prettyUnitOfTime(secs) {
 }
 
 export function isNumeric(str) {
+  if (typeof str === 'undefined' || str === null) {
+    return false;
+  }
+
   return !isNaN(str);
 }
 

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -275,6 +275,17 @@ class PipelineSchedule(BaseModel):
         return False
 
     def landing_time_enabled(self) -> bool:
+        if ScheduleType.TIME != self.schedule_type:
+            return False
+
+        if self.schedule_interval not in [
+            '@daily',
+            '@hourly',
+            '@monthly',
+            '@weekly',
+        ]:
+            return False
+
         return (self.settings or {}).get('landing_time_enabled', False)
 
     def runtime_history(
@@ -342,6 +353,9 @@ class PipelineSchedule(BaseModel):
             pipeline_run=pipeline_run,
             sample_size=sample_size,
         )
+
+        if len(previous_runtimes) == 0:
+            return None
 
         return sum(previous_runtimes) / len(previous_runtimes)
 


### PR DESCRIPTION
# Summary
- Enable landing time on trigger edit page
- Show trigger’s average runtime
- Edit the landing time

# Tests
<img width="1045" alt="image" src="https://github.com/mage-ai/mage-ai/assets/1066980/0b071b48-334f-4549-b314-9a9f24aff1c5">