### PR TITLE
[mp] swap elephantdb for supabase

### DIFF
--- a/docs/tutorials/load-api-data.mdx
+++ b/docs/tutorials/load-api-data.mdx
@@ -218,12 +218,12 @@ Follow these steps:
     ```yaml
     version: 0.1.1
     default:
-      POSTGRES_DBNAME: postgres
-      POSTGRES_USER: demo_user
-      POSTGRES_PASSWORD: make_data_magical
-      POSTGRES_HOST: db.pcrjclqaoqibkbptixsw.supabase.co
-      POSTGRES_PORT: 5432
-      POSTGRES_SCHEMA: elt_demo
+        POSTGRES_PORT: 5432
+        POSTGRES_DBNAME: xyleviup
+        POSTGRES_USER: xyleviup
+        POSTGRES_PASSWORD: edSrMWH7Mww-lTKpp-jPHX9sYSNLy7LG
+        POSTGRES_HOST: queenie.db.elephantsql.com
+        POSTGRES_SCHEMA: elt_demo
     ```
 
 1. Save the file by pressing:

--- a/docs/tutorials/load-api-data.mdx
+++ b/docs/tutorials/load-api-data.mdx
@@ -218,12 +218,12 @@ Follow these steps:
     ```yaml
     version: 0.1.1
     default:
-        POSTGRES_PORT: 5432
-        POSTGRES_DBNAME: xyleviup
-        POSTGRES_USER: xyleviup
-        POSTGRES_PASSWORD: edSrMWH7Mww-lTKpp-jPHX9sYSNLy7LG
-        POSTGRES_HOST: queenie.db.elephantsql.com
-        POSTGRES_SCHEMA: elt_demo
+      POSTGRES_PORT: 5432
+      POSTGRES_DBNAME: xyleviup
+      POSTGRES_USER: xyleviup
+      POSTGRES_PASSWORD: edSrMWH7Mww-lTKpp-jPHX9sYSNLy7LG
+      POSTGRES_HOST: queenie.db.elephantsql.com
+      POSTGRES_SCHEMA: elt_demo
     ```
 
 1. Save the file by pressing:

--- a/docs/tutorials/setup-dbt.mdx
+++ b/docs/tutorials/setup-dbt.mdx
@@ -63,13 +63,13 @@ For the rest of this tutorial, we’ll use the project name `demo_project`.
      target: dev
      outputs:
        dev:
-         dbname: postgres
-         host: db.pcrjclqaoqibkbptixsw.supabase.co
-         password: make_data_magical
+         dbname: xyleviup
+         host: queenie.db.elephantsql.com
+         password: edSrMWH7Mww-lTKpp-jPHX9sYSNLy7LG
          port: 5432
          schema: dbt_demo
          type: postgres
-         user: demo_user
+         user: xyleviup
    ```
 4. Save the `profiles.yml` file by pressing `Command (⌘)` + `S`.
 5. Close the file by pressing the **`X`** button on the right side of the file


### PR DESCRIPTION
# Summary
Apparently Supabase has a 1 week timeout on free projects. This swaps ElephantDB to avoid the limit— inspired by a [community suggestion](https://mageai.slack.com/archives/C03KW780J2F/p1690957394440159?thread_ts=1690855264.337059&cid=C03KW780J2F).

# Tests
Tested with dev instance

cc:
<!-- Optionally mention someone to let them know about this pull request -->
