### PR TITLE
[dy] Support github auth for different workspaces

### DIFF
--- a/mage_ai/api/policies/OauthPolicy.py
+++ b/mage_ai/api/policies/OauthPolicy.py
@@ -8,62 +8,95 @@ class OauthPolicy(BasePolicy):
     pass
 
 
-OauthPolicy.allow_actions([
-    constants.CREATE,
-    constants.UPDATE,
-], scopes=[
-    OauthScope.CLIENT_PRIVATE,
-], condition=lambda policy: policy.has_at_least_viewer_role())
+OauthPolicy.allow_actions(
+    [
+        constants.CREATE,
+        constants.UPDATE,
+    ],
+    scopes=[
+        OauthScope.CLIENT_PRIVATE,
+    ],
+    condition=lambda policy: policy.has_at_least_viewer_role(),
+)
 
 
-OauthPolicy.allow_actions([
-    constants.DETAIL,
-], scopes=[
-    OauthScope.CLIENT_PRIVATE,
-    OauthScope.CLIENT_PUBLIC,
-], condition=lambda policy: policy.has_at_least_viewer_role())
+OauthPolicy.allow_actions(
+    [
+        constants.DETAIL,
+    ],
+    scopes=[
+        OauthScope.CLIENT_PRIVATE,
+        OauthScope.CLIENT_PUBLIC,
+    ],
+    condition=lambda policy: policy.has_at_least_viewer_role(),
+)
 
 
-OauthPolicy.allow_read(OauthPresenter.default_attributes, scopes=[
-    OauthScope.CLIENT_PRIVATE,
-], on_action=[
-    constants.CREATE,
-    constants.UPDATE,
-], condition=lambda policy: policy.has_at_least_viewer_role())
+OauthPolicy.allow_read(
+    OauthPresenter.default_attributes,
+    scopes=[
+        OauthScope.CLIENT_PRIVATE,
+    ],
+    on_action=[
+        constants.CREATE,
+        constants.UPDATE,
+    ],
+    condition=lambda policy: policy.has_at_least_viewer_role(),
+)
 
 
-OauthPolicy.allow_read(OauthPresenter.default_attributes, scopes=[
-    OauthScope.CLIENT_PRIVATE,
-    OauthScope.CLIENT_PUBLIC,
-], on_action=[
-    constants.DETAIL,
-], condition=lambda policy: policy.has_at_least_viewer_role())
+OauthPolicy.allow_read(
+    OauthPresenter.default_attributes,
+    scopes=[
+        OauthScope.CLIENT_PRIVATE,
+        OauthScope.CLIENT_PUBLIC,
+    ],
+    on_action=[
+        constants.DETAIL,
+    ],
+    condition=lambda policy: policy.has_at_least_viewer_role(),
+)
 
 
-OauthPolicy.allow_write([
-    'provider',
-    'token',
-], scopes=[
-    OauthScope.CLIENT_PRIVATE,
-], on_action=[
-    constants.CREATE,
-], condition=lambda policy: policy.has_at_least_viewer_role())
+OauthPolicy.allow_write(
+    [
+        'provider',
+        'token',
+    ],
+    scopes=[
+        OauthScope.CLIENT_PRIVATE,
+    ],
+    on_action=[
+        constants.CREATE,
+    ],
+    condition=lambda policy: policy.has_at_least_viewer_role(),
+)
 
 
-OauthPolicy.allow_write([
-    'action_type',
-], scopes=[
-    OauthScope.CLIENT_PRIVATE,
-], on_action=[
-    constants.UPDATE,
-], condition=lambda policy: policy.has_at_least_viewer_role())
+OauthPolicy.allow_write(
+    [
+        'action_type',
+    ],
+    scopes=[
+        OauthScope.CLIENT_PRIVATE,
+    ],
+    on_action=[
+        constants.UPDATE,
+    ],
+    condition=lambda policy: policy.has_at_least_viewer_role(),
+)
 
 
-OauthPolicy.allow_query([
-    'redirect_uri',
-], on_action=[
-    constants.DETAIL,
-], scopes=[
-    OauthScope.CLIENT_PRIVATE,
-    OauthScope.CLIENT_PUBLIC,
-], condition=lambda policy: policy.has_at_least_viewer_role())
+OauthPolicy.allow_query(
+    [
+        'redirect_uri',
+    ],
+    on_action=[
+        constants.DETAIL,
+    ],
+    scopes=[
+        OauthScope.CLIENT_PRIVATE,
+        OauthScope.CLIENT_PUBLIC,
+    ],
+    condition=lambda policy: policy.has_at_least_viewer_role(),
+)

--- a/mage_ai/api/policies/OauthPolicy.py
+++ b/mage_ai/api/policies/OauthPolicy.py
@@ -10,6 +10,7 @@ class OauthPolicy(BasePolicy):
 
 OauthPolicy.allow_actions([
     constants.CREATE,
+    constants.UPDATE,
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
 ], condition=lambda policy: policy.has_at_least_viewer_role())
@@ -27,6 +28,7 @@ OauthPolicy.allow_read(OauthPresenter.default_attributes, scopes=[
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.CREATE,
+    constants.UPDATE,
 ], condition=lambda policy: policy.has_at_least_viewer_role())
 
 
@@ -45,6 +47,15 @@ OauthPolicy.allow_write([
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.CREATE,
+], condition=lambda policy: policy.has_at_least_viewer_role())
+
+
+OauthPolicy.allow_write([
+    'action_type',
+], scopes=[
+    OauthScope.CLIENT_PRIVATE,
+], on_action=[
+    constants.UPDATE,
 ], condition=lambda policy: policy.has_at_least_viewer_role())
 
 

--- a/mage_ai/authentication/oauth/utils.py
+++ b/mage_ai/authentication/oauth/utils.py
@@ -1,13 +1,23 @@
 from datetime import datetime
 from typing import List
 
-from mage_ai.orchestration.db.models.oauth import Oauth2AccessToken, Oauth2Application
+from mage_ai.orchestration.db import safe_db_query
+from mage_ai.orchestration.db.models.oauth import (
+    Oauth2AccessToken,
+    Oauth2Application,
+    User,
+)
 
 
-def access_tokens_for_provider(provider: str) -> List[Oauth2AccessToken]:
-    oauth_client = Oauth2Application.query.filter(
-        Oauth2Application.client_id == provider,
-    ).first()
+@safe_db_query
+def access_tokens_for_client(client_id: str, user: User = None) -> List[Oauth2AccessToken]:
+    query = Oauth2Application.query.filter(
+        Oauth2Application.client_id == client_id
+    )
+    if user:
+        query.filter(Oauth2Application.user_id == user.id)
+
+    oauth_client = query.first()
 
     access_tokens = []
     if oauth_client:

--- a/mage_ai/authentication/oauth/utils.py
+++ b/mage_ai/authentication/oauth/utils.py
@@ -10,10 +10,10 @@ from mage_ai.orchestration.db.models.oauth import (
 
 
 @safe_db_query
-def access_tokens_for_client(client_id: str, user: User = None) -> List[Oauth2AccessToken]:
-    query = Oauth2Application.query.filter(
-        Oauth2Application.client_id == client_id
-    )
+def access_tokens_for_client(
+    client_id: str, user: User = None
+) -> List[Oauth2AccessToken]:
+    query = Oauth2Application.query.filter(Oauth2Application.client_id == client_id)
     if user:
         query.filter(Oauth2Application.user_id == user.id)
 

--- a/mage_ai/frontend/components/VersionControl/Remote/index.tsx
+++ b/mage_ai/frontend/components/VersionControl/Remote/index.tsx
@@ -115,6 +115,21 @@ function Remote({
     },
   );
 
+  const [updateOauth, { isLoading: isLoadingUpdateOauth }] = useMutation(
+    api.oauths.useUpdate('github'),
+    {
+      onSuccess: (response: any) => onSuccess(
+        response, {
+          callback: () => window.location.href = window.location.href.split('?')[0],
+          onErrorCallback: (response, errors) => showError({
+            errors,
+            response,
+          }),
+        },
+      ),
+    },
+  );
+
   const [actionGitBranch, { isLoading: isLoadingAction }] = useMutation(
     api.git_custom_branches.useUpdate(branch?.name),
     {
@@ -372,11 +387,24 @@ function Remote({
                 Successfully authenticated with GitHub
               </Button>
 
-              <Spacing mt={1}>
+              <Spacing my={1}>
                 <Text muted>
                   You can pull, push, and create pull requests on GitHub.
                 </Text>
               </Spacing>
+
+              <Button
+                loading={isLoadingUpdateOauth}
+                // @ts-ignore
+                onClick={() => updateOauth({
+                  oauth: {
+                    action_type: 'reset',
+                  },
+                })}
+                warning
+              >
+                Reset GitHub authentication
+              </Button>
             </>
           )}
           {!oauth?.authenticated && oauth?.url && (


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Added some changes to support github auth in multiple workspaces using the same database. When creating the github `Oauth2Application`, the project uuid will be added to the client_id to differentiate it among workspaces. Also, when we query access tokens for an application, we also need to take the Mage user into account.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with k8s workspaces


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
