### PR TITLE
[jk] Explain cron syntax in a human readable way

### DIFF
--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -4,6 +4,7 @@ import React, {
   useMemo,
   useState,
 } from 'react';
+import cronstrue from 'cronstrue';
 import moment from 'moment';
 import { toast } from 'react-toastify';
 import { useMutation } from 'react-query';
@@ -266,6 +267,13 @@ function Edit({
     () => scheduleInterval &&
       !Object.values(ScheduleIntervalEnum).includes(scheduleInterval as ScheduleIntervalEnum),
     [scheduleInterval],
+  );
+  const readableCronExpression = useMemo(() => (
+    isCustomInterval
+      ? cronstrue.toString(customInterval, { throwExceptionOnParseError: false })
+      : ''
+    ),
+    [customInterval, isCustomInterval],
   );
 
   useEffect(
@@ -866,22 +874,22 @@ function Edit({
             />
 
             <Spacing mt={1} p={1}>
-              <Text muted small>
-                If you want this pipeline to trigger every 1 minute,
-                the CRON syntax is <Text inline monospace small>
-                  */1 * * * *
-                </Text>.
+              <Text monospace xsmall>
+                [minute] [hour] [day(month)] [month] [day(week)]
               </Text>
 
-              <Text muted small>
-                For more CRON syntax examples, check out this <Link
-                  href="https://crontab.guru/"
-                  openNewWindow
-                  small
-                >
-                  resource
-                </Link>.
-              </Text>
+              {!customInterval
+                ? null
+                : (
+                  <Text
+                    danger={readableCronExpression.includes('error')}
+                    muted
+                    small
+                  >
+                    &#34;{readableCronExpression}&#34;
+                  </Text>
+                )
+              }
             </Spacing>
           </div>,
         ],
@@ -913,6 +921,7 @@ function Edit({
     landingTimeEnabled,
     landingTimeInputs,
     name,
+    readableCronExpression,
     runtimeAverage,
     scheduleInterval,
     showCalendar,

--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -275,6 +275,10 @@ function Edit({
     ),
     [customInterval, isCustomInterval],
   );
+  const cronExpressionInvalid = useMemo(
+    () => readableCronExpression?.toLowerCase().includes('error'),
+    [readableCronExpression],
+  );
 
   useEffect(
     () => {
@@ -882,11 +886,14 @@ function Edit({
                 ? null
                 : (
                   <Text
-                    danger={readableCronExpression.includes('error')}
+                    danger={cronExpressionInvalid}
                     muted
                     small
                   >
-                    &#34;{readableCronExpression}&#34;
+                    {cronExpressionInvalid
+                      ? 'Invalid cron expression. Please check the cron syntax.'
+                      : <>&#34;{readableCronExpression}&#34;</>
+                    }
                   </Text>
                 )
               }
@@ -913,6 +920,7 @@ function Edit({
       </>
     );
   }, [
+    cronExpressionInvalid,
     customInterval,
     date,
     isCustomInterval,

--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -269,7 +269,7 @@ function Edit({
     [scheduleInterval],
   );
   const readableCronExpression = useMemo(() => (
-    isCustomInterval
+    (isCustomInterval && customInterval)
       ? cronstrue.toString(customInterval, { throwExceptionOnParseError: false })
       : ''
     ),

--- a/mage_ai/frontend/components/shared/Table/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/index.tsx
@@ -120,7 +120,7 @@ function Table({
   rowsGroupedByIndex,
   setRowsSorted,
   sortableColumnIndexes,
-  sortedColumn: sortedColumnInit = null,
+  sortedColumn: sortedColumnInit,
   stickyFirstColumn,
   stickyHeader,
   uuid,
@@ -247,7 +247,10 @@ function Table({
   ), [defaultSortColumnIndex, rows, sortedColumn, sortedColumnIndex, sortedColumnDirection]);
 
   const sortedRowIds = useMemo(
-    () => (rowsSorted || []).map(row => getUniqueRowIdentifier?.(row)),
+    () => (getUniqueRowIdentifier
+      ? rowsSorted?.map(row => getUniqueRowIdentifier?.(row))
+      : undefined
+    ),
     [getUniqueRowIdentifier, rowsSorted],
   );
   const sortedColumnPrev = usePrevious(sortedColumn);
@@ -259,8 +262,8 @@ function Table({
      * order and update the rowsSorted state in order to perform actions on
      * the correct row.
      */
-    if (JSON.stringify(sortedColumn) !== JSON.stringify(sortedColumnPrev)
-      || JSON.stringify(sortedRowIds) !== JSON.stringify(sortedRowIdsPrev)
+    if (sortableColumnIndexes && (JSON.stringify(sortedColumn) !== JSON.stringify(sortedColumnPrev)
+      || JSON.stringify(sortedRowIds) !== JSON.stringify(sortedRowIdsPrev))
     ) {
       setRowsSorted?.(rowsSorted);
       const sortColIdx = sortedColumnIndex || null;
@@ -279,6 +282,7 @@ function Table({
     defaultSortColumnIndex,
     rowsSorted,
     setRowsSorted,
+    sortableColumnIndexes,
     sortedColumn,
     sortedColumnIndex,
     sortedColumnDirection,

--- a/mage_ai/frontend/package.json
+++ b/mage_ai/frontend/package.json
@@ -35,6 +35,7 @@
     "@visx/voronoi": "2.10.0",
     "ansi-to-react": "^6.1.6",
     "axios": "^0.27.2",
+    "cronstrue": "^2.31.0",
     "d3-color": "^3.1.0",
     "dangerously-set-html-content": "^1.0.13",
     "js-cookie": "^3.0.1",

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -402,81 +402,83 @@ function PipelineRuns({
               tabs={TABS}
             />
 
-            <VerticalDividerStyle right={1} />
-
-            <Spacing px={2}>
-              <FlyoutMenuWrapper
-                items={pipelineRunActionItems}
-                onClickCallback={() => setShowActionsMenu(false)}
-                onClickOutside={() => setShowActionsMenu(false)}
-                open={showActionsMenu}
-                parentRef={refActionsMenu}
-                roundedStyle
-                setConfirmationAction={setConfirmationAction}
-                setConfirmationDialogueOpen={setConfirmationDialogueOpen}
-                topOffset={4}
-                uuid="PipelineRuns/ActionsMenu"
-              >
-                <Button
-                  afterIcon={<ArrowDown />}
-                  onClick={(() => setShowActionsMenu(prev => !prev))}
-                  outline
-                  padding="6px 12px"
-                >
-                  Actions
-                </Button>
-              </FlyoutMenuWrapper>
-
-              <ClickOutside
-                onClickOutside={() => setConfirmationDialogueOpen(false)}
-                open={confirmationDialogueOpen}
-              >
-                <PopupMenu
-                  danger
-                  onCancel={() => setConfirmationDialogueOpen(false)}
-                  onClick={() => {
-                    confirmationAction?.();
-                    setConfirmationDialogueOpen(false);
-                  }}
-                  subtitle="This includes runs on other pages as well, not just the current page."
-                  title="Are you sure you want to cancel all pipeline runs in progress?"
-                  width={UNIT * 40}
-                />
-              </ClickOutside>
-            </Spacing>
-
             {isPipelineRunsTab &&
-              <Select
-                compact
-                defaultColor
-                onChange={e => {
-                  e.preventDefault();
-                  const updatedStatus = e.target.value;
-                  if (updatedStatus === 'all') {
-                    setQuery(null);
-                    goToWithQuery({ tab: TAB_PIPELINE_RUNS.uuid }, { replaceParams: true });
-                  } else {
-                    goToWithQuery(
-                      {
-                        page: 0,
-                        status: e.target.value,
-                      },
-                    );
-                  }
-                }}
-                paddingRight={UNIT * 4}
-                placeholder="Select run status"
-                value={query?.status}
-              >
-                <option key="all_statuses" value="all">
-                  All statuses
-                </option>
-                {PIPELINE_RUN_STATUSES.map(status => (
-                  <option key={status} value={status}>
-                    {RUN_STATUS_TO_LABEL[status]}
+              <>
+                <VerticalDividerStyle right={1} />
+
+                <Spacing px={2}>
+                  <FlyoutMenuWrapper
+                    items={pipelineRunActionItems}
+                    onClickCallback={() => setShowActionsMenu(false)}
+                    onClickOutside={() => setShowActionsMenu(false)}
+                    open={showActionsMenu}
+                    parentRef={refActionsMenu}
+                    roundedStyle
+                    setConfirmationAction={setConfirmationAction}
+                    setConfirmationDialogueOpen={setConfirmationDialogueOpen}
+                    topOffset={4}
+                    uuid="PipelineRuns/ActionsMenu"
+                  >
+                    <Button
+                      afterIcon={<ArrowDown />}
+                      onClick={(() => setShowActionsMenu(prev => !prev))}
+                      outline
+                      padding="6px 12px"
+                    >
+                      Actions
+                    </Button>
+                  </FlyoutMenuWrapper>
+
+                  <ClickOutside
+                    onClickOutside={() => setConfirmationDialogueOpen(false)}
+                    open={confirmationDialogueOpen}
+                  >
+                    <PopupMenu
+                      danger
+                      onCancel={() => setConfirmationDialogueOpen(false)}
+                      onClick={() => {
+                        confirmationAction?.();
+                        setConfirmationDialogueOpen(false);
+                      }}
+                      subtitle="This includes runs on other pages as well, not just the current page."
+                      title="Are you sure you want to cancel all pipeline runs in progress?"
+                      width={UNIT * 40}
+                    />
+                  </ClickOutside>
+                </Spacing>
+
+                <Select
+                  compact
+                  defaultColor
+                  onChange={e => {
+                    e.preventDefault();
+                    const updatedStatus = e.target.value;
+                    if (updatedStatus === 'all') {
+                      setQuery(null);
+                      goToWithQuery({ tab: TAB_PIPELINE_RUNS.uuid }, { replaceParams: true });
+                    } else {
+                      goToWithQuery(
+                        {
+                          page: 0,
+                          status: e.target.value,
+                        },
+                      );
+                    }
+                  }}
+                  paddingRight={UNIT * 4}
+                  placeholder="Select run status"
+                  value={query?.status}
+                >
+                  <option key="all_statuses" value="all">
+                    All statuses
                   </option>
-                ))}
-              </Select>
+                  {PIPELINE_RUN_STATUSES.map(status => (
+                    <option key={status} value={status}>
+                      {RUN_STATUS_TO_LABEL[status]}
+                    </option>
+                  ))}
+                </Select>
+              </>
             }
           </FlexContainer>
         </Spacing>

--- a/mage_ai/frontend/yarn.lock
+++ b/mage_ai/frontend/yarn.lock
@@ -5229,6 +5229,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cronstrue@^2.31.0:
+  version "2.31.0"
+  resolved "https://registry.yarnpkg.com/cronstrue/-/cronstrue-2.31.0.tgz#73205a6753a245aac08b4f1f2e925f8c2989d711"
+  integrity sha512-A1cyfGyLSRdvT9MNn/pggoCTlvxnJyiCUItU9XHSXk89ZyK2YY9q9q7Rf4j8NhV9YwN1BjB0wimZlvKYb/9Bwg==
+
 cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"


### PR DESCRIPTION
# Description
- When editing a trigger and using a custom interval with cron expressions, explain the cron expression in a human readable way directly in the app so that users don't have to refer to an outside resource like crontab.guru.
- Also fix small bug when switching between the Pipeline runs and Block runs tabs for a pipeline.
- Only show Actions dropdown on Pipeline runs tab (and hide it on the Block runs tab).

# How Has This Been Tested?
Invalid cron expression:
<img width="1384" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/aa7cd9d4-8005-464d-a2d9-bf91a2efdf18">

Valid cron expression:
<img width="1383" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/0d6b8a39-5011-4fa6-a7a5-4ffb7bc2d45b">

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
