### PR TITLE
[td] Add run_pipeline_in_one_process in pipeline settings

### DIFF
--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -825,6 +825,7 @@ class Pipeline:
             'data_integration',
             'executor_type',
             'retry_config',
+            'run_pipeline_in_one_process',
         ]:
             if key in data:
                 setattr(self, key, data.get(key))

--- a/mage_ai/frontend/components/PipelineDetail/Settings/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Settings/index.tsx
@@ -172,6 +172,24 @@ function PipelineSettings({
         value={pipelineAttributes?.name || ''}
       />
 
+      <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
+        <Checkbox
+          checked={!!pipelineAttributes?.run_pipeline_in_one_process}
+          label="Run pipeline in a single process"
+          onClick={() => setPipelineAttributes(prev => ({
+            ...prev,
+            run_pipeline_in_one_process: !prev?.run_pipeline_in_one_process,
+          }))}
+        />
+
+        <Spacing mt={1}>
+          <Text muted small>
+            When enabled, this setting allows sharing of objects and memory space across blocks
+            within a single pipeline.
+          </Text>
+        </Spacing>
+      </Spacing>
+
       <Spacing mt={UNITS_BETWEEN_SECTIONS}>
         <Headline>
           Executor type
@@ -371,6 +389,7 @@ function PipelineSettings({
               executor_type: pipelineAttributes?.executor_type,
               name: pipelineAttributes?.name,
               retry_config: pipelineAttributes?.retry_config,
+              run_pipeline_in_one_process: pipelineAttributes?.run_pipeline_in_one_process,
               tags: pipelineAttributes?.tags,
               // @ts-ignore
             }).then(() => setPipelineAttributesTouched(false))}

--- a/mage_ai/frontend/interfaces/PipelineType.ts
+++ b/mage_ai/frontend/interfaces/PipelineType.ts
@@ -93,6 +93,7 @@ export default interface PipelineType {
   metadata?: PipelineMetadataType;
   name?: string;
   retry_config?: PipelineRetryConfigType;
+  run_pipeline_in_one_process?: boolean;
   schedules?: PipelineScheduleType[];
   tags?: string[];
   type?: PipelineTypeEnum;


### PR DESCRIPTION
# Description
Add the `run_pipeline_in_one_process` setting it the UI in pipeline settings.


# How Has This Been Tested?
<img width="808" alt="CleanShot 2023-08-23 at 15 19 19@2x" src="https://github.com/mage-ai/mage-ai/assets/1066980/b24a86fb-2947-4466-a422-6a401f51837c">

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
