### PR TITLE
Added disable schema creation config

### DIFF
--- a/mage_integrations/mage_integrations/destinations/bigquery/README.md
+++ b/mage_integrations/mage_integrations/destinations/bigquery/README.md
@@ -15,4 +15,11 @@ You must enter the following credentials when configuring this destination:
 | `disable_update_column_types` | If `false` and an existing column has a different column type than the schema, the existing column type will be altered to match the column type in the schema. | `false` (default value) |
 | `use_batch_load` | (In beta) Instruct the BigQuery destination to use BigQuery load jobs instead of the query API. If you encounter any issues with batch loading, let us know in the [community slack](https://www.mage.ai/chat). | `false` (default value) |
 
+### Optional Configs
+
+| Key | Description | Sample value
+| --- | --- | --- |
+| `skip_schema_creation` | If `true`, Mage won't run CREATE SCHEMA command. For more information, see this [issue](https://github.com/mage-ai/mage-ai/issues/3416) | `true`
+<br />
+
 <br />

--- a/mage_integrations/mage_integrations/destinations/mssql/README.md
+++ b/mage_integrations/mage_integrations/destinations/mssql/README.md
@@ -18,4 +18,11 @@ You must enter the following credentials when configuring this source:
 | `table` | Name of the table that will be created to store data from your source. | `users` |
 | `username` | Name of the user that will access the database (must have permissions to read and write to specified schema). | `guest` |
 
+### Optional Configs
+
+| Key | Description | Sample value
+| --- | --- | --- |
+| `skip_schema_creation` | If `true`, Mage won't run CREATE SCHEMA command. For more information, see this [issue](https://github.com/mage-ai/mage-ai/issues/3416) | `true`
+<br />
+
 <br />

--- a/mage_integrations/mage_integrations/destinations/mysql/README.md
+++ b/mage_integrations/mage_integrations/destinations/mysql/README.md
@@ -23,4 +23,13 @@ You must enter the following credentials when configuring this source:
 | `ssh_password` | (Optional) The password used to connect to the bastion server. It should be set if you authenticate with the bastion server with password. | `password` |
 | `ssh_pkey` | (Optional) The path to the private key used to connect to the bastion server or the content of the key file. It should be set if you authenticate with the bastion server with private key. | `/path/to/private/key` |
 | `use_lowercase` | (Optional) Whether to use lower case for column names. | `true` or `false` |
+
+### Optional Configs
+
+| Key | Description | Sample value
+| --- | --- | --- |
+| `skip_schema_creation` | If `true`, Mage won't run CREATE SCHEMA command. For more information, see this [issue](https://github.com/mage-ai/mage-ai/issues/3416) | `true`
+<br />
+
+
 <br />

--- a/mage_integrations/mage_integrations/destinations/postgresql/README.md
+++ b/mage_integrations/mage_integrations/destinations/postgresql/README.md
@@ -18,4 +18,11 @@ You must enter the following credentials when configuring this source:
 | `table` | Name of the table that will be created to store data from your source. | `dim_users_v1` |
 | `username` | Name of the user that will access the database (must have permissions to read and write to specified schema). | `guest` |
 
+### Optional Configs
+
+| Key | Description | Sample value
+| --- | --- | --- |
+| `skip_schema_creation` | If `true`, Mage won't run CREATE SCHEMA command. For more information, see this [issue](https://github.com/mage-ai/mage-ai/issues/3416) | `true`
+<br />
+
 <br />

--- a/mage_integrations/mage_integrations/destinations/snowflake/README.md
+++ b/mage_integrations/mage_integrations/destinations/snowflake/README.md
@@ -20,4 +20,9 @@ You must enter the following credentials when configuring this source:
 | `warehouse` | Name of the warehouse that contains the specified database and schema. | `COMPUTE_WH` |
 | `use_batch_load` | If `true`, use batch upload instead of insertion query. | `false` (default value) |
 
+### Optional Configs
+
+| Key | Description | Sample value
+| --- | --- | --- |
+| `skip_schema_creation` | If `true`, Mage won't run CREATE SCHEMA command. For more information, see this [issue](https://github.com/mage-ai/mage-ai/issues/3416) | `true`
 <br />

--- a/mage_integrations/mage_integrations/destinations/sql/base.py
+++ b/mage_integrations/mage_integrations/destinations/sql/base.py
@@ -58,11 +58,16 @@ class Destination(BaseDestination):
             r['record'] = update_record_with_internal_columns(r['record'])
 
         # Create schema if not exists
-        create_schema_commands = self.build_create_schema_commands(
-            database_name=database_name,
-            schema_name=schema_name,
-        )
-        self.build_connection().execute(create_schema_commands, commit=True)
+        # Pass if user decides to skip it
+        if self.config.get("skip_schema_creation") is True:
+            # User decided not to run CREATE SCHEMA command
+            self.logger.info('Skipping CREATE SCHEMA command')
+        else:
+            create_schema_commands = self.build_create_schema_commands(
+                database_name=database_name,
+                schema_name=schema_name,
+            )
+            self.build_connection().execute(create_schema_commands, commit=True)
 
         query_strings = self.build_query_strings(record_data, stream)
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
When running SQL Destinations in Data Integration Pipelines, a user may experience a permission error.
This is caused by the Destination user not having schema creation auth.

To fix this issue, a disable schema creation was added on SQL Base class.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
Tested on a local mage instance, using API -> PostgreSQL destination.

**With** schema creation:
![Screenshot from 2023-09-04 16-20-52](https://github.com/mage-ai/mage-ai/assets/14100959/4f500865-22f4-41bc-8860-4e871fa8099f)

**Without** schema creation:
![Screenshot from 2023-09-04 16-21-39](https://github.com/mage-ai/mage-ai/assets/14100959/4a034dde-c51c-420b-8d9e-eefd06d26132)



# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993 