### PR TITLE
fix: Typo in transformer.mdx

### DIFF
--- a/docs/design/blocks/transformer.mdx
+++ b/docs/design/blocks/transformer.mdx
@@ -31,7 +31,7 @@ If a block has more than 1 upstream block,
 then each upstream block’s output is accessible via positional arguments.
 
 For example, if you have 3 upstream blocks,
-than there will be 3 positional arguments available within the `transform_df` function.
+then there will be 3 positional arguments available within the `transform_df` function.
 
 See below for an example:
 


### PR DESCRIPTION
# Summary
Just fixing a typo

# Tests
https://www.dictionary.com/e/then-vs-than/
