### PR TITLE
[xh]Return dict for GENERATE_COMMENT_FOR_CODE usecase

### DIFF
--- a/mage_ai/ai/llm_pipeline_wizard.py
+++ b/mage_ai/ai/llm_pipeline_wizard.py
@@ -491,7 +491,9 @@ class LLMPipelineWizard:
         chain = LLMChain(llm=self.llm, prompt=prompt_template)
         function_comments_json = await chain.arun(block_content=block_content)
         function_comments = json.loads(function_comments_json)
-        return self.__insert_comments_in_functions(block_content, function_comments)
+        return dict(
+            block_code=self.__insert_comments_in_functions(block_content, function_comments)
+        )
 
     async def async_generate_pipeline_documentation(
         self,
@@ -529,8 +531,7 @@ class LLMPipelineWizard:
     ) -> str:
         pipeline = Pipeline.get(uuid=pipeline_uuid,
                                 repo_path=project_path or get_repo_path())
-        return asyncio.run(
-            self.__async_generate_block_documentation(pipeline.get_block(block_uuid)))
+        return await self.__async_generate_block_documentation(pipeline.get_block(block_uuid))
 
     async def __async_generate_block_documentation(
         self,


### PR DESCRIPTION
# Description
(1) I found for `GENERATE_COMMENT_FOR_CODE` use case, it is now returning a string directly.
This PR updates it to return a dict with key `block_code`
(2) Also a minor fix when generating block documentation, it should `await` instead of `asyncio.run`


# How Has This Been Tested?
Tested locally 
<img width="1680" alt="Screenshot 2023-08-28 at 10 46 56 PM" src="https://github.com/mage-ai/mage-ai/assets/5386254/8c48a085-a67c-45b6-92d1-de0676e94c30">


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993 @dy46 
