### PR TITLE
[dy] Add new base path environment variables

### DIFF
--- a/docs/development/environment-variables.mdx
+++ b/docs/development/environment-variables.mdx
@@ -34,7 +34,9 @@ description: "Configure Mage settings through environment variables."
 | `LDAP_GROUP_FIELD` | [More information](/production/authentication/overview#ldap) | See link |
 | `LDAP_ROLES_MAPPING` | [More information](/production/authentication/overview#ldap) | See link |
 | `LDAP_DEFAULT_ACCESS` | [More information](/production/authentication/overview#ldap) | See link |
-| `MAGE_BASE_PATH` | The base path or prefix of the Mage server url. [More information](/getting-started/setup##setting-prefix-for-mage-url) | `base/path` |
+| `MAGE_BASE_PATH` | The base path or prefix of the Mage server url. [More information](/getting-started/setup#setting-prefix-for-mage-url) | `base/path` |
+| `MAGE_REQUESTS_BASE_PATH` | [More information](/getting-started/setup#setting-prefix-for-mage-url) | `base/path` |
+| `MAGE_ROUTESBASE_PATH` | [More information](/getting-started/setup#setting-prefix-for-mage-url) | `base/path` |
 | `MAGE_CACHE_DIRECTORY` | The directory Mage uses for storing and retrieving temporary data used in the UI. | `/root/.mage_data/default_repo/.cache` |
 | `MAGE_DATABASE_CONNECTION_URL` | Specify the database connection url for orchestration DB. Defaults to local sqlite db. | [Example](/production/configuring-production-settings/overview#postgres) |
 | `MAGE_PUBLIC_HOST` | The public host url that can be used to access the Mage app. This value will be used in emails or other notifications. | `http://localhost:6789` |

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -280,8 +280,16 @@ Make sure to set the base path without the leading slash. For example, if you wa
 `http://localhost:6789/base/url/path`, you would configure your environment
 variable like this:
 
+`export MAGE_BASE_PATH=base/url/path`
+
+You can also configure the base path separately for client requests and backend routes by setting
+the `MAGE_REQUESTS_BASE_PATH` and `MAGE_ROUTES_BASE_PATH` environment variables respectively.
+
+|   |   |
 | --- | --- |
-| `MAGE_BASE_PATH` | "base/url/path" |
+| `MAGE_BASE_PATH` | Set base path for the entire app. |
+| `MAGE_REQUESTS_BASE_PATH` | Set base path for frontend requests and urls, defaults to value of `MAGE_BASE_PATH` |
+| `MAGE_ROUTES_BASE_PATH` | Set base path for backend routes, defaults to value of `MAGE_BASE_PATH` |
 
 ---
 

--- a/mage_ai/settings/__init__.py
+++ b/mage_ai/settings/__init__.py
@@ -67,9 +67,15 @@ NEW_RELIC_CONFIG_PATH = os.getenv('NEW_RELIC_CONFIG_PATH', '')
 DEFAULT_LOCALHOST_URL = 'http://localhost:6789'
 MAGE_PUBLIC_HOST = os.getenv('MAGE_PUBLIC_HOST') or DEFAULT_LOCALHOST_URL
 
-# The base path variable should not include a leading forward slash
-# e.g. BASE_PATH = 'test_prefix' -> localhost:6789/test_prefix/pipelines
+# All base path variables should not include a leading forward slash
+# e.g. MAGE_BASE_PATH = 'test_prefix' -> localhost:6789/test_prefix/pipelines
 BASE_PATH = os.getenv('MAGE_BASE_PATH')
+# Requests base path is used to configure the base path for the frontend requests. Defaults
+# to the MAGE_BASE_PATH environment variable.
+REQUESTS_BASE_PATH = os.getenv('MAGE_REQUESTS_BASE_PATH', BASE_PATH)
+# Routes base path is used to configure the base path for the backend routes. Defaults
+# to the MAGE_BASE_PATH environment variable.
+ROUTES_BASE_PATH = os.getenv('MAGE_ROUTES_BASE_PATH', BASE_PATH)
 
 # List of environment variables used to configure Mage. The value of these settings
 # will be copied between workspaces.

--- a/mage_ai/tests/server/test_server.py
+++ b/mage_ai/tests/server/test_server.py
@@ -27,7 +27,7 @@ class ServerTests(TestCase):
 
         self.assertIsNotNone(app)
 
-    @patch('mage_ai.server.server.BASE_PATH', 'test_prefix')
+    @patch('mage_ai.server.server.ROUTES_BASE_PATH', 'test_prefix')
     def test_make_app_with_update_routes(self):
         app = make_app(update_routes=True)
         request = tornado.httputil.HTTPServerRequest(
@@ -51,7 +51,7 @@ class ServerTests(TestCase):
         handler = app.default_router.find_handler(request)
         self.assertIsNone(handler)
 
-    @patch('mage_ai.server.server.BASE_PATH', 'random-test-string-1hasdfh')
+    @patch('mage_ai.server.server.REQUESTS_BASE_PATH', 'random-test-string-1hasdfh')
     @patch('mage_ai.server.server.get_variables_dir')
     def test_replace_base_path(self, mock_variables_dir):
         mock_variables_dir.return_value = os.path.dirname(server_module.__file__)
@@ -67,7 +67,7 @@ class ServerTests(TestCase):
             self.assertNotEqual(f.read().find('random-test-string-1hasdfh'), 0)
         shutil.rmtree(test_dir)
 
-    @patch('mage_ai.server.server.BASE_PATH', 'test_prefix')
+    @patch('mage_ai.server.server.REQUESTS_BASE_PATH', 'test_prefix')
     @patch('mage_ai.server.server.get_variables_dir')
     def test_replace_base_path_directory_exists(self, mock_variables_dir):
         mock_variables_dir.return_value = os.path.dirname(server_module.__file__)
@@ -82,7 +82,7 @@ class ServerTests(TestCase):
         self.assertTrue(len(os.listdir(test_dir)) > 0)
         shutil.rmtree(test_dir)
 
-    @patch('mage_ai.server.server.BASE_PATH', 'test_prefix')
+    @patch('mage_ai.server.server.REQUESTS_BASE_PATH', 'test_prefix')
     @patch('mage_ai.server.server.get_variables_dir')
     def test_replace_base_path_s3_directory(self, mock_variables_dir):
         mock_variables_dir.return_value = 's3://test-bucket/test-prefix'


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

This should be able to resolve this github issue: https://github.com/mage-ai/mage-ai/issues/1040.

I added two new base path variables called `MAGE_REQUESTS_BASE_PATH` and `MAGE_ROUTES_BASE_PATH` because in some cases, only the frontend paths need to be updated. In sagemaker studio, when the app is accessed through the url `<sagemaker-url>/proxy/6789/pipelines`, the backend route that is called is actually just `/pipelines`. Right now, when the `MAGE_BASE_PATH` variable is set, the backend routes will also get updated, so calling the `/pipelines` route will return a 404. The `MAGE_REQUESTS_BASE_PATH` variable will overwrite the urls in the frontend, and the `MAGE_ROUTES_BASE_PATH` variable will overwrite the routes in the server. The behavior of `MAGE_BASE_PATH` stays the same.

The names of the variables is based off of dash's variable names (DASH_REQUESTS_PATHNAME_PREFIX and DASH_ROUTES_PATHNAME_PREFIX): https://dash.plotly.com/reference, which has something similar to this.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested in sagemaker studio


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
