### PR TITLE
[xh] Refactor: use generic function to call LLM avoid code duplication

### DIFF
--- a/mage_ai/ai/generator.py
+++ b/mage_ai/ai/generator.py
@@ -12,7 +12,7 @@ class Generator:
             pipeline_uuid = request.get('pipeline_uuid')
             block_uuid = request.get('block_uuid')
             return dict(
-                block_doc=await LLMPipelineWizard().async_generate_block_documentation_with_name(
+                block_doc=await LLMPipelineWizard().async_generate_doc_for_block(
                     pipeline_uuid,
                     block_uuid
                 )
@@ -21,7 +21,7 @@ class Generator:
             from mage_ai.ai.llm_pipeline_wizard import LLMPipelineWizard
 
             pipeline_uuid = request.get('pipeline_uuid')
-            return await LLMPipelineWizard().async_generate_pipeline_documentation(
+            return await LLMPipelineWizard().async_generate_doc_for_pipeline(
                 pipeline_uuid,
             )
         elif use_case == LLMUseCase.GENERATE_BLOCK_WITH_DESCRIPTION:

--- a/mage_ai/ai/generator_cmds.py
+++ b/mage_ai/ai/generator_cmds.py
@@ -24,7 +24,7 @@ PRINT_BLOCK_DOC_DEFAULT = typer.Option(
 def generate_block_documentation(project_path: str = PROJECT_NAME_DEFAULT,
                                  pipeline_uuid: str = PROJECT_NAME_DEFAULT,
                                  block_uuid: str = BLOCK_NAME_DEFAULT):
-    print(asyncio.run(LLMPipelineWizard().async_generate_block_documentation_with_name(
+    print(asyncio.run(LLMPipelineWizard().async_generate_doc_for_block(
         pipeline_uuid,
         block_uuid,
         project_path=project_path,
@@ -35,7 +35,7 @@ def generate_block_documentation(project_path: str = PROJECT_NAME_DEFAULT,
 def generate_pipeline_documentation(project_path: str = PROJECT_NAME_DEFAULT,
                                     pipeline_uuid: str = PROJECT_NAME_DEFAULT,
                                     print_block_doc: bool = PRINT_BLOCK_DOC_DEFAULT):
-    print(asyncio.run(LLMPipelineWizard().async_generate_pipeline_documentation(
+    print(asyncio.run(LLMPipelineWizard().async_generate_doc_for_pipeline(
         pipeline_uuid,
         print_block_doc=print_block_doc,
         project_path=project_path,


### PR DESCRIPTION
# Description
This PR does several refactoring:
(1) Replace several `async_llm_inferene` functions with generic `__async_llm_call`. All those `async_llm_inferene` just passes different params and prompt template. They are duplicating same langchain call to LLM. Instead, I now pass different params within a dict. So generic `__async_llm_call` function can be reused.
(2) Rename function following the API function name. So they are consistent.


# How Has This Been Tested?
Run the command before the refactor and after the refactor. Record the result in the `Refactor code evaluation` tab in https://docs.google.com/spreadsheets/d/1vp0UB6EqM3vnY4f0hYV0nB36X7ngiRIVZZU4FFcybH0/edit#gid=975603530

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

cc:
@wangxiaoyou1993 
