### PR TITLE
[xy] Improve streaming pipeline stability

### DIFF
--- a/mage_ai/data_preparation/executors/streaming_pipeline_executor.py
+++ b/mage_ai/data_preparation/executors/streaming_pipeline_executor.py
@@ -173,14 +173,19 @@ class StreamingPipelineExecutor(PipelineExecutor):
             handle_batch_events_recursively(self.source_block, outputs_by_block, **kwargs)
 
         # Long running method
-        if source.consume_method == SourceConsumeMethod.BATCH_READ:
-            source.batch_read(handler=handle_batch_events)
-        elif source.consume_method == SourceConsumeMethod.READ_ASYNC:
-            loop = asyncio.get_event_loop()
-            if loop is not None:
-                loop.run_until_complete(source.read_async(handler=handle_event_async))
-            else:
-                asyncio.run(source.read_async(handler=handle_event_async))
+        try:
+            if source.consume_method == SourceConsumeMethod.BATCH_READ:
+                source.batch_read(handler=handle_batch_events)
+            elif source.consume_method == SourceConsumeMethod.READ_ASYNC:
+                loop = asyncio.get_event_loop()
+                if loop is not None:
+                    loop.run_until_complete(source.read_async(handler=handle_event_async))
+                else:
+                    asyncio.run(source.read_async(handler=handle_event_async))
+        finally:
+            source.destroy()
+            for sink in sinks_by_uuid.values():
+                sink.destroy()
 
     def __execute_in_flink(self):
         """

--- a/mage_ai/streaming/sinks/amazon_s3.py
+++ b/mage_ai/streaming/sinks/amazon_s3.py
@@ -36,6 +36,12 @@ class AmazonS3Sink(BaseSink):
         if self.buffer:
             self.upload_data_to_s3()
 
+    def destroy(self):
+        try:
+            self.timer.cancel()
+        except Exception:
+            traceback.print_exc()
+
     def write(self, data: Dict):
         self._print(f'Ingest data {data}, time={time.time()}')
         self.write_buffer([data])

--- a/mage_ai/streaming/sinks/amazon_s3.py
+++ b/mage_ai/streaming/sinks/amazon_s3.py
@@ -57,11 +57,6 @@ class AmazonS3Sink(BaseSink):
             self.upload_data_to_s3()
             return
 
-        if self.config.buffer_timeout_seconds and \
-                self.has_buffer_timed_out(self.config.buffer_timeout_seconds):
-            self.upload_data_to_s3()
-            return
-
     def upload_data_to_s3(self):
         self.__reset_timer()
         if not self.buffer:

--- a/mage_ai/streaming/sinks/base.py
+++ b/mage_ai/streaming/sinks/base.py
@@ -37,6 +37,12 @@ class BaseSink(ABC):
         with open(self.buffer_path, 'w'):
             pass
 
+    def destroy(self):
+        """
+        Close connections and destroy threads
+        """
+        pass
+
     def has_buffer_timed_out(self, buffer_timeout_seconds):
         if self.buffer_start_time is None:
             return False

--- a/mage_ai/streaming/sinks/base.py
+++ b/mage_ai/streaming/sinks/base.py
@@ -17,7 +17,11 @@ class BaseSink(ABC):
         self.buffer_path = kwargs.get('buffer_path')
         self.buffer = self.read_buffer() or []
         self.buffer_start_time = None
-        self.init_client()
+        try:
+            self.init_client()
+        except Exception:
+            self.destroy()
+            raise
 
     def init_client(self):
         pass

--- a/mage_ai/streaming/sources/amazon_sqs.py
+++ b/mage_ai/streaming/sources/amazon_sqs.py
@@ -37,12 +37,8 @@ class AmazonSqsSource(BaseSource):
 
     def init_client(self):
         self._print('Start initializing consumer.')
-        # Initialize kafka consumer
         self.sqs_client = boto3.resource('sqs')
         self.queue = self.sqs_client.get_queue_by_name(QueueName=self.config.queue_name)
-        # self.details = self.kinesis_client.describe_stream(
-        #     StreamName=self.config.stream_name,
-        # )['StreamDescription']
         print(self.queue.url)
         self._print('Finish initializing consumer.')
 

--- a/mage_ai/streaming/sources/base.py
+++ b/mage_ai/streaming/sources/base.py
@@ -23,7 +23,13 @@ class BaseSource(ABC):
         self.checkpoint = self.read_checkpoint()
         self.init_client()
 
-    def init_client():
+    def init_client(self):
+        pass
+
+    def destroy(self):
+        """
+        Close connections and destroy threads
+        """
         pass
 
     @abstractmethod


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This PR improves the stability of the streaming pipeline
* When there're exceptions thrown in streaming pipeline, the processes might not be fully terminated due to hanging threads. Thus, this PR adds the destroy method to the source and sink. It make sure the hanging threads are destroyed on exception.
* This PR removes the redundant code in S3 sink for uploading the data on timeout. This reduces the race conditions.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested running streaming pipeline locally. Made sure the processes are terminated on exceptions.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code

cc:
<!-- Optionally mention someone to let them know about this pull request -->
