### PR TITLE
[jk] Fix initial ordering of pipeline rows

### DIFF
--- a/mage_ai/frontend/components/shared/Table/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/index.tsx
@@ -224,7 +224,7 @@ function Table({
     rightClickMenuWidth,
   ]);
 
-  const rowsSorted = useMemo(() => ((setRowsSorted && (sortedColumn || defaultSortColumnIndex))
+  const rowsSorted = useMemo(() => ((setRowsSorted && sortedColumn)
     ?
       sortByKey(
         rows,

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -363,7 +363,7 @@ function PipelineListPage() {
       textArea={!pipelineName}
       title={pipelineName
         ? 'Rename pipeline'
-        : 'Edit description'
+        : `Edit description for ${pipeline?.uuid}`
       }
       value={pipelineName ? pipelineName : pipelineDescription}
     />
@@ -642,7 +642,10 @@ function PipelineListPage() {
         },
         {
           label: () => 'Edit description',
-          onClick: () => showInputModal({ pipelineDescription: selectedPipeline?.description }),
+          onClick: () => showInputModal({
+            pipeline: selectedPipeline,
+            pipelineDescription: selectedPipeline?.description,
+          }),
           uuid: 'Pipelines/MoreActionsMenu/EditDescription',
         },
       ]}
@@ -675,9 +678,7 @@ function PipelineListPage() {
     query,
     router,
     searchText,
-    selectedPipeline?.description,
-    selectedPipeline?.name,
-    selectedPipeline?.uuid,
+    selectedPipeline,
     showInputModal,
     tags,
   ]);
@@ -851,7 +852,7 @@ function PipelineListPage() {
       let value = pipeline?.[groupByQuery];
 
       if (PipelineGroupingEnum.STATUS === groupByQuery) {
-        const { schedules = [] } = pipeline;
+        const { schedules = [] } = pipeline || {};
         // TODO (tommy dang): when is the pipeline status RETRY?
         const schedulesCount = schedules.length;
         const isActive = schedules.find(({ status }) => ScheduleStatusEnum.ACTIVE === status);


### PR DESCRIPTION
# Description
- When the pipelines list was initially rendered, a default row sorting was causing issues with the correct pipeline being selected. If the pipelines fetched from the server wer already sorted by `pipeline_uuid` (which is not always the case), there wouldn't be issues with the correct pipeline being selected, but if the pipelines were not already sorted, this would cause a bug to occur where the selected pipeline does not match the correct pipeline that an action (e.g. rename, edit description) is meant to be performed on.

# How Has This Been Tested?
Before: The pipeline action is not performed on the correct selected pipeline:
![Before - selected column incorrect](https://github.com/mage-ai/mage-ai/assets/78053898/19d4decd-191f-46d9-83a3-10203fe6546d)

After: The pipeline action performed on the selected pipeline is fixed because the pipeline row ordering is consistent with the order of pipelines returned from the server (for testing purposes, the pipeline `winter_brook` was moved to the front of the pipelines array returned from the server):
![After - initial pipeline row order fixed](https://github.com/mage-ai/mage-ai/assets/78053898/0046484b-2cba-4118-8a13-5256f5aa3359)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
