### PR TITLE
[jk] Browser-specific dependency graph improvements

### DIFF
--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -319,6 +319,11 @@ function DependencyGraph({
 
   useEffect(() => {
     setTimeout(() => {
+      /*
+       * On Chrome browsers, the dep graph would not center automatically when
+       * navigating to the Pipeline Editor page even though the "fit" prop was
+       * added to the Canvas component. This centers it if it is not already.
+       */
       if (canvasRef?.current?.containerRef?.current?.scrollTop === 0) {
         canvasRef?.current?.fitCanvas?.();
       }

--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -5,6 +5,7 @@ import { parse } from 'yaml';
 import {
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -315,6 +316,14 @@ function DependencyGraph({
   ]);
   const runningBlocksMapping =
     useMemo(() => indexBy(runningBlocks, ({ uuid }) => uuid), [runningBlocks]);
+
+  useEffect(() => {
+    setTimeout(() => {
+      if (canvasRef?.current?.containerRef?.current?.scrollTop === 0) {
+        canvasRef?.current?.fitCanvas?.();
+      }
+    }, 1000);
+  }, [canvasRef]);
 
   const [updateBlock, { isLoading: isLoadingUpdateBlock }] = useMutation(
     api.blocks.pipelines.useUpdate(

--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -834,7 +834,11 @@ function DependencyGraph({
                     setShowPorts(true);
                   }
                 }}
-                onLeave={() => setShowPorts(false)}
+                onLeave={() => {
+                  if (!activePort) {
+                    setShowPorts(false);
+                  }
+                }}
                 port={(showPorts && (
                   activePort === null || isActivePort(activePort, node)))
                   ?


### PR DESCRIPTION
# Description
- [Firefox browser] Allow dependency graph connecting lines to go through nodes. This was already doable in Chrome and Safari.
- [Chrome browser] Center dependency graph when loading the Pipeline Editor page. The dependency graph would already center itself on Firefox and Safari.

# How Has This Been Tested?
Before [Firefox]: Connecting lines cannot go through nodes.
![Before - Connecting lines cant go through nodes](https://github.com/mage-ai/mage-ai/assets/78053898/e3fcea29-0b30-4b3f-8b5a-861cf51642ba)
After [Firefox]: Connecting lines CAN go through nodes.
![After - Connecting lines CAN go through nodes](https://github.com/mage-ai/mage-ai/assets/78053898/a4851996-d0f9-459a-8056-9a7d44f78647)

Before [Chrome]: Dep graph does not center automatically.
![Before - Dep graph does not center](https://github.com/mage-ai/mage-ai/assets/78053898/6bb77e6d-dece-4a7d-8705-d3a3191ecadc)
After [Chrome]: Dep graph DOES center automatically.
![After - Dep graph DOES center](https://github.com/mage-ai/mage-ai/assets/78053898/6aa62c3e-8ad6-4356-9e7d-273603b940c1)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
