### PR TITLE
[dy] Raise exception if a pipeline has duplicate block uuids

### DIFF
--- a/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
@@ -1271,6 +1271,7 @@ def run_dbt_tests(
 
     project_full_path = command_line_dict['project_full_path']
     profiles_dir = command_line_dict['profiles_dir']
+    # profile_target = command_line_dict['profile_target']
 
     _, temp_profile_full_path = create_temporary_profile(
         project_full_path,

--- a/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
@@ -1271,7 +1271,6 @@ def run_dbt_tests(
 
     project_full_path = command_line_dict['project_full_path']
     profiles_dir = command_line_dict['profiles_dir']
-    # profile_target = command_line_dict['profile_target']
 
     _, temp_profile_full_path = create_temporary_profile(
         project_full_path,

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -1048,6 +1048,12 @@ class Pipeline:
     ) -> Block:
         if upstream_block_uuids is None:
             upstream_block_uuids = []
+
+        all_block_uuids = [b.get('uuid') for b in self.all_block_configs]
+        if block.uuid in all_block_uuids:
+            raise InvalidPipelineError(
+                f'Block with uuid {block.uuid} already exists in pipeline {self.uuid}')
+
         if widget:
             self.widgets_by_uuid = self.__add_block_to_mapping(
                 self.widgets_by_uuid,
@@ -1612,13 +1618,13 @@ class Pipeline:
                     virtual_stack.append(StackFrame(child_block))
 
         check_block_uuids = set()
-        for uuid in combined_blocks:
+        for config in self.all_block_configs:
+            uuid = config.get('uuid')
             if status[uuid] == 'unvisited' and uuid in self.blocks_by_uuid:
                 __check_cycle(self.blocks_by_uuid[uuid])
             if uuid in check_block_uuids:
-                raise InvalidPipelineError(f'The block {uuid} is duplicated in the pipeline.')
+                raise InvalidPipelineError(f'Duplicate block UUID {uuid}')
             check_block_uuids.add(uuid)
-
 
 
 class StackFrame:

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -1049,7 +1049,7 @@ class Pipeline:
         if upstream_block_uuids is None:
             upstream_block_uuids = []
 
-        all_block_uuids = [b.get('uuid') for b in self.all_block_configs]
+        all_block_uuids = {b.get('uuid') for b in self.all_block_configs}
         if block.uuid in all_block_uuids:
             raise InvalidPipelineError(
                 f'Block with uuid {block.uuid} already exists in pipeline {self.uuid}')
@@ -1623,7 +1623,8 @@ class Pipeline:
             if status[uuid] == 'unvisited' and uuid in self.blocks_by_uuid:
                 __check_cycle(self.blocks_by_uuid[uuid])
             if uuid in check_block_uuids:
-                raise InvalidPipelineError(f'Duplicate block UUID {uuid}')
+                raise InvalidPipelineError(
+                    f'Pipeline is invalid: duplicate blocks with uuid {uuid}')
             check_block_uuids.add(uuid)
 
 

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -1611,9 +1611,14 @@ class Pipeline:
                     child_block = combined_blocks[frame.children.pop()]
                     virtual_stack.append(StackFrame(child_block))
 
+        check_block_uuids = set()
         for uuid in combined_blocks:
             if status[uuid] == 'unvisited' and uuid in self.blocks_by_uuid:
                 __check_cycle(self.blocks_by_uuid[uuid])
+            if uuid in check_block_uuids:
+                raise InvalidPipelineError(f'The block {uuid} is duplicated in the pipeline.')
+            check_block_uuids.add(uuid)
+
 
 
 class StackFrame:

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -1617,11 +1617,13 @@ class Pipeline:
                     child_block = combined_blocks[frame.children.pop()]
                     virtual_stack.append(StackFrame(child_block))
 
+        for uuid in combined_blocks:
+            if status[uuid] == 'unvisited' and uuid in self.blocks_by_uuid:
+                __check_cycle(self.blocks_by_uuid[uuid])
+
         check_block_uuids = set()
         for config in self.all_block_configs:
             uuid = config.get('uuid')
-            if status[uuid] == 'unvisited' and uuid in self.blocks_by_uuid:
-                __check_cycle(self.blocks_by_uuid[uuid])
             if uuid in check_block_uuids:
                 raise InvalidPipelineError(
                     f'Pipeline is invalid: duplicate blocks with uuid {uuid}')

--- a/mage_ai/tests/data_preparation/models/test_global_data_product.py
+++ b/mage_ai/tests/data_preparation/models/test_global_data_product.py
@@ -1,9 +1,9 @@
 import os
-
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
-from unittest.mock import patch
 
 from mage_ai.data_preparation.models.block import Block
 from mage_ai.data_preparation.models.constants import BlockType
@@ -11,7 +11,9 @@ from mage_ai.data_preparation.models.global_data_product import GlobalDataProduc
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.data_preparation.models.variable import Variable
 from mage_ai.orchestration.db.models.schedules import PipelineRun
-from mage_ai.orchestration.triggers.global_data_product import fetch_or_create_pipeline_schedule
+from mage_ai.orchestration.triggers.global_data_product import (
+    fetch_or_create_pipeline_schedule,
+)
 from mage_ai.settings.repo import get_repo_path
 from mage_ai.tests.base_test import DBTestCase
 
@@ -25,12 +27,12 @@ class GlobalDataProductTest(DBTestCase):
                 'test pipeline',
                 repo_path=self.repo_path,
             )
+            self.pipeline.add_block(Block('data_loader', 'data_loader', BlockType.DATA_LOADER))
+            self.pipeline.add_block(Block('transformer', 'transformer', BlockType.TRANSFORMER))
+            self.pipeline.add_block(
+                Block('data_exporter', 'data_exporter', BlockType.DATA_EXPORTER))
         except Exception:
             self.pipeline = Pipeline.get('test_pipeline')
-
-        self.pipeline.add_block(Block('data_loader', 'data_loader', BlockType.DATA_LOADER))
-        self.pipeline.add_block(Block('transformer', 'transformer', BlockType.TRANSFORMER))
-        self.pipeline.add_block(Block('data_exporter', 'data_exporter', BlockType.DATA_EXPORTER))
 
         self.global_data_product = GlobalDataProduct(
             object_type='pipeline',

--- a/mage_ai/tests/data_preparation/models/test_pipeline.py
+++ b/mage_ai/tests/data_preparation/models/test_pipeline.py
@@ -137,6 +137,19 @@ class PipelineTest(DBTestCase):
             ],
         ))
 
+    def test_add_block_with_duplicate_uuid(self):
+        self.__create_pipeline_with_blocks('test_pipeline_duplicate_blocks')
+        pipeline = Pipeline('test_pipeline_duplicate_blocks', self.repo_path)
+
+        block = Block.create(
+            'block1',
+            'data_exporter',
+            self.repo_path
+        )
+
+        with self.assertRaises(InvalidPipelineError):
+            pipeline.add_block(block)
+
     def test_update_name_existing_pipeline(self):
         pipeline1 = Pipeline.create(
             'test_pipeline_a',

--- a/mage_ai/tests/orchestration/triggers/test_global_data_product.py
+++ b/mage_ai/tests/orchestration/triggers/test_global_data_product.py
@@ -1,6 +1,6 @@
 import os
-
 from datetime import datetime, timedelta, timezone
+
 from freezegun import freeze_time
 
 from mage_ai.data_preparation.models.block import Block
@@ -24,12 +24,12 @@ class TriggerGlobalDataProductTest(DBTestCase):
                 'test pipeline',
                 repo_path=self.repo_path,
             )
+            self.pipeline.add_block(Block('data_loader', 'data_loader', BlockType.DATA_LOADER))
+            self.pipeline.add_block(Block('transformer', 'transformer', BlockType.TRANSFORMER))
+            self.pipeline.add_block(
+                Block('data_exporter', 'data_exporter', BlockType.DATA_EXPORTER))
         except Exception:
             self.pipeline = Pipeline.get('test_pipeline')
-
-        self.pipeline.add_block(Block('data_loader', 'data_loader', BlockType.DATA_LOADER))
-        self.pipeline.add_block(Block('transformer', 'transformer', BlockType.TRANSFORMER))
-        self.pipeline.add_block(Block('data_exporter', 'data_exporter', BlockType.DATA_EXPORTER))
 
         self.global_data_product = GlobalDataProduct(
             object_type='pipeline',

--- a/mage_ai/tests/orchestration/triggers/test_utils.py
+++ b/mage_ai/tests/orchestration/triggers/test_utils.py
@@ -5,7 +5,9 @@ from mage_ai.data_preparation.models.constants import BlockType
 from mage_ai.data_preparation.models.global_data_product import GlobalDataProduct
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.orchestration.db.models.schedules import PipelineRun
-from mage_ai.orchestration.triggers.global_data_product import fetch_or_create_pipeline_schedule
+from mage_ai.orchestration.triggers.global_data_product import (
+    fetch_or_create_pipeline_schedule,
+)
 from mage_ai.orchestration.triggers.utils import (
     check_pipeline_run_status,
     create_and_start_pipeline_run,
@@ -22,12 +24,12 @@ class TriggerUtilsTest(DBTestCase):
                 'test pipeline',
                 repo_path=self.repo_path,
             )
+            self.pipeline.add_block(Block('data_loader', 'data_loader', BlockType.DATA_LOADER))
+            self.pipeline.add_block(Block('transformer', 'transformer', BlockType.TRANSFORMER))
+            self.pipeline.add_block(
+                Block('data_exporter', 'data_exporter', BlockType.DATA_EXPORTER))
         except Exception:
             self.pipeline = Pipeline.get('test_pipeline')
-
-        self.pipeline.add_block(Block('data_loader', 'data_loader', BlockType.DATA_LOADER))
-        self.pipeline.add_block(Block('transformer', 'transformer', BlockType.TRANSFORMER))
-        self.pipeline.add_block(Block('data_exporter', 'data_exporter', BlockType.DATA_EXPORTER))
 
         self.global_data_product = GlobalDataProduct(
             object_type='pipeline',


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

This PR adds validation to a pipeline to ensure that blocks with duplicate uuids are not added to the same pipeline. The validation happens when loading the pipeline as well as adding a block to a pipeline.

If a pipeline already has blocks with duplicate uuids, they should see an error when opening the pipeline instead of the entire server crashing, like in this github issue: https://github.com/mage-ai/mage-ai/issues/2997.

<img width="1625" alt="Screenshot 2023-08-29 at 6 33 54 PM" src="https://github.com/mage-ai/mage-ai/assets/14357209/2e6b2999-fa7b-4bcf-93bc-b9282ea7a7fe">

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally
- [x] Unit tests


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
