### PR TITLE
[dy] Read DB credentials from AWS secret manager

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -507,7 +507,8 @@
             "production/data-sync/git",
             "production/data-sync/github"
           ]
-        }
+        },
+        "production/databases/default"
       ]
     },
     {

--- a/docs/production/databases/default.mdx
+++ b/docs/production/databases/default.mdx
@@ -13,5 +13,25 @@ To use a specific `schema_name` in PostgreSQL:
 
 `export MAGE_DATABASE_CONNECTION_URL="postgresql+psycopg2://user:password@host:port/dbname?options=-c%%20search_path%%3Dschema_name"`
 
+### Get credentials from AWS Secret Manager
+
+You can also instruct Mage to fetch your Postgres DB credentials from AWS Secret Manager. You will need to
+set the following environment variables:
+
+| Variable | Value |
+| --- | --- |
+| `AWS_DB_SECRETS_NAME` | name of secret in AWS Secret Manager |
+| `AWS_DEFAULT_REGION` | AWS region the secret is stored in |
+| `AWS_ACCESS_KEY_ID` | AWS access key id (not needed if using IAM role to authenticate) |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret access key (not needed if using IAM role to authenticate) |
+
+The expected format of the secret is JSON string with the following keys:
+* username
+* password
+* engine (must be `postgres`)
+* host
+* port
+* dbname
+
 ## MSSQL
 `export MAGE_DATABASE_CONNECTION_URL="mssql+pyodbc://?odbc_connect=DRIVER={ODBC Driver 18 for SQL Server};SERVER=host;DATABASE=dbname;UID=user;PWD=password;ENCRYPT=yes;TrustServerCertificate=yes;"`

--- a/mage_ai/cluster_manager/kubernetes/workload_manager.py
+++ b/mage_ai/cluster_manager/kubernetes/workload_manager.py
@@ -19,9 +19,9 @@ from mage_ai.cluster_manager.constants import (
 from mage_ai.data_preparation.repo_manager import ProjectType
 from mage_ai.orchestration.constants import (
     DATABASE_CONNECTION_URL_ENV_VAR,
-    DB_NAME,
-    DB_PASS,
-    DB_USER,
+    PG_DB_NAME,
+    PG_DB_PASS,
+    PG_DB_USER,
 )
 from mage_ai.services.k8s.constants import (
     DEFAULT_NAMESPACE,
@@ -412,7 +412,7 @@ class WorkloadManager:
         if db_secrets_name:
             env_vars.extend([
                 {
-                    'name': DB_USER,
+                    'name': PG_DB_USER,
                     'valueFrom': {
                         'secretKeyRef': {
                             'name': db_secrets_name,
@@ -421,7 +421,7 @@ class WorkloadManager:
                     }
                 },
                 {
-                    'name': DB_PASS,
+                    'name': PG_DB_PASS,
                     'valueFrom': {
                         'secretKeyRef': {
                             'name': db_secrets_name,
@@ -430,7 +430,7 @@ class WorkloadManager:
                     }
                 },
                 {
-                    'name': DB_NAME,
+                    'name': PG_DB_NAME,
                     'valueFrom': {
                         'secretKeyRef': {
                             'name': db_secrets_name,

--- a/mage_ai/orchestration/constants.py
+++ b/mage_ai/orchestration/constants.py
@@ -2,9 +2,17 @@ import enum
 
 DATABASE_CONNECTION_URL_ENV_VAR = 'MAGE_DATABASE_CONNECTION_URL'
 
-DB_USER = 'DB_USER'
-DB_PASS = 'DB_PASS'
-DB_NAME = 'DB_NAME'
+AWS_DB_SECRETS_NAME = 'AWS_DB_SECRETS_NAME'
+
+# ============= Postgres credentials =============
+
+PG_DB_USER = 'DB_USER'
+PG_DB_PASS = 'DB_PASS'
+PG_DB_HOST = 'DB_HOST'
+PG_DB_PORT = 'DB_PORT'
+PG_DB_NAME = 'DB_NAME'
+
+# ================================================
 
 PIPELINE_RUN_MAGE_VARIABLES_KEY = '__mage_variables'
 

--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -8,12 +8,8 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import scoped_session, sessionmaker
 
 from mage_ai.data_preparation.repo_manager import get_variables_dir
-from mage_ai.orchestration.constants import (
-    DATABASE_CONNECTION_URL_ENV_VAR,
-    DB_NAME,
-    DB_PASS,
-    DB_USER,
-)
+from mage_ai.orchestration.constants import DATABASE_CONNECTION_URL_ENV_VAR
+from mage_ai.orchestration.db.setup import get_postgres_connection_url
 from mage_ai.shared.environments import is_dev, is_test
 
 DB_RETRY_COUNT = 2
@@ -25,33 +21,14 @@ db_kwargs = dict(
     pool_pre_ping=True,
 )
 
+
 if is_test():
     db_connection_url = f'sqlite:///{TEST_DB}'
 elif not db_connection_url:
-    import boto3
+    pg_db_connection_url = get_postgres_connection_url()
 
-elif not db_connection_url:
-    if not os.getenv(DB_USER) and os.getenv('DB_SECRET_NAME'):
-        try:
-            # Connect to AWS Secrets manager
-            session = boto3.session.Session()
-            secrets_manager = session.client(service_name='secretsmanager')
-
-            # Fetch secrets
-            response = secrets_manager.get_secret_value(SecretId=os.getenv('DB_SECRET_NAME'))
-            secrets = json.loads(response['SecretString'])
-            
-            # Set connection URL
-            db_connection_url = f"postgresql+psycopg2://{secrets['username']}:{secrets['password']}@127.0.0.1:5432/{secrets['dbname']}"
-        except Exception as e:
-            print("Unable to fetch secrets from AWS Secrets Manager", e)
-    
-    if not db_connection_url and os.getenv(DB_USER):
-        db_user = os.getenv(DB_USER)
-        db_pass = os.getenv(DB_PASS)
-        db_name = os.getenv(DB_NAME)
-        db_connection_url = f'postgresql+psycopg2://{db_user}:{db_pass}@127.0.0.1:5432/{db_name}'
-
+    if pg_db_connection_url:
+        db_connection_url = pg_db_connection_url
     else:
         if is_test():
             db_connection_url = f'sqlite:///{TEST_DB}'

--- a/mage_ai/orchestration/db/setup.py
+++ b/mage_ai/orchestration/db/setup.py
@@ -1,0 +1,44 @@
+import json
+import os
+from typing import Optional
+
+from mage_ai.orchestration.constants import (
+    AWS_DB_SECRETS_NAME,
+    PG_DB_HOST,
+    PG_DB_NAME,
+    PG_DB_PASS,
+    PG_DB_PORT,
+    PG_DB_USER,
+)
+from mage_ai.services.aws.secrets_manager.secrets_manager import get_secret
+
+
+def get_postgres_connection_url() -> Optional[str]:
+    db_user = None
+    db_pass = None
+    db_name = None
+    db_host = None
+    db_port = None
+    if os.getenv(AWS_DB_SECRETS_NAME):
+        try:
+            response = get_secret(os.getenv(AWS_DB_SECRETS_NAME))
+            secrets = json.loads(response)
+
+            if secrets and secrets.get('engine') == 'postgres':
+                db_user = secrets.get('username')
+                db_pass = secrets.get('password')
+                db_name = secrets.get('dbname')
+                db_host = secrets.get('host', '127.0.0.1')
+                db_port = secrets.get('port', '5432')
+
+        except Exception as e:
+            print("Unable to fetch secrets from AWS Secrets Manager", e)
+    elif os.getenv(PG_DB_USER):
+        db_user = os.getenv(PG_DB_USER)
+        db_pass = os.getenv(PG_DB_PASS)
+        db_name = os.getenv(PG_DB_NAME)
+        db_host = os.getenv(PG_DB_HOST, '127.0.0.1')
+        db_port = os.getenv(PG_DB_PORT, '5432')
+
+    if db_user:
+        return f'postgresql+psycopg2://{db_user}:{db_pass}@{db_host}:{db_port}/{db_name}'

--- a/mage_ai/orchestration/db/setup.py
+++ b/mage_ai/orchestration/db/setup.py
@@ -12,6 +12,9 @@ from mage_ai.orchestration.constants import (
 )
 from mage_ai.services.aws.secrets_manager.secrets_manager import get_secret
 
+DEFAULT_POSTGRES_HOST = '127.0.0.1'
+DEFAULT_POSTGRES_PORT = '5432'
+
 
 def get_postgres_connection_url() -> Optional[str]:
     db_user = None
@@ -28,8 +31,8 @@ def get_postgres_connection_url() -> Optional[str]:
                 db_user = secrets.get('username')
                 db_pass = secrets.get('password')
                 db_name = secrets.get('dbname')
-                db_host = secrets.get('host', '127.0.0.1')
-                db_port = secrets.get('port', '5432')
+                db_host = secrets.get('host', DEFAULT_POSTGRES_HOST)
+                db_port = secrets.get('port', DEFAULT_POSTGRES_PORT)
 
         except Exception as e:
             print("Unable to fetch secrets from AWS Secrets Manager", e)
@@ -37,8 +40,8 @@ def get_postgres_connection_url() -> Optional[str]:
         db_user = os.getenv(PG_DB_USER)
         db_pass = os.getenv(PG_DB_PASS)
         db_name = os.getenv(PG_DB_NAME)
-        db_host = os.getenv(PG_DB_HOST, '127.0.0.1')
-        db_port = os.getenv(PG_DB_PORT, '5432')
+        db_host = os.getenv(PG_DB_HOST, DEFAULT_POSTGRES_HOST)
+        db_port = os.getenv(PG_DB_PORT, DEFAULT_POSTGRES_PORT)
 
-    if db_user:
+    if db_user and db_pass and db_name and db_host and db_port:
         return f'postgresql+psycopg2://{db_user}:{db_pass}@{db_host}:{db_port}/{db_name}'


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Add a way to populate the `db_connection_url` from AWS secret manager. The environment variable is called `AWS_DB_SECRETS_NAME`, and expects the name of the AWS secret manager secret. I will update the documentation once this PR is finalized.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with AWS secret manager


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
