### PR TITLE
[jk] Make pipeline run count pagination consistent

### DIFF
--- a/mage_ai/api/policies/PipelineRunPolicy.py
+++ b/mage_ai/api/policies/PipelineRunPolicy.py
@@ -90,6 +90,7 @@ PipelineRunPolicy.allow_write([
 
 PipelineRunPolicy.allow_query([
     'backfill_id',
+    'disable_retries_grouping',
     'end_timestamp',
     'global_data_product_uuid',
     'include_pipeline_type',

--- a/mage_ai/api/resources/PipelineRunResource.py
+++ b/mage_ai/api/resources/PipelineRunResource.py
@@ -152,7 +152,7 @@ class PipelineRunResource(DatabaseResource):
         """
         The if block below groups pipeline runs that have the same execution_date with
         its retries so that all of a run's retries may be returned in the same payload.
-        In order to disable this functionality, we add the "disable_retried_grouping"
+        In order to disable this functionality, we add the "disable_retries_grouping"
         query arg and set it to True (e.g. in order to make the number of pipeline runs
         returned consistent across pages).
         """

--- a/mage_ai/api/resources/PipelineRunResource.py
+++ b/mage_ai/api/resources/PipelineRunResource.py
@@ -149,6 +149,13 @@ class PipelineRunResource(DatabaseResource):
         disable_retries_grouping = query_arg.get('disable_retries_grouping', [False])
         if disable_retries_grouping:
             disable_retries_grouping = disable_retries_grouping[0]
+        """
+        The if block below groups pipeline runs that have the same execution_date with
+        its retries so that all of a run's retries may be returned in the same payload.
+        In order to disable this functionality, we add the "disable_retried_grouping"
+        query arg and set it to True (e.g. in order to make the number of pipeline runs
+        returned consistent across pages).
+        """
         if meta.get(META_KEY_LIMIT, None) is not None and \
             total_results.count() >= 1 and \
             not disable_retries_grouping and \

--- a/mage_ai/api/resources/PipelineRunResource.py
+++ b/mage_ai/api/resources/PipelineRunResource.py
@@ -146,8 +146,12 @@ class PipelineRunResource(DatabaseResource):
         if pipeline_uuid:
             pipeline_uuid = pipeline_uuid[0]
 
+        disable_retries_grouping = query_arg.get('disable_retries_grouping', [False])
+        if disable_retries_grouping:
+            disable_retries_grouping = disable_retries_grouping[0]
         if meta.get(META_KEY_LIMIT, None) is not None and \
             total_results.count() >= 1 and \
+            not disable_retries_grouping and \
                 (pipeline_uuid is not None or pipeline_schedule_id is not None):
 
             first_result = results[0]

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -207,7 +207,8 @@ function RetryButton({
               </Text>
               <Spacing mb={1} />
               <Text>
-                Retry the run with changes you have made to the pipeline.
+                Retry the run with changes you have made to the pipeline.<br />
+                Note that the retried run may appear on a previous page.
               </Text>
               <Spacing mb={1} />
               <Button

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -30,6 +30,7 @@ import { getTimeInUTCString } from '@components/Triggers/utils';
 import { indexBy } from '@utils/array';
 import { isViewer } from '@utils/session';
 import { onSuccess } from '@api/utils/response';
+import { queryFromUrl } from '@utils/url';
 
 const SHARED_DATE_FONT_PROPS = {
   monospace: true,
@@ -70,6 +71,13 @@ function RetryButton({
   const isCancelingPipeline = isLoadingCancelPipeline
     && pipelineRunId === cancelingRunId
     && RunStatus.RUNNING === status;
+
+  const q = queryFromUrl();
+  const isNotFirstPage = useMemo(() => {
+    const page = q?.page ? +q.page : 0;
+
+    return page > 0;
+  }, [q?.page]);
 
   const [createPipelineRun]: any = useMutation(
     (ScheduleTypeEnum.API === pipelineScheduleType && pipelineScheduleToken)
@@ -207,8 +215,11 @@ function RetryButton({
               </Text>
               <Spacing mb={1} />
               <Text>
-                Retry the run with changes you have made to the pipeline.<br />
-                Note that the retried run may appear on a previous page.
+                Retry the run with changes you have made to the pipeline.
+                {isNotFirstPage ?
+                  <><br />Note that the retried run may appear on a previous page.</>
+                  : null
+                }
               </Text>
               <Spacing mb={1} />
               <Button

--- a/mage_ai/frontend/components/shared/Paginate/index.tsx
+++ b/mage_ai/frontend/components/shared/Paginate/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Button from '@oracle/elements/Button';
 import FlexContainer from '@oracle/components/FlexContainer';
 import Spacing from '@oracle/elements/Spacing';
+import { DARK_CONTENT_DEFAULT } from '@oracle/styles/colors/content';
 import { PaginateArrowLeft, PaginateArrowRight } from '@oracle/icons';
 import { PURPLE } from '@oracle/styles/colors/main';
 import { UNIT } from '@oracle/styles/units/spacing';
@@ -14,7 +15,8 @@ type PaginateProps = {
   totalPages: number;
 };
 
-export const ROW_LIMIT = 22;
+export const ROW_LIMIT = 30;
+export const MAX_PAGES = 9;
 
 function Paginate({
   page,
@@ -53,25 +55,25 @@ function Paginate({
             disabled={page === 0}
             onClick={() => onUpdate(page - 1)}
           >
-            <PaginateArrowLeft size={1.5 * UNIT} stroke='#AEAEAE' />
+            <PaginateArrowLeft size={1.5 * UNIT} stroke={DARK_CONTENT_DEFAULT} />
           </Button>
           {!pageArray.includes(0) && (
             <>
-              <Spacing ml={1} key={0}>
+              <Spacing key={0} ml={1}>
                 <Button
-                  onClick={() => onUpdate(0)}
                   borderLess
                   noBackground
+                  onClick={() => onUpdate(0)}
                 >
                   {1}
                 </Button>
               </Spacing>
               {!pageArray.includes(1) && (
-                <Spacing ml={1} key={0}>
+                <Spacing key={0} ml={1}>
                   <Button
-                    notClickable
                     noBackground
                     noPadding
+                    notClickable
                   >
                     ...
                   </Button>
@@ -80,17 +82,17 @@ function Paginate({
             </>
           )}
           {pageArray.map((p) => (
-            <Spacing ml={1} key={p}>
+            <Spacing key={p} ml={1}>
               <Button
+                backgroundColor={p === page && PURPLE}
+                borderLess
+                noBackground
+                notClickable={p === page}
                 onClick={() => {
                   if (p !== page) {
                     onUpdate(p);
                   }
                 }}
-                notClickable={p === page}
-                backgroundColor={p === page && PURPLE}
-                borderLess
-                noBackground
               >
                 {p + 1}
               </Button>
@@ -99,21 +101,21 @@ function Paginate({
           {!pageArray.includes(totalPages - 1) && (
             <>
               {!pageArray.includes(totalPages - 2) && (
-                <Spacing ml={1} key={0}>
+                <Spacing key={0} ml={1}>
                   <Button
-                    notClickable
                     noBackground
                     noPadding
+                    notClickable
                   >
                     ...
                   </Button>
                 </Spacing>
               )}
-              <Spacing ml={1} key={totalPages - 1}>
+              <Spacing key={totalPages - 1} ml={1}>
                 <Button
-                  onClick={() => onUpdate(totalPages - 1)}
                   borderLess
                   noBackground
+                  onClick={() => onUpdate(totalPages - 1)}
                 >
                   {totalPages}
                 </Button>
@@ -125,12 +127,12 @@ function Paginate({
             disabled={page === totalPages - 1}
             onClick={() => onUpdate(page + 1)}
           >
-            <PaginateArrowRight size={1.5 * UNIT} stroke='#AEAEAE' />
+            <PaginateArrowRight size={1.5 * UNIT} stroke={DARK_CONTENT_DEFAULT} />
           </Button>
         </FlexContainer>
       )}
     </>
-  )
+  );
 }
 
 export default Paginate;

--- a/mage_ai/frontend/interfaces/PipelineRunType.ts
+++ b/mage_ai/frontend/interfaces/PipelineRunType.ts
@@ -35,6 +35,7 @@ export const RUN_STATUS_TO_LABEL = {
 export interface PipelineRunReqQueryParamsType {
   _limit?: number;
   _offset?: number;
+  disable_retries_grouping?: boolean;
   global_data_product_uuid?: string;
   pipeline_uuid?: string;
   status?: RunStatusEnum;

--- a/mage_ai/frontend/pages/pipeline-runs/index.tsx
+++ b/mage_ai/frontend/pages/pipeline-runs/index.tsx
@@ -29,6 +29,7 @@ function RunListPage() {
   const pipelineRunsRequestQuery: PipelineRunReqQueryParamsType = {
     _limit: ROW_LIMIT,
     _offset: page * ROW_LIMIT,
+    disable_retries_grouping: true,
   };
   if (q?.status) {
     pipelineRunsRequestQuery.status = q.status;

--- a/mage_ai/frontend/pages/pipeline-runs/index.tsx
+++ b/mage_ai/frontend/pages/pipeline-runs/index.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 import Dashboard from '@components/Dashboard';
 import ErrorsType from '@interfaces/ErrorsType';
 import FlexContainer from '@oracle/components/FlexContainer';
-import Paginate, { ROW_LIMIT } from '@components/shared/Paginate';
+import Paginate, { MAX_PAGES, ROW_LIMIT } from '@components/shared/Paginate';
 import PipelineRunsTable from '@components/PipelineDetail/Runs/Table';
 import PrivateRoute from '@components/shared/PrivateRoute';
 import Select from '@oracle/elements/Inputs/Select';
@@ -98,7 +98,7 @@ function RunListPage() {
       />
       <Spacing p={2}>
         <Paginate
-          maxPages={9}
+          maxPages={MAX_PAGES}
           onUpdate={(p) => {
             const newPage = Number(p);
             const updatedQuery = {

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -11,7 +11,7 @@ import ErrorsType from '@interfaces/ErrorsType';
 import FlexContainer from '@oracle/components/FlexContainer';
 import FlyoutMenuWrapper from '@oracle/components/FlyoutMenu/FlyoutMenuWrapper';
 import PageSectionHeader from '@components/shared/Sticky/PageSectionHeader';
-import Paginate from '@components/shared/Paginate';
+import Paginate, { MAX_PAGES, ROW_LIMIT } from '@components/shared/Paginate';
 import PipeIconGradient from '@oracle/icons/custom/PipeIconGradient';
 import PipelineDetailPage from '@components/PipelineDetailPage';
 import PipelineRunType, {
@@ -68,9 +68,6 @@ const TABS = [
   TAB_PIPELINE_RUNS,
   TAB_BLOCK_RUNS,
 ];
-
-const LIMIT = 30;
-const MAX_PAGES = 9;
 
 type PipelineRunsProp = {
   pipeline: {
@@ -154,8 +151,8 @@ function PipelineRuns({
   ]);
 
   const runsRequestQuery: PipelineRunReqQueryParamsType = {
-    _limit: LIMIT,
-    _offset: page * LIMIT,
+    _limit: ROW_LIMIT,
+    _offset: page * ROW_LIMIT,
     pipeline_uuid: pipelineUUID,
   };
   let blockRunsRequestQuery = ignoreKeys(
@@ -315,7 +312,7 @@ function PipelineRuns({
           );
         }}
         page={Number(page)}
-        totalPages={Math.ceil(totalRuns / LIMIT)}
+        totalPages={Math.ceil(totalRuns / ROW_LIMIT)}
       />
     </Spacing>
   ), [

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -171,6 +171,7 @@ function PipelineRuns({
 
   let pipelineRunsRequestQuery = {
     ...runsRequestQuery,
+    disable_retries_grouping: true,
   };
   if (q?.status) {
     pipelineRunsRequestQuery.status = q.status;

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -115,7 +115,7 @@ function PipelineRuns({
     pipelineUUID,
   ]);
 
-  const [selectedRun, setSelectedRun] = useState<PipelineRunType>();
+  const [selectedRun, setSelectedRun] = useState<PipelineRunType>(null);
 
   const q = queryFromUrl();
   const qPrev = usePrevious(q);
@@ -307,6 +307,7 @@ function PipelineRuns({
             ...q,
             page: newPage >= 0 ? newPage : 0,
           };
+          setSelectedRun(null);
           router.push(
             '/pipelines/[pipeline]/runs',
             `/pipelines/${pipelineUUID}/runs?${queryString(updatedQuery)}`,


### PR DESCRIPTION
# Description
- When viewing pipeline runs for an individual pipeline, the number of pipeline runs on each page was inconsistent due to grouping of retried pipeline runs with the same execution date (this was so users can see all run retries on the same page). This also led to certain runs being displayed on multiple pages, which could be confusing for users performing bulk actions like retry/cancel on specific runs across pages.
- This PR makes the number of pipeline runs on each page consistent (30 runs per page) and avoids having the same run appear on multiple pages.

# How Has This Been Tested?
- Confirmed pipeline run count on each page was consistent.

Before (same pipeline run appears on Page 1 and 2):
<img width="1877" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/9080234a-41f0-417a-89ea-b444789f6115">
After (no overlap of runs between pages):
<img width="1848" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/f3f877ad-2cc7-4d6b-ad7e-31ab00564a23">


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
