### PR TITLE
[xy] Fix EMR pyspark kernel permission error

### DIFF
--- a/mage_ai/data_preparation/repo_manager.py
+++ b/mage_ai/data_preparation/repo_manager.py
@@ -286,7 +286,10 @@ def get_variables_dir(
             variables_dir = os.path.abspath(
                 os.path.join(repo_path, variables_dir),
             )
-        os.makedirs(variables_dir, exist_ok=True)
+        try:
+            os.makedirs(variables_dir, exist_ok=True)
+        except Exception:
+            traceback.print_exc()
     return variables_dir
 
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix exception
```
An error was encountered:
[Errno 13] Permission denied: '/home/.mage_data'
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/mage_ai/orchestration/db/__init__.py", line 48, in <module>
    db_connection_url = f'sqlite:///{get_variables_dir()}/mage-ai.db'
  File "/usr/local/lib/python3.7/site-packages/mage_ai/data_preparation/repo_manager.py", line 287, in get_variables_dir
    os.makedirs(variables_dir, exist_ok=True)
  File "/usr/lib64/python3.7/os.py", line 213, in makedirs
    makedirs(head, exist_ok=exist_ok)
  File "/usr/lib64/python3.7/os.py", line 223, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '/home/.mage_data
```
When executing code on EMR via pyspark kernel, we don't use DB. So catch the exception of creating dir.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested running PySpark kernel and execute the block locally
<img width="813" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/92370475-75cd-4dd0-a3b0-5fa4435d72cb">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
