### PR TITLE
[dy] Consolidate aws region variables

### DIFF
--- a/mage_ai/cluster_manager/aws/ecs_task_manager.py
+++ b/mage_ai/cluster_manager/aws/ecs_task_manager.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 import boto3
 from botocore.config import Config
 
+from mage_ai.services.aws import get_aws_region_name
 from mage_ai.services.aws.ecs.config import EcsConfig
 from mage_ai.services.aws.ecs.ecs import list_services, list_tasks, run_task, stop_task
 from mage_ai.shared.array import find
@@ -37,7 +38,7 @@ class EcsTaskManager:
             json.dump(metadata, file)
 
     def list_tasks(self):
-        region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
+        region_name = get_aws_region_name()
         config = Config(region_name=region_name)
         ec2_client = boto3.client('ec2', config=config)
 
@@ -77,7 +78,7 @@ class EcsTaskManager:
         return tasks + stopped_instances
 
     def create_task(self, name: str, task_definition: str, container_name: str):
-        region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
+        region_name = get_aws_region_name()
         config = Config(region_name=region_name)
         ec2_client = boto3.client('ec2', config=config)
 

--- a/mage_ai/services/aws/__init__.py
+++ b/mage_ai/services/aws/__init__.py
@@ -1,0 +1,8 @@
+import os
+
+
+def get_aws_region_name():
+    return os.getenv(
+        'AWS_REGION_NAME',
+        os.getenv('AWS_DEFAULT_REGION', 'us-west-2'),
+    )

--- a/mage_ai/services/aws/ecs/ecs.py
+++ b/mage_ai/services/aws/ecs/ecs.py
@@ -1,10 +1,10 @@
 import json
-import os
 from typing import Dict, List
 
 import boto3
 from botocore.config import Config
 
+from mage_ai.services.aws import get_aws_region_name
 from mage_ai.services.aws.ecs.config import EcsConfig
 
 
@@ -63,7 +63,7 @@ def stop_task(task_arn: str, cluster: str = None) -> None:
 
 
 def list_tasks(cluster) -> List[Dict]:
-    region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
+    region_name = get_aws_region_name()
     config = Config(region_name=region_name)
     ecs_client = boto3.client('ecs', config=config)
 
@@ -81,7 +81,7 @@ def list_tasks(cluster) -> List[Dict]:
 
 
 def list_services(cluster) -> List[Dict]:
-    region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
+    region_name = get_aws_region_name()
     config = Config(region_name=region_name)
     ecs_client = boto3.client('ecs', config=config)
 

--- a/mage_ai/services/aws/emr/emr.py
+++ b/mage_ai/services/aws/emr/emr.py
@@ -1,16 +1,17 @@
-from botocore.config import Config
-from botocore.exceptions import ClientError
-from datetime import datetime
-from mage_ai.services.aws.emr import emr_basics
-from mage_ai.services.aws.emr.config import EmrConfig
-import boto3
 import json
 import logging
 import random
-import time
-import os
 import sys
+import time
+from datetime import datetime
 
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+from mage_ai.services.aws import get_aws_region_name
+from mage_ai.services.aws.emr import emr_basics
+from mage_ai.services.aws.emr.config import EmrConfig
 
 MAX_STEPS_IN_CLUSTER = 255 - 55
 MAX_RUNNING_OR_PENDING_STEPS = 15
@@ -42,7 +43,7 @@ def create_a_new_cluster(
     log_uri=None,
     tags=dict(),
 ):
-    region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
+    region_name = get_aws_region_name()
     config = Config(region_name=region_name)
     emr_client = boto3.client('emr', config=config)
     if type(emr_config) is dict:
@@ -114,14 +115,14 @@ def create_a_new_cluster(
 
 
 def describe_cluster(cluster_id):
-    region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
+    region_name = get_aws_region_name()
     config = Config(region_name=region_name)
     emr_client = boto3.client('emr', config=config)
     return emr_basics.describe_cluster(cluster_id, emr_client)
 
 
 def list_clusters():
-    region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
+    region_name = get_aws_region_name()
     config = Config(region_name=region_name)
     emr_client = boto3.client('emr', config=config)
 
@@ -140,11 +141,13 @@ def submit_spark_job(
     cluster_name,
     steps,
     bootstrap_script_path=None,
-    emr_config=dict(),
+    emr_config=None,
     idle_timeout=0,
     log_uri=None,
 ):
-    region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
+    if emr_config is None:
+        emr_config = dict()
+    region_name = get_aws_region_name()
     config = Config(region_name=region_name)
     emr_client = boto3.client('emr', config=config)
 

--- a/mage_ai/services/aws/events/events.py
+++ b/mage_ai/services/aws/events/events.py
@@ -1,13 +1,16 @@
-from botocore.config import Config
-import boto3
 import os
 import uuid
+
+import boto3
+from botocore.config import Config
+
+from mage_ai.services.aws import get_aws_region_name
 
 EVENT_RULE_LIMIT = 100
 
 
 def get_all_event_rules():
-    region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
+    region_name = get_aws_region_name()
     config = Config(region_name=region_name)
     client = boto3.client('events', config=config)
     response = client.list_rules(
@@ -31,7 +34,7 @@ def update_event_rule_targets(name):
     lambda_function_name = os.getenv('LAMBDA_FUNCTION_NAME')
     if lambda_function_arn is None or lambda_function_name is None:
         return
-    region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
+    region_name = get_aws_region_name()
     config = Config(region_name=region_name)
     client = boto3.client('events', config=config)
     event_rule_info = client.describe_rule(Name=name)

--- a/mage_ai/services/aws/secrets_manager/secrets_manager.py
+++ b/mage_ai/services/aws/secrets_manager/secrets_manager.py
@@ -1,13 +1,13 @@
-import os
+from mage_ai.services.aws import get_aws_region_name
 
 
 class SecretsManager:
     def __init__(self):
+        import boto3
         from aws_secretsmanager_caching import SecretCache, SecretCacheConfig
         from botocore.config import Config
-        import boto3
 
-        region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
+        region_name = get_aws_region_name()
         config = Config(region_name=region_name)
         client = boto3.client('secretsmanager', config=config)
         cache_config = SecretCacheConfig()
@@ -25,10 +25,10 @@ def get_secret(secret_id: str, cached=True) -> str:
 
 
 def get_secret_force(secret_id: str) -> str:
-    from botocore.config import Config
     import boto3
+    from botocore.config import Config
 
-    region_name = os.getenv('AWS_REGION_NAME', 'us-west-2')
+    region_name = get_aws_region_name()
     config = Config(region_name=region_name)
     client = boto3.client('secretsmanager', config=config)
 


### PR DESCRIPTION
# Summary

Fixes issue: https://github.com/mage-ai/mage-ai/issues/2929

Use `AWS_REGION_NAME` but default to `AWS_DEFAULT_REGION` for aws region environment variable.
<!-- Brief summary of what your code does -->

# Tests

tested locally
<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
