### PR TITLE
[jk] Save logs scroll position for trigger logs

### DIFF
--- a/mage_ai/frontend/components/FileBrowser/Folder.tsx
+++ b/mage_ai/frontend/components/FileBrowser/Folder.tsx
@@ -150,9 +150,11 @@ function Folder({
     );
 
   const uuid = `${level}/${name}`;
-  const fileUsedByPipeline = pipelineBlockUuids.includes(getBlockUUIDFromFile(file));
+  const collapsedInit = (Array.isArray(children) && children?.length > 0)
+    ? get(uuid, level > 1)
+    : false;
   const [collapsed, setCollapsed] = useState<boolean>(typeof uncollapsed === 'undefined'
-    ? get(uuid, false)
+    ? collapsedInit
     : !uncollapsed,
   );
 

--- a/mage_ai/frontend/components/Logs/Filter/index.tsx
+++ b/mage_ai/frontend/components/Logs/Filter/index.tsx
@@ -19,14 +19,23 @@ import { capitalize } from '@utils/string';
 import { getColorsForBlockType } from '@components/CodeBlock/index.style';
 import { goToWithFilters } from '@utils/routing';
 
+export enum FilterQueryParamEnum {
+  BLOCK_RUN_ID = 'block_run_id[]',
+  BLOCK_TYPE = 'block_type[]',
+  BLOCK_UUID = 'block_uuid[]',
+  LEVEL = 'level[]',
+  PIPELINE_RUN_ID = 'pipeline_run_id[]',
+  PIPELINE_SCHEDULE_ID = 'pipeline_schedule_id[]',
+}
+
 export type FilterQueryType = {
-  'block_run_id[]'?: string[];
-  'block_type[]'?: string[];
-  'block_uuid[]'?: string[];
+  [FilterQueryParamEnum.BLOCK_RUN_ID]?: string[];
+  [FilterQueryParamEnum.BLOCK_TYPE]?: string[];
+  [FilterQueryParamEnum.BLOCK_UUID]?: string[];
+  [FilterQueryParamEnum.LEVEL]?: string[];
+  [FilterQueryParamEnum.PIPELINE_RUN_ID]?: string[];
+  [FilterQueryParamEnum.PIPELINE_SCHEDULE_ID]?: string[];
   end_timestamp?: string;
-  'level[]'?: string[];
-  'pipeline_run_id[]'?: string[];
-  'pipeline_schedule_id[]'?: string[];
   start_timestamp?: string;
 };
 
@@ -40,13 +49,13 @@ function Filter({
   query,
 }: FilterProps) {
   const themeContext = useContext(ThemeContext);
-  const queryLevels: string[] = useMemo(() => query['level[]'], [query]);
-  const queryBlockTypes: string[] = useMemo(() => query['block_type[]'], [query]);
-  const queryBlockUUIDs: string[] = useMemo(() => query['block_uuid[]'], [query]);
+  const queryLevels: string[] = useMemo(() => query[FilterQueryParamEnum.LEVEL], [query]);
+  const queryBlockTypes: string[] = useMemo(() => query[FilterQueryParamEnum.BLOCK_TYPE], [query]);
+  const queryBlockUUIDs: string[] = useMemo(() => query[FilterQueryParamEnum.BLOCK_UUID], [query]);
   const queryPipelineScheduleIDs: string[] =
-    useMemo(() => query['pipeline_schedule_id[]'], [query]);
-  const queryPipelineRunIDs: string[] = useMemo(() => query['pipeline_run_id[]'], [query]);
-  const queryBlockRunIDs: string[] = useMemo(() => query['block_run_id[]'], [query]);
+    useMemo(() => query[FilterQueryParamEnum.PIPELINE_SCHEDULE_ID], [query]);
+  const queryPipelineRunIDs: string[] = useMemo(() => query[FilterQueryParamEnum.PIPELINE_RUN_ID], [query]);
+  const queryBlockRunIDs: string[] = useMemo(() => query[FilterQueryParamEnum.BLOCK_RUN_ID], [query]);
 
   return (
     <BeforeStyle>

--- a/mage_ai/frontend/components/Logs/Table/index.tsx
+++ b/mage_ai/frontend/components/Logs/Table/index.tsx
@@ -1,7 +1,7 @@
 import Ansi from 'ansi-to-react';
 import NextLink from 'next/link';
 import { FixedSizeList } from 'react-window';
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import BlockType from '@interfaces/BlockType';
 import Circle from '@oracle/elements/Circle';
@@ -25,7 +25,9 @@ import { ThemeType } from '@oracle/styles/themes/constants';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { WIDTH_OF_SINGLE_CHARACTER_MONOSPACE } from '@components/DataTable';
 import { formatTimestamp } from '@utils/models/log';
+import { get, set } from '@storage/localStorage';
 import { getColorsForBlockType } from '@components/CodeBlock/index.style';
+import { getLogScrollPositionLocalStorageKey } from '../utils';
 import { goToWithQuery } from '@utils/routing';
 import { useWindowSize } from '@utils/sizes';
 
@@ -39,6 +41,7 @@ type LogsTableProps = {
   onRowClick?: (tab?: TabType) => void;
   pipeline: PipelineType;
   query: FilterQueryType;
+  saveScrollPosition?: boolean;
   setSelectedLog: (log: LogType) => void;
   themeContext: ThemeType;
 };
@@ -51,10 +54,12 @@ function LogsTable({
   onRowClick,
   pipeline,
   query,
+  saveScrollPosition,
   setSelectedLog,
   themeContext,
 }: LogsTableProps) {
   const { height: windowHeight } = useWindowSize();
+  const tableRef = useRef(null);
   const isIntegration = useMemo(
     () => PipelineTypeEnum.INTEGRATION === pipeline?.type,
     [pipeline.type],
@@ -71,6 +76,16 @@ function LogsTable({
     logsPrev,
     tableInnerRef,
   ]);
+
+  const scrollPositionLocalStorageKey = useMemo(() => (
+    getLogScrollPositionLocalStorageKey(pipeline?.uuid)
+  ), [pipeline?.uuid]);
+
+  useEffect(() => {
+    if (saveScrollPosition) {
+      tableRef?.current?.scrollTo(get(scrollPositionLocalStorageKey, 0));
+    }
+  }, [saveScrollPosition, scrollPositionLocalStorageKey]);
 
   let blockUUIDs = Object.keys(blocksByUUID || {});
   if (isIntegration) {
@@ -313,6 +328,12 @@ function LogsTable({
           themeContext,
         }}
         itemSize={UNIT * 3.75}
+        onScroll={({ scrollOffset, scrollDirection }) => {
+          if (saveScrollPosition && !(scrollDirection === 'forward' && scrollOffset === 0)) {
+            set(scrollPositionLocalStorageKey, scrollOffset);
+          }
+        }}
+        ref={tableRef}
         width="100%"
       >
         {renderRow}

--- a/mage_ai/frontend/components/Logs/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/Logs/Toolbar/index.tsx
@@ -127,7 +127,7 @@ function LogToolbar({
     qPrev,
   ]);
 
-  const saveLogScrollPosition = useCallback(() => {
+  const resetLogScrollPosition = useCallback(() => {
     if (saveScrollPosition) {
       const localStorageKey = getLogScrollPositionLocalStorageKey(pipelineUUID);
       set(localStorageKey, 0);
@@ -141,7 +141,7 @@ function LogToolbar({
           {...SHARED_BUTTON_PROPS}
           disabled={allPastLogsLoaded}
           onClick={() => {
-            saveLogScrollPosition();
+            resetLogScrollPosition();
             loadPastLogInterval();
           }}
           uuid="logs/load_older_logs"
@@ -155,7 +155,7 @@ function LogToolbar({
           {...SHARED_BUTTON_PROPS}
           disabled={q?._offset <= 0}
           onClick={() => {
-            saveLogScrollPosition();
+            resetLogScrollPosition();
             loadNewerLogInterval();
           }}
           uuid="logs/load_newer_logs"
@@ -171,7 +171,7 @@ function LogToolbar({
           onChange={e => {
             e.preventDefault();
             const range = e.target.value;
-            saveLogScrollPosition();
+            resetLogScrollPosition();
             setSelectedRange(range);
             if (SPECIFIC_LOG_RANGES.includes(range)) {
               const startTimestamp = calculateStartTimestamp(LOG_RANGE_SEC_INTERVAL_MAPPING[range]);
@@ -258,7 +258,7 @@ function LogToolbar({
             <Button
               borderRadius={UNIT / 2}
               onClick={() => {
-                saveLogScrollPosition();
+                resetLogScrollPosition();
                 const start = isoDateFormatFromDateParts(startDate, startTime.hour, startTime.minute);
                 const end = isoDateFormatFromDateParts(endDate, endTime.hour, endTime.minute);
                 goToWithQuery({

--- a/mage_ai/frontend/components/Logs/utils.ts
+++ b/mage_ai/frontend/components/Logs/utils.ts
@@ -1,0 +1,11 @@
+import { FilterQueryParamEnum } from './Filter';
+import { queryFromUrl } from '@utils/url';
+
+export const getLogScrollPositionLocalStorageKey = (
+  pipelineUUID: string,
+) => {
+  const q = queryFromUrl();
+  const pipelineScheduleIds = (q?.[FilterQueryParamEnum.PIPELINE_SCHEDULE_ID] || []).join(',');
+
+  return `${pipelineUUID}/logs/triggers/${pipelineScheduleIds}`;
+};

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -12,11 +12,13 @@ import {
 import BlockType, { BlockTypeEnum } from '@interfaces/BlockType';
 import Divider from '@oracle/elements/Divider';
 import ErrorsType from '@interfaces/ErrorsType';
-import Filter, { FilterQueryType } from '@components/Logs/Filter';
+import Filter, { FilterQueryType, FilterQueryParamEnum } from '@components/Logs/Filter';
 import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
 import KeyboardShortcutButton from '@oracle/elements/Button/KeyboardShortcutButton';
 import LogDetail, { TAB_DETAILS } from '@components/Logs/Detail';
+import LogsTable, { LOG_UUID_PARAM } from '@components/Logs/Table';
+import LogToolbar, { SHARED_BUTTON_PROPS } from '@components/Logs/Toolbar';
 import LogType, { LogRangeEnum } from '@interfaces/LogType';
 import PipelineDetailPage from '@components/PipelineDetailPage';
 import PipelineType, { PipelineTypeEnum } from '@interfaces/PipelineType';
@@ -24,8 +26,6 @@ import PrivateRoute from '@components/shared/PrivateRoute';
 import Spacing from '@oracle/elements/Spacing';
 import Spinner from '@oracle/components/Spinner';
 import Text from '@oracle/elements/Text';
-import LogsTable, { LOG_UUID_PARAM } from '@components/Logs/Table';
-import LogToolbar, { SHARED_BUTTON_PROPS } from '@components/Logs/Toolbar';
 import ToggleSwitch from '@oracle/elements/Inputs/ToggleSwitch';
 import api from '@api';
 import dark from '@oracle/styles/themes/dark';
@@ -120,6 +120,12 @@ function PipelineLogsPage({
   }, [blocks, isIntegrationPipeline]);
 
   const q = queryFromUrl();
+  const saveScrollPosition = useMemo(() => (
+    q?.hasOwnProperty(FilterQueryParamEnum.PIPELINE_SCHEDULE_ID)
+      && !q?.hasOwnProperty(FilterQueryParamEnum.LEVEL)
+      && !q?.hasOwnProperty(FilterQueryParamEnum.BLOCK_TYPE)
+      && !q?.hasOwnProperty(FilterQueryParamEnum.BLOCK_UUID)
+  ), [q]);
   const onlyLoadPastDayLogs = !q?.start_timestamp
     && !(q?.hasOwnProperty(PIPELINE_RUN_ID_PARAM) || q?.hasOwnProperty(BLOCK_RUN_ID_PARAM));
   const dayAgoTimestamp = calculateStartTimestamp(LOG_RANGE_SEC_INTERVAL_MAPPING[LogRangeEnum.LAST_DAY]);
@@ -230,6 +236,7 @@ function PipelineLogsPage({
         start_timestamp: dayAgoTimestamp,
       });
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onlyLoadPastDayLogs]);
   useEffect(() => {
     if (!isEqual(q, qPrev)) {
@@ -303,11 +310,20 @@ function PipelineLogsPage({
       onRowClick={setSelectedTab}
       pipeline={pipeline}
       query={query}
+      saveScrollPosition={saveScrollPosition}
       setSelectedLog={setSelectedLog}
       tableInnerRef={tableInnerRef}
       themeContext={themeContext}
     />
-  ), [autoScrollLogs, blocksByUUID, logsFiltered, pipeline, query, themeContext]);
+  ), [
+    autoScrollLogs,
+    blocksByUUID,
+    logsFiltered,
+    pipeline,
+    query,
+    saveScrollPosition,
+    themeContext,
+  ]);
 
   return (
     <PipelineDetailPage
@@ -353,6 +369,7 @@ function PipelineLogsPage({
                 allPastLogsLoaded={allPastLogsLoaded}
                 loadNewerLogInterval={loadNewerLogInterval}
                 loadPastLogInterval={loadPastLogInterval}
+                saveScrollPosition={saveScrollPosition}
                 selectedRange={selectedRange}
                 setSelectedRange={setSelectedRange}
               />


### PR DESCRIPTION
# Description
- Save logs scroll position when viewing the logs for a trigger, so user would be able to view a different page and go back in the browser back to the same log scroll position. The scroll position is currently not saved for general logs (i.e. all of a pipeline's log without any filters), specific pipeline run logs, or block run logs.
- Update initial collapsed folder state in file browser so that the first level of folders are uncollapsed, but the nested folders start off collapsed (makes it easier to navigate all the folders when a new project is created, especially the `pipelines` folder).

# How Has This Been Tested?
Log scroll position is saved when navigating to different page and going back:
![saved scroll position](https://github.com/mage-ai/mage-ai/assets/78053898/05ac6dee-3d6d-48f2-bb10-9ccb527b85fb)

Initial folders collapsed state (previously, every single nested folder was uncollapsed, making it hard to navigate folders like the `pipelines` folder):
![initial folders collapsed state](https://github.com/mage-ai/mage-ai/assets/78053898/c08f5518-f45b-4441-95bc-36af7701b150)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
