### PR TITLE
[hw] Change the default search path to the schema given in the connection URL for PostgreSQL

### DIFF
--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -103,6 +103,8 @@ if db_connection_url.startswith('postgresql'):
     if db_schema:
         db_connection.start_session()
         db_connection.session.execute(f'CREATE SCHEMA IF NOT EXISTS {db_schema};')
+        db_current = db_connection.session.execute('SELECT current_database()').fetchall()[0][0]
+        db_connection.session.execute(f'ALTER DATABASE {db_current} SET search_path TO {db_schema}')
         db_connection.session.commit()
         db_connection.close_session()
         print(f'Set the default PostgreSQL schema to {db_schema}')

--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -107,7 +107,7 @@ if db_connection_url.startswith('postgresql'):
         db_connection.session.execute(f'ALTER DATABASE {db_current} SET search_path TO {db_schema}')
         db_connection.session.commit()
         db_connection.close_session()
-        print(f'Set the default PostgreSQL schema to {db_schema}')
+        print(f'Set the default PostgreSQL schema for {db_current} to {db_schema}')
     else:
         print('No schema in PostgreSQL connection URL: use the default "public" schema')
 

--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -103,6 +103,7 @@ if db_connection_url.startswith('postgresql'):
     if db_schema:
         db_connection.start_session()
         db_connection.session.execute(f'CREATE SCHEMA IF NOT EXISTS {db_schema};')
+        # Get the current database name from the query fetchall() result, e.g., [('test_database',)]
         db_current = db_connection.session.execute('SELECT current_database()').fetchall()[0][0]
         db_connection.session.execute(f'ALTER DATABASE {db_current} SET search_path TO {db_schema}')
         db_connection.session.commit()


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Encountered the following exception when adding a specific schema to a PostgreSQL connection URL:
```
mage-ai-server-1  | The above exception was the direct cause of the following exception:
mage-ai-server-1  | 
mage-ai-server-1  | Traceback (most recent call last):
mage-ai-server-1  |   File "/usr/local/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
mage-ai-server-1  |     self.run()
mage-ai-server-1  |   File "/usr/local/lib/python3.10/multiprocessing/process.py", line 108, in run
mage-ai-server-1  |     self._target(*self._args, **self._kwargs)
mage-ai-server-1  |   File "/home/src/mage_ai/orchestration/db/process.py", line 15, in start_session_and_run
mage-ai-server-1  |     results = target(*args)
mage-ai-server-1  |   File "/home/src/mage_ai/server/scheduler_manager.py", line 41, in run_scheduler
mage-ai-server-1  |     raise e
mage-ai-server-1  |   File "/home/src/mage_ai/server/scheduler_manager.py", line 38, in run_scheduler
mage-ai-server-1  |     LoopTimeTrigger().start()
mage-ai-server-1  |   File "/home/src/mage_ai/orchestration/triggers/loop_time_trigger.py", line 9, in start
mage-ai-server-1  |     self.run()
mage-ai-server-1  |   File "/home/src/mage_ai/orchestration/triggers/time_trigger.py", line 10, in run
mage-ai-server-1  |     schedule_all()
mage-ai-server-1  |   File "/home/src/mage_ai/orchestration/pipeline_scheduler.py", line 1259, in schedule_all
mage-ai-server-1  |     list(PipelineSchedule.active_schedules(pipeline_uuids=repo_pipelines))
mage-ai-server-1  |   File "/home/src/mage_ai/orchestration/db/__init__.py", line 118, in func_with_rollback
mage-ai-server-1  |     return func(*args, **kwargs)
mage-ai-server-1  |   File "/home/src/mage_ai/orchestration/db/models/schedules.py", line 153, in active_schedules
mage-ai-server-1  |     return query.all()
mage-ai-server-1  |   File "/usr/local/lib/python3.10/site-packages/sqlalchemy/orm/query.py", line 2773, in all
mage-ai-server-1  |     return self._iter().all()
mage-ai-server-1  |   File "/usr/local/lib/python3.10/site-packages/sqlalchemy/orm/query.py", line 2916, in _iter
mage-ai-server-1  |     result = self.session.execute(
mage-ai-server-1  |   File "/usr/local/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 1717, in execute
mage-ai-server-1  |     result = conn._execute_20(statement, params or {}, execution_options)
mage-ai-server-1  |   File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1710, in _execute_20
mage-ai-server-1  |     return meth(self, args_10style, kwargs_10style, execution_options)
mage-ai-server-1  |   File "/usr/local/lib/python3.10/site-packages/sqlalchemy/sql/elements.py", line 334, in _execute_on_connection
mage-ai-server-1  |     return connection._execute_clauseelement(
mage-ai-server-1  |   File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1577, in _execute_clauseelement
mage-ai-server-1  |     ret = self._execute_context(
mage-ai-server-1  |   File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1953, in _execute_context
mage-ai-server-1  |     self._handle_dbapi_exception(
mage-ai-server-1  |   File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 2134, in _handle_dbapi_exception
mage-ai-server-1  |     util.raise_(
mage-ai-server-1  |   File "/usr/local/lib/python3.10/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
mage-ai-server-1  |     raise exception
mage-ai-server-1  |   File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1910, in _execute_context
mage-ai-server-1  |     self.dialect.do_execute(
mage-ai-server-1  |   File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
mage-ai-server-1  |     cursor.execute(statement, parameters)
mage-ai-server-1  | sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedTable) relation "pipeline_schedule" does not exist
mage-ai-server-1  | LINE 2: FROM pipeline_schedule 
mage-ai-server-1  |              ^ 
```

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with the following procedure in a local development environment:
1. Build the Mage docker image:
```
./scripts/init.sh test_project_1
```
2. Start the PostgreSQL docker instance:
```
docker run --network mage-ai_default --network-alias postgres_db \
   -it -p 5432:5432 -v pgdata:/var/lib/postgresql/data \
   -e POSTGRES_USER=test_username -e POSTGRES_PASSWORD=test_password \
   -e POSTGRES_DB=test_database -e PG_DATA=/var/lib/postgresql/data/pgdata \
   postgres:13-alpine3.17 postgres
``` 
3. Set the environment variable in the terminal for Mage:
```
export DATABASE_CONNECTION_URL='postgresql+psycopg2://test_username:test_password@postgres_db:5432/test_database?options=-c%%20search_path%%3Dtest_schema_3'
```
4. Start the Mage docker image:
```
./scripts/dev.sh test_project_1
```
5. Start the PostgreSQL console:
```
psql -h localhost -p 5432 -d test_database -U test_username -W
```
6. Check the created Mage schema and database in `psql` console: 
```
test_database=# \dt test_schema_3.*
                                  List of relations
    Schema     |                    Name                     | Type  |     Owner     
---------------+---------------------------------------------+-------+---------------
 test_schema_3 | alembic_version                             | table | test_username
 test_schema_3 | backfill                                    | table | test_username
 test_schema_3 | block_run                                   | table | test_username
 test_schema_3 | event_matcher                               | table | test_username
 test_schema_3 | oauth2_access_token                         | table | test_username
 test_schema_3 | oauth2_application                          | table | test_username
 test_schema_3 | permission                                  | table | test_username
 test_schema_3 | pipeline_run                                | table | test_username
 test_schema_3 | pipeline_schedule                           | table | test_username
 test_schema_3 | pipeline_schedule_event_matcher_association | table | test_username
 test_schema_3 | role                                        | table | test_username
 test_schema_3 | secret                                      | table | test_username
 test_schema_3 | user                                        | table | test_username
 test_schema_3 | user_role                                   | table | test_username
(14 rows)
```

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@dy46 @wangxiaoyou1993 