### PR TITLE
[xy] Fix mage run cli command with variables

### DIFF
--- a/docs/production/configuring-production-settings/runtime-variable.mdx
+++ b/docs/production/configuring-production-settings/runtime-variable.mdx
@@ -92,10 +92,10 @@ Once the package is installed, you can run your pipeline through the command
 line.
 
 ```bash
-mage run <project_path> <pipeline_uuid> --runtime-vars [name value]...
+mage run <project_path> <pipeline_uuid> --runtime-vars '{"name": "value"}'...
 
 # example with 2 runtime variables "name" and "ds":
-mage run default_repo default_pipeline --runtime-vars name default ds 2022-08-18
+mage run default_repo default_pipeline --runtime-vars '{"name": "default", "ds": "2022-08-18"}'
 ```
 
 ### Run from Python script

--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from typing import List, Union
+from typing import Union
 
 import typer
 from click import Context
@@ -184,7 +184,7 @@ def run(
     callback_url: Union[str, None] = RUN_CALLBACK_URL_DEFAULT,
     block_run_id: Union[int, None] = RUN_BLOCK_RUN_ID_DEFAULT,
     pipeline_run_id: Union[int, None] = RUN_PIPELINE_RUN_ID_DEFAULT,
-    runtime_vars: Union[List[str], None] = RUN_RUNTIME_VARS_DEFAULT,
+    runtime_vars: Union[str, None] = RUN_RUNTIME_VARS_DEFAULT,
     skip_sensors: bool = RUN_SKIP_SENSORS_DEFAULT,
     template_runtime_configuration: Union[str, None] = RUN_TEMPLATE_RUNTIME_CONFIGURATION_DEFAULT,
 ):

--- a/mage_ai/cli/utils.py
+++ b/mage_ai/cli/utils.py
@@ -1,22 +1,19 @@
-from typing import Any, Dict, List, Union
 import json
+import traceback
+from typing import Any, Dict, Union
 
 
-def parse_runtime_variables(variables: List[str]) -> Dict[str, Any]:
+def parse_runtime_variables(variables_str: str) -> Dict[str, Any]:
     """
     Returns a dictionary of variable to parsed values.
+
     """
     vars_parsed = dict()
 
-    if variables is None:
-        return vars_parsed
-    for i in range(0, len(variables), 2):
-        key = variables[i]
-        try:
-            value = variables[i + 1]
-        except IndexError:
-            value = None
-        vars_parsed[key] = get_value(value)
+    try:
+        vars_parsed = json.loads(variables_str)
+    except Exception:
+        traceback.print_exc()
     return vars_parsed
 
 

--- a/mage_ai/cli/utils.py
+++ b/mage_ai/cli/utils.py
@@ -7,8 +7,15 @@ def parse_runtime_variables(variables_str: str) -> Dict[str, Any]:
     """
     Returns a dictionary of variable to parsed values.
 
+    Args:
+        variables_str (str): The variables json string
+
+    Returns:
+        Dict[str, Any]: The parsed variables dictionary
     """
     vars_parsed = dict()
+    if not variables_str:
+        return vars_parsed
 
     try:
         vars_parsed = json.loads(variables_str)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix mage run cli command with variables.

Example usage: `mage run default_repo default_pipeline --runtime-vars '{"name": "default", "ds": "2022-08-18"}'`

`Typer` doesn't support a list of values as arg value: https://github.com/tiangolo/typer/issues/110

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested run the `mage run` cli command locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
