### PR TITLE
[dy] Update error logging for block runs

### DIFF
--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -253,12 +253,12 @@ class BlockExecutor:
 
                 result = __execute_with_retry()
             except Exception as error:
-                # self.logger.exception(
-                #     f'Failed to execute block {self.block.uuid}',
-                #     **merge_dict(tags, dict(
-                #         error=error,
-                #     )),
-                # )
+                self.logger.exception(
+                    f'Failed to execute block {self.block.uuid}',
+                    **merge_dict(tags, dict(
+                        error=error,
+                    )),
+                )
                 if on_failure is not None:
                     on_failure(
                         self.block_uuid,

--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -228,6 +228,8 @@ class BlockExecutor:
                     delay=retry_config.delay,
                     max_delay=retry_config.max_delay,
                     exponential_backoff=retry_config.exponential_backoff,
+                    logger=self.logger,
+                    logging_tags=tags,
                 )
                 def __execute_with_retry():
                     return self._execute(
@@ -251,12 +253,12 @@ class BlockExecutor:
 
                 result = __execute_with_retry()
             except Exception as error:
-                self.logger.exception(
-                    f'Failed to execute block {self.block.uuid}',
-                    **merge_dict(tags, dict(
-                        error=error,
-                    )),
-                )
+                # self.logger.exception(
+                #     f'Failed to execute block {self.block.uuid}',
+                #     **merge_dict(tags, dict(
+                #         error=error,
+                #     )),
+                # )
                 if on_failure is not None:
                     on_failure(
                         self.block_uuid,

--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -228,8 +228,6 @@ class BlockExecutor:
                     delay=retry_config.delay,
                     max_delay=retry_config.max_delay,
                     exponential_backoff=retry_config.exponential_backoff,
-                    logger=self.logger,
-                    logging_tags=tags,
                 )
                 def __execute_with_retry():
                     return self._execute(
@@ -252,20 +250,18 @@ class BlockExecutor:
                     )
 
                 result = __execute_with_retry()
-            except Exception as e:
+            except Exception as error:
                 self.logger.exception(
                     f'Failed to execute block {self.block.uuid}',
                     **merge_dict(tags, dict(
-                        block_type=self.block.type,
-                        block_uuid=self.block.uuid,
-                        error=e
+                        error=error,
                     )),
                 )
                 if on_failure is not None:
                     on_failure(
                         self.block_uuid,
                         error=dict(
-                            error=str(e),
+                            error=error,
                             errors=traceback.format_stack(),
                             message=traceback.format_exc(),
                         ),
@@ -285,7 +281,7 @@ class BlockExecutor:
                     logging_tags=tags,
                     pipeline_run=pipeline_run,
                 )
-                raise e
+                raise error
             self.logger.info(f'Finish executing block with {self.__class__.__name__}.', **tags)
             if on_complete is not None:
                 on_complete(self.block_uuid)
@@ -537,7 +533,7 @@ class BlockExecutor:
         tags: Dict = None,
     ):
         """
-        Update the status of block run by edither updating the BlockRun db object or making
+        Update the status of block run by either updating the BlockRun db object or making
         API call
 
         Args:

--- a/mage_ai/shared/retry.py
+++ b/mage_ai/shared/retry.py
@@ -39,7 +39,7 @@ def retry(
                             '%d of %d' % (func, attempt, max_attempts)
                         )
                     else:
-                        logger.exception(
+                        logger.warning(
                             f'Exception thrown when attempting to run {func}, attempt '
                             f'{attempt} of {max_attempts}',
                             error=e,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Looking into the issue for [this slack thread](https://mageai.slack.com/archives/C03HTTWFEKE/p1689936582602419?thread_ts=1689928310.536919&cid=C03HTTWFEKE). It seems like the logs from the block runs are not getting logged for this user which I think is a separate issue or maybe is a result of the user's setup.

For now, I changed the logging to print one error log in the block run and one error log in the pipeline run. I also removed the error logging from the `retry` method because it doesn't really add any information and can be confusing.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with a local integration pipeline run
- [x] Tested with a local batch pipeline run


![Screenshot 2023-08-16 at 2 42 32 PM](https://github.com/mage-ai/mage-ai/assets/14357209/1b2e5e96-da59-4d75-9b0f-3d1731c4062a)

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
