### PR TITLE
[dy] Overwrite existing project_uuid if a project_uuid is set when starting the server

### DIFF
--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -58,7 +58,7 @@ START_CLUSTER_TYPE_DEFAULT = typer.Option(
 )
 START_PROJECT_UUID_DEFAULT = typer.Option(
     None,
-    help='set project uuid if it has not been set for the project already',
+    help='set project uuid for the repo that is being started',
 )
 
 RUN_PROJECT_PATH_DEFAULT = typer.Argument(

--- a/mage_ai/data_preparation/repo_manager.py
+++ b/mage_ai/data_preparation/repo_manager.py
@@ -312,7 +312,7 @@ def init_project_uuid(overwrite_uuid: str = None) -> None:
     """
     global project_uuid
     repo_config = get_repo_config()
-    if overwrite_uuid is not None:
+    if overwrite_uuid:
         if repo_config.project_uuid != overwrite_uuid:
             repo_config.save(project_uuid=overwrite_uuid)
         project_uuid = overwrite_uuid

--- a/mage_ai/data_preparation/repo_manager.py
+++ b/mage_ai/data_preparation/repo_manager.py
@@ -293,7 +293,7 @@ def get_variables_dir(
     return variables_dir
 
 
-def set_project_uuid_from_metadata():
+def set_project_uuid_from_metadata() -> None:
     global project_uuid
     if os.path.exists(get_metadata_path()):
         with open(get_metadata_path(), 'r', encoding='utf-8') as f:
@@ -301,10 +301,24 @@ def set_project_uuid_from_metadata():
             project_uuid = config.get('project_uuid')
 
 
-def init_project_uuid():
+def init_project_uuid(overwrite_uuid: str = None) -> None:
+    """
+    Initialize the project_uuid constant. The project_uuid constant is used throughout
+    the server as an identifier for the project.
+
+    Args:
+        overwrite_uuid (str): If not null, the overwrite_uuid will overwrite the current
+            value of project_uuid.
+    """
     global project_uuid
+    repo_config = get_repo_config()
+    if overwrite_uuid is not None:
+        if repo_config.project_uuid != overwrite_uuid:
+            repo_config.save(project_uuid=overwrite_uuid)
+        project_uuid = overwrite_uuid
+        return
+
     if not project_uuid:
-        repo_config = get_repo_config()
         if repo_config.project_uuid:
             project_uuid = repo_config.project_uuid
         else:

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -454,7 +454,7 @@ def start_server(
             project_uuid=project_uuid,
         )
     set_repo_path(project)
-    init_project_uuid()
+    init_project_uuid(overwrite_uuid=project_uuid)
 
     asyncio.run(UsageStatisticLogger().project_impression())
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Because of the project_uuid bug that was introduced a couple of versions ago, the `project_uuid` value for a workspace may not be what was originally set. To fix this, I'm changing the `init_project_uuid` method to overwrite the existing `project_uuid` if an `overwrite_uuid` is passed in. Only workspaces should have the `project_uuid` argument set when the server is started.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Unit tests
- [x] Tested locally with workspaces


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
