### PR TITLE
Fix+Optimize pre-commit hook check-yaml and add check-json

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     -   id: end-of-file-fixer
         types: [python]
     -   id: check-yaml
-        types: [yaml]
+        args: [--unsafe]
     -   id: debug-statements
         types: [python]
     -   id: name-tests-test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
         types: [python]
     -   id: check-yaml
         args: [--unsafe]
+    -   id: check-json
     -   id: debug-statements
         types: [python]
     -   id: name-tests-test

--- a/mage_integrations/mage_integrations/sources/commercetools/schemas/orders.json
+++ b/mage_integrations/mage_integrations/sources/commercetools/schemas/orders.json
@@ -222,9 +222,6 @@
     "taxCalculationMode": {
       "type": ["null", "string"]
     },
-    "taxCalculationMode": {
-      "type": ["null", "string"]
-    },
     "customerGroup": {
       "type": ["null", "object"],
       "additionalProperties": true

--- a/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/adcreative.json
+++ b/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/adcreative.json
@@ -6,12 +6,6 @@
         "string"
       ]
     },
-    "object_story_id": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "image_url": {
       "type": [
         "null",
@@ -590,12 +584,6 @@
           "type": [
             "null",
             "object"
-          ]
-        },
-        "page_id": {
-          "type": [
-            "null",
-            "string"
           ]
         },
         "photo_data": {

--- a/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/ads_insights.json
+++ b/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/ads_insights.json
@@ -334,12 +334,6 @@
         "null",
         "number"
       ]
-    },
-    "reach": {
-      "type": [
-        "null",
-        "integer"
-      ]
     }
   }
 }

--- a/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/ads_insights_age_and_gender.json
+++ b/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/ads_insights_age_and_gender.json
@@ -262,12 +262,6 @@
         "number"
       ]
     },
-    "reach": {
-      "type": [
-        "null",
-        "integer"
-      ]
-    },
     "canvas_avg_view_percent": {
       "type": [
         "null",

--- a/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/ads_insights_country.json
+++ b/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/ads_insights_country.json
@@ -262,12 +262,6 @@
         "number"
       ]
     },
-    "reach": {
-      "type": [
-        "null",
-        "integer"
-      ]
-    },
     "canvas_avg_view_percent": {
       "type": [
         "null",

--- a/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/ads_insights_dma.json
+++ b/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/ads_insights_dma.json
@@ -167,9 +167,6 @@
     "ctr": {
       "type": ["null", "number"]
     },
-    "reach": {
-      "type": ["null", "integer"]
-    },
     "dma": {
       "type": ["null", "string"]
     },

--- a/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/ads_insights_platform_and_device.json
+++ b/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/ads_insights_platform_and_device.json
@@ -280,12 +280,6 @@
         "number"
       ]
     },
-    "reach": {
-      "type": [
-        "null",
-        "integer"
-      ]
-    },
     "canvas_avg_view_percent": {
       "type": [
         "null",

--- a/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/ads_insights_region.json
+++ b/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/ads_insights_region.json
@@ -262,12 +262,6 @@
         "number"
       ]
     },
-    "reach": {
-      "type": [
-        "null",
-        "integer"
-      ]
-    },
     "canvas_avg_view_percent": {
       "type": [
         "null",

--- a/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/shared/targeting.json
+++ b/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/shared/targeting.json
@@ -289,9 +289,6 @@
         ]
       }
     },
-    "excluded_custom_audiences": {
-      "$ref": "targeting.json#/definitions/id_name_pairs"
-    },
     "excluded_publisher_categories": {
       "type": [
         "null",

--- a/mage_integrations/mage_integrations/sources/outreach/tap_outreach/schemas/mailboxes.json
+++ b/mage_integrations/mage_integrations/sources/outreach/tap_outreach/schemas/mailboxes.json
@@ -190,12 +190,6 @@
         "string"
       ]
     },
-    "smtpHost":  {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "smtpPort":  {
       "type": [
         "null",

--- a/mage_integrations/mage_integrations/sources/outreach/tap_outreach/schemas/mailings.json
+++ b/mage_integrations/mage_integrations/sources/outreach/tap_outreach/schemas/mailings.json
@@ -225,13 +225,6 @@
       ],
       "format": "date-time"
     },
-    "updatedAt": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "date-time"
-    },
     "calendarId": {
       "type": [
         "null",

--- a/mage_integrations/mage_integrations/sources/outreach/tap_outreach/schemas/teams.json
+++ b/mage_integrations/mage_integrations/sources/outreach/tap_outreach/schemas/teams.json
@@ -25,13 +25,6 @@
         "string"
       ],
       "format": "date-time"
-    },
-    "createdAt": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "date-time"
     }
   }
 }

--- a/mage_integrations/mage_integrations/sources/stripe/schemas/shared/charge.json
+++ b/mage_integrations/mage_integrations/sources/stripe/schemas/shared/charge.json
@@ -851,36 +851,6 @@
                 }
               }
             },
-            "country": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "exp_month": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "exp_year": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "fingerprint": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "funding": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
             "installments": {
               "type": [
                 "null",
@@ -914,12 +884,6 @@
                   }
                 }
               }
-            },
-            "last4": {
-              "type": [
-                "null",
-                "string"
-              ]
             },
             "network": {
               "type": [
@@ -1671,12 +1635,6 @@
                 "string"
               ]
             },
-            "brand": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
             "country": {
               "type": [
                 "null",
@@ -1714,12 +1672,6 @@
               ]
             },
             "cvc_check": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "type": {
               "type": [
                 "null",
                 "string"

--- a/mage_integrations/mage_integrations/sources/zendesk/tap_zendesk/schemas/tickets.json
+++ b/mage_integrations/mage_integrations/sources/zendesk/tap_zendesk/schemas/tickets.json
@@ -12,12 +12,6 @@
         "integer"
       ]
     },
-    "problem_id": {
-      "type": [
-        "null",
-        "integer"
-      ]
-    },
     "is_public": {
       "type": [
         "null",


### PR DESCRIPTION
# Description
The pre-commit hook `check-yaml` does not support multiple documents in a single file separated by `---`. I have added the `--unsafe` option to support this. No files had to be fixed.

Added the pre-commit hook `check-json` to also check json files. Found a couple of json files, which had issues by having duplicated keys. Those I have also fixed.

# How Has This Been Tested?
- [x] Ran check-yaml against all files using `pre-commit run --all-files --show-diff-on-failure check-yaml`
- [x] Ran check-json against all files using `pre-commit run --all-files --show-diff-on-failure check-json` and fixed all issues


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc: @wangxiaoyou1993 @dy46 
