### PR TITLE
[jk] Block run count formatting in PipelineRuns table

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -383,6 +383,8 @@ function PipelineRunsTable({
                 status,
               } = pipelineRun;
               const disabled = !id && !status;
+              const blockRunCountTooltipMessage =
+                `${completedBlockRunsCount} out of ${blockRunsCount} block runs completed`;
 
               const isRetry =
                 index > 0
@@ -436,12 +438,12 @@ function PipelineRunsTable({
                     key="row_block_runs"
                     passHref
                   >
-                    <Link 
-                      bold 
-                      muted 
-                      title={`${completedBlockRunsCount} out of ${blockRunsCount} block runs completed`}
+                    <Link
+                      bold
+                      muted
+                      title={blockRunCountTooltipMessage}
                     >
-                      {`${completedBlockRunsCount}/${blockRunsCount}`}
+                      {`${completedBlockRunsCount} / ${blockRunsCount}`}
                     </Link>
                   </NextLink>,
                   <Button
@@ -516,9 +518,9 @@ function PipelineRunsTable({
                       bold
                       disabled={disabled}
                       sky
-                      title={`${completedBlockRunsCount} out of ${blockRunsCount} block runs completed`}
+                      title={blockRunCountTooltipMessage}
                     >
-                      {disabled ? '' :`${completedBlockRunsCount}/${blockRunsCount}`}
+                      {disabled ? '' : `${completedBlockRunsCount} / ${blockRunsCount}`}
                     </Link>
                   </NextLink>,
                   <Button

--- a/mage_ai/frontend/components/PipelineDetail/Syncs/SyncRowDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Syncs/SyncRowDetail/index.tsx
@@ -16,7 +16,7 @@ import {
 import {
   ArrowLeft,
   Check,
-  TodoList,
+  Logs,
 } from '@oracle/icons';
 import { RunStatus as RunStatusBlockRun } from '@interfaces/BlockRunType';
 import { UNIT } from '@oracle/styles/units/spacing';
@@ -430,7 +430,7 @@ function SyncRowDetail({
                 pauseEvent(e);
               }}
             >
-              <TodoList default size={2 * UNIT} />
+              <Logs default size={2 * UNIT} />
             </Button>,
           ];
         })}

--- a/mage_ai/frontend/components/Triggers/Table.tsx
+++ b/mage_ai/frontend/components/Triggers/Table.tsx
@@ -26,7 +26,7 @@ import {
   Edit,
   Pause,
   PlayButtonFilled,
-  TodoList,
+  Logs,
   Trash,
 } from '@oracle/icons';
 import { RunStatus } from '@interfaces/BlockRunType';
@@ -378,7 +378,7 @@ function TriggersTable({
                     `/pipelines/${finalPipelineUUID}/logs?pipeline_schedule_id[]=${id}`,
                   )}
                 >
-                  <TodoList default size={2 * UNIT} />
+                  <Logs default size={2 * UNIT} />
                 </Button>,
               ]);
 


### PR DESCRIPTION
# Description
- Add spaces to block runs count in pipeline runs table so the link is easier to click.
- Make all Logs icons consistent.


# How Has This Been Tested?
- Confirmed minor UI fixes locally

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
