### PR TITLE
[dy] Escape password in db_connection_url

### DIFF
--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -59,6 +59,7 @@ try:
     )
     engine.connect()
 except SQLAlchemyError:
+    engine.dispose()
     url_parsed = urlparse(db_connection_url)
     if url_parsed.password:
         db_connection_url = db_connection_url.replace(

--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, quote_plus, urlparse
 
 import sqlalchemy
 from sqlalchemy import create_engine
@@ -46,6 +46,13 @@ elif not db_connection_url:
             # For new projects, create mage-ai.db in variables dir
             db_connection_url = f'sqlite:///{get_variables_dir()}/mage-ai.db'
         db_kwargs['connect_args']['check_same_thread'] = False
+
+url_parsed = urlparse(db_connection_url)
+if url_parsed.password:
+    db_connection_url = db_connection_url.replace(
+        url_parsed.password,
+        quote_plus(url_parsed.password),
+    )
 
 if db_connection_url.startswith('postgresql'):
     db_kwargs['pool_size'] = 50

--- a/mage_ai/orchestration/db/database_manager.py
+++ b/mage_ai/orchestration/db/database_manager.py
@@ -22,7 +22,8 @@ class DatabaseManager:
             'script_location',
             os.path.join(cur_dirpath, 'migrations'),
         )
-        alembic_cfg.set_main_option('sqlalchemy.url', db_connection_url)
+        escaped_db_connection_url = db_connection_url.replace('%', '%%')
+        alembic_cfg.set_main_option('sqlalchemy.url', escaped_db_connection_url)
         if log_level is not None:
             alembic_cfg.set_section_option('logger_alembic', 'level', log_level)
         command.upgrade(alembic_cfg, 'head')

--- a/mage_ai/orchestration/db/database_manager.py
+++ b/mage_ai/orchestration/db/database_manager.py
@@ -22,8 +22,11 @@ class DatabaseManager:
             'script_location',
             os.path.join(cur_dirpath, 'migrations'),
         )
-        escaped_db_connection_url = db_connection_url.replace('%', '%%')
-        alembic_cfg.set_main_option('sqlalchemy.url', escaped_db_connection_url)
+        try:
+            alembic_cfg.set_main_option('sqlalchemy.url', db_connection_url)
+        except ValueError:
+            escaped_db_connection_url = db_connection_url.replace('%', '%%')
+            alembic_cfg.set_main_option('sqlalchemy.url', escaped_db_connection_url)
         if log_level is not None:
             alembic_cfg.set_section_option('logger_alembic', 'level', log_level)
         command.upgrade(alembic_cfg, 'head')


### PR DESCRIPTION
# Summary

We currently don't escape characters in the db_connection_url, but the sqlalchemy and alembic docs do suggest doing so. I also ran into an error when I had a special character in the password which caused the alembic migrations to fail.

Docs:
https://docs.sqlalchemy.org/en/14/core/engines.html#database-urls
https://alembic.sqlalchemy.org/en/latest/api/config.html#alembic.config.Config.set_main_option
<!-- Brief summary of what your code does -->

# Tests

tested locally with postgres and sqlite
<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
