### PR TITLE
Docker: Python Multi Stage Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,27 @@
+ARG PIP=pip3
+ARG VIRTUAL_ENV=/opt/venv
+
+FROM python:3.10 as builder
+ARG PIP
+ARG VIRTUAL_ENV
+RUN python3 -m venv ${VIRTUAL_ENV}
+ENV PATH=${VIRTUAL_ENV}/bin:$PATH
+
+RUN ${PIP} install --no-cache-dir sparkmagic
+# Mage Integration
+RUN ${PIP} install --no-cache-dir "git+https://github.com/mage-ai/singer-python.git#egg=singer-python"
+RUN ${PIP} install --no-cache-dir "git+https://github.com/mage-ai/google-ads-python.git#egg=google-ads"
+RUN ${PIP} install --no-cache-dir "git+https://github.com/mage-ai/dbt-mysql.git#egg=dbt-mysql"
+RUN ${PIP} install --no-cache-dir "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations&subdirectory=mage_integrations"
+# Mage
+COPY ./mage_ai/server/constants.py constants.py
+RUN tag=$(tail -n 1 constants.py) && VERSION=$(echo $tag | tr -d "'") && ${PIP} install --no-cache-dir "mage-ai[all]"==$VERSION
+
+
 FROM python:3.10
 LABEL description="Deploy Mage on ECS"
-ARG PIP=pip3
+ARG PIP
+ARG VIRTUAL_ENV
 USER root
 
 # Packages
@@ -28,21 +49,14 @@ RUN \
   R -e "install.packages('renv', repos='http://cran.us.r-project.org')"
 
 # Python Packages
+COPY --link --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+ENV PATH=${VIRTUAL_ENV}/bin:$PATH
 RUN \
-  ${PIP} install --no-cache-dir sparkmagic && \
   mkdir ~/.sparkmagic && \
   wget https://raw.githubusercontent.com/jupyter-incubator/sparkmagic/master/sparkmagic/example_config.json && \
   mv example_config.json ~/.sparkmagic/config.json && \
   sed -i 's/localhost:8998/host.docker.internal:9999/g' ~/.sparkmagic/config.json && \
   jupyter-kernelspec install --user $(${PIP} show sparkmagic | grep Location | cut -d" " -f2)/sparkmagic/kernels/pysparkkernel
-# Mage Integration
-RUN ${PIP} install --no-cache-dir "git+https://github.com/mage-ai/singer-python.git#egg=singer-python"
-RUN ${PIP} install --no-cache-dir "git+https://github.com/mage-ai/google-ads-python.git#egg=google-ads"
-RUN ${PIP} install --no-cache-dir "git+https://github.com/mage-ai/dbt-mysql.git#egg=dbt-mysql"
-RUN ${PIP} install --no-cache-dir "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations&subdirectory=mage_integrations"
-# Mage
-COPY ./mage_ai/server/constants.py constants.py
-RUN tag=$(tail -n 1 constants.py) && VERSION=$(echo $tag | tr -d "'") && ${PIP} install --no-cache-dir "mage-ai[all]"==$VERSION
 
 # Startup Script
 COPY --chmod=+x ./scripts/install_other_dependencies.py ./scripts/run_app.sh /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN \
   R -e "install.packages('renv', repos='http://cran.us.r-project.org')"
 
 # Python Packages
-COPY --link --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 ENV PATH=${VIRTUAL_ENV}/bin:$PATH
 RUN \
   mkdir ~/.sparkmagic && \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -58,7 +58,7 @@ RUN \
 RUN npm install --global yarn && yarn global add next
 
 # Python Packages
-COPY --link --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 ENV PATH=${VIRTUAL_ENV}/bin:$PATH
 RUN \
   mkdir ~/.sparkmagic && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: ./dev.Dockerfile
-    command: "python mage_ai/server/server.py --host ${HOST} --port ${PORT} --project ${PROJECT} --manage-instance ${MANAGE_INSTANCE}"
+    command: /bin/bash -c "python mage_ai/server/server.py --host ${HOST} --port ${PORT} --project ${PROJECT} --manage-instance ${MANAGE_INSTANCE}"
     environment:
       - AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
# Description
Resolves: #3330

Set up a builder Image, which builds python packages inside a virtual environment.
`COPY --link` virtual environment to runner Image and set `PATH` to virtual environment bin.

If builder image is untouched by changes, then it does not need to be rebuild. If builder image is changed, then only downstream layers have to be rebuild. e.g. if a new version of an apt package is released, then the python layers do not have to be rebuild.

Also adds `/bin/bash -c` as prefix to start mage-ai/server in dev, which is needed to make `$PATH` available and therefore starting the correct python bin (virtual env). Otherwise it would start the /usr/bin/python binary.

# How Has This Been Tested?
- [x] Ran Dockerfile
- [x] Ran dev.Dockerfile with scripts/dev.sh


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works; not needed
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation; not needed

# Additional Info
Builds on top of #3329, which needs to be migrated first.
cc: @dy46, @wangxiaoyou1993 
