### PR TITLE
[dy] Import decorators when executing block module

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -17,6 +17,7 @@ import pandas as pd
 import simplejson
 from jinja2 import Template
 
+import mage_ai.data_preparation.decorators
 from mage_ai.cache.block import BlockCache
 from mage_ai.data_cleaner.shared.utils import is_geo_dataframe, is_spark_dataframe
 from mage_ai.data_preparation.logging.logger import DictLogger
@@ -1110,6 +1111,8 @@ class Block:
     ) -> List:
         if logging_tags is None:
             logging_tags = dict()
+        if input_vars is None:
+            input_vars = list()
 
         decorated_functions = []
         test_functions = []
@@ -1166,7 +1169,6 @@ class Block:
         from_notebook: bool = False,
         global_vars: Dict = None,
     ) -> Dict:
-        import mage_ai.data_preparation.decorators
         block_function_updated = block_function
         if from_notebook:
             # Initialize module
@@ -1187,7 +1189,7 @@ class Block:
                     setattr(
                         module,
                         self.type,
-                        getattr(mage_ai.data_preparation.decorators, self.type)
+                        getattr(mage_ai.data_preparation.decorators, self.type),
                     )
                     module.test = mage_ai.data_preparation.decorators.test
                     spec.loader.exec_module(module)

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -1166,6 +1166,7 @@ class Block:
         from_notebook: bool = False,
         global_vars: Dict = None,
     ) -> Dict:
+        import mage_ai.data_preparation.decorators
         block_function_updated = block_function
         if from_notebook:
             # Initialize module
@@ -1177,9 +1178,18 @@ class Block:
                         block_uuid = self.replicated_block
                         block_file_path = self.replicated_block_object.file_path
                     spec = importlib.util.spec_from_file_location(
-                        block_uuid, block_file_path,
+                        block_uuid,
+                        block_file_path,
                     )
                     module = importlib.util.module_from_spec(spec)
+                    # Set the decorators in the module in case they are not defined in the block
+                    # code
+                    setattr(
+                        module,
+                        self.type,
+                        getattr(mage_ai.data_preparation.decorators, self.type)
+                    )
+                    module.test = mage_ai.data_preparation.decorators.test
                     spec.loader.exec_module(module)
                     block_function_updated = getattr(module, block_function.__name__)
                     self.module = module


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Import block decorators in the module in case they aren't defined in the block code. The module will not be exec-ed properly because it will fail due to the decorator not being defined, and will fall back to the default block execution:

<img width="663" alt="Screenshot 2023-08-10 at 3 57 02 PM" src="https://github.com/mage-ai/mage-ai/assets/14357209/5bb41862-7893-40f9-9fce-6895cd2a8e56">

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with a block with no decorators imported
- [x] Unit tests 


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
