### PR TITLE
[hw] When comparing spark.jars, use the file names and neglect paths

### DIFF
--- a/mage_ai/services/spark/spark.py
+++ b/mage_ai/services/spark/spark.py
@@ -4,6 +4,9 @@ import os
 
 
 def get_file_names(jars: List) -> List:
+    '''
+    Extract file names from a list of jar files.
+    '''
     if jars is None:
         return None
 
@@ -11,6 +14,10 @@ def get_file_names(jars: List) -> List:
 
 
 def contains_same_jars(jars_1: List, jars_2: List) -> bool:
+    '''
+    Check if two lists of jar files contain the same jars.
+    The order of the jars in the list does not matter.
+    '''
     if jars_1 is None and jars_2 is None:
         return True
 
@@ -20,13 +27,16 @@ def contains_same_jars(jars_1: List, jars_2: List) -> bool:
     if len(jars_1) != len(jars_2):
         return False
 
-    file_names_1 = get_list_of_file_names(jars_1)
-    file_names_2 = get_list_of_file_names(jars_2)
+    file_names_1 = get_file_names(jars_1)
+    file_names_2 = get_file_names(jars_2)
 
     return set(file_names_1) == set(file_names_2)
 
 
 def has_same_spark_config(spark_session, spark_config: SparkConfig) -> bool:
+    '''
+    Check if the spark session has the same configuration as the spark config.
+    '''
     if spark_session is None:
         return False
 
@@ -61,6 +71,18 @@ def has_same_spark_config(spark_session, spark_config: SparkConfig) -> bool:
 
 
 def get_spark_session(spark_config: SparkConfig):
+    '''
+    Get a Spark session.
+    If the given spark_config is None, then create a Spark session with the
+    default configuration.
+    If the given spark_config is not None, then check if the active Spark
+    session has the same configuration as the given spark_config.
+    If the active Spark session has the same configuration as the given
+    spark_config, then reuse the active Spark session.
+    If the active Spark session does not have the same configuration as the
+    given spark_config, then create a new Spark session with the given
+    spark_config.
+    '''
     from pyspark.conf import SparkConf
     from pyspark.sql import SparkSession
 

--- a/mage_ai/services/spark/spark.py
+++ b/mage_ai/services/spark/spark.py
@@ -6,8 +6,7 @@ def get_list_of_file_names(list_of_jars):
     if list_of_jars is None:
         return None
 
-    file_names = [os.path.basename(jar) for jar in list_of_jars]
-    return file_names.sort()
+    return [os.path.basename(jar) for jar in list_of_jars]
 
 
 def contains_same_jars(list_of_jars_1, list_of_jars_2):
@@ -22,6 +21,7 @@ def contains_same_jars(list_of_jars_1, list_of_jars_2):
 
     file_names_1 = get_list_of_file_names(list_of_jars_1)
     file_names_2 = get_list_of_file_names(list_of_jars_2)
+
     for file_name in file_names_1:
         if file_name not in file_names_2:
             return False

--- a/mage_ai/services/spark/spark.py
+++ b/mage_ai/services/spark/spark.py
@@ -1,32 +1,29 @@
 from mage_ai.services.spark.config import SparkConfig
+from typing import List
 import os
 
 
-def get_list_of_file_names(list_of_jars):
-    if list_of_jars is None:
+def get_file_names(jars: List) -> List:
+    if jars is None:
         return None
 
-    return [os.path.basename(jar) for jar in list_of_jars]
+    return [os.path.basename(jar) for jar in jars]
 
 
-def contains_same_jars(list_of_jars_1, list_of_jars_2):
-    if list_of_jars_1 is None and list_of_jars_2 is None:
+def contains_same_jars(jars_1: List, jars_2: List) -> bool:
+    if jars_1 is None and jars_2 is None:
         return True
 
-    if list_of_jars_1 is None or list_of_jars_2 is None:
+    if jars_1 is None or jars_2 is None:
         return False
 
-    if len(list_of_jars_1) != len(list_of_jars_2):
+    if len(jars_1) != len(jars_2):
         return False
 
-    file_names_1 = get_list_of_file_names(list_of_jars_1)
-    file_names_2 = get_list_of_file_names(list_of_jars_2)
+    file_names_1 = get_list_of_file_names(jars_1)
+    file_names_2 = get_list_of_file_names(jars_2)
 
-    for file_name in file_names_1:
-        if file_name not in file_names_2:
-            return False
-
-    return True
+    return set(file_names_1) == set(file_names_2)
 
 
 def has_same_spark_config(spark_session, spark_config: SparkConfig) -> bool:

--- a/mage_ai/services/spark/spark.py
+++ b/mage_ai/services/spark/spark.py
@@ -2,6 +2,33 @@ from mage_ai.services.spark.config import SparkConfig
 import os
 
 
+def get_list_of_file_names(list_of_jars):
+    if list_of_jars is None:
+        return None
+
+    file_names = [os.path.basename(jar) for jar in list_of_jars]
+    return file_names.sort()
+
+
+def contains_same_jars(list_of_jars_1, list_of_jars_2):
+    if list_of_jars_1 is None and list_of_jars_2 is None:
+        return True
+
+    if list_of_jars_1 is None or list_of_jars_2 is None:
+        return False
+
+    if len(list_of_jars_1) != len(list_of_jars_2):
+        return False
+
+    file_names_1 = get_list_of_file_names(list_of_jars_1)
+    file_names_2 = get_list_of_file_names(list_of_jars_2)
+    for file_name in file_names_1:
+        if file_name not in file_names_2:
+            return False
+
+    return True
+
+
 def has_same_spark_config(spark_session, spark_config: SparkConfig) -> bool:
     if spark_session is None:
         return False
@@ -24,8 +51,8 @@ def has_same_spark_config(spark_session, spark_config: SparkConfig) -> bool:
                 if spark_session.conf.get(f'spark.executorEnv.{key}') != value:
                     print(f'Different spark.executorEnv.{key} found!')
                     return False
-        if (spark_config.spark_jars and spark_config.spark_jars
-                != spark_session.conf.get('spark.jars')):
+        if (spark_config.spark_jars and not contains_same_jars(
+                spark_config.spark_jars, spark_session.conf.get('spark.jars'))):
             print('Different spark.jars found!')
             return False
         if spark_config.others:

--- a/mage_ai/services/spark/spark.py
+++ b/mage_ai/services/spark/spark.py
@@ -4,9 +4,15 @@ import os
 
 
 def get_file_names(jars: List) -> List:
-    '''
-    Extract file names from a list of jar files.
-    '''
+    """
+    Extracts file names from a list of jar files.
+
+    Args:
+        jars (List): A list of jar files.
+
+    Returns:
+        List: A list of file names.
+    """
     if jars is None:
         return None
 
@@ -14,10 +20,17 @@ def get_file_names(jars: List) -> List:
 
 
 def contains_same_jars(jars_1: List, jars_2: List) -> bool:
-    '''
-    Check if two lists of jar files contain the same jars.
+    """
+    Checks if two lists of jar files contain the same jars.
     The order of the jars in the list does not matter.
-    '''
+
+    Args:
+        jars_1 (List): A list of jar files.
+        jars_2 (List): A list of jar files.
+
+    Returns:
+        bool: True if the lists contain the same jars, False otherwise.
+    """
     if jars_1 is None and jars_2 is None:
         return True
 
@@ -34,9 +47,17 @@ def contains_same_jars(jars_1: List, jars_2: List) -> bool:
 
 
 def has_same_spark_config(spark_session, spark_config: SparkConfig) -> bool:
-    '''
-    Check if the spark session has the same configuration as the spark config.
-    '''
+    """
+    Checks if the spark session has the same configuration as the spark config.
+
+    Args:
+        spark_session (SparkSession): The spark session.
+        spark_config (SparkConfig): The spark config.
+
+    Returns:
+        bool: True if the spark session has the same configuration as the
+        spark config, False otherwise.
+    """
     if spark_session is None:
         return False
 
@@ -71,8 +92,8 @@ def has_same_spark_config(spark_session, spark_config: SparkConfig) -> bool:
 
 
 def get_spark_session(spark_config: SparkConfig):
-    '''
-    Get a Spark session.
+    """
+    Gets a Spark session.
     If the given spark_config is None, then create a Spark session with the
     default configuration.
     If the given spark_config is not None, then check if the active Spark
@@ -82,7 +103,13 @@ def get_spark_session(spark_config: SparkConfig):
     If the active Spark session does not have the same configuration as the
     given spark_config, then create a new Spark session with the given
     spark_config.
-    '''
+
+    Args:
+        spark_config (SparkConfig): The Spark configuration.
+
+    Returns:
+        SparkSession: The Spark session.
+    """
     from pyspark.conf import SparkConf
     from pyspark.sql import SparkSession
 

--- a/mage_ai/tests/services/spark/test_spark.py
+++ b/mage_ai/tests/services/spark/test_spark.py
@@ -1,0 +1,22 @@
+from mage_ai.services.spark.spark import get_file_names
+from mage_ai.tests.base_test import TestCase
+
+
+class SparkTests(TestCase):
+    def test_get_file_names(self):
+        self.assertEqual(
+            get_file_names(['/home/spark-jars/aws-java-sdk-core-1.11.1026.jar']),
+            ['aws-java-sdk-core-1.11.1026.jar']
+        )
+        self.assertEqual(
+            get_file_names(['spark://************:2222/jars/aws-java-sdk-core-1.11.1026.jar']),
+            ['aws-java-sdk-core-1.11.1026.jar']
+        )
+        self.assertEqual(
+            get_file_names(['/home/spark-jars/test1.jar', '/home/spark-jars/test2.jar']),
+            ['test1.jar', 'test2.jar']
+        )
+        self.assertEqual(
+            get_file_names(['spark://************:2222/jars/test1.jar', 'spark://************:2222/jars/test2.jar']),
+            ['test1.jar', 'test2.jar']
+        )

--- a/mage_ai/tests/services/spark/test_spark.py
+++ b/mage_ai/tests/services/spark/test_spark.py
@@ -45,7 +45,7 @@ class SparkTests(TestCase):
                 ['spark://************:2222/jars/test2.jar',
                  'spark://************:2222/jars/test1.jar'])
         )
-        self.assertTrue(
+        self.assertFalse(
             contains_same_jars(
                 ['/home/spark-jars/test1.jar', '/home/spark-jars/test2.jar'],
                 ['spark://************:2222/jars/test1.jar'])

--- a/mage_ai/tests/services/spark/test_spark.py
+++ b/mage_ai/tests/services/spark/test_spark.py
@@ -1,4 +1,4 @@
-from mage_ai.services.spark.spark import get_file_names
+from mage_ai.services.spark.spark import contains_same_jars, get_file_names
 from mage_ai.tests.base_test import TestCase
 
 
@@ -21,4 +21,37 @@ class SparkTests(TestCase):
                 'spark://************:2222/jars/test1.jar',
                 'spark://************:2222/jars/test2.jar']),
             ['test1.jar', 'test2.jar']
+        )
+
+    def test_contains_same_jars(self):
+        self.assertEqual(
+            contains_same_jars(
+                ['/home/spark-jars/aws-java-sdk-core-1.11.1026.jar'],
+                ['aws-java-sdk-core-1.11.1026.jar']),
+            True
+        )
+        self.assertEqual(
+            contains_same_jars(
+                ['spark://************:2222/jars/aws-java-sdk-core-1.11.1026.jar'],
+                ['aws-java-sdk-core-1.11.1026.jar']),
+            True
+        )
+        self.assertEqual(
+            contains_same_jars(
+                ['/home/spark-jars/aws-java-sdk-core-1.11.1026.jar'],
+                ['spark://************:2222/jars/aws-java-sdk-core-1.11.1026.jar']),
+            True
+        )
+        self.assertEqual(
+            contains_same_jars(
+                ['/home/spark-jars/test1.jar', '/home/spark-jars/test2.jar'],
+                ['spark://************:2222/jars/test2.jar',
+                 'spark://************:2222/jars/test1.jar']),
+            True
+        )
+        self.assertEqual(
+            contains_same_jars(
+                ['/home/spark-jars/test1.jar', '/home/spark-jars/test2.jar'],
+                ['spark://************:2222/jars/test1.jar']),
+            False
         )

--- a/mage_ai/tests/services/spark/test_spark.py
+++ b/mage_ai/tests/services/spark/test_spark.py
@@ -17,6 +17,8 @@ class SparkTests(TestCase):
             ['test1.jar', 'test2.jar']
         )
         self.assertEqual(
-            get_file_names(['spark://************:2222/jars/test1.jar', 'spark://************:2222/jars/test2.jar']),
+            get_file_names([
+                'spark://************:2222/jars/test1.jar',
+                'spark://************:2222/jars/test2.jar']),
             ['test1.jar', 'test2.jar']
         )

--- a/mage_ai/tests/services/spark/test_spark.py
+++ b/mage_ai/tests/services/spark/test_spark.py
@@ -24,34 +24,29 @@ class SparkTests(TestCase):
         )
 
     def test_contains_same_jars(self):
-        self.assertEqual(
+        self.assertTrue(
             contains_same_jars(
                 ['/home/spark-jars/aws-java-sdk-core-1.11.1026.jar'],
-                ['aws-java-sdk-core-1.11.1026.jar']),
-            True
+                ['aws-java-sdk-core-1.11.1026.jar'])
         )
-        self.assertEqual(
+        self.assertTrue(
             contains_same_jars(
                 ['spark://************:2222/jars/aws-java-sdk-core-1.11.1026.jar'],
-                ['aws-java-sdk-core-1.11.1026.jar']),
-            True
+                ['aws-java-sdk-core-1.11.1026.jar'])
         )
-        self.assertEqual(
+        self.assertTrue(
             contains_same_jars(
                 ['/home/spark-jars/aws-java-sdk-core-1.11.1026.jar'],
-                ['spark://************:2222/jars/aws-java-sdk-core-1.11.1026.jar']),
-            True
+                ['spark://************:2222/jars/aws-java-sdk-core-1.11.1026.jar'])
         )
-        self.assertEqual(
+        self.assertTrue(
             contains_same_jars(
                 ['/home/spark-jars/test1.jar', '/home/spark-jars/test2.jar'],
                 ['spark://************:2222/jars/test2.jar',
-                 'spark://************:2222/jars/test1.jar']),
-            True
+                 'spark://************:2222/jars/test1.jar'])
         )
-        self.assertEqual(
+        self.assertTrue(
             contains_same_jars(
                 ['/home/spark-jars/test1.jar', '/home/spark-jars/test2.jar'],
-                ['spark://************:2222/jars/test1.jar']),
-            False
+                ['spark://************:2222/jars/test1.jar'])
         )


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

In the original `spark_config` settings, the jar files are set as:
```
/home/spark-jars/aws-java-sdk-core-1.11.1026.jar
```
However, when retrieved from the Spark context, the names of jar files are changed:
``` 
spark://************:2222/jars/aws-java-sdk-core-1.11.1026.jar
```

Thus, code changes are made to ensure the parity checking between the above two jar paths to be equivalent, to work around this issue. More details are available in [the Slack thread](https://mageai.slack.com/archives/C03GGQTS8CT/p1690897341882629).

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [X] Test A

Run the following commands in a Python3 shell:
```
>>> import os
... 
>>> a = ['/home/spark-jars/aws-java-sdk-core-1.11.1026.jar']
>>> b = ['spark://************:2222/jars/aws-java-sdk-core-1.11.1026.jar']
>>> contains_same_jars(a, b)
True
```

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@dy46 @wangxiaoyou1993 