### PR TITLE
[hw] Remove MySQL from the supported backend databases due to some unexpected issues

### DIFF
--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -93,34 +93,6 @@ To use a specific schema in the PostgreSQL database, the connection string could
       /app/run_app.sh mage start [project_name]
    ```
 
-### Using MySQL as database
-
-Mage uses SQLite as the default database engine. To use MySQL as the database engine, you'll need to run your Docker container slightly differently:
-
-1. Create Docker network
-
-   ```bash
-   docker network create mage-app
-   ```
-
-2. Start MySQL Docker container in a separate window
-
-   ```bash
-   docker run --network mage-app --network-alias mysql_db \
-      -it -p 3306:3306 -e MYSQL_DATABASE=test_database \
-      -e MYSQL_USER=test_username -e MYSQL_PASSWORD=test_password \
-      -e MYSQL_ALLOW_EMPTY_PASSWORD=yes mysql:8.0
-   ```
-
-3. Launch Mage with `MAGE_DATABASE_CONNECTION_URL` environment variable
-
-   ```bash
-   docker run --network mage-app -it -p 6789:6789 -v $(pwd):/home/src \
-      -e MAGE_DATABASE_CONNECTION_URL="mysql+mysqlconnector://test_username:test_password@mysql_db:3306/test_database" \
-      mageai/mageai \
-      /app/run_app.sh mage start [project_name]
-   ```
-
 ### Using MSSQL as database
 
 MSSQL can also be used as the database engine, as shown in the following steps using Docker container:

--- a/docs/production/configuring-production-settings/overview.mdx
+++ b/docs/production/configuring-production-settings/overview.mdx
@@ -33,9 +33,6 @@ To use a specific `schema_name` in PostgreSQL:
 
 `export MAGE_DATABASE_CONNECTION_URL="postgresql+psycopg2://user:password@host:port/dbname?options=-c%%20search_path%%3Dschema_name"`
 
-#### MySQL
-`export MAGE_DATABASE_CONNECTION_URL=mysql+mysqlconnector://user:password@host:port/dbname`
-
 #### MSSQL
 `export MAGE_DATABASE_CONNECTION_URL="mssql+pyodbc://?odbc_connect=DRIVER={ODBC Driver 18 for SQL Server};SERVER=host;DATABASE=dbname;UID=user;PWD=password;ENCRYPT=yes;TrustServerCertificate=yes;"`
 

--- a/docs/production/databases/default.mdx
+++ b/docs/production/databases/default.mdx
@@ -13,8 +13,5 @@ To use a specific `schema_name` in PostgreSQL:
 
 `export MAGE_DATABASE_CONNECTION_URL="postgresql+psycopg2://user:password@host:port/dbname?options=-c%%20search_path%%3Dschema_name"`
 
-## MySQL
-`export MAGE_DATABASE_CONNECTION_URL=mysql+mysqlconnector://user:password@host:port/dbname`
-
 ## MSSQL
 `export MAGE_DATABASE_CONNECTION_URL="mssql+pyodbc://?odbc_connect=DRIVER={ODBC Driver 18 for SQL Server};SERVER=host;DATABASE=dbname;UID=user;PWD=password;ENCRYPT=yes;TrustServerCertificate=yes;"`


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

There are issues with pipeline/block status checking in Mage with MySQL, i.e., SQLAcademy syntax was quite different in MySQL from other databases (SQLite/PostgreSQL/MSSQL), which lead to wrong pipeline/block status checking results, then hanging of pipeline/block executions. Therefore, MySQL is temporarily removed from the list of the supported backend databases.

# Tests
<!-- How did you test your change? -->
CI
cc:
<!-- Optionally mention someone to let them know about this pull request -->
@dy46 @wangxiaoyou1993 