### PR TITLE
Added all columns as replication key

### DIFF
--- a/mage_integrations/mage_integrations/sources/sql/base.py
+++ b/mage_integrations/mage_integrations/sources/sql/base.py
@@ -6,7 +6,6 @@ from singer.schema import Schema
 from mage_integrations.sources.base import Source as BaseSource
 from mage_integrations.sources.catalog import Catalog, CatalogEntry
 from mage_integrations.sources.constants import (
-    COLUMN_FORMAT_DATETIME,
     COLUMN_FORMAT_UUID,
     COLUMN_TYPE_BOOLEAN,
     COLUMN_TYPE_INTEGER,
@@ -73,6 +72,8 @@ class Source(BaseSource):
                 column_properties = None
                 column_types = []
 
+                valid_replication_keys.append(column_name)
+
                 if column_key is not None and ('PRI' in column_key or 'UNIQUE' == column_key):
                     unique_constraints.append(column_name)
 
@@ -87,13 +88,6 @@ class Source(BaseSource):
                         'numeric' in column_type or 'decimal' in column_type or \
                         'real' in column_type or 'number' in column_type:
                     column_types.append(COLUMN_TYPE_NUMBER)
-                elif 'datetime' in column_type or 'timestamp' in column_type or \
-                        'date' in column_type:
-                    column_format = COLUMN_FORMAT_DATETIME
-                    column_types.append(COLUMN_TYPE_STRING)
-                    # TODO (tommy dang): remove this so we allow any columns to be
-                    # used as a bookmark
-                    valid_replication_keys.append(column_name)
                 elif 'json' in column_type or 'variant' in column_type:
                     column_properties = {}
                     column_types.append(COLUMN_TYPE_OBJECT)

--- a/mage_integrations/mage_integrations/sources/sql/base.py
+++ b/mage_integrations/mage_integrations/sources/sql/base.py
@@ -72,8 +72,6 @@ class Source(BaseSource):
                 column_properties = None
                 column_types = []
 
-                valid_replication_keys.append(column_name)
-
                 if column_key is not None and ('PRI' in column_key or 'UNIQUE' == column_key):
                     unique_constraints.append(column_name)
 

--- a/mage_integrations/mage_integrations/sources/sql/base.py
+++ b/mage_integrations/mage_integrations/sources/sql/base.py
@@ -6,6 +6,7 @@ from singer.schema import Schema
 from mage_integrations.sources.base import Source as BaseSource
 from mage_integrations.sources.catalog import Catalog, CatalogEntry
 from mage_integrations.sources.constants import (
+    COLUMN_FORMAT_DATETIME,
     COLUMN_FORMAT_UUID,
     COLUMN_TYPE_BOOLEAN,
     COLUMN_TYPE_INTEGER,
@@ -86,6 +87,10 @@ class Source(BaseSource):
                         'numeric' in column_type or 'decimal' in column_type or \
                         'real' in column_type or 'number' in column_type:
                     column_types.append(COLUMN_TYPE_NUMBER)
+                elif 'datetime' in column_type or 'timestamp' in column_type or \
+                        'date' in column_type:
+                    column_format = COLUMN_FORMAT_DATETIME
+                    column_types.append(COLUMN_TYPE_STRING)
                 elif 'json' in column_type or 'variant' in column_type:
                     column_properties = {}
                     column_types.append(COLUMN_TYPE_OBJECT)

--- a/mage_integrations/mage_integrations/tests/sources/bigquery/test_bigquery.py
+++ b/mage_integrations/mage_integrations/tests/sources/bigquery/test_bigquery.py
@@ -1,7 +1,9 @@
-from google.cloud.bigquery import Row
-from mage_integrations.sources.bigquery import BigQuery
-from unittest.mock import MagicMock, patch
 import unittest
+from unittest.mock import MagicMock, patch
+
+from google.cloud.bigquery import Row
+
+from mage_integrations.sources.bigquery import BigQuery
 
 
 def build_sample_bigquery_rows():
@@ -153,7 +155,7 @@ class BigQuerySourceTests(unittest.TestCase):
                                         'metadata': {
                                             'table-key-properties': [],
                                             'forced-replication-method': 'FULL_TABLE',
-                                            'valid-replication-keys': ['date_joined'],
+                                            'valid-replication-keys': [],
                                             'inclusion': 'available',
                                             'schema-name': 'demo_users',
                                         },
@@ -184,7 +186,7 @@ class BigQuerySourceTests(unittest.TestCase):
                                     },
                                     {
                                         'breadcrumb': ('properties', 'date_joined'),
-                                        'metadata': {'inclusion': 'automatic'},
+                                        'metadata': {'inclusion': 'available'},
                                     },
                                 ],
                                 'auto_add_new_fields': False,

--- a/mage_integrations/mage_integrations/tests/sources/mysql/test_mysql.py
+++ b/mage_integrations/mage_integrations/tests/sources/mysql/test_mysql.py
@@ -1,6 +1,7 @@
-from mage_integrations.sources.mysql import MySQL
-from unittest.mock import MagicMock, patch
 import unittest
+from unittest.mock import MagicMock, patch
+
+from mage_integrations.sources.mysql import MySQL
 
 
 def build_sample_mysql_rows():
@@ -66,7 +67,7 @@ class MySQLSourceTests(unittest.TestCase):
                                         'metadata': {
                                             'table-key-properties': ['id'],
                                             'forced-replication-method': 'FULL_TABLE',
-                                            'valid-replication-keys': ['id', 'date_joined'],
+                                            'valid-replication-keys': ['id'],
                                             'inclusion': 'available',
                                             'schema-name': 'demo_users',
                                         },
@@ -97,7 +98,7 @@ class MySQLSourceTests(unittest.TestCase):
                                     },
                                     {
                                         'breadcrumb': ('properties', 'date_joined'),
-                                        'metadata': {'inclusion': 'automatic'},
+                                        'metadata': {'inclusion': 'available'},
                                     },
                                     {
                                         'breadcrumb': ('properties', 'power_level'),

--- a/mage_integrations/mage_integrations/tests/sources/sql/test_base.py
+++ b/mage_integrations/mage_integrations/tests/sources/sql/test_base.py
@@ -17,14 +17,12 @@ def build_sample_postgres_rows():
         ('demo_users', None, None, 'id', 'character varying', 'YES'),
     ]
 
-
 def build_log_based_sample_catalog_entry():
     return CatalogEntry(
         replication_method='LOG_BASED',
         stream='demo_users',
         tap_stream_id='demo_users',
     )
-
 
 class BaseSQLSourceTests(unittest.TestCase):
     maxDiff = None
@@ -58,7 +56,10 @@ class BaseSQLSourceTests(unittest.TestCase):
                                         'properties': {
                                             'actionid': {'type': ['null', 'string']},
                                             'actionname': {'type': ['null', 'string']},
-                                            'createddate': {'type': ['null', 'string']},
+                                            'createddate': {
+                                                'format': 'date-time',
+                                                'type': ['null', 'string'],
+                                            },
                                             'type': {'type': ['null', 'string']},
                                         },
                                         'type': 'object',

--- a/mage_integrations/mage_integrations/tests/sources/sql/test_base.py
+++ b/mage_integrations/mage_integrations/tests/sources/sql/test_base.py
@@ -1,8 +1,9 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
 from mage_integrations.sources.catalog import CatalogEntry
 from mage_integrations.sources.sql.base import Source
 from mage_integrations.tests.sources.test_base import build_sample_streams_catalog
-from unittest.mock import MagicMock, patch
-import unittest
 
 
 def build_sample_postgres_rows():
@@ -16,12 +17,14 @@ def build_sample_postgres_rows():
         ('demo_users', None, None, 'id', 'character varying', 'YES'),
     ]
 
+
 def build_log_based_sample_catalog_entry():
     return CatalogEntry(
         replication_method='LOG_BASED',
         stream='demo_users',
         tap_stream_id='demo_users',
     )
+
 
 class BaseSQLSourceTests(unittest.TestCase):
     maxDiff = None
@@ -55,10 +58,7 @@ class BaseSQLSourceTests(unittest.TestCase):
                                         'properties': {
                                             'actionid': {'type': ['null', 'string']},
                                             'actionname': {'type': ['null', 'string']},
-                                            'createddate': {
-                                                'format': 'date-time',
-                                                'type': ['null', 'string'],
-                                            },
+                                            'createddate': {'type': ['null', 'string']},
                                             'type': {'type': ['null', 'string']},
                                         },
                                         'type': 'object',
@@ -70,7 +70,7 @@ class BaseSQLSourceTests(unittest.TestCase):
                                             'metadata': {
                                                 'table-key-properties': [],
                                                 'forced-replication-method': 'FULL_TABLE',
-                                                'valid-replication-keys': ['createddate'],
+                                                'valid-replication-keys': [],
                                                 'inclusion': 'available',
                                                 'schema-name': 'demo_actions',
                                             },
@@ -85,7 +85,7 @@ class BaseSQLSourceTests(unittest.TestCase):
                                         },
                                         {
                                             'breadcrumb': ('properties', 'createddate'),
-                                            'metadata': {'inclusion': 'automatic'},
+                                            'metadata': {'inclusion': 'available'},
                                         },
                                         {
                                             'breadcrumb': ('properties', 'type'),


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Added all SQL generated columns as replication_key, allowing for all columns to be used as bookmarks.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
Tested on a local mage instance using PostgreSQL -> Clickhouse

Catalog before enhancement:
![Screenshot from 2023-08-17 00-26-15](https://github.com/mage-ai/mage-ai/assets/14100959/4731ebca-75f5-45e9-a51a-41e6474428c6)

Catalog after:

![Screenshot from 2023-08-17 00-33-52](https://github.com/mage-ai/mage-ai/assets/14100959/7fe4354a-9858-4acb-b342-f75422c9600e)

Incremental run tests:
![Screenshot from 2023-08-17 00-44-14](https://github.com/mage-ai/mage-ai/assets/14100959/c3fd6441-f190-4941-aa74-a42f25d82824)

![Screenshot from 2023-08-17 00-44-32](https://github.com/mage-ai/mage-ai/assets/14100959/d145be87-5cf0-482d-8d6d-95bb6e55b013)

![Screenshot from 2023-08-17 00-44-36](https://github.com/mage-ai/mage-ai/assets/14100959/29d8e07e-8683-45a6-b8e6-f46564c85fee)



# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

