### PR TITLE
Removed unique_constraints from valid_replication_keys definition

### DIFF
--- a/mage_integrations/mage_integrations/sources/sql/base.py
+++ b/mage_integrations/mage_integrations/sources/sql/base.py
@@ -121,7 +121,7 @@ class Source(BaseSource):
                 replication_method=REPLICATION_METHOD_FULL_TABLE,
                 schema=schema.to_dict(),
                 stream_id=stream_id,
-                valid_replication_keys=unique_constraints + valid_replication_keys,
+                valid_replication_keys=valid_replication_keys,
             )
             catalog_entry = CatalogEntry(
                 key_properties=unique_constraints,

--- a/mage_integrations/mage_integrations/tests/sources/mysql/test_mysql.py
+++ b/mage_integrations/mage_integrations/tests/sources/mysql/test_mysql.py
@@ -67,7 +67,7 @@ class MySQLSourceTests(unittest.TestCase):
                                         'metadata': {
                                             'table-key-properties': ['id'],
                                             'forced-replication-method': 'FULL_TABLE',
-                                            'valid-replication-keys': ['id'],
+                                            'valid-replication-keys': [],
                                             'inclusion': 'available',
                                             'schema-name': 'demo_users',
                                         },


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Issue:
In Data integrations SQL Sources,if defined, only rows set as `Unique` will be eligible to be set as `Bookmark` 
All rows should be eligible as `Bookmark`

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
Tested on a local mage instance

![Screenshot from 2023-08-28 21-14-30](https://github.com/mage-ai/mage-ai/assets/14100959/33f59d5a-96b8-4415-804b-323cc0e5e04f)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code

cc:
@wangxiaoyou1993 
