### PR TITLE
[jk] Preview next pipeline run time for triggers

### DIFF
--- a/mage_ai/api/policies/PipelineSchedulePolicy.py
+++ b/mage_ai/api/policies/PipelineSchedulePolicy.py
@@ -61,6 +61,7 @@ PipelineSchedulePolicy.allow_read(PipelineSchedulePresenter.default_attributes +
 PipelineSchedulePolicy.allow_read(PipelineSchedulePresenter.default_attributes + [
     'event_matchers',
     'last_pipeline_run_status',
+    'next_pipeline_run_date',
     'pipeline_runs_count',
     'tags',
 ], scopes=[

--- a/mage_ai/api/policies/PipelineSchedulePolicy.py
+++ b/mage_ai/api/policies/PipelineSchedulePolicy.py
@@ -39,6 +39,7 @@ PipelineSchedulePolicy.allow_read(PipelineSchedulePresenter.default_attributes +
 
 PipelineSchedulePolicy.allow_read(PipelineSchedulePresenter.default_attributes + [
     'event_matchers',
+    'next_pipeline_run_date',
     'tags',
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
@@ -48,6 +49,7 @@ PipelineSchedulePolicy.allow_read(PipelineSchedulePresenter.default_attributes +
 
 PipelineSchedulePolicy.allow_read(PipelineSchedulePresenter.default_attributes + [
     'event_matchers',
+    'next_pipeline_run_date',
     'runtime_average',
     'tags',
 ], scopes=[

--- a/mage_ai/api/presenters/PipelineSchedulePresenter.py
+++ b/mage_ai/api/presenters/PipelineSchedulePresenter.py
@@ -39,6 +39,7 @@ class PipelineSchedulePresenter(BasePresenter):
                 'event_matchers',
             ])
             data['tags'] = sorted([tag.name for tag in self.get_tag_associations])
+            data['next_pipeline_run_date'] = self.model.next_execution_date()
 
             return data
         elif 'with_runtime_average' == display_format:

--- a/mage_ai/api/presenters/PipelineSchedulePresenter.py
+++ b/mage_ai/api/presenters/PipelineSchedulePresenter.py
@@ -24,6 +24,7 @@ class PipelineSchedulePresenter(BasePresenter):
     async def present(self, **kwargs):
         display_format = kwargs['format']
         data = self.model.to_dict()
+        next_execution_date = self.model.next_execution_date()
 
         if constants.LIST == display_format:
             data = self.model.to_dict(include_attributes=[
@@ -32,6 +33,7 @@ class PipelineSchedulePresenter(BasePresenter):
                 'pipeline_runs_count',
             ])
             data['tags'] = sorted([tag.name for tag in self.get_tag_associations])
+            data['next_pipeline_run_date'] = next_execution_date
 
             return data
         elif display_format in [constants.DETAIL, constants.UPDATE]:
@@ -39,7 +41,7 @@ class PipelineSchedulePresenter(BasePresenter):
                 'event_matchers',
             ])
             data['tags'] = sorted([tag.name for tag in self.get_tag_associations])
-            data['next_pipeline_run_date'] = self.model.next_execution_date()
+            data['next_pipeline_run_date'] = next_execution_date
 
             return data
         elif 'with_runtime_average' == display_format:

--- a/mage_ai/api/presenters/PipelineSchedulePresenter.py
+++ b/mage_ai/api/presenters/PipelineSchedulePresenter.py
@@ -47,6 +47,7 @@ class PipelineSchedulePresenter(BasePresenter):
         elif 'with_runtime_average' == display_format:
             data['runtime_average'] = self.model.runtime_average()
             data['tags'] = sorted([tag.name for tag in self.get_tag_associations])
+            data['next_pipeline_run_date'] = next_execution_date
 
         return data
 

--- a/mage_ai/frontend/components/Triggers/Detail/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Detail/index.tsx
@@ -57,13 +57,13 @@ import {
 } from '@oracle/styles/units/spacing';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
 import { PROVIDER_EVENTS_BY_UUID } from '@interfaces/EventMatcherType';
-import { RunStatus as RunStatusEnum } from '@interfaces/BlockRunType';
 import {
   addTriggerVariables,
   getFormattedVariable,
   getFormattedVariables,
 } from '@components/Sidekick/utils';
 import { convertSeconds, getTriggerApiEndpoint } from '../utils';
+import { dateFormatLong } from '@utils/date';
 import { getModelAttributes } from '@utils/models/dbt';
 import { goToWithQuery } from '@utils/routing';
 import { indexBy } from '@utils/array';
@@ -102,6 +102,7 @@ function TriggerDetail({
     id: pipelineScheduleID,
     event_matchers: eventMatchers,
     name: pipelineScheduleName,
+    next_pipeline_run_date: nextRunDate,
     schedule_interval: scheduleInterval,
     schedule_type: scheduleType,
     settings,
@@ -313,24 +314,51 @@ function TriggerDetail({
     }
 
     if (scheduleInterval) {
-      rows.push([
-        <FlexContainer
-          alignItems="center"
-          key="trigger_frequency_label"
-        >
-          <Schedule {...iconProps} />
-          <Spacing mr={1} />
-          <Text default>
-            Frequency
-          </Text>
-        </FlexContainer>,
-        <Text
-          key="trigger_frequency"
-          monospace
-        >
-          {scheduleInterval.replace('@', '')}
-        </Text>,
-      ]);
+      rows.push(
+        [
+          <FlexContainer
+            alignItems="center"
+            key="trigger_frequency_label"
+          >
+            <Schedule {...iconProps} />
+            <Spacing mr={1} />
+            <Text default>
+              Frequency
+            </Text>
+          </FlexContainer>,
+          <Text
+            key="trigger_frequency"
+            monospace
+          >
+            {scheduleInterval.replace('@', '')}
+          </Text>,
+        ],
+        [
+          <FlexContainer
+            alignItems="center"
+            key="trigger_next_run_date_label"
+          >
+            <CalendarDate {...iconProps} />
+            <Spacing mr={1} />
+            <Text default>
+              Next run date
+            </Text>
+          </FlexContainer>,
+          <Text
+            key="trigger_next_run_date"
+            monospace
+          >
+            {nextRunDate
+              ?
+                dateFormatLong(
+                  nextRunDate,
+                  { includeSeconds: true, utcFormat: true },
+                )
+              : 'N/A'
+            }
+          </Text>,
+        ],
+      );
     }
 
     if (startTime) {
@@ -437,6 +465,7 @@ function TriggerDetail({
     );
   }, [
     isActive,
+    nextRunDate,
     pipelineSchedule,
     scheduleInterval,
     scheduleType,

--- a/mage_ai/frontend/components/Triggers/Table.tsx
+++ b/mage_ai/frontend/components/Triggers/Table.tsx
@@ -32,6 +32,7 @@ import {
 import { RunStatus } from '@interfaces/BlockRunType';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { TableContainerStyle } from '@components/shared/Table/index.style';
+import { dateFormatLong } from '@utils/date';
 import { isViewer } from '@utils/session';
 import { onSuccess } from '@api/utils/response';
 import { pauseEvent } from '@utils/events';
@@ -159,10 +160,15 @@ function TriggersTable({
     ]);
   }
 
-  columnFlex.push(...[null, null, null]);
+  columnFlex.push(...[null, 1, 1, null]);
   columns.push(...[
     {
       uuid: 'Runs',
+    },
+    {
+      tooltipMessage: 'This is the execution date of the next pipeline run \
+        (after the initial run if the trigger has no runs yet).',
+      uuid: 'Next run date',
     },
     {
       uuid: 'Latest status',
@@ -216,6 +222,7 @@ function TriggersTable({
               const {
                 id,
                 created_at: createdAt,
+                next_pipeline_run_date: nextRunDate,
                 pipeline_runs_count: pipelineRunsCount,
                 pipeline_uuid: triggerPipelineUUID,
                 last_pipeline_run_status: lastPipelineRunStatus,
@@ -358,6 +365,21 @@ function TriggersTable({
               rows.push(...[
                 <Text default key={`trigger_run_count_${idx}`} monospace>
                   {pipelineRunsCount}
+                </Text>,
+                <Text
+                  default
+                  key={`trigger_next_run_date_${idx}`}
+                  monospace
+                  small
+                >
+                  {nextRunDate
+                    ?
+                      dateFormatLong(
+                        nextRunDate,
+                        { includeSeconds: true, utcFormat: true },
+                      )
+                    : <>&#8212;</>
+                  }
                 </Text>,
                 <Text
                   danger={RunStatus.FAILED === lastPipelineRunStatus}

--- a/mage_ai/frontend/interfaces/PipelineScheduleType.ts
+++ b/mage_ai/frontend/interfaces/PipelineScheduleType.ts
@@ -66,6 +66,7 @@ export default interface PipelineScheduleType {
   id?: string;
   last_pipeline_run_status?: RunStatusEnum;
   name?: string;
+  next_pipeline_run_date?: string;
   pipeline_runs_count?: number;
   pipeline_uuid?: string;
   runtime_average?: number;

--- a/mage_ai/frontend/utils/date.ts
+++ b/mage_ai/frontend/utils/date.ts
@@ -43,7 +43,7 @@ export function dateFormatLong(
     dayAgo,
     includeSeconds,
     utcFormat,
-  } = opts;
+  } = opts || {};
   let momentObj = moment(text);
   let dateFormat = DATE_FORMAT_LONG_NO_SEC;
 

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -244,6 +244,29 @@ class PipelineSchedule(BaseModel):
 
         return current_execution_date
 
+    def next_execution_date(self) -> datetime:
+        next_execution_date = None
+        current_execution_date = self.current_execution_date()
+
+        if current_execution_date is None:
+            return None
+
+        if self.schedule_interval == '@once':
+            pass
+        elif self.schedule_interval == '@daily':
+            next_execution_date = current_execution_date + timedelta(days=1)
+        elif self.schedule_interval == '@hourly':
+            next_execution_date = current_execution_date + timedelta(hours=1)
+        elif self.schedule_interval == '@weekly':
+            next_execution_date = current_execution_date + timedelta(weeks=1)
+        elif self.schedule_interval == '@monthly':
+            next_execution_date = (current_execution_date + timedelta(days=32)).replace(day=1)
+        else:
+            cron_itr = croniter(self.schedule_interval, current_execution_date)
+            next_execution_date = cron_itr.get_next(datetime)
+
+        return next_execution_date
+
     @safe_db_query
     def should_schedule(self, previous_runtimes: List[int] = None) -> bool:
         now = datetime.now(tz=pytz.UTC)

--- a/mage_ai/tests/orchestration/db/models/test_schedules.py
+++ b/mage_ai/tests/orchestration/db/models/test_schedules.py
@@ -597,7 +597,7 @@ class PipelineScheduleTests(DBTestCase):
             start_time=datetime(2023, 8, 19, 19, 14, 15).replace(tzinfo=timezone.utc),
         )
 
-        self.assertEqual(PipelineSchedule.create(**shared_attrs).current_execution_date(), now)
+        self.assertEqual(PipelineSchedule.create(**shared_attrs).next_execution_date(), None)
 
         self.assertEqual(
             PipelineSchedule.create(**merge_dict(shared_attrs, dict(


### PR DESCRIPTION
# Description
- Show the next pipeline run datetime for triggers on the Triggers list page for an individual pipeline, as well as an individual trigger's detail page.

# How Has This Been Tested?
Triggers list page:
<img width="1413" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/ecf7b6dc-7032-4b21-a64f-6a00fb6bfd3b">
<img width="318" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/7561193d-056c-488d-92c7-35ede0990e67">

Trigger detail page (under the "Settings" section):
<img width="1412" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/8b748c1d-b951-4fc4-93fd-43abba202e14">

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
