### PR TITLE
[xy] Fix using location in dbt bigquery.

### DIFF
--- a/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
@@ -501,9 +501,12 @@ def config_file_loader_and_configuration(
         database = kwargs.get('database') or profile.get('project')
         schema = profile.get('dataset')
 
-        config_file_loader = ConfigFileLoader(config=dict(
+        config_file_loader_kwargs = dict(
             GOOGLE_SERVICE_ACC_KEY_FILEPATH=keyfile,
-        ))
+        )
+        if profile.get('location'):
+            config_file_loader_kwargs['GOOGLE_LOCATION'] = profile.get('location')
+        config_file_loader = ConfigFileLoader(config=config_file_loader_kwargs)
         configuration = dict(
             data_provider=profile_type,
             data_provider_database=database,

--- a/mage_ai/data_preparation/models/variable.py
+++ b/mage_ai/data_preparation/models/variable.py
@@ -433,11 +433,11 @@ class Variable:
             df_col = df_output[c]
             if type(df_col) is pd.DataFrame:
                 raise Exception(f'Please do not use duplicate column name: "{c}"')
-            c_dtype = df_output[c].dtype
+            c_dtype = df_col.dtype
             if not is_object_dtype(c_dtype):
                 column_types[c] = str(c_dtype)
             else:
-                series_non_null = df_output[c].dropna()
+                series_non_null = df_col.dropna()
                 if len(series_non_null) > 0:
                     coltype = type(series_non_null.iloc[0])
                     if is_object_dtype(series_non_null.dtype):


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix using location in dbt bigquery.

Original issue
```
  I’m having some issues with Bigquery data loading from GCS with a downstream dbt model block.
  When pulling the data from the GCS block as source, my dbt profile expects this data to be in the EU,
  however the mage configuration seems to auto-load the data into location: US by default and I cannot
  find a place to change this even though all of my dbt settings are set as EU. Any suggestions on this?
```


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested setting `location` to `EU` in the profiles.yaml and run the dbt block. It succeeds
<img width="145" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/78645a81-6fa0-4ea0-99bb-314d8304677d">
<img width="651" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/5b5212ab-8435-41f8-b135-5bd8ac9ce3fd">




# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
