### PR TITLE
[jk] Fix log detail metrics object rendering issue

### DIFF
--- a/mage_ai/frontend/components/Logs/Detail/index.tsx
+++ b/mage_ai/frontend/components/Logs/Detail/index.tsx
@@ -159,6 +159,13 @@ function LogDetail({
               valueTitle = JSON.stringify(JSON.parse(v), null, 2);
               valueToDisplay = <pre>{valueTitle}</pre>;
             }
+            if (typeof valueToDisplay === 'object') {
+              valueToDisplay = JSON.stringify(valueToDisplay, null, 2);
+              valueToDisplay = <pre>{valueToDisplay}</pre>;
+            }
+            if (typeof valueTitle === 'object') {
+              valueTitle = JSON.stringify(valueTitle);
+            }
 
             return [
               <Text

--- a/mage_ai/frontend/components/Logs/Table/index.tsx
+++ b/mage_ai/frontend/components/Logs/Table/index.tsx
@@ -12,6 +12,7 @@ import LogType from '@interfaces/LogType';
 import PipelineType, { PipelineTypeEnum } from '@interfaces/PipelineType';
 import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
+import usePrevious from '@utils/usePrevious';
 
 import { ChevronRight } from '@oracle/icons';
 import { FilterQueryType } from '@components/Logs/Filter';
@@ -59,13 +60,15 @@ function LogsTable({
     [pipeline.type],
   );
 
+  const logsPrev = usePrevious(logs);
   useEffect(() => {
-    if (autoScrollLogs) {
+    if (autoScrollLogs && (logsPrev || []).length !== (logs || []).length) {
       tableInnerRef?.current?.scrollIntoView(false);
     }
   }, [
     autoScrollLogs,
     logs,
+    logsPrev,
     tableInnerRef,
   ]);
 

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -411,7 +411,7 @@ function PipelineLogsPage({
           <Spacing mr={1} />
 
           <Flex>
-            <Text>
+            <Text noWrapping>
               Auto-scroll to new logs
             </Text>
             <Spacing mr={1} />


### PR DESCRIPTION
# Summary
- When clicking on certain logs that have metrics in the log detail, app will crash if the metrics is a javascript object (React cannot have a js object as the child of a React component).
- Fixed issue with logs scrolling to bottom any time an individual log was clicked and "Auto-scroll to bottom of logs" setting turned on.

# Tests
Metrics property rendering properly in the log detail panel: 
![image](https://github.com/mage-ai/mage-ai/assets/78053898/615d99dc-cf85-4b73-ba07-2c13f05158f9)
