### PR TITLE
Integration pipeline source docs - inline display in the UI

### DIFF
--- a/mage_ai/api/policies/IntegrationSourcePolicy.py
+++ b/mage_ai/api/policies/IntegrationSourcePolicy.py
@@ -22,6 +22,7 @@ IntegrationSourcePolicy.allow_actions([
 ], condition=lambda policy: policy.has_at_least_editor_role())
 
 IntegrationSourcePolicy.allow_read(IntegrationSourcePresenter.default_attributes + [
+    'docs'
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[

--- a/mage_ai/frontend/components/IntegrationPipeline/index.style.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/index.style.tsx
@@ -14,6 +14,16 @@ export const SectionStyle = styled.div`
   `}
 `;
 
+// targeting a nested Markdown element with inline images that can be large
+export const DocsStyle = styled.div`
+  > div {
+    overflow: initial;
+  }
+  > div img {
+    max-width: 80%;
+  }
+`;
+
 export const CodeEditorStyle = styled.div`
   padding-top: ${PADDING_UNITS * UNIT}px;
 

--- a/mage_ai/frontend/components/IntegrationPipeline/index.style.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/index.style.tsx
@@ -21,6 +21,9 @@ export const DocsStyle = styled.div`
   }
   > div img {
     max-width: 80%;
+    background: white;
+    padding: 1rem;
+    max-height: 20vh;
   }
 `;
 

--- a/mage_ai/frontend/components/IntegrationPipeline/index.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/index.tsx
@@ -742,7 +742,7 @@ function IntegrationPipeline({
                     Configuration
                   </Headline>
 
-                  {dataLoaderBlockContent?.source && (
+                  {dataLoaderBlockContent?.source && integrationSourceDocs && (
                     <Spacing mb={2}>
                       <Accordion>
                         <AccordionPanel title={`Documentation: ${dataLoaderBlockContent.source}`}>

--- a/mage_ai/frontend/components/IntegrationPipeline/index.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/index.tsx
@@ -2,6 +2,8 @@ import { parse, stringify } from 'yaml';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMutation } from 'react-query';
 
+import Accordion from '@oracle/components/Accordion';
+import AccordionPanel from '@oracle/components/Accordion/AccordionPanel';
 import AddNewBlocks from '@components/PipelineDetail/AddNewBlocks';
 import Button from '@oracle/elements/Button';
 import BlockType, {
@@ -12,7 +14,6 @@ import BlockType, {
 import CopyToClipboard from '@oracle/components/CopyToClipboard';
 import ErrorsType from '@interfaces/ErrorsType';
 import FlexContainer from '@oracle/components/FlexContainer';
-import Markdown from '@oracle/components/Markdown';
 import Headline from '@oracle/elements/Headline';
 import IntegrationSourceType, {
   CatalogType,
@@ -25,6 +26,7 @@ import IntegrationSourceType, {
   UniqueConflictMethodEnum,
 } from '@interfaces/IntegrationSourceType';
 import Link from '@oracle/elements/Link';
+import Markdown from '@oracle/components/Markdown';
 import PipelineType from '@interfaces/PipelineType';
 import PipelineVariableType from '@interfaces/PipelineVariableType';
 import SchemaSettings from './SchemaSettings';
@@ -32,8 +34,6 @@ import Select from '@oracle/elements/Inputs/Select';
 import SelectStreams from './SelectStreams';
 import SourceConfig from './SourceConfig';
 import Spacing from '@oracle/elements/Spacing';
-import Accordion, { AccordionProps } from '@oracle/components/Accordion';
-import AccordionPanel from '@oracle/components/Accordion/AccordionPanel';
 import Spinner from '@oracle/components/Spinner';
 import Table from '@components/shared/Table';
 import Text from '@oracle/elements/Text';
@@ -101,7 +101,7 @@ function IntegrationPipeline({
   const [sourceVisible, setSourceVisible] = useState(true);
   const [transformerVisible, setTransformerVisible] = useState(true);
   const [integrationSourceDocs, setIntegrationSourceDocs] =
-    useState<String>('');
+    useState<string>('');
 
   const { data: dataIntegrationSources } = api.integration_sources.list({}, {
     revalidateOnFocus: false,
@@ -137,7 +137,7 @@ function IntegrationPipeline({
     if (dataLoaderBlockContent?.source) {
       setIntegrationSourceDocs(integrationSourcesByUUID[dataLoaderBlockContent.source]?.docs);
     }
-  }, [integrationSources, dataLoaderBlockContent]);
+  }, [integrationSourcesByUUID, dataLoaderBlockContent]);
 
   const dataLoaderEditor = useMemo(() => (
     <SourceConfig

--- a/mage_ai/server/api/integration_sources.py
+++ b/mage_ai/server/api/integration_sources.py
@@ -20,6 +20,12 @@ def get_collection(key: str, available_options: List[Dict]):
         uuid = d['uuid']
         try:
             module = importlib.import_module(f"mage_integrations.{key}.{uuid}")
+            absolute_file_path = '/'.join(module.__file__.split('/')[:-2])
+            # have the source README available to front-end for inline documentation
+            readme_file_path = f'{absolute_file_path}/{uuid}/README.md'
+            d['docs'] = f"{uuid} documentation"
+            with open(readme_file_path, encoding='utf8') as f:
+                d['docs'] = f.read()
             mod = getattr(module, module_name)
             d['templates'] = mod.templates()
         except FileNotFoundError:
@@ -27,7 +33,12 @@ def get_collection(key: str, available_options: List[Dict]):
         except Exception:
             try:
                 absolute_file_path = '/'.join(module.__file__.split('/')[:-2])
+                # have the source README available to front-end for inline documentation
+                readme_file_path = f'{absolute_file_path}/{uuid}/README.md'
                 absolute_file_path = f'{absolute_file_path}/{uuid}/__init__.py'
+                d['docs'] = f"{uuid} documentation"
+                with open(readme_file_path, encoding='utf8') as f:
+                    d['docs'] = f.read()
                 proc = subprocess.run([
                     PYTHON_COMMAND,
                     absolute_file_path,

--- a/mage_integrations/mage_integrations/sources/github/README.md
+++ b/mage_integrations/mage_integrations/sources/github/README.md
@@ -53,8 +53,3 @@ This tap:
 
 
 Note: at this time, incremental sync is not supported for any endpoint. In order to support, we'll need to modify the `./tap_github/streams.py` `IncrementalStream` class to support incremental sync. This appears to be due to a malformed bookmark value.
-<!---
-```json
-{ "type": "STATE", "value": { "currently_syncing_repo": "mage-ai/mage-ai", "currently_syncing": "commits", "bookmarks": { "mage-ai/mage-ai": { "commits": { "since": "2023-08-22T19:26:01Z" } } } } }
-```
--->


### PR DESCRIPTION
Adds inline docs to integration pipeline sources UI

# Description

The integration pipeline sources have separate links out to github for the documentation. It would be cooler to show this documentation inline!

Step 1 - Read the `README.md` files that are included within each integration source when listing the source collections via the API, add to a 'docs' parameter.
Step 2 - Look for that 'docs' param and render an Accordian > Markdown block with the docs contents when the source dropdown changes, or when loading a pipeline config and it's already set.


# How Has This Been Tested?

I've run the PR changes on my local development setup, and verified that the 'docs' param is present in each item in the API response, and that selecting a source in the pipeline updates the documentation block accordingly.

Update:
Additionally, the policy rule change has been tested by enabling authentication in my local dev environment, creating a non-admin non-owner user, verifying that the request to list integration sources results in a 403 error, and then adding the included change in `mage_ai/api/policies/IntegrationSourcePolicy.py` to include the 'docs' param, and reloading and verifying that the API request to list sources now succeeds, and includes 'docs' param.

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
