### PR TITLE
[xy] Fix dbt command failure due to empty content args

### DIFF
--- a/mage_ai/data_preparation/models/block/dbt/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/__init__.py
@@ -297,6 +297,7 @@ class DBTBlock(Block):
                     cmds,
                     preexec_fn=os.setsid,  # os.setsid doesn't work on Windows
                     stdout=stdout,
+                    stderr=subprocess.STDOUT,
                 )
 
                 if not snapshot:
@@ -319,6 +320,7 @@ class DBTBlock(Block):
                     encoding='utf-8',
                     preexec_fn=os.setsid,  # os.setsid doesn't work on Windows
                     stdout=stdout,
+                    stderr=subprocess.STDOUT,
                     universal_newlines=True,
                 )
                 for line in proc.stdout:

--- a/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
@@ -1166,7 +1166,8 @@ def build_command_line_arguments(
             # If args do not contain "--vars", continue.
             pass
 
-        args += content_args
+        # Add non-empty content args
+        args += [c for c in content_args if c]
 
     variables_json = {}
     for k, v in variables.items():


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
* Fix dbt command failure due to empty content args
* Print dbt command errors to stdout

Close: https://github.com/mage-ai/mage-ai/issues/3271

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested dbt build command with empty content args
Before this change:
<img width="798" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/44e8871e-afe3-4b41-9a50-3327276a4bc3">
The command was 
<img width="543" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/9510e150-c76a-4ff1-a78f-25208e9ea6db">

After this change
<img width="922" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/e610bbf7-45f0-4ba5-814d-562ca013dd24">

- [x] Tested dbt run command with empty content args


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
cc:
<!-- Optionally mention someone to let them know about this pull request -->
