### PR TITLE
Feat: Added Missing destination block warning

### DIFF
--- a/mage_ai/data_integrations/utils/scheduler.py
+++ b/mage_ai/data_integrations/utils/scheduler.py
@@ -103,6 +103,10 @@ def create_block_runs(pipeline_run: PipelineRun, logger: DictLogger) -> List[Blo
     data_loader_block = integration_pipeline.data_loader
     data_exporter_block = integration_pipeline.data_exporter
 
+    if data_exporter_block is None:
+        raise Exception("No Destination Block was found. \
+                         Mage expects 1 Source and 1 Destination Block")
+
     transformer_blocks = [b for b in executable_blocks if b.uuid not in [
         data_loader_block.uuid,
         data_exporter_block.uuid,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
If a user does not specify a Destination block for a Data integration pipeline run, it will receive this log message:
![Screenshot from 2023-09-01 15-27-38](https://github.com/mage-ai/mage-ai/assets/14100959/77c94b4e-2e90-49b4-8df4-dafc1ef214a0)

In order to make it easier to understand that 1 Source and 1 Destination block are necessary, a None check was added to the Destination Block type, and a exception message explaining what happened:
![Screenshot from 2023-09-01 15-27-32](https://github.com/mage-ai/mage-ai/assets/14100959/0bb8c28b-c49c-499a-a3dc-45738c5ec874)


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
Tested on a Local mage instance



# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- 
cc:
@wangxiaoyou1993 