### PR TITLE
[dy] Fix aws secrets manager dependency issue

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
@@ -310,7 +310,6 @@ function KernelStatus({
                         : () => updateCluster({
                             cluster: {
                               id,
-                              is_active: true,
                             },
                           }),
                       uuid: id,

--- a/mage_ai/orchestration/db/setup.py
+++ b/mage_ai/orchestration/db/setup.py
@@ -10,7 +10,6 @@ from mage_ai.orchestration.constants import (
     PG_DB_PORT,
     PG_DB_USER,
 )
-from mage_ai.services.aws.secrets_manager.secrets_manager import get_secret
 
 DEFAULT_POSTGRES_HOST = '127.0.0.1'
 DEFAULT_POSTGRES_PORT = '5432'
@@ -24,6 +23,7 @@ def get_postgres_connection_url() -> Optional[str]:
     db_port = None
     if os.getenv(AWS_DB_SECRETS_NAME):
         try:
+            from mage_ai.services.aws.secrets_manager.secrets_manager import get_secret
             response = get_secret(os.getenv(AWS_DB_SECRETS_NAME))
             secrets = json.loads(response)
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fix aws secrets manager dependency issue in `db/setup.py`. The `secrets_manager` module only needs to be imported if the environment variable is set.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally
- [x] Tested with AWS EMR


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
