### PR TITLE
[td] Add block layout item in between others

### DIFF
--- a/mage_ai/frontend/components/BlockLayout/BlockLayoutItem/index.style.tsx
+++ b/mage_ai/frontend/components/BlockLayout/BlockLayoutItem/index.style.tsx
@@ -2,16 +2,15 @@ import styled from 'styled-components';
 
 import dark from '@oracle/styles/themes/dark';
 import { BORDER_RADIUS_XLARGE, BORDER_STYLE, BORDER_WIDTH } from '@oracle/styles/units/borders';
+import { DIVIDER_WIDTH } from '../LayoutDivider/index.style';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 
-export const WIDTH_OFFSET = ((BORDER_WIDTH + (PADDING_UNITS * UNIT)) * 2)
-  // Margin left and right
-  + (2 * UNIT);
+export const WIDTH_OFFSET = ((BORDER_WIDTH + (PADDING_UNITS * UNIT)) * 2) + DIVIDER_WIDTH;
 
 export const ItemStyle = styled.div`
   border-radius: ${BORDER_RADIUS_XLARGE}px;
-  margin-left: ${1 * UNIT}px;
-  margin-right: ${1 * UNIT}px;
+  // margin-left: ${1 * UNIT}px;
+  // margin-right: ${1 * UNIT}px;
   padding: ${PADDING_UNITS * UNIT}px;
 
   ${props => `

--- a/mage_ai/frontend/components/BlockLayout/BlockLayoutItem/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/BlockLayoutItem/index.tsx
@@ -5,14 +5,17 @@ import BlockLayoutItemDetail from '../BlockLayoutItemDetail';
 import BlockLayoutItemType from '@interfaces/BlockLayoutItemType';
 import Button from '@oracle/elements/Button';
 import ChartController from '@components/ChartBlock/ChartController';
+import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
 import FlyoutMenuWrapper from '@oracle/components/FlyoutMenu/FlyoutMenuWrapper';
+import LayoutDivider from '../LayoutDivider';
 import Spacing from '@oracle/elements/Spacing';
 import Spinner from '@oracle/components/Spinner';
 import Text from '@oracle/elements/Text';
 import TextInput from '@oracle/elements/Inputs/TextInput';
 import api from '@api';
 import { ColumnType } from '@interfaces/PageBlockLayoutType';
+import { DIVIDER_WIDTH } from '../LayoutDivider/index.style';
 import { Ellipsis } from '@oracle/icons';
 import { ItemStyle, WIDTH_OFFSET } from './index.style';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
@@ -24,9 +27,15 @@ type BlockLayoutItemProps = {
   blockUUID: string;
   columnIndex?: number;
   columnLayoutSettings?: ColumnType;
+  columnsInRow?: number;
+  createNewBlockItem?: (opts?: {
+    columnIndex: number;
+    rowIndex: number;
+  }) => void;
   detail?: boolean;
   disableDrag?: boolean;
   height?: number;
+  first?: boolean;
   onDrop?: (opts: {
     blockLayoutItem: BlockLayoutItemType;
     columnIndex: number;
@@ -47,8 +56,11 @@ function BlockLayoutItem({
   blockUUID,
   columnIndex,
   columnLayoutSettings,
+  columnsInRow,
+  createNewBlockItem,
   detail,
   disableDrag,
+  first,
   height,
   onDrop,
   onSave,
@@ -179,178 +191,199 @@ function BlockLayoutItem({
   }
 
   return (
-    <div
-      onMouseEnter={() => setIsHovering(true)}
-      onMouseLeave={() => setIsHovering(false)}
-      ref={drop}
-    >
-      <ItemStyle
-        {...collected}
-        ref={disableDrag ? null : drag}
-      >
-        <Spacing mb={1}>
-          <FlexContainer
-            alignContent="center"
-            justifyContent="space-between"
+    <>
+      {first && (
+        <LayoutDivider
+          onClickAdd={() => createNewBlockItem({
+            columnIndex,
+            rowIndex,
+          })}
+        />
+      )}
+
+      <Flex flex={1} flexDirection="column">
+        <div
+          onMouseEnter={() => setIsHovering(true)}
+          onMouseLeave={() => setIsHovering(false)}
+          ref={drop}
+        >
+          <ItemStyle
+            {...collected}
+            ref={disableDrag ? null : drag}
           >
-            <Spacing py={1}>
-              <Text bold default>
-                {blockLayoutItem?.name || blockUUID}
-              </Text>
-            </Spacing>
-
-            <div>
-              <FlyoutMenuWrapper
-                items={[
-                  {
-                    label: () => 'Edit content',
-                    onClick: () => setSelectedBlockItem?.(blockLayoutItem),
-                    uuid: 'Edit content',
-                  },
-                  {
-                    label: () => 'Change height and/or width',
-                    onClick: () => setEditing(true),
-                    uuid: 'Change',
-                  },
-                  {
-                    label: () => 'Remove chart',
-                    onClick: () => removeBlockLayoutItem?.(),
-                    uuid: 'Remove chart',
-                  },
-                ]}
-                onClickCallback={() => setMenuVisible(false)}
-                onClickOutside={() => setMenuVisible(false)}
-                open={menuVisible}
-                parentRef={refMenu}
-                rightOffset={0}
-                uuid={`BlockLayoutItem/${blockUUID}`}
-              >
-                {(isHovering || menuVisible) && (
-                  <Button
-                    iconOnly
-                    noBackground
-                    onClick={() => {
-                      setMenuVisible(true);
-                    }}
-                  >
-                    <Ellipsis default size={UNIT * 2} />
-                  </Button>
-                )}
-              </FlyoutMenuWrapper>
-            </div>
-
-          </FlexContainer>
-        </Spacing>
-
-        {editing && (
-          <>
-            <FlexContainer
-              alignItems="center"
-              fullWidth
-            >
-              <TextInput
-                compact
-                fullWidth
-                label="Width"
-                // @ts-ignore
-                onChange={e => updateLayout?.({
-                  ...columnLayoutSettings,
-                  width: typeof e.target.value !== 'undefined'
-                    ? Number(e.target.value)
-                    : e.target.value
-                  ,
-                })}
-                primary
-                setContentOnMount
-                small
-                type="number"
-                value={columnLayoutSettings?.width || ''}
-              />
-
-              <Spacing mr={1} />
-
-              <TextInput
-                compact
-                fullWidth
-                label="Max width percentage"
-                // @ts-ignore
-                onChange={e => updateLayout?.({
-                  ...columnLayoutSettings,
-                  max_width_percentage: typeof e.target.value !== 'undefined'
-                    ? Number(e.target.value)
-                    : e.target.value
-                  ,
-                })}
-                primary
-                setContentOnMount
-                small
-                type="number"
-                value={columnLayoutSettings?.max_width_percentage || ''}
-              />
-
-              <Spacing mr={1} />
-
-              <TextInput
-                compact
-                fullWidth
-                label="Height"
-                // @ts-ignore
-                onChange={e => updateLayout?.({
-                  ...columnLayoutSettings,
-                  height: typeof e.target.value !== 'undefined'
-                    ? Number(e.target.value)
-                    : e.target.value
-                  ,
-                })}
-                primary
-                setContentOnMount
-                small
-                type="number"
-                value={columnLayoutSettings?.height || ''}
-              />
-            </FlexContainer>
-
-            <Spacing mt={PADDING_UNITS}>
+            <Spacing mb={1}>
               <FlexContainer
-                alignItems="center"
-                justifyContent="flex-end"
+                alignContent="center"
+                justifyContent="space-between"
               >
-                <Button
-                  compact
-                  onClick={() => {
-                    onSave?.();
-                    setEditing(false);
-                  }}
-                  primary
-                  small
-                >
-                  Save
-                </Button>
+                <Spacing py={1}>
+                  <Text bold default>
+                    {blockLayoutItem?.name || blockUUID}
+                  </Text>
+                </Spacing>
 
-                <Spacing mr={1} />
+                <div>
+                  <FlyoutMenuWrapper
+                    items={[
+                      {
+                        label: () => 'Edit content',
+                        onClick: () => setSelectedBlockItem?.(blockLayoutItem),
+                        uuid: 'Edit content',
+                      },
+                      {
+                        label: () => 'Change height and/or width',
+                        onClick: () => setEditing(true),
+                        uuid: 'Change',
+                      },
+                      {
+                        label: () => 'Remove chart',
+                        onClick: () => removeBlockLayoutItem?.(),
+                        uuid: 'Remove chart',
+                      },
+                    ]}
+                    onClickCallback={() => setMenuVisible(false)}
+                    onClickOutside={() => setMenuVisible(false)}
+                    open={menuVisible}
+                    parentRef={refMenu}
+                    rightOffset={0}
+                    uuid={`BlockLayoutItem/${blockUUID}`}
+                  >
+                    {(isHovering || menuVisible) && (
+                      <Button
+                        iconOnly
+                        noBackground
+                        onClick={() => {
+                          setMenuVisible(true);
+                        }}
+                      >
+                        <Ellipsis default size={UNIT * 2} />
+                      </Button>
+                    )}
+                  </FlyoutMenuWrapper>
+                </div>
 
-                <Button
-                  compact
-                  onClick={() => {
-                    setEditing(false);
-                    updateLayout?.(columnLayoutSettingsInit);
-                  }}
-                  small
-                >
-                  Cancel
-                </Button>
               </FlexContainer>
             </Spacing>
-          </>
-        )}
 
-        {!dataBlockLayoutItem && !data && <Spinner inverted />}
-        {data && buildChart({
-          height: height || blockLayoutItem?.configuration?.[VARIABLE_NAME_HEIGHT],
-          width: width - (WIDTH_OFFSET + 1),
+            {editing && (
+              <>
+                <FlexContainer
+                  alignItems="center"
+                  fullWidth
+                >
+                  <TextInput
+                    compact
+                    fullWidth
+                    label="Width"
+                    // @ts-ignore
+                    onChange={e => updateLayout?.({
+                      ...columnLayoutSettings,
+                      width: typeof e.target.value !== 'undefined'
+                        ? Number(e.target.value)
+                        : e.target.value
+                      ,
+                    })}
+                    primary
+                    setContentOnMount
+                    small
+                    type="number"
+                    value={columnLayoutSettings?.width || ''}
+                  />
+
+                  <Spacing mr={1} />
+
+                  <TextInput
+                    compact
+                    fullWidth
+                    label="Max width percentage"
+                    // @ts-ignore
+                    onChange={e => updateLayout?.({
+                      ...columnLayoutSettings,
+                      max_width_percentage: typeof e.target.value !== 'undefined'
+                        ? Number(e.target.value)
+                        : e.target.value
+                      ,
+                    })}
+                    primary
+                    setContentOnMount
+                    small
+                    type="number"
+                    value={columnLayoutSettings?.max_width_percentage || ''}
+                  />
+
+                  <Spacing mr={1} />
+
+                  <TextInput
+                    compact
+                    fullWidth
+                    label="Height"
+                    // @ts-ignore
+                    onChange={e => updateLayout?.({
+                      ...columnLayoutSettings,
+                      height: typeof e.target.value !== 'undefined'
+                        ? Number(e.target.value)
+                        : e.target.value
+                      ,
+                    })}
+                    primary
+                    setContentOnMount
+                    small
+                    type="number"
+                    value={columnLayoutSettings?.height || ''}
+                  />
+                </FlexContainer>
+
+                <Spacing mt={PADDING_UNITS}>
+                  <FlexContainer
+                    alignItems="center"
+                    justifyContent="flex-end"
+                  >
+                    <Button
+                      compact
+                      onClick={() => {
+                        onSave?.();
+                        setEditing(false);
+                      }}
+                      primary
+                      small
+                    >
+                      Save
+                    </Button>
+
+                    <Spacing mr={1} />
+
+                    <Button
+                      compact
+                      onClick={() => {
+                        setEditing(false);
+                        updateLayout?.(columnLayoutSettingsInit);
+                      }}
+                      small
+                    >
+                      Cancel
+                    </Button>
+                  </FlexContainer>
+                </Spacing>
+              </>
+            )}
+
+            {!dataBlockLayoutItem && !data && <Spinner inverted />}
+            {data && buildChart({
+              height: height || blockLayoutItem?.configuration?.[VARIABLE_NAME_HEIGHT],
+              width: width - (WIDTH_OFFSET + 1) - (columnsInRow ? DIVIDER_WIDTH / columnsInRow : 0),
+            })}
+          </ItemStyle>
+        </div>
+
+      </Flex>
+
+      <LayoutDivider
+        onClickAdd={() => createNewBlockItem({
+          columnIndex: columnIndex + 1,
+          rowIndex,
         })}
-      </ItemStyle>
-    </div>
+      />
+    </>
   );
 }
 

--- a/mage_ai/frontend/components/BlockLayout/LayoutDivider/index.style.tsx
+++ b/mage_ai/frontend/components/BlockLayout/LayoutDivider/index.style.tsx
@@ -1,0 +1,83 @@
+import styled from 'styled-components';
+
+import dark from '@oracle/styles/themes/dark';
+import { BORDER_RADIUS_XLARGE, BORDER_WIDTH_THICK } from '@oracle/styles/units/borders';
+import { UNIT } from '@oracle/styles/units/spacing';
+
+export const DIVIDER_WIDTH = 3 * UNIT;
+
+export const DividerStyle = styled.div<{
+  horizontal?: boolean;
+}>`
+  display: flex;
+  position: relative;
+
+  ${props => !props.horizontal && `
+    height: 100%;
+    justify-content: center;
+    width: ${DIVIDER_WIDTH}px;
+  `};
+
+  ${props => props.horizontal && `
+    align-items: center;
+    height: ${DIVIDER_WIDTH}px;
+    margin-left: ${DIVIDER_WIDTH}px;
+    margin-right: ${DIVIDER_WIDTH}px;
+    width: calc(100% - ${2 * DIVIDER_WIDTH}px);
+  `};
+`;
+
+export const BarStyle = styled.div<{
+  horizontal?: boolean;
+}>`
+  border-radius: ${BORDER_RADIUS_XLARGE}px;
+
+  // &:hover {
+  //   cursor: col-resize;
+  // }
+
+  ${props => `
+    background-color: ${(props.theme || dark).accent.blueLight};
+  `}
+
+  ${props => !props.horizontal && `
+    height: 100%;
+    width: ${0.5 * UNIT}px;
+  `};
+
+  ${props => props.horizontal && `
+    height: ${0.5 * UNIT}px;
+    width: 100%;
+  `};
+`;
+
+export const ButtonStyle = styled.a`
+  align-items: center;
+  border-radius: 50%;
+  display: flex;
+  height: ${3 * UNIT}px;
+  justify-content: center;
+  position: absolute;
+  width: ${3 * UNIT}px;
+
+  ${props => `
+    background-color: ${(props.theme || dark).background.page};
+    border: ${BORDER_WIDTH_THICK}px solid ${(props.theme || dark).accent.blueLight};
+    box-shadow:
+      0 0 0 ${BORDER_WIDTH_THICK}px ${(props.theme || dark).background.page};
+
+    &:hover {
+      background-color: ${(props.theme || dark).interactive.linkPrimary};
+      border: ${BORDER_WIDTH_THICK}px solid ${(props.theme || dark).interactive.linkPrimary};
+      cursor: pointer;
+    }
+  `}
+
+  ${props => !props.horizontal && `
+    top: ${3 * UNIT}px;
+  `};
+
+  ${props => props.horizontal && `
+    left: ${3 * UNIT}px;
+  `};
+`;

--- a/mage_ai/frontend/components/BlockLayout/LayoutDivider/index.style.tsx
+++ b/mage_ai/frontend/components/BlockLayout/LayoutDivider/index.style.tsx
@@ -51,7 +51,9 @@ export const BarStyle = styled.div<{
   `};
 `;
 
-export const ButtonStyle = styled.a`
+export const ButtonStyle = styled.a<{
+  horizontal?: boolean;
+}>`
   align-items: center;
   border-radius: 50%;
   display: flex;

--- a/mage_ai/frontend/components/BlockLayout/LayoutDivider/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/LayoutDivider/index.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+import { Add } from '@oracle/icons';
+import {
+  BarStyle,
+  ButtonStyle,
+  DividerStyle,
+} from './index.style';
+import { UNIT } from '@oracle/styles/units/spacing';
+
+type LayoutDividerProps = {
+  horizontal?: boolean;
+  onClickAdd?: () => void;
+};
+
+function LayoutDivider({
+  horizontal,
+  onClickAdd,
+}: LayoutDividerProps) {
+  const [isHovering, setIsHovering] = useState<boolean>(false);
+
+  return (
+    <DividerStyle
+      horizontal={horizontal}
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
+    >
+      {isHovering && (
+        <>
+          <ButtonStyle
+            horizontal={horizontal}
+            href="#"
+            onClick={(e) => {
+              e.preventDefault();
+              onClickAdd?.();
+            }}
+          >
+            <Add size={2 * UNIT} />
+          </ButtonStyle>
+
+          <BarStyle horizontal={horizontal} />
+        </>
+      )}
+    </DividerStyle>
+  );
+}
+
+export default LayoutDivider;


### PR DESCRIPTION
# Description
Add block layout items in between columns and in between rows

# How Has This Been Tested?
<img width="1036" alt="CleanShot 2023-09-06 at 23 56 41@2x" src="https://github.com/mage-ai/mage-ai/assets/1066980/9bf5c88e-e6ca-4e26-9748-088ac022f93c">

<img width="1216" alt="CleanShot 2023-09-06 at 23 56 46@2x" src="https://github.com/mage-ai/mage-ai/assets/1066980/eb693407-b74e-4dee-b99e-e956b14f733d">

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
