### PR TITLE
Fixed NULL headers breaking API Source

### DIFF
--- a/mage_integrations/mage_integrations/sources/api/__init__.py
+++ b/mage_integrations/mage_integrations/sources/api/__init__.py
@@ -134,7 +134,8 @@ class Api(Source):
             'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) \
              Chrome/86.0.4240.111 Safari/537.36',
         }
-        headers.update(self.config.get('headers', {}))
+        if self.config.get('headers') is not None:  # preventing iteration errors in headers.update
+            headers.update(self.config.get('headers', {}))
 
         tags = dict(
             headers=headers,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
[Slack thread with issue reporting](https://mageai.slack.com/archives/C03HTTWFEKE/p1693065753296649)
Issue:
Whenever `headers` config was set as `NULL`, the API Source in Data Integrations pipelines would break
Fixed by adding a None check before trying to update the default headers with the config file headers

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
Tested on a local mage instance

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

cc:
@wangxiaoyou1993 
