### PR TITLE
[jk] Delete individual run from pipeline runs table

### DIFF
--- a/mage_ai/api/policies/PipelineRunPolicy.py
+++ b/mage_ai/api/policies/PipelineRunPolicy.py
@@ -31,6 +31,7 @@ PipelineRunPolicy.allow_actions([
 
 PipelineRunPolicy.allow_actions([
     constants.CREATE,
+    constants.DELETE,
     constants.UPDATE,
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
@@ -64,6 +65,12 @@ PipelineRunPolicy.allow_read(PipelineRunPresenter.default_attributes + [], scope
     constants.CREATE,
     constants.UPDATE,
 ], condition=lambda policy: policy.has_at_least_viewer_role())
+
+PipelineRunPolicy.allow_read(PipelineRunPresenter.default_attributes + [], scopes=[
+    OauthScope.CLIENT_PRIVATE,
+], on_action=[
+    constants.DELETE,
+], condition=lambda policy: policy.has_at_least_editor_role())
 
 PipelineRunPolicy.allow_write([
     'backfill_id',

--- a/mage_ai/api/resources/PipelineRunResource.py
+++ b/mage_ai/api/resources/PipelineRunResource.py
@@ -289,6 +289,6 @@ class PipelineRunResource(DatabaseResource):
     @safe_db_query
     def delete(self, **kwargs):
         block_runs = self.model.block_runs
-        for br in block_runs:
-            br.delete()
+        block_run_ids = [br.id for br in block_runs]
+        BlockRun.batch_delete(block_run_ids)
         self.model.delete()

--- a/mage_ai/api/resources/PipelineRunResource.py
+++ b/mage_ai/api/resources/PipelineRunResource.py
@@ -285,3 +285,10 @@ class PipelineRunResource(DatabaseResource):
             stop_pipeline_run(self.model, pipeline)
 
         return self
+
+    @safe_db_query
+    def delete(self, **kwargs):
+        block_runs = self.model.block_runs
+        for br in block_runs:
+            br.delete()
+        self.model.delete()

--- a/mage_ai/frontend/components/Orchestration/Sidebar/index.tsx
+++ b/mage_ai/frontend/components/Orchestration/Sidebar/index.tsx
@@ -16,7 +16,7 @@ type SidebarProps = {
   pipelineSchedules: {
     [uuid: string]: PipelineScheduleType[],
   };
-  pipelineScheduleId: string;
+  pipelineScheduleId: number;
   pipelineUuid: string;
   width?: number;
 };
@@ -25,7 +25,7 @@ type PipelineSchedulesProps = {
   pipelineUuid: string;
   schedules: PipelineScheduleType[];
   selectedPipelineUuid: string;
-  selectedScheduleId: string;
+  selectedScheduleId: number;
 };
 
 function PipelineSchedules({
@@ -92,6 +92,7 @@ function PipelineSchedules({
 
         return (
           <Link
+            key={id}
             noHoverUnderline
             noOutline
             onClick={() => Router.push({
@@ -127,8 +128,9 @@ function Sidebar({
 }: SidebarProps) {
   return (
     <FlexContainer flexDirection="column" width={width}>
-      {Object.entries(pipelineSchedules || {}).map(([pipelineUuid, schedules]) => (
+      {Object.entries(pipelineSchedules || {}).map(([pipelineUuid, schedules], idx) => (
         <PipelineSchedules
+          key={`${pipelineUuid}_${idx}`}
           pipelineUuid={pipelineUuid}
           schedules={schedules}
           selectedPipelineUuid={selectedPipelineUuid}

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -1,6 +1,6 @@
 import NextLink from 'next/link';
-import { createRef, useCallback, useMemo, useRef, useState } from 'react';
 import { MutateFunction, useMutation } from 'react-query';
+import { createRef, useCallback, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 
 import Button from '@oracle/elements/Button';

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -1,7 +1,7 @@
 import NextLink from 'next/link';
-import Router from 'next/router';
-import { useCallback, useMemo, useState } from 'react';
-import { useMutation } from 'react-query';
+import { createRef, useCallback, useMemo, useRef, useState } from 'react';
+import { MutateFunction, useMutation } from 'react-query';
+import { useRouter } from 'next/router';
 
 import Button from '@oracle/elements/Button';
 import Checkbox from '@oracle/elements/Checkbox';
@@ -14,6 +14,7 @@ import PipelineRunType, {
   RunStatus,
   RUN_STATUS_TO_LABEL,
 } from '@interfaces/PipelineRunType';
+import PopupMenu from '@oracle/components/PopupMenu';
 import Spacing from '@oracle/elements/Spacing';
 import Spinner from '@oracle/components/Spinner';
 import Table, { ColumnType } from '@components/shared/Table';
@@ -21,7 +22,21 @@ import Text from '@oracle/elements/Text';
 import api from '@api';
 import dark from '@oracle/styles/themes/dark';
 import { BORDER_RADIUS_XXXLARGE } from '@oracle/styles/units/borders';
-import { Check, ChevronRight, Logs, PlayButtonFilled, Subitem } from '@oracle/icons';
+import {
+  Check,
+  ChevronRight,
+  Logs,
+  PlayButtonFilled,
+  Subitem,
+  Trash,
+} from '@oracle/icons';
+import {
+  DELETE_CONFIRM_WIDTH,
+  DELETE_CONFIRM_LEFT_OFFSET_DIFF,
+  DELETE_CONFIRM_TOP_OFFSET_DIFF,
+  DELETE_CONFIRM_TOP_OFFSET_DIFF_FIRST,
+} from '@components/shared/Table/constants';
+import { ICON_SIZE_SMALL } from '@oracle/styles/units/icons';
 import { PopupContainerStyle } from './Table.style';
 import { ScheduleTypeEnum } from '@interfaces/PipelineScheduleType';
 import { TableContainerStyle } from '@components/shared/Table/index.style';
@@ -30,6 +45,7 @@ import { getTimeInUTCString } from '@components/Triggers/utils';
 import { indexBy } from '@utils/array';
 import { isViewer } from '@utils/session';
 import { onSuccess } from '@api/utils/response';
+import { pauseEvent } from '@utils/events';
 import { queryFromUrl } from '@utils/url';
 
 const SHARED_DATE_FONT_PROPS = {
@@ -141,11 +157,11 @@ function RetryButton({
         beforeIcon={
           (RunStatus.INITIAL !== status && !disabled) && (
             <>
-              {RunStatus.COMPLETED === status && <Check size={2 * UNIT} />}
+              {RunStatus.COMPLETED === status && <Check size={ICON_SIZE_SMALL} />}
               {[RunStatus.FAILED, RunStatus.CANCELLED].includes(status) && (
                 <PlayButtonFilled
                   inverted={RunStatus.CANCELLED === status && !isViewerRole}
-                  size={2 * UNIT}
+                  size={ICON_SIZE_SMALL}
                 />
               )}
               {[RunStatus.RUNNING].includes(status) && (
@@ -237,6 +253,8 @@ function RetryButton({
 
 type PipelineRunsTableProps = {
   allowBulkSelect?: boolean;
+  allowDelete?: boolean;
+  deletePipelineRun?: MutateFunction<any>;
   disableRowSelect?: boolean;
   emptyMessage?: string;
   fetchPipelineRuns?: () => void;
@@ -251,6 +269,8 @@ type PipelineRunsTableProps = {
 
 function PipelineRunsTable({
   allowBulkSelect,
+  allowDelete,
+  deletePipelineRun,
   disableRowSelect,
   emptyMessage = 'No runs available',
   fetchPipelineRuns,
@@ -262,8 +282,14 @@ function PipelineRunsTable({
   setSelectedRuns,
   setErrors,
 }: PipelineRunsTableProps) {
+  const router = useRouter();
+  const isViewerRole = isViewer();
+  const deleteButtonRefs = useRef({});
   const [cancelingRunId, setCancelingRunId] = useState<number>(null);
   const [showConfirmationId, setShowConfirmationId] = useState<number>(null);
+  const [deleteConfirmationOpenIdx, setDeleteConfirmationOpenIdx] = useState<number>(null);
+  const [confirmDialogueTopOffset, setConfirmDialogueTopOffset] = useState<number>(0);
+  const [confirmDialogueLeftOffset, setConfirmDialogueLeftOffset] = useState<number>(0);
   const [updatePipelineRun, { isLoading: isLoadingCancelPipeline }] = useMutation(
     ({
       id,
@@ -292,6 +318,8 @@ function PipelineRunsTable({
       ),
     },
   );
+
+  
 
   const columnFlex = [null, 1];
   const columns: ColumnType[] = [
@@ -325,6 +353,14 @@ function PipelineRunsTable({
       uuid: 'Logs',
     },
   ]);
+
+  if (allowDelete && !isViewerRole) {
+    columnFlex.push(...[null]);
+    columns.push({
+      label: () => '',
+      uuid: 'Delete',
+    });
+  }
 
   const allRunsSelected =  useMemo(() =>
     pipelineRuns.every(({ id }) => !!selectedRuns?.[id]),
@@ -394,6 +430,7 @@ function PipelineRunsTable({
                 pipeline_uuid: pipelineUUID,
                 status,
               } = pipelineRun;
+              deleteButtonRefs.current[id] = createRef();
               const disabled = !id && !status;
               const blockRunCountTooltipMessage =
                 `${completedBlockRunsCount} out of ${blockRunsCount} block runs completed`;
@@ -408,7 +445,7 @@ function PipelineRunsTable({
                 arr = [
                   <Spacing key="row_status" ml={1}>
                     <FlexContainer alignItems="center">
-                      <Subitem size={2 * UNIT} useStroke/>
+                      <Subitem size={ICON_SIZE_SMALL} useStroke/>
                       <Button
                         borderRadius={BORDER_RADIUS_XXXLARGE}
                         notClickable
@@ -463,11 +500,11 @@ function PipelineRunsTable({
                     iconOnly
                     key="row_logs"
                     noBackground
-                    onClick={() => Router.push(
+                    onClick={() => router.push(
                       `/pipelines/${pipelineUUID}/logs?pipeline_run_id[]=${id}`,
                     )}
                   >
-                    <Logs default size={2 * UNIT} />
+                    <Logs default size={ICON_SIZE_SMALL} />
                   </Button>,
                 ]);
               } else {
@@ -539,15 +576,58 @@ function PipelineRunsTable({
                     default
                     disabled={disabled}
                     iconOnly
-                    key="row_item_13"
+                    key="row_logs"
                     noBackground
-                    onClick={() => Router.push(
+                    onClick={() => router.push(
                       `/pipelines/${pipelineUUID}/logs?pipeline_run_id[]=${id}`,
                     )}
                   >
-                    <Logs default size={2 * UNIT} />
+                    <Logs default size={ICON_SIZE_SMALL} />
                   </Button>,
                 ]);
+              }
+
+              if (allowDelete && !isViewerRole) {
+                arr.push(
+                  <>
+                    <Button
+                      default
+                      iconOnly
+                      noBackground
+                      onClick={(e) => {
+                        pauseEvent(e);
+                        setDeleteConfirmationOpenIdx(id);
+                        setConfirmDialogueTopOffset(deleteButtonRefs.current[id]?.current?.offsetTop || 0);
+                        setConfirmDialogueLeftOffset(deleteButtonRefs.current[id]?.current?.offsetLeft || 0);
+                      }}
+                      ref={deleteButtonRefs.current[id]}
+                      title="Delete"
+                    >
+                      <Trash default size={ICON_SIZE_SMALL} />
+                    </Button>
+                    <ClickOutside
+                      onClickOutside={() => setDeleteConfirmationOpenIdx(null)}
+                      open={deleteConfirmationOpenIdx === id}
+                    >
+                      <PopupMenu
+                        danger
+                        left={(confirmDialogueLeftOffset || 0) - DELETE_CONFIRM_LEFT_OFFSET_DIFF}
+                        onCancel={() => setDeleteConfirmationOpenIdx(null)}
+                        onClick={() => {
+                          setDeleteConfirmationOpenIdx(null);
+                          deletePipelineRun(id);
+                        }}
+                        title={
+                          `Are you sure you want to delete this run (id ${id} for trigger "${pipelineScheduleName}")?`
+                        }
+                        top={(confirmDialogueTopOffset || 0)
+                          - (index <= 1 ? DELETE_CONFIRM_TOP_OFFSET_DIFF_FIRST : DELETE_CONFIRM_TOP_OFFSET_DIFF)
+                        }
+                        width={DELETE_CONFIRM_WIDTH}
+                      />
+                    </ClickOutside>
+                  </>,
+                );
               }
 
               if (allowBulkSelect) {
@@ -569,7 +649,7 @@ function PipelineRunsTable({
               if (!disableRowSelect && onClickRow) {
                 arr.push(
                   <Flex flex={1} justifyContent="flex-end">
-                    <ChevronRight default size={2 * UNIT} />
+                    <ChevronRight default size={ICON_SIZE_SMALL} />
                   </Flex>,
                 );
               }

--- a/mage_ai/frontend/components/Triggers/Table.tsx
+++ b/mage_ai/frontend/components/Triggers/Table.tsx
@@ -29,6 +29,13 @@ import {
   Logs,
   Trash,
 } from '@oracle/icons';
+import {
+  DELETE_CONFIRM_WIDTH,
+  DELETE_CONFIRM_LEFT_OFFSET_DIFF,
+  DELETE_CONFIRM_TOP_OFFSET_DIFF,
+  DELETE_CONFIRM_TOP_OFFSET_DIFF_FIRST,
+} from '@components/shared/Table/constants';
+import { ICON_SIZE_SMALL } from '@oracle/styles/units/icons';
 import { RunStatus } from '@interfaces/BlockRunType';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { TableContainerStyle } from '@components/shared/Table/index.style';
@@ -73,7 +80,7 @@ function TriggersTable({
   const pipelineUUID = pipeline?.uuid;
   const router = useRouter();
   const deleteButtonRefs = useRef({});
-  const [deleteConfirmationOpenIdx, setDeleteConfirmationOpenIdx] = useState<string>(null);
+  const [deleteConfirmationOpenIdx, setDeleteConfirmationOpenIdx] = useState<number>(null);
   const [confirmDialogueTopOffset, setConfirmDialogueTopOffset] = useState<number>(0);
   const [confirmDialogueLeftOffset, setConfirmDialogueLeftOffset] = useState<number>(0);
 
@@ -98,7 +105,7 @@ function TriggersTable({
   );
 
   const [deletePipelineTrigger] = useMutation(
-    (id: string) => api.pipeline_schedules.useDelete(id)(),
+    (id: number) => api.pipeline_schedules.useDelete(id)(),
     {
       onSuccess: (response: any) => onSuccess(
         response, {
@@ -274,8 +281,8 @@ function TriggersTable({
                     }}
                   >
                     {ScheduleStatusEnum.ACTIVE === status
-                      ? <Pause muted size={2 * UNIT} />
-                      : <PlayButtonFilled default size={2 * UNIT} />
+                      ? <Pause muted size={ICON_SIZE_SMALL} />
+                      : <PlayButtonFilled default size={ICON_SIZE_SMALL} />
                     }
                   </Button>,
                   <FlexContainer
@@ -400,7 +407,7 @@ function TriggersTable({
                     `/pipelines/${finalPipelineUUID}/logs?pipeline_schedule_id[]=${id}`,
                   )}
                 >
-                  <Logs default size={2 * UNIT} />
+                  <Logs default size={ICON_SIZE_SMALL} />
                 </Button>,
               ]);
 
@@ -414,7 +421,7 @@ function TriggersTable({
                       onClick={() => router.push(`/pipelines/${finalPipelineUUID}/triggers/${id}/edit`)}
                       title="Edit"
                     >
-                      <Edit default size={2 * UNIT} />
+                      <Edit default size={ICON_SIZE_SMALL} />
                     </Button>
                     <Spacing mr={1} />
                     <Button
@@ -429,7 +436,7 @@ function TriggersTable({
                       ref={deleteButtonRefs.current[id]}
                       title="Delete"
                     >
-                      <Trash default size={2 * UNIT} />
+                      <Trash default size={ICON_SIZE_SMALL} />
                     </Button>
                     <ClickOutside
                       onClickOutside={() => setDeleteConfirmationOpenIdx(null)}
@@ -437,15 +444,17 @@ function TriggersTable({
                     >
                       <PopupMenu
                         danger
-                        left={(confirmDialogueLeftOffset || 0) - 286}
+                        left={(confirmDialogueLeftOffset || 0) - DELETE_CONFIRM_LEFT_OFFSET_DIFF}
                         onCancel={() => setDeleteConfirmationOpenIdx(null)}
                         onClick={() => {
                           setDeleteConfirmationOpenIdx(null);
                           deletePipelineTrigger(id);
                         }}
                         title={`Are you sure you want to delete the trigger ${name}?`}
-                        top={(confirmDialogueTopOffset || 0) - (idx <= 1 ? 40 : 96)}
-                        width={UNIT * 40}
+                        top={(confirmDialogueTopOffset || 0)
+                          - (idx <= 1 ? DELETE_CONFIRM_TOP_OFFSET_DIFF_FIRST : DELETE_CONFIRM_TOP_OFFSET_DIFF)
+                        }
+                        width={DELETE_CONFIRM_WIDTH}
                       />
                     </ClickOutside>
                   </FlexContainer>,

--- a/mage_ai/frontend/components/shared/Table/constants.ts
+++ b/mage_ai/frontend/components/shared/Table/constants.ts
@@ -1,6 +1,10 @@
 import { UNIT } from '@oracle/styles/units/spacing';
 
 export const MENU_WIDTH: number = UNIT * 20;
+export const DELETE_CONFIRM_WIDTH = UNIT * 40;
+export const DELETE_CONFIRM_TOP_OFFSET_DIFF_FIRST = 40;
+export const DELETE_CONFIRM_TOP_OFFSET_DIFF = 96;
+export const DELETE_CONFIRM_LEFT_OFFSET_DIFF = 286;
 
 export enum SortDirectionEnum {
   ASC = 'ascending',

--- a/mage_ai/frontend/interfaces/PipelineScheduleType.ts
+++ b/mage_ai/frontend/interfaces/PipelineScheduleType.ts
@@ -63,7 +63,7 @@ export default interface PipelineScheduleType {
   created_at?: string;
   event_matchers?: EventMatcherType[];
   global_data_product_uuid?: string;
-  id?: string;
+  id?: number;
   last_pipeline_run_status?: RunStatusEnum;
   name?: string;
   next_pipeline_run_date?: string;

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -84,6 +84,7 @@ function PipelineRuns({
   const [errors, setErrors] = useState<ErrorsType>(null);
   const [selectedTab, setSelectedTab] = useState<TabType>(TAB_PIPELINE_RUNS);
   const [selectedTabSidekick, setSelectedTabSidekick] = useState<TabType>(TABS_SIDEKICK[0]);
+  const [selectedRun, setSelectedRun] = useState<PipelineRunType>(null);
   const [selectedRuns, setSelectedRuns] = useState<{ [keyof: string]: PipelineRunType }>({});
   const [showActionsMenu, setShowActionsMenu] = useState<boolean>(false);
   const [confirmationDialogueOpen, setConfirmationDialogueOpen] = useState<boolean>(false);
@@ -114,8 +115,6 @@ function PipelineRuns({
     dataPipeline,
     pipelineUUID,
   ]);
-
-  const [selectedRun, setSelectedRun] = useState<PipelineRunType>(null);
 
   const q = queryFromUrl();
   const qPrev = usePrevious(q);
@@ -233,6 +232,36 @@ function PipelineRuns({
     },
   );
 
+  const [deletePipelineRun] = useMutation(
+    (id: number) => api.pipeline_runs.useDelete(id)(),
+    {
+      onSuccess: (response: any) => onSuccess(
+        response, {
+          callback: ({
+            pipeline_run: {
+              pipeline_uuid: pipelineUUID,
+            },
+          }) => {
+            fetchPipelineRuns?.();
+            if (pipelineUUID) {
+              router.push(
+                '/pipelines/[pipeline]/runs',
+                `/pipelines/${pipelineUUID}/runs`,
+              );
+            } else {
+              fetchPipelineRuns?.();
+            }
+            setSelectedRun(null);
+          },
+          onErrorCallback: (response, errors) => setErrors({
+            errors,
+            response,
+          }),
+        },
+      ),
+    },
+  );
+
   const selectedTabPrev = usePrevious(selectedTab);
   useEffect(() => {
     const uuid = q[TAB_URL_PARAM];
@@ -329,6 +358,8 @@ function PipelineRuns({
     <>
       <PipelineRunsTable
         allowBulkSelect={pipeline?.type !== PipelineTypeEnum.STREAMING}
+        allowDelete
+        deletePipelineRun={deletePipelineRun}
         fetchPipelineRuns={fetchPipelineRuns}
         onClickRow={(rowIndex: number) => setSelectedRun((prev) => {
           const run = pipelineRuns[rowIndex];
@@ -344,6 +375,7 @@ function PipelineRuns({
       {paginationEl}
     </>
   ), [
+    deletePipelineRun,
     fetchPipelineRuns,
     paginationEl,
     pipeline?.type,

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -878,6 +878,14 @@ class BlockRun(BaseModel):
 
     @classmethod
     @safe_db_query
+    def batch_delete(self, block_run_ids: List[int]):
+        BlockRun.query.filter(BlockRun.id.in_(block_run_ids)).delete(
+            synchronize_session=False
+        )
+        db_connection.session.commit()
+
+    @classmethod
+    @safe_db_query
     def get(self, pipeline_run_id: int = None, block_uuid: str = None) -> 'BlockRun':
         block_runs = self.query.filter(
             BlockRun.pipeline_run_id == pipeline_run_id,


### PR DESCRIPTION
# Description
- Add optional button for deleting individual pipeline runs from pipeline runs table.
- Support deleting individual pipeline runs on `/pipelines/[pipeline_uuid]/runs` page.
- Allows users to clean up pipeline runs table (e.g. if they prefer to remove all failed runs). Bulk deleting pipeline runs would be a separate feature/PR.

# How Has This Been Tested?
![delete pipeline run](https://github.com/mage-ai/mage-ai/assets/78053898/65e00954-6751-44b2-9f36-da8883f4e5ab)

## Sample API Request
DELETE `http://localhost:6789/api/pipeline_runs/479`
Response:
```
{
	"pipeline_run": {
		"id": 479,
		"created_at": "2023-03-04 00:27:08",
		"updated_at": "2023-03-04 00:27:10",
		"pipeline_schedule_id": 227,
		"pipeline_uuid": "little_fog",
		"execution_date": "2023-03-04 00:25:40.075355",
		"status": "cancelled",
		"started_at": null,
		"completed_at": null,
		"variables": null,
		"passed_sla": false,
		"event_variables": null,
		"metrics": null,
		"backfill_id": null,
		"executor_type": null
	}
}
```

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code

