### PR TITLE
[xy] Do not start pipeline run immediately after creation.

### DIFF
--- a/mage_ai/orchestration/queue/queue_factory.py
+++ b/mage_ai/orchestration/queue/queue_factory.py
@@ -9,7 +9,8 @@ class QueueFactory:
     def get_queue(self):
         if self.queue is not None:
             return self.queue
-        queue_config = QueueConfig.load(config=get_repo_config().queue_config)
+
+        queue_config = QueueConfig.load(config=get_repo_config().queue_config or dict())
         if queue_config.queue_type == QueueType.CELERY:
             from mage_ai.orchestration.queue.celery_queue import CeleryQueue
             self.queue = CeleryQueue(queue_config)

--- a/mage_ai/orchestration/triggers/utils.py
+++ b/mage_ai/orchestration/triggers/utils.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 from time import sleep
 from typing import Dict, Optional
 
-from mage_ai.data_integrations.utils.scheduler import initialize_state_and_runs
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.orchestration.db import db_connection
 from mage_ai.orchestration.db.models.schedules import PipelineRun, PipelineSchedule
@@ -70,16 +69,17 @@ def create_and_start_pipeline_run(
 
     pipeline_run = PipelineRun.create(**configured_payload)
 
-    from mage_ai.orchestration.pipeline_scheduler import PipelineScheduler
-    pipeline_scheduler = PipelineScheduler(pipeline_run)
+    # Do not start the pipeline run immediately due to concurrency control
+    # from mage_ai.orchestration.pipeline_scheduler import PipelineScheduler
+    # pipeline_scheduler = PipelineScheduler(pipeline_run)
 
-    if is_integration:
-        initialize_state_and_runs(
-            pipeline_run,
-            pipeline_scheduler.logger,
-            pipeline_run.get_variables(),
-        )
+    # if is_integration:
+    #     initialize_state_and_runs(
+    #         pipeline_run,
+    #         pipeline_scheduler.logger,
+    #         pipeline_run.get_variables(),
+    #     )
 
-    pipeline_scheduler.start(should_schedule=should_schedule)
+    # pipeline_scheduler.start(should_schedule=should_schedule)
 
     return pipeline_run


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Do not start pipeline run immediately after creation. The pipeline run is started in scheduler when there's enough concurrency quota to start a new pipeline run.
https://github.com/mage-ai/mage-ai/blob/master/mage_ai/orchestration/pipeline_scheduler.py#L1413-L1422

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
