### PR TITLE
[jk] Fix infinite rendering loop in SchemaTable

### DIFF
--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
@@ -146,9 +146,11 @@ function SchemaTable({
         [streamUUID]: bookmarkValuesInit,
       }));
     }
+  // The bookmarkValues dependency is not included below in the dep array
+  // because it would cause an infinite rendering loop.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     bookmarkProperties?.length,
-    bookmarkValues,
     bookmarkValuesInit,
     streamUUID,
   ]);


### PR DESCRIPTION
# Summary
- See title.

# Tests
- Ran integration pipeline with manually set bookmark value and confirmed destination contained values starting from that bookmark value.
- Bookmark values can be edited properly now:
![bookmark values](https://github.com/mage-ai/mage-ai/assets/78053898/a1357ecd-76d3-4392-83aa-97c3840b58cb)

Fixes https://github.com/mage-ai/mage-ai/issues/3153