### PR TITLE
[jk] Add and update block variables through UI

### DIFF
--- a/docs/development/variables/block-variables.mdx
+++ b/docs/development/variables/block-variables.mdx
@@ -4,6 +4,8 @@ sidebarTitle: "Block variables"
 description: "Use pipeline-specific variables scoped to an individual block."
 ---
 
+<Note>Requires version `0.9.23` or greater.</Note>
+
 In addition to the global runtime variables that can be used by any block in
 a pipeline, there are also variables scoped at the block-level, meaning
 they are accessible in a specific block but not other blocks in the same pipeline.

--- a/docs/development/variables/block-variables.mdx
+++ b/docs/development/variables/block-variables.mdx
@@ -1,0 +1,81 @@
+---
+title: "Mage block variables"
+sidebarTitle: "Block variables"
+description: "Use pipeline-specific variables scoped to an individual block."
+---
+
+In addition to the global runtime variables that can be used by any block in
+a pipeline, there are also variables scoped at the block-level, meaning
+they are accessible in a specific block but not other blocks in the same pipeline.
+Block variables are not accessible by other pipelines that use the same block.
+
+## Using block variables
+
+Block variables can be accessed via the `kwargs` parameter in your block function.
+The variables are stored in a block's configuration, which is accessible through
+`kwargs['configuration']`.
+
+```python
+@data_exporter
+def export_data(*args, **kwargs):
+    demo_block_var = kwargs['configuration'].get('demo_block_var')
+
+```
+
+### Supported block types
+
+Block variables are currently only supported for Python blocks with the
+following block types:
+  1. `data_loader`
+  2. `transformer`
+  3. `data_exporter`
+  4. `custom`
+  5. `sensor`
+
+## Creating block variables
+
+### In Mage UI
+
+You can create new block variables from the Mage UI through the "Block settings" tab
+in the Sidekick of the Pipeline Editor page. The block settings can also be quickly accessed
+by clicking the settings icon in a block's header.
+
+In the "Block variables" section of the block settings, click the `+ New` button, enter
+the variable's name and value in the input fields and then press `Enter` or `Return` on
+your keyboard while still focused on one of the input fields (this step can be repeated
+multiple times).
+
+This will add the variable(s), but not save it. You need to also click the blue
+`Update block settings` button below the "Block variables" section in order to save
+and persist these new variables. You can also edit/delete existing block variables by
+hovering over a variable and clicking the edit/trash icons. You can press the `Escape`
+key to exit a variable's edit mode.
+
+### In code
+
+You can also create or edit block variables by going to a pipeline's `metadata.yaml` file
+(located in the `pipelines/[pipeline_uuid]` directory) and adding them to a block's
+`configuration` property. 
+
+```yaml
+blocks:
+- all_upstream_blocks_executed: true
+  color: null
+  configuration:
+    demo_block_var: block_var_value
+    block_var2: val2
+    block_var3: val3
+  downstream_blocks: []
+  executor_config: null
+  executor_type: local_python
+  has_callback: false
+  language: python
+  name: billowing snow
+  retry_config: {}
+  status: updated
+  timeout: '60'
+  type: data_exporter
+  upstream_blocks:
+  - muddy_waterfall
+  uuid: billowing_snow
+```

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -298,6 +298,7 @@
               "pages": [
                 "development/variables/environment-variables",
                 "getting-started/runtime-variable",
+                "development/variables/block-variables",
                 "development/variables/secrets",
                 "development/variables/referencing-variables"
               ]

--- a/mage_ai/frontend/components/BlockSettings/index.tsx
+++ b/mage_ai/frontend/components/BlockSettings/index.tsx
@@ -160,7 +160,7 @@ function BlockSettings({
   }, []);
 
   const blockVariables: { [key: string]: string } = useMemo(() =>
-    ignoreKeys(blockAttributes?.configuration || configuration, ['global_data_product']),
+    ignoreKeys(blockAttributes?.configuration || configuration, ['global_data_product', 'file_path']),
     [blockAttributes?.configuration, configuration],
   );
   const updateBlockVariable = useCallback(
@@ -692,12 +692,13 @@ function BlockSettings({
                   Press
                   <Text {...SHARED_EMPHASIZED_TEXT_PROPS}> Enter</Text> or
                   <Text {...SHARED_EMPHASIZED_TEXT_PROPS}> Return</Text> on a row to add or update a variable.
+                  These variables are pipeline-specific (they are not accessible on other pipelines).
                 </Text>
                 <Text muted>
                   <Text bold inline warning>Note: </Text>
                   Click the
                   <Text {...SHARED_EMPHASIZED_TEXT_PROPS}> Update block settings</Text> button
-                  below to save changes. If you do not, any new block variables will not be added.
+                  below to save changes. If you do not, any new or updated block variables will not be persisted.
                 </Text>
               </Spacing>
 

--- a/mage_ai/frontend/components/BlockSettings/index.tsx
+++ b/mage_ai/frontend/components/BlockSettings/index.tsx
@@ -692,7 +692,17 @@ function BlockSettings({
                   Press
                   <Text {...SHARED_EMPHASIZED_TEXT_PROPS}> Enter</Text> or
                   <Text {...SHARED_EMPHASIZED_TEXT_PROPS}> Return</Text> on a row to add or update a variable.
-                  These variables are pipeline-specific (they are not accessible on other pipelines).
+                  These variables are only accessible in this block&nbsp;
+                  <Text {...SHARED_EMPHASIZED_TEXT_PROPS} bold={false}>
+                    &#40;{blockUUID}&#41;.
+                  </Text>
+                  <Text inline muted> Refer to the
+                    <Link
+                      href="https://docs.mage.ai/development/variables/block-variables"
+                      openNewWindow
+                    > documentation
+                    </Link> for more details.
+                  </Text>
                 </Text>
                 <Text muted>
                   <Text bold inline warning>Note: </Text>

--- a/mage_ai/frontend/components/BlockSettings/index.tsx
+++ b/mage_ai/frontend/components/BlockSettings/index.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation } from 'react-query';
 
 import BlockType, {
+  BLOCK_TYPES_WITH_VARIABLES,
+  BlockLanguageEnum,
   BlockPipelineType,
   BlockRetryConfigType,
   BlockTypeEnum,
@@ -107,6 +109,7 @@ function BlockSettings({
   const {
     color: blockColor,
     configuration,
+    language,
     name: blockName,
     type: blockType,
     uuid: blockUUID,
@@ -663,7 +666,7 @@ function BlockSettings({
             </Spacing>
           )}
 
-          {BlockTypeEnum.GLOBAL_DATA_PRODUCT !== blockType && (
+          {BLOCK_TYPES_WITH_VARIABLES.includes(blockType) && BlockLanguageEnum.PYTHON === language && (
             <Spacing mb={UNITS_BETWEEN_SECTIONS} px={PADDING_UNITS}>
               <FlexContainer alignItems="center">
                 <Headline level={5}>

--- a/mage_ai/frontend/components/BlockSettings/index.tsx
+++ b/mage_ai/frontend/components/BlockSettings/index.tsx
@@ -15,6 +15,7 @@ import GlobalDataProductType, {
   GlobalDataProductObjectTypeEnum,
 } from '@interfaces/GlobalDataProductType';
 import Headline from '@oracle/elements/Headline';
+import KeyboardShortcutButton from '@oracle/elements/Button/KeyboardShortcutButton';
 import Link from '@oracle/elements/Link';
 import OutdatedAfterField from '@components/GlobalDataProductDetail/OutdatedAfterField';
 import OutdatedStartingAtField from '@components/GlobalDataProductDetail/OutdatedStartingAtField';
@@ -27,11 +28,11 @@ import Spinner from '@oracle/components/Spinner';
 import Table from '@components/shared/Table';
 import Text from '@oracle/elements/Text';
 import TextInput from '@oracle/elements/Inputs/TextInput';
-import Tooltip from '@oracle/components/Tooltip';
+import VariableRow from '@components/Sidekick/GlobalVariables/VariableRow';
 import api from '@api';
 import usePrevious from '@utils/usePrevious';
+import { Add, DiamondShared, Edit } from '@oracle/icons';
 import { BannerStyle } from './index.style';
-import { DiamondDetached, DiamondShared, Edit } from '@oracle/icons';
 import { EXECUTOR_TYPES } from '@interfaces/ExecutorType';
 import {
   ICON_SIZE_SMALL,
@@ -48,7 +49,7 @@ import { YELLOW } from '@oracle/styles/colors/main';
 import { indexBy } from '@utils/array';
 import { capitalize } from '@utils/string';
 import { getBlockColorHexCodeMapping } from '@components/CodeBlock/utils';
-import { isEmptyObject } from '@utils/hash';
+import { ignoreKeys, isEmptyObject } from '@utils/hash';
 import { onSuccess } from '@api/utils/response';
 import { useError } from '@context/Error';
 
@@ -58,6 +59,13 @@ const SHARED_BUTTON_PROPS = {
   noBackground: true,
   outline: true,
   padding: '4px',
+};
+const SHARED_EMPHASIZED_TEXT_PROPS = {
+  bold: true,
+  default: true,
+  inline: true,
+  monospace: true,
+  small: true,
 };
 const BLOCK_COLOR_HEX_CODE_MAPPING = getBlockColorHexCodeMapping();
 
@@ -90,8 +98,7 @@ function BlockSettings({
   const pipelineUUID = useMemo(() => pipeline?.uuid, [pipeline]);
   const pipelineRetryConfig: PipelineRetryConfigType =
     useMemo(() => pipeline?.retry_config || {}, [pipeline]);
-  
-  console.log('pipeline', pipeline);
+
   const showBlockRunTimeout = useMemo(
     () => !pipeline?.run_pipeline_in_one_process &&
       [PipelineTypeEnum.PYSPARK, PipelineTypeEnum.PYTHON].includes(pipeline?.type),
@@ -133,6 +140,7 @@ function BlockSettings({
   const [blockAttributes, setBlockAttributesState] = useState<BlockType>(null);
   const [blockAttributesTouched, setBlockAttributesTouched] = useState<boolean>(false);
   const [editCustomExecutorType, setEditCustomExecutorType] = useState<boolean>(false);
+  const [showNewBlockVariable, setShowNewBlockVariable] = useState<boolean>(false);
 
   const blockPrev = usePrevious(block);
   useEffect(() => {
@@ -147,6 +155,21 @@ function BlockSettings({
     setBlockAttributesTouched(true);
     setBlockAttributesState(handlePrevious);
   }, []);
+
+  const blockVariables: { [key: string]: string } = useMemo(() =>
+    ignoreKeys(blockAttributes?.configuration || configuration, ['global_data_product']),
+    [blockAttributes?.configuration, configuration],
+  );
+  const updateBlockVariable = useCallback(
+    (variable:  { [key: string]: string }) => setBlockAttributes(prev => ({
+      ...prev,
+      configuration: {
+        ...blockAttributes?.configuration,
+        ...variable,
+      },
+    })),
+    [blockAttributes?.configuration, setBlockAttributes],
+  );
 
   const executorType = useMemo(() => blockAttributes?.executor_type, [blockAttributes]);
   useEffect(() => {
@@ -588,6 +611,7 @@ function BlockSettings({
               </Spacing>
             </Spacing>
           </Spacing>
+
           {showBlockRunTimeout && (
             <Spacing mb={UNITS_BETWEEN_SECTIONS} px={PADDING_UNITS}>
               <Headline level={5}>
@@ -607,7 +631,7 @@ function BlockSettings({
                 value={blockAttributes?.timeout || ''}
               />
               <Spacing mb={1} />
-              <Text small>
+              <Text muted small>
                 The block timeout will only be applied when the block is run through a trigger.
                 If a block times out, the block run will be set to a failed state.
               </Text>
@@ -635,6 +659,84 @@ function BlockSettings({
                     },
                   }))}
                 />
+              </Spacing>
+            </Spacing>
+          )}
+
+          {BlockTypeEnum.GLOBAL_DATA_PRODUCT !== blockType && (
+            <Spacing mb={UNITS_BETWEEN_SECTIONS} px={PADDING_UNITS}>
+              <FlexContainer alignItems="center">
+                <Headline level={5}>
+                  Block variables
+                </Headline>
+                <Spacing ml={2} />
+                <KeyboardShortcutButton
+                  Icon={Add}
+                  blackBorder
+                  halfPaddingBottom
+                  halfPaddingTop
+                  inline
+                  onClick={() => setShowNewBlockVariable(prevState => !prevState)}
+                  smallIcon
+                  uuid="Sidekick/BlockSettings/addNewBlockVariable"
+                >
+                  New
+                </KeyboardShortcutButton>
+              </FlexContainer>
+
+              <Spacing mb={PADDING_UNITS}>
+                <Text muted>
+                  Press
+                  <Text {...SHARED_EMPHASIZED_TEXT_PROPS}> Enter</Text> or
+                  <Text {...SHARED_EMPHASIZED_TEXT_PROPS}> Return</Text> on a row to add or update a variable.
+                </Text>
+                <Text muted>
+                  <Text bold inline warning>Note: </Text>
+                  Click the
+                  <Text {...SHARED_EMPHASIZED_TEXT_PROPS}> Update block settings</Text> button
+                  below to save changes. If you do not, any new block variables will not be added.
+                </Text>
+              </Spacing>
+
+              <Spacing mb={PADDING_UNITS}>
+                {showNewBlockVariable &&
+                  <VariableRow
+                    editStateInit
+                    focusKey
+                    key="new_block_variable"
+                    onEnterCallback={() => setShowNewBlockVariable(false)}
+                    onEscapeCallback={() => setShowNewBlockVariable(false)}
+                    updateVariable={updateBlockVariable}
+                  />
+                }
+                {Object.entries(blockVariables)?.map((tuple: [string, any]) => {
+                  const variableKey = tuple[0];
+
+                  return (
+                    <VariableRow
+                      copyText={`kwargs['configuration'].get('${variableKey}')`}
+                      deleteVariable={() =>{
+                        const blockConfigUpdated = {
+                          ...blockAttributes?.configuration,
+                        };
+                        delete blockConfigUpdated[variableKey];
+                        setBlockAttributes(prev => ({
+                          ...prev,
+                          configuration: {
+                            ...blockConfigUpdated,
+                          },
+                        }));
+                      }}
+                      disableKeyEdit
+                      key={variableKey}
+                      updateVariable={updateBlockVariable}
+                      variable={{
+                        uuid: variableKey,
+                        value: tuple[1],
+                      }}
+                    />
+                  );
+                })}
               </Spacing>
             </Spacing>
           )}

--- a/mage_ai/frontend/components/CodeBlock/utils.ts
+++ b/mage_ai/frontend/components/CodeBlock/utils.ts
@@ -307,7 +307,8 @@ export const getMoreActionsItems = (
             });
           } else {
             goToWithQuery({
-              sideview: ViewKeyEnum.CALLBACKS,
+              addon: ViewKeyEnum.CALLBACKS,
+              sideview: ViewKeyEnum.ADDON_BLOCKS,
             });
           }
         },

--- a/mage_ai/frontend/interfaces/BlockType.ts
+++ b/mage_ai/frontend/interfaces/BlockType.ts
@@ -124,6 +124,14 @@ export const BLOCK_TYPES_WITH_NO_PARENTS = [
   BlockTypeEnum.MARKDOWN,
 ];
 
+export const BLOCK_TYPES_WITH_VARIABLES = [
+  BlockTypeEnum.CUSTOM,
+  BlockTypeEnum.DATA_EXPORTER,
+  BlockTypeEnum.DATA_LOADER,
+  BlockTypeEnum.SENSOR,
+  BlockTypeEnum.TRANSFORMER,
+];
+
 export enum StatusTypeEnum {
   EXECUTED = 'executed',
   FAILED = 'failed',

--- a/mage_ai/frontend/interfaces/PipelineVariableType.ts
+++ b/mage_ai/frontend/interfaces/PipelineVariableType.ts
@@ -15,6 +15,6 @@ export default interface PipelineVariableType {
 
 export interface VariableType {
   uuid: string,
-  type: string,
+  type?: string,
   value: any,
 }

--- a/mage_ai/frontend/oracle/elements/Button/KeyboardShortcutButton.tsx
+++ b/mage_ai/frontend/oracle/elements/Button/KeyboardShortcutButton.tsx
@@ -193,6 +193,10 @@ const SHARED_STYLES = css<KeyboardShortcutButtonProps>`
     padding: ${UNIT * 0.5}px ${UNIT * 0.75}px;
   `}
 
+  ${props => props.withIcon && `
+    padding: ${(UNIT * 1.25) - 1}px;
+  `}
+
   ${props => !props.noPadding && !props.spacious && props.paddingTop && `
     padding-top: ${props.paddingTop}px;
   `}
@@ -392,10 +396,6 @@ const SHARED_STYLES = css<KeyboardShortcutButtonProps>`
 
   ${props => (props.selected || props.useModelTheme) && props.water && `
     background-color: ${(props.theme.brand || dark.brand).water400};
-  `}
-
-  ${props => props.withIcon && `
-    padding: ${(UNIT * 1.25) - 1}px;
   `}
 
   ${props => props.padding > 0 && `

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -2014,7 +2014,7 @@ function PipelineDetailPage({
         },
       }, {
         contentOnly: true,
-      }).then(() => runBlockOrig(payload));
+      })?.then(() => runBlockOrig(payload));
     }
   }, [
     disablePipelineEditAccess,


### PR DESCRIPTION
# Description
- Update the `Block settings` section of the Sidekick so that users can add or update block variables stored on an individual block's configuration.
- Fix redirect when clicking `Add callback` from block "More actions" dropdown.

# How Has This Been Tested?
![add block variables](https://github.com/mage-ai/mage-ai/assets/78053898/865e738c-ab81-4040-96a0-d631916db65f)

![image](https://github.com/mage-ai/mage-ai/assets/78053898/cdefeb1f-6db5-4123-b57c-23895ecf1ba5)

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
