### PR TITLE
[dy] Catch timeout exception for test_connection

### DIFF
--- a/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
+++ b/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
@@ -217,6 +217,8 @@ class IntegrationPipeline(Pipeline):
                 elif not error and line.startswith('CRITICAL'):
                     error = line
             raise Exception(filter_out_config_values(error, config_interpolated))
+        except Exception as err:
+            raise Exception(filter_out_config_values(str(err), config_interpolated))
 
     def preview_data(self, block_type: BlockType, streams: List[str] = None) -> List[str]:
         from mage_integrations.utils.logger.constants import TYPE_SAMPLE_DATA


### PR DESCRIPTION
# Summary

The `test_connection` subprocess has a timeout, so if it times out, it will raise not raise a `subprocess.CalledProcessError`. This PR will catch the other exceptions and hide the config values in them.
<!-- Brief summary of what your code does -->

# Tests

tested locally
<!-- How did you test your change? -->

cc:
<!-- Optionally mention someone to let them know about this pull request -->
