### PR TITLE
[td] Add global data product block to add block v1

### DIFF
--- a/mage_ai/frontend/components/GlobalDataProductDetail/SettingsField.tsx
+++ b/mage_ai/frontend/components/GlobalDataProductDetail/SettingsField.tsx
@@ -76,7 +76,7 @@ function OutdatedStartingAtField({
 
           const setSelected = (value: boolean) => {
             setObjectAttributes(prev => {
-              const settingsPrev = prev?.settings;
+              const settingsPrev = prev?.settings || {};
 
               if (value) {
                 settingsPrev[uuid] = {};

--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
@@ -10,7 +10,7 @@ import KeyboardShortcutButton from '@oracle/elements/Button/KeyboardShortcutButt
 import PipelineType, { PipelineTypeEnum } from '@interfaces/PipelineType';
 import ProjectType, { FeatureUUIDEnum } from '@interfaces/ProjectType';
 import Tooltip from '@oracle/components/Tooltip';
-import { Add, Sensor as SensorIcon } from '@oracle/icons';
+import { Add, HexagonAll, Sensor as SensorIcon } from '@oracle/icons';
 import { AxisEnum } from '@interfaces/ActionPayloadType';
 import {
   BlockLanguageEnum,
@@ -622,6 +622,36 @@ function AddNewBlocks({
                   uuid="AddNewBlocks/Scratchpad"
                 >
                   Scratchpad
+                </KeyboardShortcutButton>
+              </Tooltip>
+            </ButtonWrapper>
+          )}
+
+          {!hideScratchpad && (
+            <ButtonWrapper>
+              <Tooltip
+                block
+                label="Add a global data product block"
+                maxWidth={MAX_TOOLTIP_WIDTH}
+                size={null}
+              >
+                <KeyboardShortcutButton
+                  {...sharedProps}
+                  beforeElement={
+                    <IconContainerStyle compact={compact}>
+                      <HexagonAll size={iconSize} />
+                    </IconContainerStyle>
+                  }
+                  onClick={(e) => {
+                    e.preventDefault();
+                    showGlobalDataProducts({
+                      // @ts-ignore
+                      addNewBlock,
+                    });
+                  }}
+                  uuid="AddNewBlocks/GlobalDataProducts"
+                >
+                  Global data product
                 </KeyboardShortcutButton>
               </Tooltip>
             </ButtonWrapper>

--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/v2/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/v2/index.tsx
@@ -413,19 +413,19 @@ function AddNewBlocksV2({
       label: () => BLOCK_TYPE_NAME_MAPPING[BlockTypeEnum.DBT],
       uuid: BlockTypeEnum.DBT,
     },
-    // {
-    //   beforeIcon: (
-    //     <HexagonAll
-    //       size={ICON_SIZE}
-    //     />
-    //   ),
-    //   label: () => BLOCK_TYPE_NAME_MAPPING[BlockTypeEnum.GLOBAL_DATA_PRODUCT],
-    //   onClick: () => showGlobalDataProducts({
-    //     // @ts-ignore
-    //     addNewBlock,
-    //   }),
-    //   uuid: BlockTypeEnum.GLOBAL_DATA_PRODUCT,
-    // },
+    {
+      beforeIcon: (
+        <HexagonAll
+          size={ICON_SIZE}
+        />
+      ),
+      label: () => BLOCK_TYPE_NAME_MAPPING[BlockTypeEnum.GLOBAL_DATA_PRODUCT],
+      onClick: () => showGlobalDataProducts({
+        // @ts-ignore
+        addNewBlock,
+      }),
+      uuid: BlockTypeEnum.GLOBAL_DATA_PRODUCT,
+    },
     {
       isGroupingTitle: true,
       label: () => 'Custom templates',


### PR DESCRIPTION
# Description
Adding a global data product block was available in the v2 flow of adding block.

This change enables this block for v1.


# How Has This Been Tested?
<img width="725" alt="image" src="https://github.com/mage-ai/mage-ai/assets/1066980/9cfabe16-611c-4027-8295-316ee7bc49b3">


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
