### PR TITLE
[xy] Allow customize the timeout for the ECS task.

### DIFF
--- a/docs/production/configuring-production-settings/compute-resource.mdx
+++ b/docs/production/configuring-production-settings/compute-resource.mdx
@@ -123,6 +123,14 @@ There're 2 ways to customize the compute resource of ECS executor,
         memory: 2048
     ```
 
+The default wait timeout for the ECS task is 10 minutes. To customize the timeout, you can specify the `wait_timeout` (in seconds) field in `ecs_config`. Here is one example:
+```yaml
+ecs_config:
+  cpu: 1024
+  memory: 2048
+  wait_timeout: 1200
+```
+
 ### GCP Cloud Run executor
 
 If your Mage app is deployed on GCP, you can choose to launch separate GCP Cloud Run jobs to execute blocks.

--- a/mage_ai/services/aws/ecs/config.py
+++ b/mage_ai/services/aws/ecs/config.py
@@ -21,6 +21,7 @@ class EcsConfig(BaseConfig):
     network_configuration: Dict = None
     cpu: int = 512
     memory: int = 1024
+    wait_timeout: int = 600
 
     @classmethod
     def load_extra_config(self):

--- a/mage_ai/services/aws/ecs/ecs.py
+++ b/mage_ai/services/aws/ecs/ecs.py
@@ -23,7 +23,16 @@ def run_task(
     if wait_for_completion:
         arn = response['tasks'][0]['taskArn']
         waiter = client.get_waiter('tasks_stopped')
-        waiter.wait(cluster=ecs_config.cluster, tasks=[arn])
+        wait_kwargs = dict(
+            cluster=ecs_config.cluster,
+            tasks=[arn],
+        )
+        if ecs_config.wait_timeout:
+            wait_kwargs['WaiterConfig'] = {
+                'Delay': 15,
+                'MaxAttempts': int(ecs_config.wait_timeout / 15),
+            }
+        waiter.wait(**wait_kwargs)
 
         tasks = client.describe_tasks(
             cluster=ecs_config.cluster,


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Allow customize the timeout for the ECS task. The default timeout is 10 minutes.

Example config:
```yaml
ecs_config:
  cpu: 1024
  memory: 2048
  wait_timeout: 1200
```

# Tests
<!-- How did you test your change? -->
tested on ECS

cc:
<!-- Optionally mention someone to let them know about this pull request -->
