### PR TITLE
[jk] Remove unnecessary query from block runs request

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -163,7 +163,7 @@ function PipelineRuns({
     [TAB_URL_PARAM, 'page', SortQueryEnum.SORT_COL_IDX, SortQueryEnum.SORT_DIRECTION],
   );
   if (isPipelineRunsTab) {
-    blockRunsRequestQuery = ignoreKeys(blockRunsRequestQuery, [OFFSET_PARAM]);
+    blockRunsRequestQuery = ignoreKeys(blockRunsRequestQuery, [OFFSET_PARAM, 'status']);
   }
   const sortColumnIndexQuery = q?.[SortQueryEnum.SORT_COL_IDX];
   const sortDirectionQuery = q?.[SortQueryEnum.SORT_DIRECTION];


### PR DESCRIPTION
# Description
- The `status` query param was being included in the blocks runs request, but it should only have been included in the pipeline runs request.

# How Has This Been Tested?
- Local

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
