### PR TITLE
[xy] Create lsn and _mage_deleted_at in initial log_based sync.

### DIFF
--- a/mage_integrations/mage_integrations/sources/postgresql/__init__.py
+++ b/mage_integrations/mage_integrations/sources/postgresql/__init__.py
@@ -95,7 +95,7 @@ WHERE TABLE_NAME = '{table_name}' AND TABLE_SCHEMA = '{schema_name}'
         return [r[0].lower() for r in results]
 
     def internal_column_schema(self, stream, bookmarks: Dict = None) -> Dict[str, Dict]:
-        if REPLICATION_METHOD_LOG_BASED == self._replication_method(stream, bookmarks=bookmarks):
+        if REPLICATION_METHOD_LOG_BASED == stream.replication_method:
             return {
                 INTERNAL_COLUMN_DELETED_AT: DATETIME_COLUMN_SCHEMA,
                 INTERNAL_COLUMN_LSN: {'type': ['integer']},


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Create lsn and _mage_deleted_at in initial log_based sync.
Close: https://github.com/mage-ai/mage-ai/issues/3344


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested running the data integration pipeline with postgres source. Set the replication method to LOG_BASED, after the first sync, the `lsn` and `_mage_deleted_at` columns are created.
<img width="931" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/5172780f-455c-4e12-897a-890bdddac4a6">

Before this PR, those two columns are not created in the first sync.
<img width="738" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/d4253a87-cd4e-4426-925f-45e1e4c80745">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code

cc:
<!-- Optionally mention someone to let them know about this pull request -->
