### PR TITLE
[dy] Fix variables dir construction

### DIFF
--- a/mage_ai/data_preparation/repo_manager.py
+++ b/mage_ai/data_preparation/repo_manager.py
@@ -259,20 +259,22 @@ def get_variables_dir(
     variables_dir = None
     if os.getenv(MAGE_DATA_DIR_ENV_VAR):
         variables_dir = os.getenv(MAGE_DATA_DIR_ENV_VAR)
-    elif repo_config is not None:
-        variables_dir = repo_config.get('variables_dir')
     else:
-        from mage_ai.data_preparation.shared.utils import get_template_vars_no_db
-        if os.path.exists(get_metadata_path()):
-            with open(get_metadata_path(), 'r', encoding='utf-8') as f:
-                config_file = Template(f.read()).render(
-                    **get_template_vars_no_db()
-                )
-                repo_config = yaml.full_load(config_file) or {}
-                if repo_config.get('variables_dir'):
-                    variables_dir = os.path.expanduser(repo_config.get('variables_dir'))
-    if variables_dir is None:
-        variables_dir = DEFAULT_MAGE_DATA_DIR
+        if repo_config is not None:
+            variables_dir = repo_config.get('variables_dir')
+        else:
+            from mage_ai.data_preparation.shared.utils import get_template_vars_no_db
+            if os.path.exists(get_metadata_path()):
+                with open(get_metadata_path(), 'r', encoding='utf-8') as f:
+                    config_file = Template(f.read()).render(
+                        **get_template_vars_no_db()
+                    )
+                    repo_config = yaml.full_load(config_file) or {}
+                    if repo_config.get('variables_dir'):
+                        variables_dir = repo_config.get('variables_dir')
+        if variables_dir is None:
+            variables_dir = DEFAULT_MAGE_DATA_DIR
+        variables_dir = os.path.expanduser(variables_dir)
 
     if not variables_dir.startswith('s3'):
         if os.path.isabs(variables_dir) and variables_dir != repo_path:

--- a/mage_ai/tests/data_preparation/test_repo_manager.py
+++ b/mage_ai/tests/data_preparation/test_repo_manager.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import uuid
 
 import yaml
 
@@ -27,7 +28,7 @@ class RepoManagerTest(DBTestCase):
             variables_dir='variables_dir_from_metadata',
         )
         test_repo_path = os.path.join(self.repo_path, 'repo_manager_test')
-        os.makedirs(test_repo_path)
+        os.makedirs(test_repo_path, exist_ok=True)
         with open(os.path.join(test_repo_path, 'metadata.yaml'), 'w') as f:
             yaml.dump(metadata_dict, f)
         test2 = RepoConfig(repo_path=test_repo_path)
@@ -37,13 +38,6 @@ class RepoManagerTest(DBTestCase):
         )
         shutil.rmtree(test2.variables_dir)
 
-        test3 = RepoConfig(repo_path=os.path.join(self.repo_path, 'non_existing_path'))
-        self.assertEqual(
-            test3.variables_dir,
-            os.path.join(self.repo_path, 'non_existing_path')
-        )
-        shutil.rmtree(test3.variables_dir)
-
         os.environ[MAGE_DATA_DIR_ENV_VAR] = 'variables_dir_from_env_var'
         test4 = RepoConfig(repo_path=self.repo_path)
         self.assertEqual(
@@ -52,3 +46,28 @@ class RepoManagerTest(DBTestCase):
         )
         del os.environ[MAGE_DATA_DIR_ENV_VAR]
         shutil.rmtree(test4.variables_dir)
+
+    def test_variables_dir_default(self):
+        test = RepoConfig(repo_path=os.path.join(self.repo_path, 'non_existing_path'))
+        self.assertEqual(
+            test.variables_dir,
+            os.path.join(self.repo_path, 'non_existing_path')
+        )
+        shutil.rmtree(test.variables_dir)
+
+    def test_variables_dir_expanduser(self):
+        dir_name = uuid.uuid4().hex
+        metadata_dict = dict(
+            variables_dir=f'~/{dir_name}',
+        )
+        test_repo_path = os.path.join(self.repo_path, 'repo_manager_test')
+        os.makedirs(test_repo_path, exist_ok=True)
+        with open(os.path.join(test_repo_path, 'metadata.yaml'), 'w') as f:
+            yaml.dump(metadata_dict, f)
+        test = RepoConfig(repo_path=test_repo_path)
+        self.assertEqual(
+            test.variables_dir,
+            os.path.expanduser(os.path.join(f'~/{dir_name}', 'repo_manager_test'))
+        )
+        test_dir = os.path.expanduser(f'~/{dir_name}')
+        shutil.rmtree(test_dir)


### PR DESCRIPTION
# Summary

Call `os.expanduser` on the variables dir when it comes from the project metadata or the default path.
<!-- Brief summary of what your code does -->

# Tests

tested locally
<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
