### PR TITLE
[dy] Get schema from generate_schema_name

### DIFF
--- a/mage_ai/data_preparation/models/block/dbt/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/__init__.py
@@ -371,7 +371,6 @@ class DBTBlock(Block):
                             self,
                             dbt_profile_target,
                             project_full_path,
-                            profiles_dir,
                             limit=limit,
                             variables=variables,
                         )

--- a/mage_ai/data_preparation/models/block/dbt/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/__init__.py
@@ -370,6 +370,8 @@ class DBTBlock(Block):
                         df = fetch_model_data(
                             self,
                             dbt_profile_target,
+                            project_full_path,
+                            profiles_dir,
                             limit=limit,
                             variables=variables,
                         )

--- a/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
@@ -1338,15 +1338,12 @@ def fetch_model_data(
     attributes_dict = parse_attributes(block, variables=variables)
     table_name = attributes_dict['table_name']
 
-    # bigquery: dataset, schema
-    # postgres: schema
-    # redshift: schema
-    # snowflake: schema
-    # trino: schema
     profile = get_profile(block, profile_target, variables=variables)
 
     config = model_config(block.content)
     config_database = config.get('database')
+
+    # settings from the dbt_project.yml
     model_configurations = get_model_configurations_from_dbt_project_settings(
         block,
         variables=variables,
@@ -1456,6 +1453,11 @@ def get_schema(
     if schema:
         return schema
     else:
+        # bigquery: dataset, schema
+        # postgres: schema
+        # redshift: schema
+        # snowflake: schema
+        # trino: schema
         schema = profile.get('schema') or profile.get('+schema')
         if not schema and 'dataset' in profile:
             schema = profile['dataset']


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

This PR is to resolve this issue: https://github.com/mage-ai/mage-ai/issues/3202

~~From what I've gathered from dbt docs, you can overwrite the default schema naming convention by overwriting the `generate_schema_name` macro. The only way that I could figure out how to get the schema from that macro is by doing the following:~~

* ~~create a new macro that calls the `generate_schema_name` macro and prints out the result~~
* ~~execute the new macro with `dbt run-operation`~~
* ~~parse the output of the command to get the schema.~~

Updated (8/30)

Instead of running the macro in Mage which can potentially take a long time, we will try to get the schema from the `manifest.json` file that is updated after every dbt operation. Each model will have its own entry in the `nodes` field. 

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally
- [ ] Unit tests (will add after the approach in the PR is verified)


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
