### PR TITLE
[xy] Fix creating subfolder when renaming block.

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -2281,8 +2281,7 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
             if os.path.exists(new_file_path):
                 raise Exception(f'Block {new_uuid} already exists. Please use a different name.')
 
-            file_path_parts = new_file_path.split(os.sep)
-            parent_dir = os.path.join(*file_path_parts[:-1])
+            parent_dir = os.path.dirname(new_file_path)
             os.makedirs(parent_dir, exist_ok=True)
 
             os.rename(old_file_path, new_file_path)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix creating subfolder when renaming block.
The subfolder was created with a wrong path (relative path, missing the `/` at the beginning). This PR fixes it.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested renaming a block with subfolder
Before the fix, it failed
<img width="875" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/c6cf175e-283c-4357-a260-68669b7993fb">
After the fix, it successfully renames the block
<img width="594" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/7c77e241-9732-4a87-9d99-5e24c4813e23">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code

cc:
<!-- Optionally mention someone to let them know about this pull request -->
