### PR TITLE
[td] Polish custom templates from bug bash

### DIFF
--- a/mage_ai/api/resources/CustomTemplateResource.py
+++ b/mage_ai/api/resources/CustomTemplateResource.py
@@ -20,6 +20,7 @@ from mage_ai.data_preparation.models.custom_templates.utils import (
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.data_preparation.templates.template import fetch_template_source
 from mage_ai.shared.hash import ignore_keys
+from mage_ai.shared.utils import clean_name
 
 OBJECT_TYPE_KEY = 'object_type'
 
@@ -56,6 +57,9 @@ class CustomTemplateResource(GenericResource):
         custom_template = None
         object_type = payload.get(OBJECT_TYPE_KEY)
         template_uuid = payload.get('template_uuid')
+
+        if template_uuid:
+            template_uuid = clean_name(template_uuid)
 
         if DIRECTORY_FOR_BLOCK_TEMPLATES == object_type:
             custom_template = CustomBlockTemplate.load(template_uuid=template_uuid)
@@ -130,9 +134,12 @@ class CustomTemplateResource(GenericResource):
         self.model.delete
 
     async def update(self, payload, **kwargs):
-        cache = await BlockActionObjectCache.initialize_cache()
+        object_type = payload.get('object_type')
 
-        cache.update_custom_block_template(self.model, remove=True)
+        cache = None
+        if DIRECTORY_FOR_BLOCK_TEMPLATES == object_type:
+            cache = await BlockActionObjectCache.initialize_cache()
+            cache.update_custom_block_template(self.model, remove=True)
 
         for key, value in ignore_keys(payload, [
             'uuid',
@@ -141,4 +148,5 @@ class CustomTemplateResource(GenericResource):
             setattr(self.model, key, value)
         self.model.save()
 
-        cache.update_custom_block_template(self.model)
+        if DIRECTORY_FOR_BLOCK_TEMPLATES == object_type and cache:
+            cache.update_custom_block_template(self.model)

--- a/mage_ai/frontend/components/CustomTemplates/PipelineTemplateDetail/index.tsx
+++ b/mage_ai/frontend/components/CustomTemplates/PipelineTemplateDetail/index.tsx
@@ -1,4 +1,5 @@
 import NextLink from 'next/link';
+import { toast } from 'react-toastify';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMutation } from 'react-query';
 import { useRouter } from 'next/router';
@@ -17,6 +18,7 @@ import TextArea from '@oracle/elements/Inputs/TextArea';
 import TextInput from '@oracle/elements/Inputs/TextInput';
 import TripleLayout from '@components/TripleLayout';
 import api from '@api';
+import useConfirmLeave from '@utils/hooks/useConfirmLeave';
 import usePrevious from '@utils/usePrevious';
 import { HEADER_HEIGHT } from '@components/shared/Header/index.style';
 import {
@@ -105,11 +107,10 @@ function PipelineTemplateDetail({
       return !templateAttributes?.template_uuid;
     }
 
-    return !touched;
+    return false;
   }, [
     isNewCustomTemplate,
     templateAttributes,
-    touched,
   ]);
 
   const [beforeHidden, setBeforeHidden] = useState<boolean>(false);
@@ -170,6 +171,14 @@ function PipelineTemplateDetail({
             } else {
               setTemplateAttributesState(ct);
               setTouched(false);
+
+              toast.success(
+                'Template successfully saved.',
+                {
+                  position: toast.POSITION.BOTTOM_RIGHT,
+                  toastId: 'custom_pipeline_template',
+                },
+              );
             }
           },
           onErrorCallback: (response, errors) => showError({
@@ -281,6 +290,7 @@ function PipelineTemplateDetail({
                   ...prev,
                   template_uuid: e.target.value,
                 }))}
+                placeholder="e.g. some_template_name"
                 primary
                 setContentOnMount
                 value={templateAttributes?.template_uuid || ''}
@@ -359,6 +369,11 @@ function PipelineTemplateDetail({
     templateAttributes,
   ]);
 
+  const { ConfirmLeaveModal } = useConfirmLeave({
+    shouldWarn: touched,
+    warningMessage: 'You have unsaved changes. Are you sure you want to leave?',
+  });
+
   return (
     // @ts-ignore
     <TripleLayout
@@ -370,6 +385,7 @@ function PipelineTemplateDetail({
       setBeforeHidden={setBeforeHidden}
       setBeforeWidth={setBeforeWidth}
     >
+      <ConfirmLeaveModal />
       <DependencyGraph
         blocks={blocks}
         height={heightWindow}

--- a/mage_ai/frontend/components/CustomTemplates/TemplateDetail/index.tsx
+++ b/mage_ai/frontend/components/CustomTemplates/TemplateDetail/index.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
+import { toast } from 'react-toastify';
 import { useMutation } from 'react-query';
 import { useRouter } from 'next/router';
 
@@ -25,6 +26,7 @@ import Text from '@oracle/elements/Text';
 import TextArea from '@oracle/elements/Inputs/TextArea';
 import TextInput from '@oracle/elements/Inputs/TextInput';
 import api from '@api';
+import useConfirmLeave from '@utils/hooks/useConfirmLeave';
 import usePrevious from '@utils/usePrevious';
 import {
   BLOCK_TYPE_NAME_MAPPING,
@@ -189,6 +191,14 @@ function TemplateDetail({
 
             setTemplateAttributesState(ct);
             setTouched(false);
+
+            toast.success(
+              'Template successfully saved.',
+              {
+                position: toast.POSITION.BOTTOM_RIGHT,
+                toastId: 'custom_block_template',
+              },
+            );
           },
           onErrorCallback: (response, errors) => showError({
             errors,
@@ -211,12 +221,11 @@ function TemplateDetail({
         || (!isMarkdown && !templateAttributes?.language);
     }
 
-    return !touched;
+    return false;
   }, [
     isMarkdown,
     isNewCustomTemplate,
     templateAttributes,
-    touched,
   ]);
 
   const {
@@ -528,8 +537,14 @@ function TemplateDetail({
     heightOffset,
   ]);
 
+  const { ConfirmLeaveModal } = useConfirmLeave({
+    shouldWarn: touched,
+    warningMessage: 'You have unsaved changes. Are you sure you want to leave?',
+  });
+
   return (
     <ContainerStyle>
+      <ConfirmLeaveModal />
       <NavigationStyle height={contained ? heightFinal : null}>
         <FlexContainer
           flexDirection="column"
@@ -572,6 +587,7 @@ function TemplateDetail({
                       ...prev,
                       template_uuid: e.target.value,
                     }))}
+                    placeholder="e.g. some_template_name"
                     primary
                     setContentOnMount
                     value={templateAttributes?.template_uuid || ''}

--- a/mage_ai/frontend/utils/hooks/useConfirmLeave.tsx
+++ b/mage_ai/frontend/utils/hooks/useConfirmLeave.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+
+import Button from '@oracle/elements/Button';
+import FlexContainer from '@oracle/components/FlexContainer';
+import Panel from '@oracle/components/Panel';
+import Spacing from '@oracle/elements/Spacing';
+import Text from '@oracle/elements/Text';
+import { useModal } from '@context/Modal';
+
+const useConfirmLeave = ({
+  shouldWarn,
+  warningMessage,
+}: {
+  shouldWarn: boolean;
+  warningMessage?: string;
+}) => {
+  const router = useRouter();
+  const [hasConfirmed, setHasConfirmed] = useState(false);
+  const [navigationConfig, setNavigationConfig] = useState<{
+    isModalOpen: boolean;
+    nextRoute: string | null;
+  }>({
+    isModalOpen: false,
+    nextRoute: null,
+  });
+
+  // Use beforeunload to prevent closing the tab, refreshing the page or moving outside the Next app
+  useEffect(() => {
+    const handleWindowClose = (e: BeforeUnloadEvent) => {
+      if (!shouldWarn) return;
+      e.preventDefault();
+      const event = e || window.event;
+      return (event.returnValue = 'Are you sure you want to leave?');
+    };
+
+    window.addEventListener('beforeunload', handleWindowClose);
+    return () => {
+      window.removeEventListener('beforeunload', handleWindowClose);
+    };
+  }, [shouldWarn]);
+
+  // Use routeChangeStart to prevent navigation inside of the Next app
+  useEffect(() => {
+    const onRouteChangeStart = (route: string) => {
+      if (!shouldWarn || hasConfirmed) return;
+      else {
+        setNavigationConfig({
+          isModalOpen: true,
+          nextRoute: route,
+        });
+        router.events.emit('routeChangeError');
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw 'navigation aborted';
+      }
+    };
+    router.events.on('routeChangeStart', onRouteChangeStart);
+    const cleanUp = () =>
+      router.events.off('routeChangeStart', onRouteChangeStart);
+
+    if (hasConfirmed) {
+      if (!navigationConfig.nextRoute) return;
+      void router.push(navigationConfig.nextRoute);
+      return cleanUp;
+    }
+
+    return cleanUp;
+  }, [navigationConfig, hasConfirmed, router, shouldWarn]);
+
+  const [showModal, hideModal] = useModal(() => (
+    <Panel>
+      <Text>
+        {warningMessage}
+      </Text>
+
+      <Spacing mt={2}>
+        <FlexContainer alignItems="center">
+          <Button
+            onClick={() => setHasConfirmed(true)}
+            primary
+          >
+            Leave
+          </Button>
+
+          <Spacing mr={1} />
+
+          <Button
+            onClick={() => {
+              setNavigationConfig({
+                isModalOpen: false,
+                nextRoute: null,
+              });
+            }}
+            secondary
+          >
+            Cancel
+          </Button>
+        </FlexContainer>
+      </Spacing>
+    </Panel>
+  ), {}, [
+    warningMessage,
+  ], {
+    background: true,
+    uuid: 'stale_pipeline_message',
+  });
+
+  useEffect(() => {
+    if (navigationConfig.isModalOpen) {
+      showModal();
+    } else {
+      hideModal();
+    }
+  }, [
+    hideModal,
+    navigationConfig.isModalOpen,
+    showModal,
+  ]);
+
+  const ConfirmLeaveModal = () => (
+    <div />
+  );
+
+  return {
+    ConfirmLeaveModal,
+  };
+};
+
+export default useConfirmLeave;


### PR DESCRIPTION
# Summary
- Add confirm dialogue when user tries to exit template edit mode without saving.
- Add placeholder label for template uuid input field so it’s clear users should type in a uuid for the new template.
- Add success toast message or change button text to “Saved” (instead of just disabling the button) when Save template is clicked so users know a template is ready to use. (Ideally, they can go back into a template-edit mode from the UI after the template has already been created).
- Clean new template file name (i.e. add underscores) on creation if uuid has spaces. Could potentially causes issues since the template filename and folder has spaces in it.