### PR TITLE
[hw] Fix the `bool` data type conversion issue with the ClickHouse exporter

### DIFF
--- a/mage_ai/shared/utils.py
+++ b/mage_ai/shared/utils.py
@@ -58,7 +58,7 @@ def convert_pandas_dtype_to_python_type(dtype):
         return int
     elif 'float' in dtype:
         return float
-    elif dtype == 'bool':
+    elif dtype in ['bool', 'boolean']:
         return bool
     elif 'datetime' in dtype:
         return datetime


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

When a boolean field is present in the source DataFrame, an exception was thrown when running with a ClickHouse exporter.

# Tests
<!-- How did you test your change? -->
Manually tested in a local development environment, with a Standard Batch pipeline consisting of a Data Loader `Python/Generic (no template)` and a Data Exporter `SQL/ClickHouse`:

Data Loader:
```
if 'data_loader' not in globals():
    from mage_ai.data_preparation.decorators import data_loader
if 'test' not in globals():
    from mage_ai.data_preparation.decorators import test

@data_loader
def load_data(*args, **kwargs):
    """
    Template code for loading data from any source.

    Returns:
        Anything (e.g. data frame, dictionary, array, int, str, etc.)
    """
    # Specify your data loading logic here
    import pandas as pd
    return pd.DataFrame({'num_legs': [2, 4, 8, 0],
                    'num_wings': [2, 0, 0, 0],
                    'num_specimen_seen': [10, 2, 1, 8],
                    'flag': [True, True, False, False]},
                    index=['falcon', 'dog', 'spider', 'fish']
                    )


@test
def test_output(output, *args) -> None:
    """
    Template code for testing the output of the block.
    """
    assert output is not None, 'The output is undefined'
```
![Screenshot 2023-08-03 at 1 11 33 AM](https://github.com/mage-ai/mage-ai/assets/42320565/6663854e-f886-4527-a6b7-efd4dd198268)

Data Exporter:
```
SELECT * FROM {{ df_1 }}
```
![Screenshot 2023-08-03 at 1 11 45 AM](https://github.com/mage-ai/mage-ai/assets/42320565/63ae7336-ef95-46c8-b092-28b875c1d06c)

It was verified that a new ClickHouse table was created as expected with a ClickHouse client. Without the code change in this PR, an exception was thrown in the Mage UI.
```
bins-mbp.repeater :) use helloworld

USE helloworld

Query id: 07ec6525-ba01-45f0-8d89-75da28fbcf95

Ok.

0 rows in set. Elapsed: 0.003 sec. 

bins-mbp.repeater :) show tables

SHOW TABLES

Query id: 3bbd078f-efa9-4f48-b0c9-eb7320a8c052

┌─name──────────────────────────────┐
│ ch_test                           │
│ dev_damp_firefly_falling_smoke_v1 │
│ dev_lingering_tree_late_snow_v1   │
│ dev_lingering_tree_still_frog_v1  │
│ my_first_table                    │
└───────────────────────────────────┘

5 rows in set. Elapsed: 0.010 sec. 

bins-mbp.repeater :) select * from dev_lingering_tree_still_frog_v1

SELECT *
FROM dev_lingering_tree_still_frog_v1

Query id: bc7db64c-0b94-4449-b309-b283f66dc480

┌─num_legs─┬─num_wings─┬─num_specimen_seen─┬─flag──┐
│        2 │         2 │                10 │ true  │
│        4 │         0 │                 2 │ true  │
│        8 │         0 │                 1 │ false │
│        0 │         0 │                 8 │ false │
└──────────┴───────────┴───────────────────┴───────┘

4 rows in set. Elapsed: 0.007 sec. 
```


cc:
<!-- Optionally mention someone to let them know about this pull request -->
@dy46 @wangxiaoyou1993 