### PR TITLE
add-repo-owner-write-permissions

### DIFF
--- a/mage_ai/data_preparation/templates/utils.py
+++ b/mage_ai/data_preparation/templates/utils.py
@@ -1,7 +1,9 @@
 import jinja2
 import os
+import stat
 import shutil
 
+from mage_ai.shared.io import chmod
 
 template_env = jinja2.Environment(
     loader=jinja2.FileSystemLoader(os.path.dirname(__file__)),
@@ -28,6 +30,7 @@ def copy_template_directory(template_path: str, dest_path: str) -> None:
     if not os.path.exists(template_path):
         raise IOError(f'Could not find templates for {template_path}.')
     shutil.copytree(template_path, dest_path)
+    chmod(dest_path, stat.S_IRWXU)
 
 
 def read_template_file(template_path: str) -> jinja2.Template:

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import os
 import shutil
+import stat
 import traceback
 import webbrowser
 from time import sleep
@@ -78,6 +79,7 @@ from mage_ai.settings import (
 )
 from mage_ai.settings.repo import DEFAULT_MAGE_DATA_DIR, get_repo_name, set_repo_path
 from mage_ai.shared.constants import InstanceType
+from mage_ai.shared.io import chmod
 from mage_ai.shared.logger import LoggingLevel
 from mage_ai.shared.utils import is_port_in_use
 from mage_ai.usage_statistics.logger import UsageStatisticLogger
@@ -140,6 +142,7 @@ def replace_base_path(base_path: str) -> str:
     if os.path.exists(dst):
         shutil.rmtree(dst)
     shutil.copytree(src, dst)
+    chmod(dst, stat.S_IRWXU)
     for path, _, files in os.walk(os.path.abspath(dst)):
         for filename in files:
             if filename.endswith(('.html', '.js', '.css')):

--- a/mage_ai/shared/io.py
+++ b/mage_ai/shared/io.py
@@ -1,8 +1,24 @@
-from typing import Callable
-import aiofiles
 import os
 import shutil
 import traceback
+from typing import Callable
+
+import aiofiles
+
+
+def chmod(path, mode, append=True):
+    # recursively runs chmod against the path and either adds or sets the permission(mode)
+    try:
+        current_mode = os.stat(path).st_mode
+    except Exception as e:
+        raise e
+    if append:
+        mode = current_mode | mode
+    os.chmod(path, mode)
+    for dirpath, _dirnames, filenames in os.walk(path):
+        os.chmod(dirpath, mode)
+        for filename in filenames:
+            os.chmod(os.path.join(dirpath, filename), mode)
 
 
 def safe_write(filepath: str, content: str, write_func: Callable = None):

--- a/mage_ai/tests/shared/test_io.py
+++ b/mage_ai/tests/shared/test_io.py
@@ -1,10 +1,32 @@
-from mage_ai.shared.io import safe_write, safe_write_async
-from mage_ai.tests.base_test import TestCase
 import asyncio
 import os
+import stat
+
+from mage_ai.shared.io import chmod, safe_write, safe_write_async
+from mage_ai.tests.base_test import TestCase
 
 
 class IOTests(TestCase):
+    def test_chmod(self):
+        path = 'test_io'
+        file = 'test_chmod'
+        file_path = os.path.join(path, file)
+
+        os.mkdir(path)
+        with open(file_path, 'w') as fp:
+            fp.write('MESSAGE1')
+
+        target_mode = stat.S_IRWXU
+        chmod(file_path, target_mode)
+
+        # checks whether the permission bits target_mode are set in current_mode
+        # current_mode & target_mode will keep only those bits which are true for both expressions
+        self.assertTrue(os.stat(path).st_mode & target_mode == target_mode)
+        self.assertTrue(os.stat(file_path).st_mode & target_mode == target_mode)
+
+        os.remove(file_path)
+        os.rmdir(path)
+
     def test_safe_write(self):
         file_path = 'test_file_write'
         with open(file_path, 'w') as fp:


### PR DESCRIPTION
# Description
Resolves #3260

Adds a function to recursively chmod files.
- Adds `700` on top of current permissions to default_repo recursively
- If file permission is `555`, then after `chmod(file, 0x700)` the file permission is `755`
- This is based on bitwise or => `0x555 | 0x700 == 0x755`

# How Has This Been Tested?
- [x] Running the Dockerfile and manually checking the permissions using `ls -l`
- [x] Added unit test `tests/shared/test_io.py IOTests.test_chmod`

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation; not needed

cc: @wangxiaoyou1993