### PR TITLE
[jk] Block run and pipeline run start/completion times in UTC

### DIFF
--- a/mage_ai/api/resources/BackfillResource.py
+++ b/mage_ai/api/resources/BackfillResource.py
@@ -1,11 +1,13 @@
 from datetime import datetime
+
+import pytz
+from sqlalchemy import desc
+
 from mage_ai.api.resources.DatabaseResource import DatabaseResource
-from mage_ai.orchestration.backfills.service import start_backfill, cancel_backfill
+from mage_ai.orchestration.backfills.service import cancel_backfill, start_backfill
 from mage_ai.orchestration.db import safe_db_query
 from mage_ai.orchestration.db.models.schedules import Backfill
 from mage_ai.shared.hash import extract, merge_dict
-from sqlalchemy import desc
-import pytz
 
 ALLOWED_PAYLOAD_KEYS = [
     'block_uuid',

--- a/mage_ai/api/resources/BackfillResource.py
+++ b/mage_ai/api/resources/BackfillResource.py
@@ -5,6 +5,7 @@ from mage_ai.orchestration.db import safe_db_query
 from mage_ai.orchestration.db.models.schedules import Backfill
 from mage_ai.shared.hash import extract, merge_dict
 from sqlalchemy import desc
+import pytz
 
 ALLOWED_PAYLOAD_KEYS = [
     'block_uuid',
@@ -51,7 +52,7 @@ class BackfillResource(DatabaseResource):
             if Backfill.Status.INITIAL == payload['status']:
                 pipeline_runs += start_backfill(self.model)
                 return super().update(dict(
-                    started_at=datetime.now(),
+                    started_at=datetime.now(tz=pytz.UTC),
                     status=payload['status'],
                 ))
             elif Backfill.Status.CANCELLED == payload['status']:

--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -20,7 +20,6 @@ import BlockType, {
   StatusTypeEnum,
 } from '@interfaces/BlockType';
 import FlexContainer from '@oracle/components/FlexContainer';
-import GraphNode from './GraphNode';
 import KernelOutputType  from '@interfaces/KernelOutputType';
 import KeyboardShortcutButton from '@oracle/elements/Button/KeyboardShortcutButton';
 import PipelineType, { PipelineTypeEnum } from '@interfaces/PipelineType';
@@ -41,7 +40,6 @@ import { ThemeType } from '@oracle/styles/themes/constants';
 import {
   PADDING_UNITS,
   UNIT,
-  WIDTH_OF_SINGLE_CHARACTER_SMALL,
 } from '@oracle/styles/units/spacing';
 import { find, indexBy, removeAtIndex } from '@utils/array';
 import { getBlockNodeHeight, getBlockNodeWidth } from './BlockNode/utils';
@@ -54,7 +52,6 @@ import {
 import { getModelAttributes } from '@utils/models/dbt';
 import { isActivePort } from './utils';
 import { onSuccess } from '@api/utils/response';
-import { useDynamicUpstreamBlocks } from '@utils/models/block';
 
 const Canvas = dynamic(
   async () => {

--- a/mage_ai/frontend/components/Triggers/Detail/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Detail/index.tsx
@@ -13,8 +13,9 @@ import Paginate from '@components/shared/Paginate';
 import PipelineDetailPage from '@components/PipelineDetailPage';
 import PipelineRunsTable from '@components/PipelineDetail/Runs/Table';
 import PipelineRunType, {
-  PipelineRunReqQueryParamsType,
+  PIPELINE_RUN_STATUSES,
   RUN_STATUS_TO_LABEL,
+  PipelineRunReqQueryParamsType,
  } from '@interfaces/PipelineRunType';
 import PipelineScheduleType, {
   SCHEDULE_TYPE_TO_LABEL,
@@ -857,7 +858,7 @@ function TriggerDetail({
             <option key="all_statuses" value="all">
               All statuses
             </option>
-            {Object.values(RunStatusEnum).map(status => (
+            {PIPELINE_RUN_STATUSES.map(status => (
               <option key={status} value={status}>
                 {RUN_STATUS_TO_LABEL[status]}
               </option>

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -556,7 +556,7 @@ class PipelineRun(BaseModel):
     @safe_db_query
     def complete(self):
         self.update(
-            completed_at=datetime.now(),
+            completed_at=datetime.now(tz=pytz.UTC),
             status=self.PipelineRunStatus.COMPLETED,
         )
 

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -246,7 +246,7 @@ class PipelineSchedule(BaseModel):
 
     @safe_db_query
     def should_schedule(self, previous_runtimes: List[int] = None) -> bool:
-        now = datetime.now()
+        now = datetime.now(tz=pytz.UTC)
 
         if self.status != ScheduleStatus.ACTIVE:
             return False

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -213,7 +213,7 @@ class PipelineScheduler:
                         if all([PipelineRun.PipelineRunStatus.COMPLETED == pr.status
                                 for pr in backfill.pipeline_runs]):
                             backfill.update(
-                                completed_at=datetime.now(),
+                                completed_at=datetime.now(tz=pytz.UTC),
                                 status=Backfill.Status.COMPLETED,
                             )
                             schedule.update(
@@ -247,7 +247,7 @@ class PipelineScheduler:
         def update_status():
             block_run.update(
                 status=BlockRun.BlockRunStatus.COMPLETED,
-                completed_at=datetime.now(),
+                completed_at=datetime.now(tz=pytz.UTC),
             )
 
         update_status()
@@ -281,7 +281,7 @@ class PipelineScheduler:
         def update_status():
             block_run.update(
                 status=BlockRun.BlockRunStatus.COMPLETED,
-                completed_at=datetime.now(),
+                completed_at=datetime.now(tz=pytz.UTC),
             )
 
         update_status()

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -186,7 +186,7 @@ class PipelineScheduler:
                 if self.pipeline_run.any_blocks_failed():
                     self.pipeline_run.update(
                         status=PipelineRun.PipelineRunStatus.FAILED,
-                        completed_at=datetime.now(),
+                        completed_at=datetime.now(tz=pytz.UTC),
                     )
                     self.notification_sender.send_pipeline_run_failure_message(
                         pipeline=self.pipeline,
@@ -924,7 +924,7 @@ def run_integration_stream(
                 return
 
             block_run.update(
-                started_at=datetime.now(),
+                started_at=datetime.now(tz=pytz.UTC),
                 status=BlockRun.BlockRunStatus.RUNNING,
             )
             pipeline_scheduler.logger.info(
@@ -1015,7 +1015,7 @@ def run_block(
         return {}
 
     block_run.update(
-        started_at=datetime.now(),
+        started_at=datetime.now(tz=pytz.UTC),
         status=BlockRun.BlockRunStatus.RUNNING,
     )
 
@@ -1464,7 +1464,7 @@ def schedule_with_event(event: Dict = None):
 
         for p in matched_pipeline_schedules:
             payload = dict(
-                execution_date=datetime.now(),
+                execution_date=datetime.now(tz=pytz.UTC),
                 pipeline_schedule_id=p.id,
                 pipeline_uuid=p.pipeline_uuid,
                 variables=merge_dict(p.variables or dict(), dict(event=event)),


### PR DESCRIPTION
# Description
- If the timezone setting on a VM or Docker container running Mage was changed from UTC (which Mage uses across the app), the block and pipeline run completion times would be set in that timezone, although the start times were still in UTC. This caused confusion as a run could seem like it took a lot longer than it actually did. For example, if the timezone was set to UTC+3 (3 hours ahead of UTC) and a pipeline was run, its completion time appeared 3 hours after the start time even though the run did not take 3 hours.
- This PR makes the completion time for block and pipeline runs in UTC even if the VM or Docker container is set to a different timezone. This also updates the backfill start and completion time as those were also set to the system's timezone setting.
- Resolves https://github.com/mage-ai/mage-ai/issues/3122

# How Has This Been Tested?
- [x] Changed timezone of local Docker container to Egypt time (UTC+3). Ran a pipeline and confirmed its start time (`execution_date` since the run was created using "Run pipeline now" button) and creation time were in UTC, while the completion time was in Egypt time. After adding fix, re-ran same pipeline and confirmed its completion time was now in UTC while the system timezone setting was still Egypt time. In screenshot below, the top row was in UTC (after fix) and the bottom row was in UTC+3 time (before fix).
![image](https://github.com/mage-ai/mage-ai/assets/78053898/3d723e7e-b863-4013-80d1-b288fd5ff5a1)

- [x] Performed same test as above but with backfills. Previously, the backfill start and end times were in the system timezone setting, or Egypt/UTC+3 on my Docker container, but after adding the fix, the backfill start and end times were in UTC. In screenshot below, the top row was in UTC (after fix) and the bottom row was in UTC+3 time (before fix).
![image](https://github.com/mage-ai/mage-ai/assets/78053898/857ebd9c-e80c-4e5b-93aa-0eb9bacc36dd)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code