### PR TITLE
[xy] Add healthcheck to sqs streaming source.

### DIFF
--- a/mage_ai/streaming/sources/amazon_sqs.py
+++ b/mage_ai/streaming/sources/amazon_sqs.py
@@ -1,12 +1,16 @@
+import json
+import threading
+import time
 from dataclasses import dataclass
 from enum import Enum
+from typing import Callable, Dict
+
+import boto3
+
 from mage_ai.shared.config import BaseConfig
 from mage_ai.streaming.constants import DEFAULT_BATCH_SIZE
 from mage_ai.streaming.sources.base import BaseSource
-from mage_ai.streaming.sources.shared import SerializationMethod, SerDeConfig
-from typing import Callable, Dict
-import boto3
-import json
+from mage_ai.streaming.sources.shared import SerDeConfig, SerializationMethod
 
 DEFAULT_WAIT_TIME_SECONDS = 1
 
@@ -32,6 +36,78 @@ class AmazonSqsConfig(BaseConfig):
         return config
 
 
+class MessageConsumerThread(threading.Thread):
+    def __init__(self, source, handler):
+        super().__init__()
+        self.source = source
+        self.handler = handler
+        self.is_running = True
+        self.last_message_time = time.time()
+
+    def run(self):
+        if self.source.config.batch_size > 0:
+            batch_size = self.source.config.batch_size
+        else:
+            batch_size = DEFAULT_BATCH_SIZE
+
+        try:
+            while self.is_running:
+                messages = self.source.queue.receive_messages(
+                    MessageAttributeNames=['All'],
+                    MaxNumberOfMessages=batch_size,
+                    WaitTimeSeconds=self.source.config.wait_time_seconds,
+                )
+                self.update_last_message_time()
+                parsed_messages = []
+                for msg in messages:
+                    parsed_msg_body = self.__deserialize_message(msg.body)
+                    if self.source.config.message_deletion_method == \
+                            MessageDeletionMethod.AFTER_RECEIVED:
+                        parsed_messages.append(parsed_msg_body)
+                        msg.delete()
+                    else:
+                        parsed_messages.append(dict(
+                            parsed_msg_body=self.__deserialize_message(msg.body),
+                            raw_message=msg,
+                        ))
+                if len(parsed_messages) > 0:
+                    self.source._print(
+                        f'Received {len(parsed_messages)} message. '
+                        f'Sample: {parsed_messages[0]}.')
+                    self.handler(parsed_messages)
+        except Exception:
+            self.source._print(
+                f'Couldn\'t receive messages from queue {self.source.config.queue_name}.')
+            raise
+
+    def stop(self):
+        self.is_running = False
+
+    def update_last_message_time(self):
+        self.last_message_time = time.time()
+
+
+class HealthCheckThread(threading.Thread):
+    def __init__(self, message_consumer_thread, timeout_seconds):
+        super().__init__()
+        self.message_consumer_thread = message_consumer_thread
+        self.timeout_seconds = timeout_seconds
+
+    def run(self):
+        while True:
+            current_time = time.time()
+            last_message_time = self.message_consumer_thread.last_message_time
+            if current_time - last_message_time > self.timeout_seconds:
+                print("No messages consumed for a while. Initiating restart...")
+                self.message_consumer_thread.stop()  # Gracefully stop the consumer
+                # Perform any necessary cleanup or notification
+                # Restart the consumer thread
+                self.message_consumer_thread = MessageConsumerThread()
+                self.message_consumer_thread.start()
+
+            time.sleep(self.timeout_seconds)
+
+
 class AmazonSqsSource(BaseSource):
     config_class = AmazonSqsConfig
 
@@ -46,37 +122,24 @@ class AmazonSqsSource(BaseSource):
         pass
 
     def batch_read(self, handler: Callable):
+        """
+        Batch read messages from SQS queue with health check.
+        """
         self._print('Start consuming messages.')
-        if self.config.batch_size > 0:
-            batch_size = self.config.batch_size
-        else:
-            batch_size = DEFAULT_BATCH_SIZE
+        consumer_thread = MessageConsumerThread(self, handler)
 
-        try:
-            while True:
-                messages = self.queue.receive_messages(
-                    MessageAttributeNames=['All'],
-                    MaxNumberOfMessages=batch_size,
-                    WaitTimeSeconds=self.config.wait_time_seconds,
-                )
-                parsed_messages = []
-                for msg in messages:
-                    parsed_msg_body = self.__deserialize_message(msg.body)
-                    if self.config.message_deletion_method == MessageDeletionMethod.AFTER_RECEIVED:
-                        parsed_messages.append(parsed_msg_body)
-                        msg.delete()
-                    else:
-                        parsed_messages.append(dict(
-                            parsed_msg_body=self.__deserialize_message(msg.body),
-                            raw_message=msg,
-                        ))
-                if len(parsed_messages) > 0:
-                    self._print(f'Received {len(parsed_messages)} message. '
-                                f'Sample: {parsed_messages[0]}.')
-                    handler(parsed_messages)
-        except Exception:
-            self._print(f'Couldn\'t receive messages from queue {self.config.queue_name}.')
-            raise
+        # Start the consumer thread as the main thread
+        consumer_thread.start()
+
+        # Set the desired timeout
+        health_check_thread = HealthCheckThread(consumer_thread, timeout_seconds=60)
+
+        # Start the health check thread as a daemon thread
+        health_check_thread.daemon = True
+        health_check_thread.start()
+
+        # Wait for the consumer thread to finish (optional)
+        consumer_thread.join()
 
     def __deserialize_message(self, message):
         if self.config.serde_config is not None and \

--- a/mage_ai/streaming/sources/base.py
+++ b/mage_ai/streaming/sources/base.py
@@ -1,7 +1,7 @@
+import json
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Callable, Dict
-import json
 
 
 class SourceConsumeMethod(str, Enum):
@@ -67,5 +67,8 @@ class BaseSource(ABC):
     def test_connection(self):
         return True
 
-    def _print(self, msg):
+    def print(self, msg: str):
+        self._print(msg)
+
+    def _print(self, msg: str):
         print(f'[{self.__class__.__name__}] {msg}')


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Add healthcheck to sqs streaming source.
* Run consumer thread and health check thread separately
* Automatically terminate the consumer thread if health check fails.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested running streaming pipeline with sqs source locally
- [x] Tested commenting out the `update_last_message_time` method call. The sqs pipeline restarted after health check timeout.
<img width="1129" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/02fb6ac0-bee9-4e9c-9e17-93d0d3d76660">


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

cc:
<!-- Optionally mention someone to let them know about this pull request -->
