### PR TITLE
[xy] Throw correct exception about io config.

### DIFF
--- a/mage_ai/api/resources/DataProviderResource.py
+++ b/mage_ai/api/resources/DataProviderResource.py
@@ -37,10 +37,7 @@ class DataProviderResource(GenericResource):
     @safe_db_query
     async def collection(self, query, meta, user, **kwargs):
         async with aiofiles.open(f'{get_repo_path()}/io_config.yaml', mode='r') as file:
-            try:
-                profiles = list(yaml.safe_load(await file.read()).keys())
-            except yaml.YAMLError as exc:
-                print(exc)
+            profiles = list(yaml.safe_load(await file.read()).keys())
 
         collection = [dict(
             id=DATA_PROVIDERS_NAME[ds.value],


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Throw correct exception about io config.

# Tests
<!-- How did you test your change? -->
tested locally

Old exception: `"exception": "free variable 'profiles' referenced before assignment in enclosing scope",`
New exception shows the invalid yaml error: 
<img width="837" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/f5d2d9b3-caf4-4464-85d9-8fe71b3b70e5">


cc:
<!-- Optionally mention someone to let them know about this pull request -->
