### PR TITLE
[jk] Allow adding block from search

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/v2/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/v2/index.tsx
@@ -915,6 +915,7 @@ function AddNewBlocksV2({
                   } else {
                     addNewBlock({
                       block_action_object: blockActionObject,
+                      require_unique_name: false,
                     });
                     setInputValue(null);
                     setSearchResult(null);

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1333,11 +1333,11 @@ function PipelineDetailPage({
           },
           onErrorCallback: (response, errors) => {
             const exception = response?.error?.exception;
-            if (exception && exception.startsWith(BLOCK_EXISTS_ERROR)) {
-              const filePath = getRelativePathFromBlock({
-                ...block,
-                name,
-              });
+            const filePath = getRelativePathFromBlock({
+              ...block,
+              name,
+            });
+            if (exception && filePath && exception.startsWith(BLOCK_EXISTS_ERROR)) {
               setErrors(() => ({
                 errors,
                 links: [{


### PR DESCRIPTION
# Description
- Fix error when adding a block via the "Search for a block..." input in the V2 Add Block flow.

# How Has This Been Tested?
Before (adding a block would throw an error):
![BEFORE - adding block from search](https://github.com/mage-ai/mage-ai/assets/78053898/a4afcc7f-a602-4e4c-99c7-27bcc49852e6)

After (Adding a searched block is allowed--it's assumed a user wants to reuse a block if they are searching for it. If user searches for a block already existing in the pipeline, an error is displayed.):
![AFTER - adding block from search](https://github.com/mage-ai/mage-ai/assets/78053898/3e026799-fbf0-4b86-95dc-449f2f28cc9e)

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code

