### PR TITLE
Add namespace to K8sBlockExecutor config

### DIFF
--- a/docs/production/configuring-production-settings/compute-resource.mdx
+++ b/docs/production/configuring-production-settings/compute-resource.mdx
@@ -68,6 +68,7 @@ There're two ways to customize the Kubernetes executor config:
       downstream_blocks: []
       executor_type: k8s
       executor_config:
+        namespace: default
         resource_limits:
           cpu: 1000m
           memory: 2048Mi
@@ -80,6 +81,7 @@ in this project. Example config:
     ```yaml
     k8s_executor_config:
       job_name_prefix: data-prep
+      namespace: default
       resource_limits:
         cpu: 1000m
         memory: 2048Mi

--- a/mage_ai/data_preparation/executors/k8s_block_executor.py
+++ b/mage_ai/data_preparation/executors/k8s_block_executor.py
@@ -4,6 +4,7 @@ from mage_ai.data_preparation.executors.block_executor import BlockExecutor
 from mage_ai.services.k8s.config import K8sExecutorConfig
 from mage_ai.services.k8s.job_manager import JobManager as K8sJobManager
 from mage_ai.shared.hash import merge_dict
+from mage_ai.services.k8s.constants import DEFAULT_NAMESPACE
 
 
 class K8sBlockExecutor(BlockExecutor):
@@ -26,10 +27,17 @@ class K8sBlockExecutor(BlockExecutor):
             job_name_prefix = 'data-prep'
         else:
             job_name_prefix = self.executor_config.job_name_prefix
+
+        if self.executor_config.namespace:
+            namespace = self.executor_config.namespace
+        else:
+            namespace = DEFAULT_NAMESPACE
+            
         job_manager = K8sJobManager(
             job_name=f'mage-{job_name_prefix}-block-{block_run_id}',
             logger=self.logger,
             logging_tags=kwargs.get('tags', dict()),
+            namespace=namespace,
         )
         cmd = self._run_commands(
             block_run_id=block_run_id,

--- a/mage_ai/data_preparation/executors/k8s_block_executor.py
+++ b/mage_ai/data_preparation/executors/k8s_block_executor.py
@@ -32,7 +32,6 @@ class K8sBlockExecutor(BlockExecutor):
             namespace = self.executor_config.namespace
         else:
             namespace = DEFAULT_NAMESPACE
-            
         job_manager = K8sJobManager(
             job_name=f'mage-{job_name_prefix}-block-{block_run_id}',
             logger=self.logger,

--- a/mage_ai/services/k8s/config.py
+++ b/mage_ai/services/k8s/config.py
@@ -24,7 +24,7 @@ class K8sExecutorConfig(BaseConfig):
     resource_limits: Dict = None
     resource_requests: Dict = None
     service_account_name: str = DEFAULT_SERVICE_ACCOUNT_NAME
-    
+
     @classmethod
     def load(self, config_path: str = None, config: Dict = None):
         executor_config = super().load(config_path=config_path, config=config)

--- a/mage_ai/services/k8s/config.py
+++ b/mage_ai/services/k8s/config.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Dict
 
 from mage_ai.shared.config import BaseConfig
+from mage_ai.services.k8s.constants import DEFAULT_NAMESPACE
 
 # import traceback
 
@@ -22,6 +23,7 @@ class K8sExecutorConfig(BaseConfig):
     resource_limits: Dict = None
     resource_requests: Dict = None
     service_account_name: str = DEFAULT_SERVICE_ACCOUNT_NAME
+    namespace: str = DEFAULT_NAMESPACE
 
     @classmethod
     def load(self, config_path: str = None, config: Dict = None):

--- a/mage_ai/services/k8s/config.py
+++ b/mage_ai/services/k8s/config.py
@@ -20,11 +20,11 @@ class K8sResourceConfig(BaseConfig):
 class K8sExecutorConfig(BaseConfig):
     container_config: Dict = None
     job_name_prefix: str = None
+    namespace: str = DEFAULT_NAMESPACE
     resource_limits: Dict = None
     resource_requests: Dict = None
     service_account_name: str = DEFAULT_SERVICE_ACCOUNT_NAME
-    namespace: str = DEFAULT_NAMESPACE
-
+    
     @classmethod
     def load(self, config_path: str = None, config: Dict = None):
         executor_config = super().load(config_path=config_path, config=config)

--- a/mage_ai/tests/data_preparation/executors/test_k8s_block_executor.py
+++ b/mage_ai/tests/data_preparation/executors/test_k8s_block_executor.py
@@ -42,6 +42,7 @@ class K8sBlockExecutorTestCase(unittest.TestCase):
             job_name='mage-data-prep-block-1',
             logger=self.executor.logger,
             logging_tags={},
+            namespace='default',
         )
         job_manager_instance_mock.run_job.assert_called_once_with(
             'mocked_cmd',
@@ -70,6 +71,7 @@ class K8sBlockExecutorTestCase(unittest.TestCase):
             job_name='mage-custom-prefix-block-1',
             logger=self.executor.logger,
             logging_tags={},
+            namespace='default',
         )
         job_manager_instance_mock.run_job.assert_called_once_with(
             'mocked_cmd',


### PR DESCRIPTION
Add a config param to control block executor namespace

This has been tested locally as much as possible but really needs to be deployed into a kubernetes cluster to work.