### PR TITLE
Add note to Update data-loading.mdx

### DIFF
--- a/docs/design/data-loading.mdx
+++ b/docs/design/data-loading.mdx
@@ -1107,6 +1107,13 @@ Connections to third-party data storage require you to specify confidential info
 
 Instead, Mage provides **configuration loaders** which allow data loading clients to use your secrets without explicitly writing them in code.
 
+<Warning>
+  Currently Mage only supports AWS Secrets Manager as a configuration loader. If you need to use secrets from Azure Key Vault
+  or GCP Secret Manager, you can reference the following docs:
+    - [Azure Key Vault](https://docs.mage.ai/production/deploying-to-cloud/secrets/Azure)
+    - [GCP Secret Manager](https://docs.mage.ai/production/deploying-to-cloud/secrets/GCP)
+</Warning>
+
 Currently, the following sources (and their corresponding configuration loader) can be used to load configuration settings:
 
 -   Configuration File - `ConfigFileLoader`


### PR DESCRIPTION
Adds a note to the # Configuration Settings section with links to using secrets for other secret providers

# Description
While searching for how to use Azure Key Vault secrets in Mage, I came across the docs for the AWS secret loader, but didn't notice anything there for Azure Key Vault. I found some relevant information with broken links while searching Slack, and eventually made it to other secrets docs. I thought it would be nice to have a little note in the docs that point folks directly to the relevant ways to use secrets for Azure Key Vault and GCP Secret Manager.


# How Has This Been Tested?
No code, no tests. I didn't see any guidance specifically related to docs contributions in the Contributing.md, but I'm happy to do whatever in order to verify.

- [ ] Test A
- [ ] Test B


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation) `I'm unable to add labels to the PR`
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

