### PR TITLE
[jk] Add pagination to pipeline run block runs page

### DIFF
--- a/mage_ai/api/policies/PipelineRunPolicy.py
+++ b/mage_ai/api/policies/PipelineRunPolicy.py
@@ -92,6 +92,7 @@ PipelineRunPolicy.allow_query([
     'backfill_id',
     'disable_retries_grouping',
     'end_timestamp',
+    'exclude_block_runs',
     'global_data_product_uuid',
     'include_pipeline_type',
     'order_by[]',

--- a/mage_ai/api/policies/PipelineRunPolicy.py
+++ b/mage_ai/api/policies/PipelineRunPolicy.py
@@ -92,7 +92,6 @@ PipelineRunPolicy.allow_query([
     'backfill_id',
     'disable_retries_grouping',
     'end_timestamp',
-    'exclude_block_runs',
     'global_data_product_uuid',
     'include_pipeline_type',
     'order_by[]',

--- a/mage_ai/api/presenters/PipelineRunPresenter.py
+++ b/mage_ai/api/presenters/PipelineRunPresenter.py
@@ -21,9 +21,8 @@ class PipelineRunPresenter(BasePresenter):
     ]
 
     async def present(self, **kwargs):
+        query = kwargs.get('query', {})
         if constants.LIST == kwargs['format']:
-            query = kwargs.get('query', {})
-
             additional_attributes = [
                 'block_runs',
                 'block_runs_count',
@@ -45,18 +44,24 @@ class PipelineRunPresenter(BasePresenter):
 
             return self.model.to_dict(include_attributes=additional_attributes)
         elif constants.DETAIL == kwargs['format']:
-            block_runs = self.model.block_runs
             data = self.model.to_dict()
-            pipeline_schedule = self.resource.pipeline_schedule
 
-            arr = []
-            for r in block_runs:
-                block_run = r.to_dict()
-                block_run['pipeline_schedule_id'] = pipeline_schedule.id
-                block_run['pipeline_schedule_name'] = pipeline_schedule.name
-                arr.append(block_run)
-            arr.sort(key=lambda b: b.get('created_at'))
-            data['block_runs'] = arr
+            exclude_block_runs = query.get('exclude_block_runs', [False])
+            if exclude_block_runs:
+                exclude_block_runs = exclude_block_runs[0]
+
+            if not exclude_block_runs:
+                block_runs = self.model.block_runs
+                pipeline_schedule = self.resource.pipeline_schedule
+                arr = []
+                for r in block_runs:
+                    block_run = r.to_dict()
+                    block_run['pipeline_schedule_id'] = pipeline_schedule.id
+                    block_run['pipeline_schedule_name'] = pipeline_schedule.name
+                    arr.append(block_run)
+                arr.sort(key=lambda b: b.get('created_at'))
+                data['block_runs'] = arr
+
             return data
 
         return self.model.to_dict()

--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
@@ -252,10 +252,9 @@ function BlockRunsTable({
                 forceVisible={downloadingOutput}
                 label={downloadingOutput
                   ? `${blockOutputDownloadProgress || 0}mb downloaded...`
-                  : 'Save block run output as CSV file'
+                  : 'Save block run output as CSV file (not supported for dynamic blocks)'
                 }
                 size={null}
-                widthFitContent
               >
                 <Button
                   default

--- a/mage_ai/frontend/interfaces/BlockRunType.ts
+++ b/mage_ai/frontend/interfaces/BlockRunType.ts
@@ -8,6 +8,13 @@ export enum RunStatus {
   CONDITION_FAILED = 'condition_failed',
 }
 
+export interface BlockRunReqQueryParamsType {
+  _limit?: number;
+  _offset?: number;
+  pipeline_run_id?: number;
+  pipeline_uuid?: string;
+}
+
 export default interface BlockRunType {
   block_uuid: string;
   completed_at?: string;

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
@@ -73,7 +73,7 @@ function PipelineBlockRuns({
   const { data: dataPipelineRun } = api.pipeline_runs.detail(
     pipelineRunProp.id,
     {
-      exclude_block_runs: true,
+      _format: 'with_basic_details',
     },
     {
       refreshInterval: 3000,

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -215,7 +215,7 @@ function PipelineRuns({
   ), [selectedRuns]);
   const selectedRunningRunsCount = selectedRunningRunsArr.length;
 
-  const [updatePipeline, { isLoading: isLoadingUpdatePipeline }]: any = useMutation(
+  const [updatePipeline]: any = useMutation(
     api.pipelines.useUpdate(pipelineUUID),
     {
       onSuccess: (response: any) => onSuccess(


### PR DESCRIPTION
# Description
- Add pagination to Block Runs page (for a specific pipeline run). Helps to organize block runs, especially for dynamic pipelines that create many block runs.

# How Has This Been Tested?
Before (no pagination):
![before - no block run pagination](https://github.com/mage-ai/mage-ai/assets/78053898/9551c4da-1efb-4723-9082-78117c232ac8)

After (with pagination):
![after - with block run pagination](https://github.com/mage-ai/mage-ai/assets/78053898/27abfe3c-e055-45dd-9f35-19ee88f1d8ac)

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
