### PR TITLE
[xy] Use greater than operator for unique columns in source sql bookmark comparison.

### DIFF
--- a/mage_integrations/mage_integrations/sources/sql/base.py
+++ b/mage_integrations/mage_integrations/sources/sql/base.py
@@ -345,12 +345,15 @@ WHERE table_schema = '{schema}'
             for col, val in bookmarks.items():
                 if col not in bookmark_properties or val is None:
                     continue
+                comparison_operator = '>='
+                if col in unique_constraints:
+                    comparison_operator = '>'
                 where_statements.append(
                     self._build_comparison_statement(
                         col,
                         val,
                         stream.schema.to_dict()['properties'],
-                        operator='>='
+                        operator=comparison_operator,
                     )
                 )
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Per suggestion from ticket https://github.com/mage-ai/mage-ai/issues/3198#issuecomment-1672496332, this PR updates the data integration source to use "greater than" operator instead :greater than or equal" operator to compare bookmark values for unique columns.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested setting the bookmark column also as unique column, and set the bookmark value to the largest value in the source table. No rows are synced with this change.
<img width="365" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/be0ebe2a-42b1-487e-a7f7-41d5e58101f6">

Without this change, there's always one row synced:
<img width="347" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/a2dbf434-0cd8-4b3f-ad8a-821e4587f255">
- [x] Tested when using a non-unique column as the bookmark column, and set the bookmark value to the largest value in the source table. One row is synced.



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
