### PR TITLE
[xy] Support auto scaling for EMR cluster.

### DIFF
--- a/mage_ai/services/aws/emr/config.py
+++ b/mage_ai/services/aws/emr/config.py
@@ -1,7 +1,8 @@
-from dataclasses import dataclass
-from mage_ai.shared.config import BaseConfig
-from typing import Dict
 import os
+from dataclasses import dataclass
+from typing import Dict
+
+from mage_ai.shared.config import BaseConfig
 
 DEFAULT_DRIVER_MEMORY = '32000M'
 DEFAULT_INSTANCE_TYPE = 'r5.4xlarge'
@@ -12,12 +13,22 @@ INSTANCE_DRIVER_MEMORY_MAPPING = {
 
 
 @dataclass
+class EmrScalingPocliy(BaseConfig):
+    unit_type: str = 'Instances'    # 'InstanceFleetUnits'|'Instances'|'VCPU'
+    minimum_capacity_units: int = 1
+    maximum_capacity_units: int = 2
+    maximum_on_demand_capacity_units: int = 2
+    maximum_core_capacity_units: int = 2
+
+
+@dataclass
 class EmrConfig(BaseConfig):
     ec2_key_name: str = None
     master_security_group: str = None
     slave_security_group: str = None
     master_instance_type: str = DEFAULT_INSTANCE_TYPE
     slave_instance_type: str = DEFAULT_INSTANCE_TYPE
+    scaling_policy: EmrScalingPocliy = None
 
     def get_instances_config(
         self,
@@ -82,6 +93,20 @@ class EmrConfig(BaseConfig):
         if self.slave_security_group is not None:
             instances_config['EmrManagedSlaveSecurityGroup'] = self.slave_security_group
         return instances_config
+
+    def get_managed_scaling_policy(self):
+        if self.scaling_policy is not None:
+            return {
+                'ComputeLimits': {
+                    'UnitType': self.scaling_policy.unit_type,
+                    'MinimumCapacityUnits': self.scaling_policy.minimum_capacity_units,
+                    'MaximumCapacityUnits': self.scaling_policy.maximum_capacity_units,
+                    'MaximumOnDemandCapacityUnits':
+                        self.scaling_policy.maximum_on_demand_capacity_units,
+                    'MaximumCoreCapacityUnits': self.scaling_policy.maximum_core_capacity_units,
+                },
+            }
+        return None
 
     def __driver_memory(self, instance_size: str) -> str:
         return INSTANCE_DRIVER_MEMORY_MAPPING.get(instance_size, DEFAULT_DRIVER_MEMORY)

--- a/mage_ai/services/aws/emr/emr.py
+++ b/mage_ai/services/aws/emr/emr.py
@@ -41,8 +41,10 @@ def create_a_new_cluster(
     idle_timeout=0,
     keep_alive=False,
     log_uri=None,
-    tags=dict(),
+    tags=None,
 ):
+    if tags is None:
+        tags = dict()
     region_name = get_aws_region_name()
     config = Config(region_name=region_name)
     emr_client = boto3.client('emr', config=config)
@@ -72,6 +74,9 @@ def create_a_new_cluster(
         Tags=[dict(Key=k, Value=v) for k, v in tags.items()],
         VisibleToAllUsers=True,
     )
+    managed_scaling_policy = emr_config.get_managed_scaling_policy()
+    if managed_scaling_policy:
+        emr_kwargs['ManagedScalingPolicy'] = managed_scaling_policy
     if log_uri is not None:
         emr_kwargs['LogUri'] = log_uri
     if bootstrap_script_path is not None:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Support auto scaling for EMR cluster.

Example config
```yaml
emr_config:
    # You can customize the EMR cluster instance size with the two parameters
  master_instance_type: 'r5.4xlarge'
  slave_instance_type: 'r5.4xlarge'
  scaling_policy:
    unit_type: 'Instances'    # 'InstanceFleetUnits'|'Instances'|'VCPU'
    minimum_capacity_units: 1
    maximum_capacity_units: 4
    maximum_on_demand_capacity_units: 4
    maximum_core_capacity_units: 3
```

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with pyspark kernel and customized scaling policy. The EMR cluster is created with correct scaling policy
<img width="1389" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/e04d905c-9e43-449a-bccc-7604289bf7d6">


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code


cc:
<!-- Optionally mention someone to let them know about this pull request -->
