### PR TITLE
[cp] Add `DISABLE_TERMINAL` in docs

### DIFF
--- a/docs/development/environment-variables.mdx
+++ b/docs/development/environment-variables.mdx
@@ -10,6 +10,7 @@ description: "Configure Mage settings through environment variables."
 | `AUTHENTICATION_MODE` | Set the authentication mode in Mage. Omitting the variable will default to basic password authentication. | `ldap` |
 | `DEBUG` | Turn on "debug" mode. Mage will output more logs that could be useful for debugging issues. | 1 |
 | `DISABLE_NOTEBOOK_EDIT_ACCESS` | Setting this variable will disable edit access based on the value. [More information](/production/configuring-production-settings/overview#read-only-access) | 1 |
+| `DISABLE_TERMINAL` | Setting this variable will disable access to the terminal. | 1 |
 | `ENV`               | Set the environment of the Mage app. You can use different code or configurations in different environments. | `dev`, `staging`, `production`/`prod` |
 | `GIT_REPO_LINK`               | [More information](/production/data-sync/git#git-settings-as-environment-variables) | See link |
 | `GIT_REPO_PATH`               | [More information](/production/data-sync/git#git-settings-as-environment-variables) | See link |


### PR DESCRIPTION
# Description
The documentation was not updated when `DISABLE_TERMINAL` variable was introduced in https://github.com/mage-ai/mage-ai/pull/3174

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

