### PR TITLE
[xy] Not obfuscate data in data integration records.

### DIFF
--- a/mage_ai/data_preparation/models/block/integration/__init__.py
+++ b/mage_ai/data_preparation/models/block/integration/__init__.py
@@ -122,7 +122,7 @@ class IntegrationBlock(Block):
                 proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
                 for line in proc.stdout:
-                    f.write(filter_out_config_values(line.decode(), config)),
+                    f.write(line.decode()),
                     print_log_from_line(
                         line,
                         config=config,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Issue:
```
  I’m setting up a data integration pipeline for Google Search Console to be loaded into BigQuery, and for some reason
  two of the fields are being loaded into BigQuery obfuscated as *************, site_url and date.  There doesn’t
  seem to be any options to configure field level obfuscation that I can see, what’s happening?
```
The bug was introduced in version 0.9.4
Thus, this PR removes filter_out_config_values method call when writing the source output to file.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested syncing data from Google Search Console to BigQuery. The data is synced correctly without obfscated data.
<img width="687" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/16dd23df-0d39-4d5f-9f7c-c2d1706346a3">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
