### PR TITLE
[xy] Compare start_time and execution_date in should_schedule.

### DIFF
--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -20,8 +20,8 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     String,
-    Text,
     Table,
+    Text,
     or_,
 )
 from sqlalchemy.orm import joinedload, relationship, validates
@@ -195,6 +195,19 @@ class PipelineSchedule(BaseModel):
             self.create(**kwargs)
 
     def current_execution_date(self) -> datetime:
+        """
+        Calculate the current execution date and time based on the schedule_interval and start_time.
+
+        Returns:
+            datetime: The calculated current execution date and time in the UTC timezone.
+
+        Note:
+            This method calculates the current execution date and time based on the
+            schedule_interval, and if landing_time is enabled, it takes the start_time into
+            account to adjust the execution time accordingly.
+
+            The returned datetime object is in the UTC timezone.
+        """
         now = datetime.now(timezone.utc)
         current_execution_date = None
 
@@ -274,6 +287,24 @@ class PipelineSchedule(BaseModel):
 
     @safe_db_query
     def should_schedule(self, previous_runtimes: List[int] = None) -> bool:
+        """
+        Determine whether a pipeline schedule should be executed based on its configuration and
+        history.
+
+        Args:
+            previous_runtimes (List[int], optional): A list of previous execution runtimes,
+                in seconds, used for decision-making when scheduling based on landing time.
+                Defaults to None.
+
+        Returns:
+            bool: True if the schedule should be executed; False otherwise.
+
+        Note:
+            This method evaluates whether a pipeline schedule should be executed, taking into
+            account various factors such as the schedule's status, start time, landing time,
+            schedule interval, and previous runtimes. It returns True if the schedule should be
+            executed and False otherwise.
+        """
         now = datetime.now(tz=pytz.UTC)
 
         if self.status != ScheduleStatus.ACTIVE:
@@ -302,12 +333,15 @@ class PipelineSchedule(BaseModel):
             if executor_count > 1 and pipeline_run_count < executor_count:
                 return True
         else:
-            """
-            TODO: Implement other schedule interval checks
-            """
             current_execution_date = self.current_execution_date()
             if current_execution_date is None:
                 return False
+
+            # If the execution date is before start time, don't schedule it
+            if self.start_time is not None and \
+                    compare(current_execution_date, self.start_time.replace(tzinfo=pytz.UTC)) == -1:
+                return False
+
             # If there is a pipeline_run with an execution_date the same as the
             # current_execution_date, then don’t schedule
             if not find(

--- a/mage_ai/tests/orchestration/db/models/test_schedules.py
+++ b/mage_ai/tests/orchestration/db/models/test_schedules.py
@@ -162,9 +162,18 @@ class PipelineScheduleTests(DBTestCase):
                 datetime(2023, 10, 1, 0, 0, 0),
             ),
         ]:
+            pipeline_schedule_false = PipelineSchedule.create(**merge_dict(shared_attrs, dict(
+                schedule_interval=schedule_interval,
+                # Set the start time to one second ago
+                start_time=datetime(2023, 10, 11, 12, 13, 13),
+                status=ScheduleStatus.ACTIVE,
+            )))
+            self.assertFalse(pipeline_schedule_false.should_schedule())
+
             pipeline_schedule = PipelineSchedule.create(**merge_dict(shared_attrs, dict(
                 schedule_interval=schedule_interval,
-                start_time=datetime(2023, 10, 11, 12, 13, 13),
+                # Set the start time to one month ago
+                start_time=datetime(2023, 9, 11, 12, 13, 13),
                 status=ScheduleStatus.ACTIVE,
             )))
             PipelineRun.create(
@@ -202,16 +211,16 @@ class PipelineScheduleTests(DBTestCase):
                 # AVG: 4
                 # STD: 2
                 [1, 2, 3, 4, 5, 6, 7],
-                datetime(2023, 10, 12, 13, 13, 20),
-                datetime(2023, 10, 13, 14, 13, 21),
+                datetime(2023, 10, 5, 13, 13, 20),
+                datetime(2023, 10, 6, 14, 13, 21),
             ),
             (
                 ScheduleInterval.DAILY,
                 # AVG: 4000
                 # STD: 1081
                 [1000, 2000, 3000, 4000, 5000, 6000, 7000],
-                datetime(2023, 10, 12, 13, 37, 55),
-                datetime(2023, 10, 13, 13, 37, 56),
+                datetime(2023, 10, 5, 13, 37, 55),
+                datetime(2023, 10, 6, 13, 37, 56),
             ),
             (
                 # 2023-10-11 is a Wednesday
@@ -228,8 +237,8 @@ class PipelineScheduleTests(DBTestCase):
                     4 * 86400,
                 ],
                 # 2023-10-21 is a Saturday
-                datetime(2023, 10, 21, 13, 10, 56),
-                datetime(2023, 10, 28, 13, 10, 57),
+                datetime(2023, 10, 7, 13, 10, 56),
+                datetime(2023, 10, 7, 13, 10, 57),
             ),
             (
                 ScheduleInterval.MONTHLY,
@@ -248,8 +257,8 @@ class PipelineScheduleTests(DBTestCase):
                     7.5 * 86400,
                     12 * 86400,
                 ],
-                datetime(2023, 11, 19, 5, 50, 13),
-                datetime(2023, 12, 19, 5, 50, 14),
+                datetime(2023, 9, 19, 5, 50, 13),
+                datetime(2023, 9, 19, 5, 50, 14),
             ),
         ]:
             self.assertTrue(PipelineSchedule.create(**merge_dict(shared_attrs, dict(

--- a/mage_ai/tests/orchestration/test_pipeline_scheduler.py
+++ b/mage_ai/tests/orchestration/test_pipeline_scheduler.py
@@ -118,7 +118,7 @@ class PipelineSchedulerTests(DBTestCase):
         )
 
         pipeline_schedule = PipelineSchedule.create(**merge_dict(shared_attrs, dict(
-            start_time=datetime(2023, 10, 12, 13, 13, 20),
+            start_time=datetime(2023, 10, 10, 13, 13, 20),
         )))
 
         # No previous pipeline runs
@@ -159,7 +159,7 @@ class PipelineSchedulerTests(DBTestCase):
         )
 
         pipeline_schedule = PipelineSchedule.create(**merge_dict(shared_attrs, dict(
-            start_time=datetime(2023, 10, 12, 13, 13, 20),
+            start_time=datetime(2023, 10, 10, 13, 13, 20),
         )))
 
         # No previous pipeline runs


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Compare start_time and execution_date in should_schedule. If current_execution_date is before start_time, don't schedule it.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested create a daily trigger and set the start_time to several hours ago.
After the fix, it doesn't schedule the pipeline run immediately after I start the trigger.
Before the fix, it schedules the pipeline run with execution date before the start time.
<img width="370" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/7c623bf8-a0df-42ac-802d-05f8d0b7d0cb">
<img width="234" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/1c007917-535f-492f-976b-889f04d11b59">




# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
