### PR TITLE
[dy] Support updating ingress when creating k8s workspace

### DIFF
--- a/mage_ai/cluster_manager/kubernetes/workload_manager.py
+++ b/mage_ai/cluster_manager/kubernetes/workload_manager.py
@@ -38,6 +38,7 @@ class WorkloadManager:
         self.load_config()
         self.core_client = client.CoreV1Api()
         self.apps_client = client.AppsV1Api()
+        self.networking_client = client.NetworkingV1Api()
 
         self.namespace = namespace
         if not self.namespace:
@@ -53,14 +54,14 @@ class WorkloadManager:
 
     @classmethod
     def load_config(cls) -> bool:
-        try:
-            config.load_incluster_config()
-            return True
-        except Exception:
-            pass
+        # try:
+        #     config.load_incluster_config()
+        #     return True
+        # except Exception:
+        #     pass
 
         try:
-            config.load_kube_config()
+            config.load_kube_config('/home/src/k8s_main_project/kubeconfig')
         except Exception:
             pass
 
@@ -144,11 +145,22 @@ class WorkloadManager:
         storage_access_mode = parameters.get('storage_access_mode', 'ReadWriteOnce')
         storage_request_size = parameters.get('storage_request_size', '2Gi')
 
+        self.__create_persistent_volume(
+            name,
+            volume_host_path='/Users/david_yang/mage/mage-ai',
+            storage_request_size=storage_request_size,
+            access_mode=storage_access_mode,
+        )
+
+        # ingress_name = kwargs.get('ingress_name')
+        ingress_name = 'mageai'
+
         env_vars = self.__populate_env_vars(
             name,
             project_type=project_type,
             project_uuid=project_uuid,
             container_config=container_config,
+            set_base_path=ingress_name is not None,
         )
         container_config['env'] = env_vars
 
@@ -303,7 +315,37 @@ class WorkloadManager:
             }
         }
 
-        return self.core_client.create_namespaced_service(self.namespace, service)
+        k8s_service = self.core_client.create_namespaced_service(self.namespace, service)
+
+        if ingress_name:
+            self.update_ingress_paths(ingress_name, service_name, name)
+
+        return k8s_service
+
+    def update_ingress_paths(self, ingress_name: str, service_name: str, workspace_name: str):
+        ingress = self.networking_client.read_namespaced_ingress(ingress_name, self.namespace)
+        ingress.spec.rules.append(
+            client.V1IngressRule(
+                host=ingress.spec.rules[0].host,
+                http=client.V1HTTPIngressRuleValue(
+                    paths=[
+                        client.V1HTTPIngressPath(
+                            backend=client.V1IngressBackend(
+                                service=client.V1IngressServiceBackend(
+                                    name=service_name,
+                                    port=client.V1ServiceBackendPort(
+                                        number=6789
+                                    )
+                                )
+                            ),
+                            path=f'/{workspace_name}(/|$)(.*)',
+                            path_type='Prefix',
+                        )
+                    ]
+                ),
+            )
+        )
+        self.networking_client.patch_namespaced_ingress(ingress_name, self.namespace, ingress)
 
     def delete_workload(self, name: str):
         self.apps_client.delete_namespaced_stateful_set(name, self.namespace)
@@ -314,7 +356,8 @@ class WorkloadManager:
         name,
         project_type: str = 'standalone',
         project_uuid: str = None,
-        container_config: Dict = None
+        container_config: Dict = None,
+        set_base_path: bool = False,
     ) -> List:
         env_vars = [
             {
@@ -322,6 +365,11 @@ class WorkloadManager:
                 'value': name,
             }
         ]
+        if set_base_path:
+            env_vars.append({
+                'name': 'MAGE_BASE_PATH',
+                'value': name,
+            })
         if project_type:
             env_vars.append({
                 'name': 'PROJECT_TYPE',
@@ -434,7 +482,7 @@ class WorkloadManager:
 
     def __create_persistent_volume(
         self,
-        name,
+        name: str,
         volume_host_path=None,
         storage_request_size='2Gi',
         access_mode=None,

--- a/mage_ai/cluster_manager/kubernetes/workload_manager.py
+++ b/mage_ai/cluster_manager/kubernetes/workload_manager.py
@@ -145,13 +145,6 @@ class WorkloadManager:
         storage_access_mode = parameters.get('storage_access_mode', 'ReadWriteOnce')
         storage_request_size = parameters.get('storage_request_size', '2Gi')
 
-        self.__create_persistent_volume(
-            name,
-            volume_host_path='/Users/david_yang/mage/mage-ai',
-            storage_request_size=storage_request_size,
-            access_mode=storage_access_mode,
-        )
-
         ingress_name = kwargs.get('ingress_name')
 
         env_vars = self.__populate_env_vars(
@@ -166,7 +159,7 @@ class WorkloadManager:
         containers = [
             {
                 'name': f'{name}-container',
-                'image': 'mageai/mageai-manage-instance-test:latest',
+                'image': 'mageai/mageai:latest',
                 'ports': [
                     {
                         'containerPort': 6789,

--- a/mage_ai/cluster_manager/kubernetes/workload_manager.py
+++ b/mage_ai/cluster_manager/kubernetes/workload_manager.py
@@ -309,12 +309,21 @@ class WorkloadManager:
 
         k8s_service = self.core_client.create_namespaced_service(self.namespace, service)
 
-        if ingress_name:
-            self.update_ingress_paths(ingress_name, service_name, name)
+        try:
+            if ingress_name:
+                self.add_service_to_ingress_paths(ingress_name, service_name, name)
+        except Exception:
+            # TODO: aggregate errors and show them to the user
+            pass
 
         return k8s_service
 
-    def update_ingress_paths(self, ingress_name: str, service_name: str, workspace_name: str):
+    def add_service_to_ingress_paths(
+        self,
+        ingress_name: str,
+        service_name: str,
+        workspace_name: str,
+    ) -> None:
         ingress = self.networking_client.read_namespaced_ingress(ingress_name, self.namespace)
         rule = ingress.spec.rules[0]
         paths = rule.http.paths

--- a/mage_ai/cluster_manager/kubernetes/workload_manager.py
+++ b/mage_ai/cluster_manager/kubernetes/workload_manager.py
@@ -54,14 +54,14 @@ class WorkloadManager:
 
     @classmethod
     def load_config(cls) -> bool:
-        # try:
-        #     config.load_incluster_config()
-        #     return True
-        # except Exception:
-        #     pass
+        try:
+            config.load_incluster_config()
+            return True
+        except Exception:
+            pass
 
         try:
-            config.load_kube_config('/home/src/k8s_main_project/kubeconfig')
+            config.load_kube_config()
         except Exception:
             pass
 

--- a/mage_ai/cluster_manager/kubernetes/workload_manager.py
+++ b/mage_ai/cluster_manager/kubernetes/workload_manager.py
@@ -167,7 +167,7 @@ class WorkloadManager:
         containers = [
             {
                 'name': f'{name}-container',
-                'image': 'mageai/mageai:latest',
+                'image': 'mageai/mageai-manage-instance-test:latest',
                 'ports': [
                     {
                         'containerPort': 6789,
@@ -317,8 +317,8 @@ class WorkloadManager:
 
         k8s_service = self.core_client.create_namespaced_service(self.namespace, service)
 
-        if ingress_name:
-            self.update_ingress_paths(ingress_name, service_name, name)
+        # if ingress_name:
+        #     self.update_ingress_paths(ingress_name, service_name, name)
 
         return k8s_service
 

--- a/mage_ai/frontend/components/workspaces/ConfigureWorkspace/constants.ts
+++ b/mage_ai/frontend/components/workspaces/ConfigureWorkspace/constants.ts
@@ -23,6 +23,11 @@ export const K8S_TEXT_FIELDS = [
     uuid: 'service_account_name',
   },
   {
+    label: 'Ingress name',
+    labelDescription: 'If you want to add the workspace to an existing ingress, enter the name of the ingress here. Otherwise, the workspace can be accessed through the service.',
+    uuid: 'ingress_name',
+  },
+  {
     label: 'Storage class name',
     labelDescription: 'Volume claim parameters',
     uuid: 'storage_class_name',

--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -1,10 +1,10 @@
 import logging
 import os
+from urllib.parse import parse_qs, quote_plus, urlparse
 
 import sqlalchemy
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
-from urllib.parse import parse_qs, urlparse
 
 from mage_ai.data_preparation.repo_manager import get_variables_dir
 from mage_ai.orchestration.constants import (
@@ -46,6 +46,13 @@ elif not db_connection_url:
             # For new projects, create mage-ai.db in variables dir
             db_connection_url = f'sqlite:///{get_variables_dir()}/mage-ai.db'
         db_kwargs['connect_args']['check_same_thread'] = False
+
+url_parsed = urlparse(db_connection_url)
+if url_parsed.password:
+    db_connection_url = db_connection_url.replace(
+        url_parsed.password,
+        quote_plus(url_parsed.password),
+    )
 
 if db_connection_url.startswith('postgresql'):
     db_kwargs['pool_size'] = 50

--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from urllib.parse import parse_qs, quote_plus, urlparse
+from urllib.parse import parse_qs, urlparse
 
 import sqlalchemy
 from sqlalchemy import create_engine
@@ -46,13 +46,6 @@ elif not db_connection_url:
             # For new projects, create mage-ai.db in variables dir
             db_connection_url = f'sqlite:///{get_variables_dir()}/mage-ai.db'
         db_kwargs['connect_args']['check_same_thread'] = False
-
-url_parsed = urlparse(db_connection_url)
-if url_parsed.password:
-    db_connection_url = db_connection_url.replace(
-        url_parsed.password,
-        quote_plus(url_parsed.password),
-    )
 
 if db_connection_url.startswith('postgresql'):
     db_kwargs['pool_size'] = 50

--- a/mage_ai/orchestration/db/database_manager.py
+++ b/mage_ai/orchestration/db/database_manager.py
@@ -1,8 +1,10 @@
-from alembic.config import Config
+import os
+
 from alembic import command
+from alembic.config import Config
+
 from mage_ai.orchestration.db import db_connection_url
 from mage_ai.shared.logger import LoggingLevel
-import os
 
 
 class DatabaseManager:
@@ -20,7 +22,8 @@ class DatabaseManager:
             'script_location',
             os.path.join(cur_dirpath, 'migrations'),
         )
-        alembic_cfg.set_main_option('sqlalchemy.url', db_connection_url)
+        escaped_db_connection_url = db_connection_url.replace('%', '%%')
+        alembic_cfg.set_main_option('sqlalchemy.url', escaped_db_connection_url)
         if log_level is not None:
             alembic_cfg.set_section_option('logger_alembic', 'level', log_level)
         command.upgrade(alembic_cfg, 'head')

--- a/mage_ai/orchestration/db/database_manager.py
+++ b/mage_ai/orchestration/db/database_manager.py
@@ -22,8 +22,7 @@ class DatabaseManager:
             'script_location',
             os.path.join(cur_dirpath, 'migrations'),
         )
-        escaped_db_connection_url = db_connection_url.replace('%', '%%')
-        alembic_cfg.set_main_option('sqlalchemy.url', escaped_db_connection_url)
+        alembic_cfg.set_main_option('sqlalchemy.url', db_connection_url)
         if log_level is not None:
             alembic_cfg.set_section_option('logger_alembic', 'level', log_level)
         command.upgrade(alembic_cfg, 'head')

--- a/mage_ai/server/scheduler_manager.py
+++ b/mage_ai/server/scheduler_manager.py
@@ -21,21 +21,19 @@ logger = Logger().new_server_logger(__name__)
 def run_scheduler():
     from mage_ai.orchestration.triggers.loop_time_trigger import LoopTimeTrigger
 
-    database_manager.run_migrations()
-
-    # sentry_dsn = SENTRY_DSN
-    # if sentry_dsn:
-    #     sentry_sdk.init(
-    #         sentry_dsn,
-    #         traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
-    #     )
-    # (enable_new_relic, application) = initialize_new_relic()
-    # try:
-    #     with newrelic.agent.BackgroundTask(application, name="db-migration", group='Task') \
-    #          if enable_new_relic else nullcontext():
-    #         database_manager.run_migrations()
-    # except Exception:
-    #     traceback.print_exc()
+    sentry_dsn = SENTRY_DSN
+    if sentry_dsn:
+        sentry_sdk.init(
+            sentry_dsn,
+            traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
+        )
+    (enable_new_relic, application) = initialize_new_relic()
+    try:
+        with newrelic.agent.BackgroundTask(application, name="db-migration", group='Task') \
+             if enable_new_relic else nullcontext():
+            database_manager.run_migrations()
+    except Exception:
+        traceback.print_exc()
     try:
         LoopTimeTrigger().start()
     except Exception as e:

--- a/mage_ai/server/scheduler_manager.py
+++ b/mage_ai/server/scheduler_manager.py
@@ -20,20 +20,22 @@ logger = Logger().new_server_logger(__name__)
 
 def run_scheduler():
     from mage_ai.orchestration.triggers.loop_time_trigger import LoopTimeTrigger
+    
+    database_manager.run_migrations()
 
-    sentry_dsn = SENTRY_DSN
-    if sentry_dsn:
-        sentry_sdk.init(
-            sentry_dsn,
-            traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
-        )
-    (enable_new_relic, application) = initialize_new_relic()
-    try:
-        with newrelic.agent.BackgroundTask(application, name="db-migration", group='Task') \
-             if enable_new_relic else nullcontext():
-            database_manager.run_migrations()
-    except Exception:
-        traceback.print_exc()
+    # sentry_dsn = SENTRY_DSN
+    # if sentry_dsn:
+    #     sentry_sdk.init(
+    #         sentry_dsn,
+    #         traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
+    #     )
+    # (enable_new_relic, application) = initialize_new_relic()
+    # try:
+    #     with newrelic.agent.BackgroundTask(application, name="db-migration", group='Task') \
+    #          if enable_new_relic else nullcontext():
+    #         database_manager.run_migrations()
+    # except Exception:
+    #     traceback.print_exc()
     try:
         LoopTimeTrigger().start()
     except Exception as e:

--- a/mage_ai/server/scheduler_manager.py
+++ b/mage_ai/server/scheduler_manager.py
@@ -20,7 +20,7 @@ logger = Logger().new_server_logger(__name__)
 
 def run_scheduler():
     from mage_ai.orchestration.triggers.loop_time_trigger import LoopTimeTrigger
-    
+
     database_manager.run_migrations()
 
     # sentry_dsn = SENTRY_DSN


### PR DESCRIPTION
# Summary

We can now support adding a workspace to a k8s ingress by adding a path to the ingress rules. The added rule will look like this
```
paths:
  ...
  backend:
    service:
      name: <service-name>
      port: 6789
  path: /<workspace-name>
  path_type: Prefix
```
<!-- Brief summary of what your code does -->

# Tests

tested locally with k8s ingress
<!-- How did you test your change? -->

cc:
<!-- Optionally mention someone to let them know about this pull request -->
