### PR TITLE
Docker: Lint Image and some best practices

### DIFF
--- a/.github/workflows/lint_docker_image.yml
+++ b/.github/workflows/lint_docker_image.yml
@@ -1,0 +1,67 @@
+name: Lint Docker Images
+
+on:
+  pull_request:
+    paths:
+      - '*Dockerfile'
+
+jobs:
+  changed-images:
+    runs-on: ubuntu-latest
+    name: List changed images
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v38
+        with:
+          files: '*Dockerfile'
+          json: true
+      - name: Create Job Matrix
+        id: image-matrix
+        run: echo images=${{ steps.changed-files.outputs.all_changed_files }} >> $GITHUB_OUTPUT
+    outputs:
+      images: ${{ steps.image-matrix.outputs.images }}
+
+  hadolint:
+    name: Lint Docker Images
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    # Skip job if there are no images to test
+    # https://github.com/dorny/paths-filter/issues/66
+    if: ${{ needs.changed-images.outputs.images != '' && toJson(fromJson(needs.changed-images.outputs.images)) != '[]' }}
+    needs: [changed-images]
+    strategy:
+      matrix:
+        image: ${{ fromJSON(needs.changed-images.outputs.images) }}
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: hadolint/hadolint-action@v3.1.0
+        id: hadolint
+        with:
+          dockerfile: ${{ matrix.image }}
+          ignore: DL3002,DL3008,DL3013,DL3016
+      - name: Annotate Pull Request
+        uses: actions/github-script@v6
+        if: github.event_name == 'pull_request' && failure()
+        with:
+          script: |
+            const output = `
+            #### Hadolint: \`${{ steps.hadolint.outcome }}\`
+            \`\`\`
+            ${process.env.HADOLINT_RESULTS}
+            \`\`\`
+            `;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM python:3.10
+FROM python:3.10-bookworm
 LABEL description="Deploy Mage on ECS"
-ARG PIP=pip3
 USER root
 
-# Packages
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+## System Packages
 RUN \
   curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
   curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
@@ -22,29 +23,33 @@ RUN \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-# R Packages
+## R Packages
 RUN \
   R -e "install.packages('pacman', repos='http://cran.us.r-project.org')" && \
   R -e "install.packages('renv', repos='http://cran.us.r-project.org')"
 
-# Python Packages
+## Python Packages
 RUN \
-  ${PIP} install --no-cache-dir sparkmagic && \
+  pip3 install --no-cache-dir sparkmagic && \
   mkdir ~/.sparkmagic && \
-  wget https://raw.githubusercontent.com/jupyter-incubator/sparkmagic/master/sparkmagic/example_config.json && \
-  mv example_config.json ~/.sparkmagic/config.json && \
+  curl https://raw.githubusercontent.com/jupyter-incubator/sparkmagic/master/sparkmagic/example_config.json > ~/.sparkmagic/config.json && \
   sed -i 's/localhost:8998/host.docker.internal:9999/g' ~/.sparkmagic/config.json && \
-  jupyter-kernelspec install --user $(${PIP} show sparkmagic | grep Location | cut -d" " -f2)/sparkmagic/kernels/pysparkkernel
-# Mage Integration
-RUN ${PIP} install --no-cache-dir "git+https://github.com/mage-ai/singer-python.git#egg=singer-python"
-RUN ${PIP} install --no-cache-dir "git+https://github.com/mage-ai/google-ads-python.git#egg=google-ads"
-RUN ${PIP} install --no-cache-dir "git+https://github.com/mage-ai/dbt-mysql.git#egg=dbt-mysql"
-RUN ${PIP} install --no-cache-dir "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations&subdirectory=mage_integrations"
+  jupyter-kernelspec install --user "$(pip3 show sparkmagic | grep Location | cut -d' ' -f2)/sparkmagic/kernels/pysparkkernel"
+# Mage integrations and other related packages
+RUN \
+  pip3 install --no-cache-dir "git+https://github.com/mage-ai/singer-python.git#egg=singer-python" && \
+  pip3 install --no-cache-dir "git+https://github.com/mage-ai/google-ads-python.git#egg=google-ads" && \
+  pip3 install --no-cache-dir "git+https://github.com/mage-ai/dbt-mysql.git#egg=dbt-mysql" && \
+  pip3 install --no-cache-dir "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations&subdirectory=mage_integrations"
 # Mage
-COPY ./mage_ai/server/constants.py constants.py
-RUN tag=$(tail -n 1 constants.py) && VERSION=$(echo $tag | tr -d "'") && ${PIP} install --no-cache-dir "mage-ai[all]"==$VERSION
+COPY ./mage_ai/server/constants.py /tmp/constants.py
+RUN \
+  tag=$(tail -n 1 /tmp/constants.py) && \
+  VERSION=$(echo "$tag" | tr -d "'") && \
+  pip3 install --no-cache-dir "mage-ai[all]==$VERSION" && \
+  rm /tmp/constants.py
 
-# Startup Script
+## Startup Script
 COPY --chmod=+x ./scripts/install_other_dependencies.py ./scripts/run_app.sh /app/
 
 ENV MAGE_DATA_DIR="/home/src/mage_data"

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,9 +1,11 @@
-FROM python:3.10
+FROM python:3.10-bookworm
 LABEL description="Mage data management platform"
 ARG PIP=pip3
 USER root
 
-# Packages
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+## System Packages
 RUN \
   curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
   curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
@@ -27,35 +29,40 @@ RUN \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-# R Packages
+## R Packages
 # RUN \
 #   R -e "install.packages('pacman', repos='http://cran.us.r-project.org')" && \
 #   R -e "install.packages('renv', repos='http://cran.us.r-project.org')"
 
-# Node Packages
+## Node Packages
 RUN npm install --global yarn && yarn global add next
 
-# Python Packages
+## Python Packages
 RUN \
-  ${PIP} install --no-cache-dir sparkmagic && \
+  pip3 install --no-cache-dir sparkmagic && \
   mkdir ~/.sparkmagic && \
-  wget https://raw.githubusercontent.com/jupyter-incubator/sparkmagic/master/sparkmagic/example_config.json && \
-  mv example_config.json ~/.sparkmagic/config.json && \
+  curl https://raw.githubusercontent.com/jupyter-incubator/sparkmagic/master/sparkmagic/example_config.json > ~/.sparkmagic/config.json && \
   sed -i 's/localhost:8998/host.docker.internal:9999/g' ~/.sparkmagic/config.json && \
-  jupyter-kernelspec install --user $(${PIP} show sparkmagic | grep Location | cut -d" " -f2)/sparkmagic/kernels/pysparkkernel
-# Mage Integration
-COPY requirements.txt requirements.txt
-RUN ${PIP} install --no-cache-dir "git+https://github.com/mage-ai/singer-python.git#egg=singer-python"
-RUN ${PIP} install --no-cache-dir "git+https://github.com/mage-ai/google-ads-python.git#egg=google-ads"
-RUN ${PIP} install --no-cache-dir "git+https://github.com/mage-ai/dbt-mysql.git#egg=dbt-mysql"
-COPY mage_integrations mage_integrations
-RUN ${PIP} install mage_integrations/
+  jupyter-kernelspec install --user "$(pip3 show sparkmagic | grep Location | cut -d' ' -f2)/sparkmagic/kernels/pysparkkernel"
+# Mage integrations and other related packages
+RUN \
+  pip3 install --no-cache-dir "git+https://github.com/mage-ai/singer-python.git#egg=singer-python" && \
+  pip3 install --no-cache-dir "git+https://github.com/mage-ai/google-ads-python.git#egg=google-ads" && \
+  pip3 install --no-cache-dir "git+https://github.com/mage-ai/dbt-mysql.git#egg=dbt-mysql"
+COPY mage_integrations /tmp/mage_integrations
+RUN \
+  pip3 install --no-cache-dir /tmp/mage_integrations && \
+  rm -rf /tmp/mage_integrations
 # Mage Dependencies
-RUN ${PIP} install --no-cache-dir -r requirements.txt
+COPY requirements.txt /tmp/requirements.txt
+RUN \
+  pip3 install --no-cache-dir -r /tmp/requirements.txt && \
+  rm /tmp/requirements.txt
 
-# Mage Frontend
+## Mage Frontend
 COPY ./mage_ai /home/src/mage_ai
-RUN cd /home/src/mage_ai/frontend && yarn install
+WORKDIR /home/src/mage_ai/frontend
+RUN yarn install && yarn cache clean
 
 ENV PYTHONPATH="${PYTHONPATH}:/home/src"
 WORKDIR /home/src


### PR DESCRIPTION
Resolves: #3249, #3250

# Description
Adds some basic Docker image linting using hadolint. The workflow will only run, if a Dockerfile is changed and is very lightweight.

Corrects warnings from hadolint:
- Missing quotes
- No consecutive `RUN` statements
- No pipefail configured

Ignores warnings from hadolint:
- Not using root
- Missing specific package versions for apt, pip and node

Additional changes:
- Added specific python image. Currently 3.10 is 3.10-bookworm (Debian 12), but this might change in the future.
  mssql does not yet officially support Debian 12 (apt sources list only available for Debian 11), but is working somehow. Therefore pinning the debian version makes it a bit more stable.
- Removed the `PIP` argument, as I couldn't find any use case for it.

# How Has This Been Tested?
- [x] Build Dockerfile and ran it using docker run -p 6789:6789
- [x] Build dev.Dockerfile and ran it using scripts/dev.sh

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - no interface changes

cc: @dy46, @wangxiaoyou1993 
