### PR TITLE
[jk] Add pipeline "created_at" property

### DIFF
--- a/mage_ai/api/presenters/PipelinePresenter.py
+++ b/mage_ai/api/presenters/PipelinePresenter.py
@@ -7,6 +7,7 @@ class PipelinePresenter(BasePresenter):
     default_attributes = [
         'blocks',
         'concurrency_config',
+        'created_at',
         'data_integration',
         'description',
         'executor_config',

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -6,6 +6,7 @@ import shutil
 from typing import Callable, Dict, List
 
 import aiofiles
+import pytz
 import yaml
 from jinja2 import Template
 
@@ -55,7 +56,7 @@ class Pipeline:
         self.block_configs = []
         self.blocks_by_uuid = {}
         self.concurrency_config = dict()
-        self.created_at = datetime.datetime.utcnow()
+        self.created_at = None
         self.data_integration = None
         self.description = None
         self.executor_config = dict()
@@ -68,7 +69,7 @@ class Pipeline:
         self.schedules = []
         self.tags = []
         self.type = PipelineType.PYTHON
-        self.updated_at = datetime.datetime.utcnow()
+        self.updated_at = datetime.datetime.now(tz=pytz.UTC)
         self.uuid = uuid
         self.widget_configs = []
         self._executor_count = 1  # Used by streaming pipeline to launch multiple executors
@@ -155,7 +156,7 @@ class Pipeline:
         # Update metadata.yaml with pipeline config
         with open(os.path.join(pipeline_path, PIPELINE_CONFIG_FILE), 'w') as fp:
             yaml.dump(dict(
-                created_at=str(datetime.datetime.utcnow()),
+                created_at=str(datetime.datetime.now(tz=pytz.UTC)),
                 name=name,
                 uuid=uuid,
                 type=format_enum(pipeline_type or PipelineType.PYTHON),

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -55,6 +55,7 @@ class Pipeline:
         self.block_configs = []
         self.blocks_by_uuid = {}
         self.concurrency_config = dict()
+        self.created_at = datetime.datetime.utcnow()
         self.data_integration = None
         self.description = None
         self.executor_config = dict()
@@ -67,7 +68,7 @@ class Pipeline:
         self.schedules = []
         self.tags = []
         self.type = PipelineType.PYTHON
-        self.updated_at = datetime.datetime.now()
+        self.updated_at = datetime.datetime.utcnow()
         self.uuid = uuid
         self.widget_configs = []
         self._executor_count = 1  # Used by streaming pipeline to launch multiple executors
@@ -154,6 +155,7 @@ class Pipeline:
         # Update metadata.yaml with pipeline config
         with open(os.path.join(pipeline_path, PIPELINE_CONFIG_FILE), 'w') as fp:
             yaml.dump(dict(
+                created_at=str(datetime.datetime.utcnow()),
                 name=name,
                 uuid=uuid,
                 type=format_enum(pipeline_type or PipelineType.PYTHON),
@@ -466,6 +468,7 @@ class Pipeline:
             self._executor_count = int(config.get('executor_count'))
         except Exception:
             pass
+        self.created_at = config.get('created_at')
         self.updated_at = config.get('updated_at')
         self.type = config.get('type') or self.type
 
@@ -590,6 +593,7 @@ class Pipeline:
     def to_dict_base(self, exclude_data_integration=False) -> Dict:
         base = dict(
             concurrency_config=self.concurrency_config,
+            created_at=self.created_at,
             data_integration=self.data_integration if not exclude_data_integration else None,
             description=self.description,
             executor_config=self.executor_config,

--- a/mage_ai/frontend/interfaces/PipelineType.ts
+++ b/mage_ai/frontend/interfaces/PipelineType.ts
@@ -82,6 +82,7 @@ export default interface PipelineType {
   blocks?: BlockType[];
   callbacks?: BlockType[];
   conditionals?: BlockType[];
+  created_at?: string;
   data_integration?: {
     catalog: CatalogType;
   };

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -803,7 +803,7 @@ function PipelineListPage() {
             maxHeight={`calc(100vh - ${HEADER_HEIGHT + 74}px)`}
           >
             <Table
-              columnFlex={[null, null, null, 2, null, null, 1, null, null, null]}
+              columnFlex={[null, null, null, 2, null, null, null, 1, null, null, null]}
               columns={[
                 {
                   label: () => '',
@@ -823,6 +823,9 @@ function PipelineListPage() {
                 },
                 {
                   uuid: 'Updated at',
+                },
+                {
+                  uuid: 'Created at',
                 },
                 {
                   uuid: 'Tags',
@@ -929,6 +932,7 @@ function PipelineListPage() {
               rows={pipelines.map((pipeline, idx) => {
                 const {
                   blocks,
+                  created_at: createdAt,
                   description,
                   schedules,
                   tags,
@@ -1020,6 +1024,14 @@ function PipelineListPage() {
                     title={updatedAt}
                   >
                     {updatedAt ? updatedAt.slice(0, -3) : <>&#8212;</>}
+                  </Text>,
+                  <Text
+                    key={`pipeline_created_at_${idx}`}
+                    monospace
+                    small
+                    title={createdAt}
+                  >
+                    {createdAt ? createdAt.slice(0, 16) : <>&#8212;</>}
                   </Text>,
                   tagsEl,
                   <Text

--- a/mage_ai/tests/data_preparation/models/test_pipeline.py
+++ b/mage_ai/tests/data_preparation/models/test_pipeline.py
@@ -5,6 +5,7 @@ import uuid
 from unittest.mock import patch
 
 import yaml
+from freezegun import freeze_time
 
 from mage_ai.data_preparation.models.block import Block
 from mage_ai.data_preparation.models.constants import PipelineType
@@ -26,6 +27,7 @@ class PipelineTest(DBTestCase):
         self.assertTrue(os.path.exists(f'{self.repo_path}/pipelines/test_pipeline/__init__.py'))
         self.assertTrue(os.path.exists(f'{self.repo_path}/pipelines/test_pipeline/metadata.yaml'))
 
+    @freeze_time('2023-08-01 08:08:24')
     def test_add_block(self):
         self.__create_pipeline_with_blocks('test pipeline 2')
         pipeline = Pipeline('test_pipeline_2', self.repo_path)
@@ -112,6 +114,7 @@ class PipelineTest(DBTestCase):
             ],
             callbacks=[],
             conditionals=[],
+            created_at='2023-08-01 08:08:24',
             updated_at=None,
             widgets=[
                 dict(
@@ -164,6 +167,7 @@ class PipelineTest(DBTestCase):
         self.assertEqual(pipeline_run.pipeline_uuid, 'test_pipeline_c2')
         self.assertEqual(pipeline_schedule.pipeline_uuid, 'test_pipeline_c2')
 
+    @freeze_time('2023-08-01 08:08:24')
     def test_delete_block(self):
         pipeline = self.__create_pipeline_with_blocks('test pipeline 3')
         block = pipeline.blocks_by_uuid['block4']
@@ -237,10 +241,12 @@ class PipelineTest(DBTestCase):
             ],
             callbacks=[],
             conditionals=[],
+            created_at='2023-08-01 08:08:24',
             updated_at=None,
             widgets=[],
         ))
 
+    @freeze_time('2023-08-01 08:08:24')
     def test_execute(self):
         pipeline = Pipeline.create(
             'test pipeline 4',
@@ -337,10 +343,12 @@ class PipelineTest(DBTestCase):
             ],
             callbacks=[],
             conditionals=[],
+            created_at='2023-08-01 08:08:24',
             updated_at=None,
             widgets=[],
         ))
 
+    @freeze_time('2023-08-01 08:08:24')
     def test_execute_multiple_paths(self):
         pipeline = Pipeline.create(
             'test pipeline 5',
@@ -491,6 +499,7 @@ class PipelineTest(DBTestCase):
             ],
             callbacks=[],
             conditionals=[],
+            created_at='2023-08-01 08:08:24',
             updated_at=None,
             widgets=[],
         ))
@@ -570,6 +579,7 @@ class PipelineTest(DBTestCase):
         with self.assertRaises(InvalidPipelineError):
             pipeline.update_block(block4)
 
+    @freeze_time('2023-08-01 08:08:24')
     def test_save_and_get_data_integration_catalog(self):
         pipeline = self.__create_pipeline_with_integration('test_pipeline_9')
         pipeline.save()

--- a/mage_ai/tests/data_preparation/models/test_pipeline.py
+++ b/mage_ai/tests/data_preparation/models/test_pipeline.py
@@ -114,7 +114,7 @@ class PipelineTest(DBTestCase):
             ],
             callbacks=[],
             conditionals=[],
-            created_at='2023-08-01 08:08:24',
+            created_at='2023-08-01 08:08:24+00:00',
             updated_at=None,
             widgets=[
                 dict(
@@ -241,7 +241,7 @@ class PipelineTest(DBTestCase):
             ],
             callbacks=[],
             conditionals=[],
-            created_at='2023-08-01 08:08:24',
+            created_at='2023-08-01 08:08:24+00:00',
             updated_at=None,
             widgets=[],
         ))
@@ -343,7 +343,7 @@ class PipelineTest(DBTestCase):
             ],
             callbacks=[],
             conditionals=[],
-            created_at='2023-08-01 08:08:24',
+            created_at='2023-08-01 08:08:24+00:00',
             updated_at=None,
             widgets=[],
         ))
@@ -499,7 +499,7 @@ class PipelineTest(DBTestCase):
             ],
             callbacks=[],
             conditionals=[],
-            created_at='2023-08-01 08:08:24',
+            created_at='2023-08-01 08:08:24+00:00',
             updated_at=None,
             widgets=[],
         ))
@@ -609,7 +609,7 @@ class PipelineTest(DBTestCase):
                 config_json,
                 dict(
                     concurrency_config=dict(),
-                    created_at='2023-08-01 08:08:24',
+                    created_at='2023-08-01 08:08:24+00:00',
                     data_integration=None,
                     description=None,
                     executor_config={},

--- a/mage_ai/tests/data_preparation/models/test_pipeline.py
+++ b/mage_ai/tests/data_preparation/models/test_pipeline.py
@@ -609,6 +609,7 @@ class PipelineTest(DBTestCase):
                 config_json,
                 dict(
                     concurrency_config=dict(),
+                    created_at='2023-08-01 08:08:24',
                     data_integration=None,
                     description=None,
                     executor_config={},


### PR DESCRIPTION
# Description
- Add `created_at` property to pipeline model and display in the Pipelines dashboard table, which users can use to sort the pipelines table by when sorting is implemented.

# How Has This Been Tested?
- Updated unit tests
- New pipelines will now have the `created_at` property (old pipelines are not applicable since they were already created):
![image](https://github.com/mage-ai/mage-ai/assets/78053898/de35a802-f465-4264-b295-1dc97739b583)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have added unit tests that prove my fix is effective or that my feature works
