### PR TITLE
[td] Fix dbt snowflake when password null

### DIFF
--- a/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
@@ -579,11 +579,11 @@ def config_file_loader_and_configuration(
             SNOWFLAKE_ROLE=profile.get('role'),
         )
 
-        if 'password' in profile:
+        if profile.get('password', None):
             config['SNOWFLAKE_PASSWORD'] = profile['password']
-        if 'private_key_passphrase' in profile:
+        if profile.get('private_key_passphrase', None):
             config['SNOWFLAKE_PRIVATE_KEY_PASSPHRASE'] = profile['private_key_passphrase']
-        if 'private_key_path' in profile:
+        if profile.get('private_key_path', None):
             config['SNOWFLAKE_PRIVATE_KEY_PATH'] = profile['private_key_path']
 
         config_file_loader = ConfigFileLoader(config=config)


### PR DESCRIPTION
# Description
When using Key Pair authentication with dbt and Snowflake, if the `password` key in the `profiles.yml` is present but the value is null or empty, an error occurs:

![image](https://github.com/mage-ai/mage-ai/assets/1066980/2f6aa44b-7ef0-47e9-9a46-9d4f6e2449ed)


# How Has This Been Tested?

- [x] Use the key pair authentication method for dbt Snowflake: https://docs.getdbt.com/docs/core/connect-data-platform/snowflake-setup
- [x] Add the `password` key with a null value
- [x] Run a dbt model block
- [x] An error will occur


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
