### PR TITLE
[dy] Update terminal server user token handling

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -2026,7 +2026,6 @@ function PipelineDetailPage({
     lastMessage: lastTerminalMessage,
     sendMessage: sendTerminalMessage,
   } = useWebSocket(getWebSocket('terminal'), {
-    queryParams: sharedWebsocketData,
     shouldReconnect: () => true,
   });
 

--- a/mage_ai/frontend/pages/terminal/index.tsx
+++ b/mage_ai/frontend/pages/terminal/index.tsx
@@ -22,7 +22,7 @@ function TerminalPage() {
     sendMessage,
   } = useWebSocket(getWebSocket('terminal'), {
     shouldReconnect: () => true,
-    queryParams: sharedWebsocketData,
+    protocols: [OAUTH2_APPLICATION_CLIENT_ID, token.decodedToken.token],
   });
 
   return (

--- a/mage_ai/frontend/pages/terminal/index.tsx
+++ b/mage_ai/frontend/pages/terminal/index.tsx
@@ -7,24 +7,19 @@ import PrivateRoute from '@components/shared/PrivateRoute';
 import Terminal from '@components/Terminal';
 import { OAUTH2_APPLICATION_CLIENT_ID } from '@api/constants';
 import { getWebSocket } from '@api/utils/url';
+import { getUser } from '@utils/session';
 
 function TerminalPage() {
-  const token = useMemo(() => new AuthToken(), []);
-  const sharedWebsocketData = useMemo(() => ({
-    api_key: OAUTH2_APPLICATION_CLIENT_ID,
-    token: token.decodedToken.token,
-  }), [
-    token,
-  ]);
+  const user = getUser() || {};
 
   const {
     lastMessage,
     sendMessage,
   } = useWebSocket(getWebSocket('terminal'), {
-    shouldReconnect: () => true,
     queryParams: {
-      api_key: OAUTH2_APPLICATION_CLIENT_ID,
+      term_name: user?.id,
     },
+    shouldReconnect: () => true,
   });
 
   return (

--- a/mage_ai/frontend/pages/terminal/index.tsx
+++ b/mage_ai/frontend/pages/terminal/index.tsx
@@ -22,7 +22,9 @@ function TerminalPage() {
     sendMessage,
   } = useWebSocket(getWebSocket('terminal'), {
     shouldReconnect: () => true,
-    protocols: [OAUTH2_APPLICATION_CLIENT_ID, token.decodedToken.token],
+    queryParams: {
+      api_key: OAUTH2_APPLICATION_CLIENT_ID,
+    },
   });
 
   return (


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

When initially creating the terminal websocket connection, we were passing the api key and oauth token through the query params which is a security risk. This PR removes the need to pass in those fields for the initial request.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
