### PR TITLE
[td] Open and edit any file, including prefix .

### DIFF
--- a/mage_ai/frontend/components/FileBrowser/Folder.tsx
+++ b/mage_ai/frontend/components/FileBrowser/Folder.tsx
@@ -134,19 +134,19 @@ function Folder({
     ? isFileDisabled(filePathToUse, children)
     : (
       disabledProp
-        || name === '__init__.py'
-        || !!name?.match(/^\./)
-        || (!name.match(ALL_SUPPORTED_FILE_EXTENSIONS_REGEX) && !childrenProp)
+        // || name === '__init__.py'
+        // || !!name?.match(/^\./)
+        // || (!name.match(ALL_SUPPORTED_FILE_EXTENSIONS_REGEX) && !childrenProp)
     );
 
   const disabled = isFileDisabled
     ? isFileDisabled(filePathToUse, children)
     : (
       disabledProp
-        || name === '__init__.py'
-        // Don’t disable hidden folders
-        || (!!name?.match(/^\./) && !children)
-        || (!name.match(ALL_SUPPORTED_FILE_EXTENSIONS_REGEX) && !childrenProp)
+        // || name === '__init__.py'
+        // // Don’t disable hidden folders
+        // || (!!name?.match(/^\./) && !children)
+        // || (!name.match(ALL_SUPPORTED_FILE_EXTENSIONS_REGEX) && !childrenProp)
     );
 
   const uuid = `${level}/${name}`;

--- a/mage_ai/frontend/components/FileEditor/index.tsx
+++ b/mage_ai/frontend/components/FileEditor/index.tsx
@@ -55,6 +55,7 @@ type FileEditorProps = {
   filePath: string;
   hideHeaderButtons?: boolean;
   onContentChange?: (content: string) => void;
+  onUpdateFileSuccess?: (fileContent: FileType) => void;
   openSidekickView?: (newView: ViewKeyEnum) => void;
   pipeline?: PipelineType;
   saveFile?: (value: string, file: FileType) => void;
@@ -77,6 +78,7 @@ function FileEditor({
   filePath,
   hideHeaderButtons,
   onContentChange,
+  onUpdateFileSuccess,
   openSidekickView,
   pipeline,
   saveFile: saveFileProp,
@@ -135,11 +137,17 @@ function FileEditor({
     {
       onSuccess: (response: any) => onSuccess(
         response, {
-          callback: () => {
+          callback: ({
+            file_content: fc,
+          }) => {
             setApiReloads(prev => ({
               ...prev,
               [`FileVersions/${file?.path}`]: Number(new Date()),
             }));
+
+            if (onUpdateFileSuccess) {
+              onUpdateFileSuccess?.(fc);
+            }
           },
           onErrorCallback: (response, errors) => setErrors?.({
             errors,

--- a/mage_ai/frontend/components/FileVersions/index.tsx
+++ b/mage_ai/frontend/components/FileVersions/index.tsx
@@ -93,7 +93,7 @@ function FileVersions({
             }));
 
             setSelectedFileVersionIndex(prev => prev + 1);
-            onActionCallback?.(resp);
+            onActionCallback?.(resp?.file_content);
           },
           onErrorCallback: (response, errors) => setErrors({
             errors,

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -94,6 +94,9 @@ type PipelineDetailProps = {
   autocompleteItems: AutocompleteItemType[];
   blockRefs: any;
   blocks: BlockType[];
+  blocksThatNeedToRefresh?: {
+    [uuid: string]: number;
+  };
   dataProviders: DataProviderType[];
   deleteBlock: (block: BlockType) => Promise<any>;
   disableShortcuts: boolean;
@@ -179,6 +182,7 @@ function PipelineDetail({
   autocompleteItems,
   blockRefs,
   blocks = [],
+  blocksThatNeedToRefresh,
   dataProviders,
   deleteBlock,
   disableShortcuts,
@@ -529,12 +533,20 @@ function PipelineDetail({
       const noDivider = idx === numberOfBlocks - 1 || isIntegration;
       const currentBlockRef = blockRefs.current[path];
 
+      let key = uuid;
+      const refreshTimestamp = blocksThatNeedToRefresh?.[type]?.[uuid];
+      if (refreshTimestamp) {
+        key = `${key}:${refreshTimestamp}`;
+      }
+
+      // console.log(key)
+
       if (isHidden) {
         el = (
           <HiddenBlock
             block={block}
             blocks={blocks}
-            key={uuid}
+            key={key}
             // @ts-ignore
             onClick={() => setHiddenBlocks(prev => ({
               ...prev,
@@ -593,7 +605,7 @@ function PipelineDetail({
             globalDataProducts={globalDataProducts}
             hideRunButton={isStreaming || isMarkdown || (isIntegration && isTransformer)}
             interruptKernel={interruptKernel}
-            key={uuid}
+            key={key}
             mainContainerRef={mainContainerRef}
             mainContainerWidth={mainContainerWidth}
             messages={messages[uuid]}
@@ -644,6 +656,7 @@ function PipelineDetail({
     autocompleteItems,
     blockRefs,
     blockTemplates,
+    blocksThatNeedToRefresh,
     blocks,
     dataProviders,
     deleteBlock,

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -18,6 +18,7 @@ import DependencyGraph from '@components/DependencyGraph';
 import ErrorsType from '@interfaces/ErrorsType';
 import EmptyCharts from '@oracle/icons/custom/EmptyCharts';
 import Extensions, { ExtensionsProps } from '@components/PipelineDetail/Extensions';
+import FileType from '@interfaces/FileType';
 import FileVersions from '@components/FileVersions';
 import FlexContainer from '@oracle/components/FlexContainer';
 import GlobalDataProductType from '@interfaces/GlobalDataProductType';
@@ -97,6 +98,7 @@ export type SidekickProps = {
   globalVariables: PipelineVariableType[];
   lastTerminalMessage: WebSocketEventMap['message'] | null;
   metadata: MetadataType;
+  onUpdateFileSuccess?: (fileContent: FileType) => void;
   pipeline: PipelineType;
   pipelineMessages: KernelOutputType[];
   runningBlocks: BlockType[];
@@ -154,6 +156,7 @@ function Sidekick({
   onChangeChartBlock,
   onChangeCodeBlock,
   onSelectBlockFile,
+  onUpdateFileSuccess,
   pipeline,
   pipelineMessages,
   runBlock,
@@ -251,6 +254,7 @@ function Sidekick({
 
   const fileVersionsMemo = useMemo(() => (
     <FileVersions
+      onActionCallback={onUpdateFileSuccess}
       selectedBlock={selectedBlock}
       selectedFilePath={selectedFilePath}
       setErrors={setErrors}
@@ -258,6 +262,7 @@ function Sidekick({
     />
   ), [
     afterWidth,
+    onUpdateFileSuccess,
     selectedBlock,
     selectedFilePath,
     setErrors,


### PR DESCRIPTION
# Description
- Allow opening and editing any file via the file browser.
- Open any file even if it’s an existing block in a pipeline


# How Has This Been Tested?
- [x] Files starting with `.` can be edited

<img width="563" alt="image" src="https://github.com/mage-ai/mage-ai/assets/1066980/7baacf7e-bfa8-4ee9-adeb-53be595c0a6d">

- [x] Open a file that was a block in the pipeline. Edited the file and saw the changes reflected in the block. Restored the file version and saw the block was updated.

![2023-08-14 23 10 07](https://github.com/mage-ai/mage-ai/assets/1066980/e404d10f-5738-4a6d-893a-d276c2d48f08)


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
