### PR TITLE
[xy] Improve error message for duplicate column name.

### DIFF
--- a/mage_ai/data_preparation/models/variable.py
+++ b/mage_ai/data_preparation/models/variable.py
@@ -430,6 +430,9 @@ class Variable:
         df_output = data.copy()
         # Clean up data types since parquet doesn't support mixed data types
         for c in df_output.columns:
+            df_col = df_output[c]
+            if type(df_col) is pd.DataFrame:
+                raise Exception(f'Please do not use duplicate column name: "{c}"')
             c_dtype = df_output[c].dtype
             if not is_object_dtype(c_dtype):
                 column_types[c] = str(c_dtype)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Improve error message for duplicate column name.

The current error message "AttributeError: 'DataFrame' object has no attribute 'dtype'" is misleading

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with the SQL query 
<img width="411" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/883678fd-78c8-4913-b3ef-eb63c2830e48">

Before this change
<img width="497" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/34986ca1-475d-41cd-9960-f196af851e58">


After this change
<img width="539" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/13b317f1-3d37-4425-8610-c36ca7afb659">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
