### PR TITLE
[xy] Fix passing variables to run_blocks.

### DIFF
--- a/mage_ai/data_preparation/executors/pipeline_executor.py
+++ b/mage_ai/data_preparation/executors/pipeline_executor.py
@@ -64,6 +64,7 @@ class PipelineExecutor:
             asyncio.run(self.__run_blocks(
                 pipeline_run,
                 allow_blocks_to_fail=allow_blocks_to_fail,
+                global_vars=global_vars,
             ))
 
         self.logger_manager.output_logs_to_destination()


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix passing variables to run_blocks.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with variables set in pipeline trigger
<img width="648" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/70c2ce70-854e-4014-ba5d-ef51ff8ec55b">
<img width="302" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/dc658b2c-2b92-4089-93f7-5c01c996c47a">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code

cc:
<!-- Optionally mention someone to let them know about this pull request -->
