### PR TITLE
[jk] Auto-update triggers in code when making changes in UI

### DIFF
--- a/docs/orchestration/triggers/configure-triggers-in-code.mdx
+++ b/docs/orchestration/triggers/configure-triggers-in-code.mdx
@@ -71,9 +71,9 @@ triggers:
 
 ## Modify triggers
 
-For triggers that are configured in yaml file, any trigger settings made through UI will be overriden by
-the config from yaml file. Thus, to modify the trigger settings, you'll need to update the trigger configs
-in yaml file directly. The new trigger configs will be automatically synced to the triggers in UI.
+If an existing trigger is configured in the yaml file, any updates to it through the UI will also update
+trigger config in the yaml file. If you modify the trigger settings directly in the yaml, it will
+automatically update the trigger in the UI. The new trigger configs are synced to the triggers in UI.
 
 
 ## Delete triggers
@@ -81,5 +81,6 @@ in yaml file directly. The new trigger configs will be automatically synced to t
 If you don't want to use a trigger anymore, you can either update the trigger status to `inactive` or
 delete the trigger completely.
 
-To delete the trigger completely, you'll need to remove the trigger config from the yaml file first and
-then delete the trigger from the UI.
+To delete the trigger completely, you can delete the trigger from the UI by clicking the delete button
+(with trash can icon) in the Pipeline triggers table (`/pipeline/[pipeline_uuid]/triggers`). This will
+also remove the trigger from the pipeline's `triggers.yaml` config file.

--- a/mage_ai/api/resources/PipelineScheduleResource.py
+++ b/mage_ai/api/resources/PipelineScheduleResource.py
@@ -7,6 +7,7 @@ from mage_ai.api.resources.DatabaseResource import DatabaseResource
 from mage_ai.data_preparation.models.triggers import (
     Trigger,
     add_or_update_trigger_for_pipeline_and_persist,
+    remove_trigger,
 )
 from mage_ai.orchestration.db import db_connection, safe_db_query
 from mage_ai.orchestration.db.models.schedules import (
@@ -249,6 +250,14 @@ class PipelineScheduleResource(DatabaseResource):
             return self.tag_associations
         else:
             return self.tag_associations_updated
+
+    @safe_db_query
+    def delete(self, **kwargs):
+        if self.model.trigger_as_code_exists:
+            remove_trigger(self.model.name, self.model.pipeline_uuid)
+        self.model.delete()
+
+        return self
 
 
 def __load_tag_associations(resource):

--- a/mage_ai/api/resources/PipelineScheduleResource.py
+++ b/mage_ai/api/resources/PipelineScheduleResource.py
@@ -14,7 +14,11 @@ from mage_ai.orchestration.db.models.schedules import (
     PipelineSchedule,
     pipeline_schedule_event_matcher_association_table,
 )
-from mage_ai.orchestration.db.models.tags import Tag, TagAssociation, TagAssociationWithTag
+from mage_ai.orchestration.db.models.tags import (
+    Tag,
+    TagAssociation,
+    TagAssociationWithTag,
+)
 from mage_ai.settings.repo import get_repo_path
 from mage_ai.shared.hash import merge_dict
 
@@ -228,6 +232,7 @@ class PipelineScheduleResource(DatabaseResource):
                 pipeline_uuid=pipeline_uuid,
                 schedule_interval=payload.get('schedule_interval', self.model.schedule_interval),
                 schedule_type=payload.get('schedule_type', self.model.schedule_type),
+                settings=payload.get('settings', self.model.settings),
                 sla=payload.get('sla', self.model.sla),
                 start_time=payload.get('start_time', self.model.start_time),
                 status=payload.get('status', self.model.status),

--- a/mage_ai/api/resources/PipelineScheduleResource.py
+++ b/mage_ai/api/resources/PipelineScheduleResource.py
@@ -226,10 +226,10 @@ class PipelineScheduleResource(DatabaseResource):
             trigger = Trigger(
                 name=payload.get('name', self.model.name),
                 pipeline_uuid=pipeline_uuid,
+                schedule_interval=payload.get('schedule_interval', self.model.schedule_interval),
                 schedule_type=payload.get('schedule_type', self.model.schedule_type),
                 sla=payload.get('sla', self.model.sla),
                 start_time=payload.get('start_time', self.model.start_time),
-                schedule_interval=payload.get('schedule_interval', self.model.schedule_interval),
                 status=payload.get('status', self.model.status),
                 variables=payload.get('variables', self.model.variables),
             )

--- a/mage_ai/data_preparation/models/triggers/__init__.py
+++ b/mage_ai/data_preparation/models/triggers/__init__.py
@@ -204,3 +204,17 @@ def update_triggers_for_pipeline_and_persist(
     safe_write(trigger_file_path, content)
 
     return trigger_configs
+
+
+def remove_trigger(
+    name: str,
+    pipeline_uuid: str,
+) -> Dict:
+    trigger_configs_by_name = get_trigger_configs_by_name(pipeline_uuid)
+    deleted_trigger = trigger_configs_by_name.pop(name, None)
+    update_triggers_for_pipeline_and_persist(
+        list(trigger_configs_by_name.values()),
+        pipeline_uuid,
+    )
+
+    return deleted_trigger

--- a/mage_ai/data_preparation/models/triggers/__init__.py
+++ b/mage_ai/data_preparation/models/triggers/__init__.py
@@ -182,7 +182,7 @@ def add_or_update_trigger_for_pipeline_and_persist(
     have, so we need to set "envs" on the updated trigger if it already exists.
     Otherwise, it will get overwritten when updating the trigger in code.
     """
-    existing_trigger = triggers_by_name[trigger.name]
+    existing_trigger = triggers_by_name.get(trigger.name)
     if existing_trigger is not None:
         trigger.envs = existing_trigger.envs
     triggers_by_name[trigger.name] = trigger

--- a/mage_ai/data_preparation/models/triggers/__init__.py
+++ b/mage_ai/data_preparation/models/triggers/__init__.py
@@ -122,6 +122,17 @@ def get_triggers_by_pipeline(pipeline_uuid: str) -> List[Trigger]:
     return triggers
 
 
+def get_trigger_configs_by_name(pipeline_uuid: str) -> Dict:
+    yaml_config = load_triggers_file_data(pipeline_uuid)
+    trigger_configs = yaml_config.get('triggers') or {}
+    trigger_configs_by_name = index_by(
+        lambda config: config.get('name'),
+        trigger_configs,
+    )
+
+    return trigger_configs_by_name
+
+
 def build_triggers(
     trigger_configs: Dict,
     pipeline_uuid: str = None,
@@ -175,3 +186,16 @@ def add_or_update_trigger_for_pipeline_and_persist(
     safe_write(trigger_file_path, content)
 
     return triggers_by_name
+
+
+def update_triggers_for_pipeline_and_persist(
+    trigger_configs: List[Dict],
+    pipeline_uuid: str,
+) -> Dict:
+    yaml_config = dict()
+    yaml_config['triggers'] = trigger_configs
+    content = yaml.safe_dump(yaml_config)
+    trigger_file_path = get_triggers_file_path(pipeline_uuid)
+    safe_write(trigger_file_path, content)
+
+    return trigger_configs

--- a/mage_ai/data_preparation/models/triggers/__init__.py
+++ b/mage_ai/data_preparation/models/triggers/__init__.py
@@ -192,6 +192,11 @@ def update_triggers_for_pipeline_and_persist(
     trigger_configs: List[Dict],
     pipeline_uuid: str,
 ) -> Dict:
+    """
+    Used to update all of a pipeline's triggers saved in code at once.
+    Overwrites triggers in triggers.yaml config with updated triggers
+    passed as first argument.
+    """
     yaml_config = dict()
     yaml_config['triggers'] = trigger_configs
     content = yaml.safe_dump(yaml_config)

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -122,19 +122,6 @@ class PipelineSchedule(BaseModel):
         return sorted(self.pipeline_runs, key=lambda x: x.created_at)[-1].status
 
     @property
-    def trigger_as_code_exists(self) -> bool:
-        yaml_config = load_triggers_file_data(self.pipeline_uuid)
-        trigger_configs = yaml_config.get('triggers') or []
-        trigger = find(
-            lambda config: config.get('name') == self.name,
-            trigger_configs,
-        )
-        if trigger is not None:
-            return True
-
-        return False
-
-    @property
     def tag_associations(self):
         return (
             TagAssociation.

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -41,7 +41,6 @@ from mage_ai.data_preparation.models.triggers import (
     ScheduleType,
     SettingsConfig,
     Trigger,
-    load_triggers_file_data,
 )
 from mage_ai.data_preparation.variable_manager import get_global_variables
 from mage_ai.orchestration.db import db_connection, safe_db_query

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -41,6 +41,7 @@ from mage_ai.data_preparation.models.triggers import (
     ScheduleType,
     SettingsConfig,
     Trigger,
+    load_triggers_file_data,
 )
 from mage_ai.data_preparation.variable_manager import get_global_variables
 from mage_ai.orchestration.db import db_connection, safe_db_query
@@ -119,6 +120,19 @@ class PipelineSchedule(BaseModel):
         if len(self.pipeline_runs) == 0:
             return None
         return sorted(self.pipeline_runs, key=lambda x: x.created_at)[-1].status
+
+    @property
+    def trigger_as_code_exists(self) -> bool:
+        yaml_config = load_triggers_file_data(self.pipeline_uuid)
+        trigger_configs = yaml_config.get('triggers') or []
+        trigger = find(
+            lambda config: config.get('name') == self.name,
+            trigger_configs,
+        )
+        if trigger is not None:
+            return True
+
+        return False
 
     @property
     def tag_associations(self):

--- a/mage_ai/tests/api/operations/test_pipeline_schedules.py
+++ b/mage_ai/tests/api/operations/test_pipeline_schedules.py
@@ -88,7 +88,7 @@ class PipelineScheduleOperationTests(BaseApiTestCase):
         )
         response = await operation.execute()
 
-        self.assertEqual(response['pipeline_schedule']['status'], ScheduleStatus.INACTIVE)
+        self.assertEqual(response['pipeline_schedule']['status'], ScheduleStatus.ACTIVE)
         self.assertEqual(
             response['pipeline_schedule']['schedule_interval'],
             ScheduleInterval.HOURLY,
@@ -97,11 +97,11 @@ class PipelineScheduleOperationTests(BaseApiTestCase):
         updated_trigger_configs_by_name = get_trigger_configs_by_name('test_pipeline')
         self.assertEqual(
             updated_trigger_configs_by_name['test_schedule_2']['schedule_interval'],
-            ScheduleInterval.DAILY,
+            ScheduleInterval.HOURLY,
         )
         self.assertEqual(
             updated_trigger_configs_by_name['test_schedule_2']['status'],
-            ScheduleStatus.INACTIVE,
+            ScheduleStatus.ACTIVE,
         )
 
     async def test_execute_list(self):

--- a/mage_ai/tests/api/operations/test_pipeline_schedules.py
+++ b/mage_ai/tests/api/operations/test_pipeline_schedules.py
@@ -64,17 +64,17 @@ class PipelineScheduleOperationTests(BaseApiTestCase):
             schedule_type=pipeline_schedule.schedule_type,
             start_time=pipeline_schedule.start_time,
         )
-        triggers_by_name = add_or_update_trigger_for_pipeline_and_persist(
+        trigger_configs_by_name = add_or_update_trigger_for_pipeline_and_persist(
             trigger,
             pipeline_schedule.pipeline_uuid,
         )
 
         self.assertEqual(
-            triggers_by_name['test_schedule_2'].schedule_interval,
+            trigger_configs_by_name['test_schedule_2'].get('schedule_interval'),
             ScheduleInterval.DAILY,
         )
         self.assertEqual(
-            triggers_by_name['test_schedule_2'].status,
+            trigger_configs_by_name['test_schedule_2'].get('status'),
             ScheduleStatus.INACTIVE,
         )
 

--- a/mage_ai/tests/api/operations/test_pipeline_schedules.py
+++ b/mage_ai/tests/api/operations/test_pipeline_schedules.py
@@ -78,12 +78,15 @@ class PipelineScheduleOperationTests(BaseApiTestCase):
             ScheduleStatus.INACTIVE,
         )
 
+        update_payload = dict(
+            schedule_interval='@hourly',
+            status='active',
+        )
         operation = self.build_update_operation(
             pipeline_schedule.id,
-            dict(
-                schedule_interval=ScheduleInterval.HOURLY,
-                status=ScheduleStatus.ACTIVE,
-            ),
+            {
+                'pipeline_schedule': update_payload,
+            },
             user=user,
         )
         response = await operation.execute()
@@ -94,6 +97,7 @@ class PipelineScheduleOperationTests(BaseApiTestCase):
             ScheduleInterval.HOURLY,
         )
 
+        # Check if trigger in triggers.yaml config file was also updated
         updated_trigger_configs_by_name = get_trigger_configs_by_name('test_pipeline')
         self.assertEqual(
             updated_trigger_configs_by_name['test_schedule_2']['schedule_interval'],

--- a/mage_ai/tests/api/operations/test_pipeline_schedules.py
+++ b/mage_ai/tests/api/operations/test_pipeline_schedules.py
@@ -49,14 +49,14 @@ class PipelineScheduleOperationTests(BaseApiTestCase):
     async def test_execute_update_schedule_saved_in_code(self):
         email = self.faker.email()
         user = create_user(email=email, roles=1)
-        pipeline_schedule = PipelineSchedule.create(dict(
+        pipeline_schedule = PipelineSchedule.create(
             name='test_schedule_2',
             pipeline_uuid='test_pipeline',
             schedule_interval=ScheduleInterval.DAILY,
             schedule_type=ScheduleType.TIME,
             start_time=datetime(2023, 8, 30, 12, 30, 45),
             status=ScheduleStatus.INACTIVE,
-        ))
+        )
         trigger = Trigger(
             name=pipeline_schedule.name,
             pipeline_uuid=pipeline_schedule.pipeline_uuid,


### PR DESCRIPTION
# Description
- The saved triggers in code (i.e. the `triggers.yaml` files) were not getting updated when users interacted with the UI (e.g. starting or pausing pipeline schedules). This PR automatically updates the `triggers.yaml` files when user makes changes through the UI to the pipeline schedules that are saved as code.
- In addition to starting/pausing an individual trigger, users can also start or pause a pipeline, which can change the `status` of multiple triggers at once and require the `triggers.yaml` config file to be updated for multiple triggers.
- When deleting a trigger saved as code, also remove that trigger from the `triggers.yaml` file. Otherwise, the trigger will keep getting recreated since it is still saved as code.

# How Has This Been Tested?
- Added unit test
- Tested through UI and confirmed changes in `triggers.yaml` file:
![auto update triggers in code](https://github.com/mage-ai/mage-ai/assets/78053898/4109a2fa-d002-4667-82c6-de0613d21d38)


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x]  I have made corresponding changes to the documentation


