### PR TITLE
[dy] Add support for key properties for postgresql destination

### DIFF
--- a/mage_integrations/mage_integrations/destinations/postgresql/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/postgresql/__init__.py
@@ -56,6 +56,7 @@ class PostgreSQL(Destination):
                 if_not_exists=True,
                 unique_constraints=unique_constraints,
                 column_identifier=self.quote,
+                key_properties=self.key_properties.get(stream),
             ),
         ]
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Add `key_properties` argument to `build_create_table_command` so that the primary key constraint can be added to the destinations. Right now, I only added support for Postgresql. For other data warehouses, the command may be slightly different.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with a postgresql destination


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
