### PR TITLE
[dy] Add column identifier for trino

### DIFF
--- a/mage_integrations/mage_integrations/destinations/trino/connectors/base.py
+++ b/mage_integrations/mage_integrations/destinations/trino/connectors/base.py
@@ -1,20 +1,23 @@
+import json
+from typing import Dict, Generator, List, Tuple
+
 from mage_integrations.connections.trino import Trino as TrinoConnection
-from mage_integrations.destinations.constants import (
-    UNIQUE_CONFLICT_METHOD_UPDATE,
-)
+from mage_integrations.destinations.constants import UNIQUE_CONFLICT_METHOD_UPDATE
 from mage_integrations.destinations.sql.base import Destination
 from mage_integrations.destinations.sql.utils import (
     build_alter_table_command,
     build_create_table_command,
     build_insert_command,
     clean_column_name,
+)
+from mage_integrations.destinations.sql.utils import (
     column_type_mapping as column_type_mapping_orig,
 )
-from mage_integrations.destinations.trino.utils import convert_column_type, convert_json_or_string
+from mage_integrations.destinations.trino.utils import (
+    convert_column_type,
+    convert_json_or_string,
+)
 from mage_integrations.utils.dictionary import merge_dict
-from typing import Dict, Generator, List, Tuple
-import json
-
 
 # https://trino.io/docs/current/develop/supporting-merge.html
 MERGEABLE_CONNECTORS = [
@@ -54,6 +57,7 @@ class TrinoConnector(Destination):
     ) -> List[str]:
         return [
             build_create_table_command(
+                column_identifier='"',
                 column_type_mapping=self.column_type_mapping(schema),
                 columns=schema['properties'].keys(),
                 full_table_name=f'{schema_name}.{table_name}',
@@ -224,8 +228,10 @@ DESCRIBE {schema_name}.{table_name}
         query_strings: List[str],
         record_data: List[Dict],
         stream: str,
-        tags: Dict = {},
+        tags: Dict = None,
     ) -> List[List[Tuple]]:
+        if tags is None:
+            tags = {}
         results = []
 
         if self.debug:
@@ -273,7 +279,7 @@ DESCRIBE {schema_name}.{table_name}
         self,
         record_data: List[Dict],
         stream: str,
-        tags: Dict = {},
+        tags: Dict = None,
     ) -> List[str]:
         return []
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Resolves this issue: https://github.com/mage-ai/mage-ai/issues/3267. Adds double quotes around column names in Trino `CREATE TABLE` query.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
