### PR TITLE
[td] Fix custom templates with empty parent names

### DIFF
--- a/mage_ai/data_preparation/models/custom_templates/utils.py
+++ b/mage_ai/data_preparation/models/custom_templates/utils.py
@@ -56,18 +56,24 @@ def group_and_hydrate_files(
     file_dicts: List[Dict],
     custom_template_class,
 ) -> List:
-    groups = group_by(
-        lambda x: os.path.join(
-            *x.get('parent_names', []) if x else '',
-        ),
-        file_dicts,
-    )
+    def _func(x):
+        arr = ['']
 
-    arr = []
+        if x:
+            parent_names = x.get('parent_names', []) or []
+            if parent_names and len(parent_names) >= 1:
+                arr = [str(parent_name) for parent_name in parent_names]
+
+        return os.path.join(*arr)
+
+
+    groups = group_by(_func, file_dicts)
+
+    custom_templates = []
 
     for template_uuid, _ in groups.items():
         custom_template = custom_template_class.load(template_uuid=template_uuid)
         if custom_template:
-            arr.append(custom_template)
+            custom_templates.append(custom_template)
 
-    return arr
+    return custom_templates

--- a/mage_ai/data_preparation/models/custom_templates/utils.py
+++ b/mage_ai/data_preparation/models/custom_templates/utils.py
@@ -56,7 +56,12 @@ def group_and_hydrate_files(
     file_dicts: List[Dict],
     custom_template_class,
 ) -> List:
-    groups = group_by(lambda x: os.path.join(*x.get('parent_names', [])), file_dicts)
+    groups = group_by(
+        lambda x: os.path.join(
+            *x.get('parent_names', []) if x else '',
+        ),
+        file_dicts,
+    )
 
     arr = []
 

--- a/mage_ai/data_preparation/models/custom_templates/utils.py
+++ b/mage_ai/data_preparation/models/custom_templates/utils.py
@@ -66,7 +66,6 @@ def group_and_hydrate_files(
 
         return os.path.join(*arr)
 
-
     groups = group_by(_func, file_dicts)
 
     custom_templates = []

--- a/mage_ai/tests/data_preparation/models/custom_templates/test_utils.py
+++ b/mage_ai/tests/data_preparation/models/custom_templates/test_utils.py
@@ -1,0 +1,38 @@
+import os
+from unittest.mock import patch
+
+
+from mage_ai.data_preparation.models.custom_templates.custom_block_template import (
+    CustomBlockTemplate,
+)
+from mage_ai.data_preparation.models.custom_templates.utils import group_and_hydrate_files
+from mage_ai.shared.array import find
+from mage_ai.tests.base_test import DBTestCase
+
+
+class CustomTemplatesUtilsTest(DBTestCase):
+    def test_file_path(self):
+        file_dicts = [
+            None,
+            dict(parent_names=None),
+            dict(parent_names=[]),
+            dict(parent_names=[None]),
+            dict(parent_names=['mage']),
+            dict(parent_names=['mage', 'fire']),
+        ]
+
+
+        def load(template_uuid: str):
+            return CustomBlockTemplate(template_uuid=template_uuid)
+
+        with patch.object(
+            CustomBlockTemplate,
+            'load',
+            load,
+        ):
+            arr = group_and_hydrate_files(file_dicts, CustomBlockTemplate)
+
+            self.assertTrue(find(lambda x: x.template_uuid == '', arr))
+            self.assertTrue(find(lambda x: x.template_uuid == 'None', arr))
+            self.assertTrue(find(lambda x: x.template_uuid == 'mage', arr))
+            self.assertTrue(find(lambda x: x.template_uuid == 'mage/fire', arr))

--- a/mage_ai/tests/data_preparation/models/custom_templates/test_utils.py
+++ b/mage_ai/tests/data_preparation/models/custom_templates/test_utils.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import patch
 
 
@@ -20,7 +19,6 @@ class CustomTemplatesUtilsTest(DBTestCase):
             dict(parent_names=['mage']),
             dict(parent_names=['mage', 'fire']),
         ]
-
 
         def load(template_uuid: str):
             return CustomBlockTemplate(template_uuid=template_uuid)

--- a/mage_ai/tests/data_preparation/models/custom_templates/test_utils.py
+++ b/mage_ai/tests/data_preparation/models/custom_templates/test_utils.py
@@ -11,7 +11,7 @@ from mage_ai.tests.base_test import DBTestCase
 
 
 class CustomTemplatesUtilsTest(DBTestCase):
-    def test_file_path(self):
+    def test_group_and_hydrate_files(self):
         file_dicts = [
             None,
             dict(parent_names=None),


### PR DESCRIPTION
# Description
Fix this error:

`TypeError: posixpath.join() argument after * must be an iterable, not NoneType`


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [ ] Add unit test for the function `group_and_hydrate_files`


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
