### PR TITLE
[xh]Add upstream block Ids when generating pipeline code

### DIFF
--- a/mage_ai/ai/generator.py
+++ b/mage_ai/ai/generator.py
@@ -33,7 +33,7 @@ class Generator:
         elif use_case == LLMUseCase.GENERATE_PIPELINE_WITH_DESCRIPTION:
             from mage_ai.ai.llm_pipeline_wizard import LLMPipelineWizard
 
-            return await LLMPipelineWizard().async_generate_pipeline_with_description(
+            return await LLMPipelineWizard().async_generate_pipeline_from_description(
                 request.get('pipeline_description'),
             )
         elif use_case == LLMUseCase.GENERATE_COMMENT_FOR_CODE:

--- a/mage_ai/ai/generator_cmds.py
+++ b/mage_ai/ai/generator_cmds.py
@@ -49,7 +49,7 @@ def generate_block_with_description(block_description: str):
 
 @app.command()
 def generate_pipeline_with_description(pipeline_description: str):
-    print(asyncio.run(LLMPipelineWizard().async_generate_pipeline_with_description(
+    print(asyncio.run(LLMPipelineWizard().async_generate_pipeline_from_description(
                                             pipeline_description)))
 
 

--- a/mage_ai/ai/llm_pipeline_wizard.py
+++ b/mage_ai/ai/llm_pipeline_wizard.py
@@ -2,8 +2,8 @@ import ast
 import asyncio
 import json
 import os
-from typing import Dict
 import re
+from typing import Dict
 
 import openai
 from langchain.chains import LLMChain


### PR DESCRIPTION
# Summary
Add upstream block Ids when generating pipeline code

# Tests
The block split function return the following response instead:
```
BLOCK 1: function: load data from MySQL. upstream:
BLOCK 2: function: load data from Postgres. upstream:
BLOCK 3: function: merge data from MySQL and Postgres. upstream: 1, 2
BLOCK 4: function: filter row that block_id > 10. upstream: 3
BLOCK 5: function: export data to Postgres. upstream: 4
BLOCK 6: function: export data to Amazon S3. upstream: 4
```
I parse the `upstream` and add field `upstream_blocks` in the block configuration.

cc:
@wangxiaoyou1993 
