### PR TITLE
[mp] Remove WIP sections from documentation

### DIFF
--- a/docs/api-reference/pipeline-schedules/create-pipeline-schedule.mdx
+++ b/docs/api-reference/pipeline-schedules/create-pipeline-schedule.mdx
@@ -1,6 +1,0 @@
----
-title: "Create schedule"
-api: "POST /api/pipeline_schedules/"
----
-
-*WIP*

--- a/docs/api-reference/pipeline-schedules/delete-pipeline-schedule.mdx
+++ b/docs/api-reference/pipeline-schedules/delete-pipeline-schedule.mdx
@@ -1,5 +1,0 @@
----
-title: "Delete schedule"
-api: "DELETE /api/pipeline_schedules/:id"
----
-*WIP*

--- a/docs/data-integrations/destinations/adapt-existing-destination.mdx
+++ b/docs/data-integrations/destinations/adapt-existing-destination.mdx
@@ -1,5 +1,0 @@
----
-title: "Adapt existing destination"
----
-
-WIP

--- a/docs/data-integrations/overview.mdx
+++ b/docs/data-integrations/overview.mdx
@@ -53,7 +53,6 @@ Read more about Sources:
 
 - [Technical documentation](/data-integrations/sources/overview)
 - [Add a new source](/data-integrations/sources/add-new-source)
-- [Adapt an existing source (aka Tap)](/data-integrations/sources/adapt-existing-source)
 
 ### Available sources
 
@@ -124,7 +123,6 @@ Read more about destinations:
 
 - [Technical documentation](/data-integrations/destinations/overview)
 - [Add a new destination](/data-integrations/destinations/add-new-destination)
-- [Adapt an existing destination (aka Target)](/data-integrations/destinations/adapt-existing-destination)
 
 ### Available destinations
 

--- a/docs/data-integrations/sources/adapt-existing-source.mdx
+++ b/docs/data-integrations/sources/adapt-existing-source.mdx
@@ -1,5 +1,0 @@
----
-title: "Adapt existing source"
----
-
-WIP

--- a/docs/design/core-abstractions.mdx
+++ b/docs/design/core-abstractions.mdx
@@ -335,23 +335,3 @@ where you want log files written to (e.g. Amazon S3, Google Storage, etc).
 ## Backfill
 
 A backfill creates 1 or more pipeline runs for a pipeline.
-
-## Event
-
-_WIP_
-
-## Metric
-
-_WIP_
-
-## Partition
-
-_WIP_
-
-## Version
-
-_WIP_
-
-## Service
-
-_WIP_

--- a/docs/guides/transformer-blocks.mdx
+++ b/docs/guides/transformer-blocks.mdx
@@ -283,6 +283,8 @@ Note: Action variables are inferred from `arguments` and `df`.
   ```
 
 # Transformer Action Reference
+- [Building Transformer Actions](#building-transformer-actions)
+- [Transformer Action Reference](#transformer-action-reference)
 - [Column Actions](#column-actions)
   - [Aggregation Actions](#aggregation-actions)
   - [Formatting Actions](#formatting-actions)
@@ -307,6 +309,8 @@ Note: Action variables are inferred from `arguments` and `df`.
     - [Filter](#filter)
     - [Remove Rows](#remove-rows)
     - [Sort](#sort)
+- [Appendix: Filter Syntax](#appendix-filter-syntax)
+- [Appendix: Column Types](#appendix-column-types)
 # Column Actions
 
 ## Aggregation Actions

--- a/docs/integrations/spark-pyspark.mdx
+++ b/docs/integrations/spark-pyspark.mdx
@@ -669,13 +669,3 @@ Please make sure to terminate your EMR cluster when you’re done using it so yo
 can save money.
 
 ---
-
-## [WIP] GCP
-
-Coming soon...
-
----
-
-## [WIP] Azure
-
-Coming soon...


### PR DESCRIPTION
# Description
A user felt that WIP sections in our docs did not convey the best message. This PR removes those sections. Notes have been made to track WIP sections for future work. 

https://mageai.slack.com/archives/C03GGQTS8CT/p1691774680116499?thread_ts=1691774418.401199&cid=C03GGQTS8CT

# How Has This Been Tested?
- `mintlify dev`
- `mintlify broken-links`

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
