### PR TITLE
[dy] Restrict file creation through the API

### DIFF
--- a/mage_ai/data_preparation/models/errors.py
+++ b/mage_ai/data_preparation/models/errors.py
@@ -3,3 +3,7 @@ from mage_ai.errors.base import MageBaseException
 
 class FileExistsError(MageBaseException):
     pass
+
+
+class FileNotInProjectError(MageBaseException):
+    pass

--- a/mage_ai/data_preparation/models/file.py
+++ b/mage_ai/data_preparation/models/file.py
@@ -358,7 +358,9 @@ class File:
 
 
 def ensure_file_is_in_project(file_path: str) -> None:
-    if not Path(file_path).resolve().is_relative_to(get_repo_path()):
+    full_file_path = str(Path(file_path).resolve())
+    full_repo_path = str(Path(get_repo_path()).resolve())
+    if full_repo_path != os.path.commonpath([full_file_path, full_repo_path]):
         raise FileNotInProjectError(
             f'File at path: {file_path} is not in the project directory.')
 

--- a/mage_ai/tests/data_preparation/models/test_file.py
+++ b/mage_ai/tests/data_preparation/models/test_file.py
@@ -1,0 +1,36 @@
+import os
+
+from mage_ai.data_preparation.models.errors import FileNotInProjectError
+from mage_ai.data_preparation.models.file import ensure_file_is_in_project
+from mage_ai.tests.base_test import TestCase
+
+
+class FileTest(TestCase):
+    @classmethod
+    def setUpClass(self):
+        super().setUpClass()
+        self.original_path = os.getcwd()
+        os.chdir(self.repo_path)
+
+    @classmethod
+    def tearDownClass(self):
+        super().tearDownClass()
+        os.chdir(self.original_path)
+
+    def test_ensure_file_is_in_project_relative_file_path(self):
+        file_path = 'file.txt'
+        self.assertIsNone(ensure_file_is_in_project(file_path))
+
+    def test_ensure_file_is_in_project_absolute_file_path_in_project(self):
+        file_path = os.path.join(self.repo_path, 'file.txt')
+        self.assertIsNone(ensure_file_is_in_project(file_path))
+
+    def test_ensure_file_is_in_project_absolute_file_path_not_in_project(self):
+        file_path = os.path.join('/other/path', 'file.txt')
+        with self.assertRaises(FileNotInProjectError):
+            ensure_file_is_in_project(file_path)
+
+    def test_ensure_file_is_in_project_relative_file_path_outside_project(self):
+        file_path = '../file.txt'
+        with self.assertRaises(FileNotInProjectError):
+            ensure_file_is_in_project(file_path)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Resolves file/folder create issue through the file explorer. This should not allow users to create files or folders outside of the project repo.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally

![Screenshot 2023-08-24 at 3 06 13 PM](https://github.com/mage-ai/mage-ai/assets/14357209/7666c3f7-190e-46a0-b1e4-2df3bedeae74)


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
