### PR TITLE
Docker: Installation Method of Node using setup_17.x is no longer supported

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -7,12 +7,13 @@ USER root
 RUN \
   curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
   curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
-  curl -fsSL https://deb.nodesource.com/setup_17.x | bash - && \
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  NODE_MAJOR=20 && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
   apt-get -y update && \
   ACCEPT_EULA=Y apt-get -y install --no-install-recommends \
     # Node
     nodejs \
-    npm \
     # NFS dependencies
     nfs-common \
     # odbc dependencies


### PR DESCRIPTION
# Description
Nodesource does not support setup scripts anymore. The installation is straight forward.
In addition I have
- updated to Nodejs 20, as its the current version and Nodejs 17 is EOL.
- removed npm as its already included in nodejs package

# How Has This Been Tested?
Ran dev.Dockerfile using scripts/dev.sh and checked whether localhost:3000 still works.

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works - no need
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc: @dy46 