### PR TITLE
Change the table creation into two steps as required by the ClickHouse Cloud

### DIFF
--- a/mage_ai/io/clickhouse.py
+++ b/mage_ai/io/clickhouse.py
@@ -236,7 +236,9 @@ EXISTS TABLE {database}.{table_name}
                 self.client.command(f'USE {database}')
 
                 if should_create_table:
-                    self.client.command(f"""
+                    with self.printer.print_msg(
+                           f'Creating a new table: {database}.{table_name}'):
+                        self.client.command(f"""
 CREATE TABLE IF NOT EXISTS {database}.{table_name} ENGINE = Memory EMPTY AS
 {query_string}
 """)
@@ -254,8 +256,9 @@ INSERT INTO {database}.{table_name}
                             table_name=table_name,
                             database=database,
                         )
-                        self.printer.print_msg(f'Creating a new table: {create_table_stmt}')
-                    self.client.command(create_table_stmt)
+                    with self.printer.print_msg(
+                           f'Creating a new table: {create_table_stmt}'):
+                        self.client.command(create_table_stmt)
 
                 self.client.insert_df(f'{database}.{table_name}', df)
 

--- a/mage_ai/io/clickhouse.py
+++ b/mage_ai/io/clickhouse.py
@@ -237,11 +237,11 @@ EXISTS TABLE {database}.{table_name}
 
                 if should_create_table:
                     self.client.command(f"""
-CREATE TABLE IF NOT EXISTS {database}.{table_name} ENGINE = Memory AS
+CREATE TABLE IF NOT EXISTS {database}.{table_name} ENGINE = Memory EMPTY AS
 {query_string}
 """)
-                else:
-                    self.client.command(f"""
+
+                self.client.command(f"""
 INSERT INTO {database}.{table_name}
 {query_string}
 """)


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->

When running the following SQL statement on the ClickHouse Cloud, it threw exceptions:
```
clickhouse-cloud :) CREATE TABLE IF NOT EXISTS test_002 ENGINE = Memory AS select * from insert_select_testtable;

CREATE TABLE IF NOT EXISTS helloworld_2.test_002
ENGINE = Memory AS
SELECT *
FROM insert_select_testtable

Query id: 900ee1d8-ed25-4c44-b4b2-bb21dceb6350


0 rows in set. Elapsed: 0.169 sec. 

Received exception from server (version 23.8.1):
Code: 344. DB::Exception: Received from fadpvrevk3.us-west-2.aws.clickhouse.cloud:9440. DB::Exception: CREATE AS SELECT is not supported with Replicated databases. Use separate CREATE and INSERT queries. (SUPPORT_IS_DISABLED)
```

Thus the following 2-step procedure is used instead to work-around this issue:

1. Create an empty table:
```
CREATE TABLE IF NOT EXISTS helloworld_2.test_002
ENGINE = Memory 
EMPTY AS
SELECT *
FROM insert_select_testtable
```
2. Insert data into the empty table with the SELECT statement.
```
INSERT INTO helloworld_2.test_002
SELECT *
FROM insert_select_testtable
```

# Tests
<!-- How did you test your change? -->
It has been tested against the ClickHouse Cloud, and the destination table has been created without issues:
<img width="1148" alt="Screenshot 2023-08-05 at 4 17 42 PM" src="https://github.com/mage-ai/mage-ai/assets/42320565/e3d34e8c-4447-418f-9e33-b11f508cabaa">

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@dy46 @wangxiaoyou1993 