### PR TITLE
[xy] Support custom k8s executor config.

### DIFF
--- a/mage_ai/services/k8s/config.py
+++ b/mage_ai/services/k8s/config.py
@@ -17,6 +17,7 @@ class K8sResourceConfig(BaseConfig):
 
 @dataclass
 class K8sExecutorConfig(BaseConfig):
+    container_config: Dict = None
     job_name_prefix: str = None
     resource_limits: Dict = None
     resource_requests: Dict = None

--- a/mage_ai/services/k8s/job_manager.py
+++ b/mage_ai/services/k8s/job_manager.py
@@ -107,6 +107,8 @@ class JobManager():
             container_kwargs['resources'] = client.V1ResourceRequirements(
                 **resource_kwargs,
             )
+        if k8s_config and k8s_config.container_config:
+            container_kwargs = merge_dict(container_kwargs, k8s_config.container_config)
 
         container = client.V1Container(
             **container_kwargs,


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Support custom k8s executor config.

Example config:
```
k8s_executor_config:
  service_account_name: mageai
  job_name_prefix: "{{ env_var('KUBE_NAMESPACE') }}"
  container_config:
    image: mageai/mageai:0.9.7
    env:
    - name: USER_CODE_PATH
      value: /home/src/k8s_project
```

# Tests
<!-- How did you test your change? -->
tested locally
unit tests

cc:
<!-- Optionally mention someone to let them know about this pull request -->
