### PR TITLE
base.py: add XML support

### DIFF
--- a/docs/design/data-loading.mdx
+++ b/docs/design/data-loading.mdx
@@ -260,6 +260,7 @@ Handles data transfer between an S3 bucket and the Mage app. The `S3` client sup
 -   JSON
 -   Parquet
 -   HDF5
+-   XML
 
 If an IAM profile is not set up using `aws configure`, then AWS credentials for accesses the S3 bucket can be manually specified through either Mage's [configuration loader](#configuration-settings) system or through keyword arguments in the constructor (see constructor).
 
@@ -317,6 +318,7 @@ If the format is HDF5, the default key under which the data frame is stored is t
         | JSON    | [_DataFrame.to_json_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_json.html)       |
         | Parquet | [_DataFrame.to_parquet_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_parquet.html) |
         | HDF5    | [_DataFrame.to_hdf_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_hdf.html)         |
+        | XML     | [_DataFrame.to_xml_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_xml.html)         |
 
 **_load_** - `load(bucket_name: str, object_key: str, format: FileFormat | str = None, limit: int = QUERY_ROW_LIMIT **kwargs) -> DataFrame`
 
@@ -336,6 +338,7 @@ Loads data from object in S3 bucket into a Pandas data frame. This function will
         | JSON    | [_read_json_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_json.html)       |
         | Parquet | [_read_parquet_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_parquet.html) |
         | HDF5    | [_read_hdf_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_hdf.html)         |
+        | XML     | [_read_xml_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_xml.html)         |
 
 -   **Returns**: (`DataFrame`) Data frame object loaded from data in the specified file.
 
@@ -349,6 +352,7 @@ Handles data transfer between the filesystem and the Mage app. The `FileIO` clie
 -   JSON
 -   Parquet
 -   HDF5
+-   XML
 
 <h3> Constructor </h3>
 
@@ -380,6 +384,7 @@ If the format is HDF5, the default key under which the data frame is stored is t
         | JSON    | [_DataFrame.to_json_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_json.html)       |
         | Parquet | [_DataFrame.to_parquet_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_parquet.html) |
         | HDF5    | [_DataFrame.to_hdf_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_hdf.html)         |
+        | XML     | [_DataFrame.to_xml_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_xml.html)         |
 
 **_load_** - `load(filepath: os.PathLike, format: FileFormat | str = None, limit: int = QUERY_ROW_LIMIT **kwargs) -> DataFrame`
 
@@ -398,6 +403,7 @@ Loads the data frame from the filepath specified. This function will load at max
         | JSON    | [_read_json_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_json.html)       |
         | Parquet | [_read_parquet_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_parquet.html) |
         | HDF5    | [_read_hdf_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_hdf.html)         |
+        | XML     | [_read_xml_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_xml.html)         |
 
 -   **Returns**: (`DataFrame`) Data frame object loaded from data in the specified file.
 
@@ -411,6 +417,7 @@ Handles data transfer between a Google Cloud Storage bucket and the Mage app. Su
 -   JSON
 -   Parquet
 -   HDF5
+-   XML
 
 If `GOOGLE_APPLICATION_CREDENTIALS` environment is set, no further arguments are needed other than those specified below. Otherwise, use the factory method `with_config` to construct the data loader using manually specified credentials.
 
@@ -466,6 +473,7 @@ Exports data frame to a GoogleCloudStorage bucket.
         | JSON    | [_DataFrame.to_json_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_json.html)       |
         | Parquet | [_DataFrame.to_parquet_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_parquet.html) |
         | HDF5    | [_DataFrame.to_hdf_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_hdf.html)         |
+        | XML     | [_DataFrame.to_xml_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_xml.html)         |
 
 **_load_** - `load(bucket_name: str, object_key: str, format: FileFormat | str = None, limit: int = QUERY_ROW_LIMIT, **kwargs) -> DataFrame`
 
@@ -485,6 +493,7 @@ Loads data from object in GoogleCloudStorage bucket into a Pandas data frame. Th
         | JSON    | [_read_json_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_json.html)       |
         | Parquet | [_read_parquet_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_parquet.html) |
         | HDF5    | [_read_hdf_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_hdf.html)         |
+        | XML     | [_read_xml_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_xml.html)         |
 
 -   **Returns**: (`DataFrame`) Data frame object loaded from data in the specified file.
 
@@ -498,6 +507,7 @@ Handles data transfer between an Azure Blob Storage conatiner and Mage. Supports
 -   JSON
 -   Parquet
 -   HDF5
+-   XML
 
 To authenticate access to Azure Blob Storage, the following environment variables must be set:
 
@@ -547,6 +557,7 @@ Exports data frame to an Azure Blob Storage container.
         | JSON    | [_DataFrame.to_json_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_json.html)       |
         | Parquet | [_DataFrame.to_parquet_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_parquet.html) |
         | HDF5    | [_DataFrame.to_hdf_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_hdf.html)         |
+        | XML     | [_DataFrame.to_xml_](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_xml.html)         |
 
 **_load_** - `load(container_name: str, blob_path: str, format: FileFormat | str = None, limit: int = QUERY_ROW_LIMIT, **kwargs) -> DataFrame`
 

--- a/mage_ai/io/base.py
+++ b/mage_ai/io/base.py
@@ -35,6 +35,7 @@ class FileFormat(str, Enum):
     JSON = 'json'
     PARQUET = 'parquet'
     HDF5 = 'hdf5'
+    XML = 'xml'
 
 
 class ExportWritePolicy(str, Enum):
@@ -137,6 +138,8 @@ class BaseFile(BaseIO):
             return pd.read_parquet
         elif format == FileFormat.HDF5:
             return pd.read_hdf
+        elif format == FileFormat.XML:
+            return pd.read_xml
         else:
             raise ValueError(f'Invalid format \'{format}\' specified.')
 
@@ -226,6 +229,8 @@ class BaseFile(BaseIO):
             return df.to_json
         elif format == FileFormat.HDF5:
             return df.to_hdf
+        elif format == FileFormat.XML:
+            return df.to_xml
         return df.to_parquet
 
     def __del__(self):


### PR DESCRIPTION
# Description
Add support for reading & writing XML documents on the base io class.


# How Has This Been Tested?
Manually tested by reading and writing to minio using the S3 loader/exporter. Ran all the existing tests.

- [ ] Test A
- [ ] Test B


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

