### PR TITLE
[xy] Limit the number of rows of sql block output in pipeline run

### DIFF
--- a/docs/guides/sql-blocks.mdx
+++ b/docs/guides/sql-blocks.mdx
@@ -56,6 +56,29 @@ There are 4 - 5 fields that must be configured for each SQL block:
 | Replace | Delete the existing data.        |
 | Fail    | Raise an error during execution. |
 
+
+#### YAML configuration
+
+You can also modify block configuration in pipeline's `metadata.yaml` file. Each block has a `configuration` field.
+
+
+Example configuration
+```yaml
+  configuration:
+    data_provider: sqlserver
+    data_provider_profile: default
+    data_provider_schema: ''
+    export_write_policy: append
+    limit: 1000
+    limit_in_pipeline_run: 1
+    use_raw_sql: false
+```
+
+In addition to the fields mentioned in the table above. Here are some extra fields that can be included in the configuration:
+| Field                 | Required                 | Description                                                                     |
+| --------------------- | ------------------------ | --------------------------------------------------------------------------------|
+| limit                 | No                       | The maximum number of rows to return in notebook.                               |
+| limit_in_pipeline_run | No                       | The maximum number of rows to return when running the block in the pipeline run.|
 ---
 
 <img

--- a/mage_ai/data_preparation/models/block/sql/__init__.py
+++ b/mage_ai/data_preparation/models/block/sql/__init__.py
@@ -46,6 +46,44 @@ def execute_sql_code(
     config_file_loader: Any = None,
     configuration: Dict = None,
 ) -> List[Any]:
+    """
+    Execute SQL code within the given block's data context.
+
+    Args:
+        block (Block): The block containing the SQL execution context.
+        query (str): The SQL query to execute.
+        dynamic_block_index (int, optional): Index of the dynamic block, if applicable.
+        dynamic_upstream_block_uuids (List[str], optional): List of upstream block UUIDs for
+            dynamic execution.
+        execution_partition (str, optional): The partition for execution.
+        from_notebook (bool, optional): Indicates if execution is from a notebook.
+        global_vars (Dict, optional): Global variables to be used in the execution.
+        config_file_loader (Any, optional): Configuration file loader for data sources.
+        configuration (Dict, optional): Configuration settings for the block. If not provided, the
+            configuration from the block's context will be used. The configuration dictionary may
+            contain the following parameters:
+
+            - `use_raw_sql` (bool): If True, execute the query as raw SQL. Default is False.
+            - `data_provider` (str): The data provider for the execution, e.g., 'bigquery',
+                'clickhouse', etc.
+            - `data_provider_database` (str): The database name for the data provider.
+            - `data_provider_schema` (str): The schema name for the data provider.
+            - `export_write_policy` (str): The write policy for exporting data. Default is
+                ExportWritePolicy.APPEND.
+            - `limit` (int): The maximum number of rows to return in notebook.
+                Default is QUERY_ROW_LIMIT.
+            - `limit_in_pipeline_run` (int): Limit rows when running the block in the pipeline run.
+                Default is QUERY_ROW_LIMIT.
+            - Other provider-specific parameters may also be present.
+    Returns:
+        List[Any]: A list containing the query execution results.
+
+    Note:
+        This method executes the provided SQL query within the context of the given block.
+        It supports various data sources such as BigQuery, ClickHouse, Druid, MSSQL, MySQL,
+        PostgreSQL, Redshift, Snowflake, and Trino, applying relevant configurations and
+        returning the query execution results.
+    """
     configuration = configuration if configuration else block.configuration
     use_raw_sql = configuration.get('use_raw_sql')
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Limit the number of rows of sql block output in pipeline run. The original limit is only applied to the notebook.
When running the sql block in pipeline run, it fetches maximum 10 million rows, which could slow the the pipeline run execution and could be unnecessary. So this PR makes the row limit configurable when running the sql block in pipeline run.

Example block config:
```
blocks:
- all_upstream_blocks_executed: true
  color: null
  configuration:
    data_provider: sqlserver
    data_provider_profile: default
    export_write_policy: replace
    limit: 1000
    limit_in_pipeline_run: 2000
    use_raw_sql: false
    ....
```

This PR also made a fix on limiting the number of rows fetched from MSSQL.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested setting the limit_in_pipeline_run in a MSSQL sql block and run it in pipeline run. The row fetched is limited to a smaller number.
- [x] When the limit_in_pipeline_run is not configured, it fetches up to 10 million rows.

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
