### PR TITLE
[jk] Local timezone setting

### DIFF
--- a/mage_ai/api/resources/ProjectResource.py
+++ b/mage_ai/api/resources/ProjectResource.py
@@ -53,11 +53,16 @@ class ProjectResource(GenericResource):
 
         if 'features' in payload:
             for k, v in payload.get('features', {}).items():
-                feature = (repo_config.features or {}).get(k)
-                if (feature and not v) or (not feature and v):
+                if v is not None:
                     if 'features' not in data:
                         data['features'] = {}
                     data['features'][k] = v
+            features = data.get('features')
+            if features is not None:
+                data['features'] = merge_dict(
+                    repo_config.features or {},
+                    features,
+                )
 
         if 'help_improve_mage' in payload:
             if payload['help_improve_mage']:

--- a/mage_ai/data_preparation/models/project/constants.py
+++ b/mage_ai/data_preparation/models/project/constants.py
@@ -3,3 +3,4 @@ from enum import Enum
 
 class FeatureUUID(str, Enum):
     ADD_NEW_BLOCK_V2 = 'add_new_block_v2'
+    LOCAL_TIMEZONE = 'display_local_timezone'

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -297,6 +297,7 @@ function BackfillDetail({
           <Text
             key="backfill_start_date"
             monospace
+            small
           >
             {displayLocalTimezone
               ? datetimeInLocalTimezone(startDatetime, displayLocalTimezone)
@@ -318,6 +319,7 @@ function BackfillDetail({
           <Text
             key="backfill_end_date"
             monospace
+            small
           >
             {displayLocalTimezone
               ? datetimeInLocalTimezone(endDatetime, displayLocalTimezone)

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -48,6 +48,7 @@ import {
 } from '@oracle/styles/units/spacing';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
 import { capitalize } from '@utils/string';
+import { datetimeInLocalTimezone } from '@utils/date';
 import {
   getFormattedVariable,
   getFormattedVariables,
@@ -59,6 +60,7 @@ import { isViewer } from '@utils/session';
 import { onSuccess } from '@api/utils/response';
 import { pauseEvent } from '@utils/events';
 import { queryFromUrl, queryString } from '@utils/url';
+import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
 
 const LIMIT = 40;
 
@@ -80,6 +82,7 @@ function BackfillDetail({
   variables,
 }: BackfillDetailProps) {
   const isViewerRole = isViewer();
+  const displayLocalTimezone = shouldDisplayLocalTimezone();
   const router = useRouter();
   const {
     block_uuid: blockUUID,
@@ -189,6 +192,7 @@ function BackfillDetail({
     q,
     router,
     selectedRun,
+    setErrors,
     showPreviewRuns,
     totalRuns,
   ]);
@@ -294,7 +298,10 @@ function BackfillDetail({
             key="backfill_start_date"
             monospace
           >
-            {getTimeInUTCString(startDatetime)}
+            {displayLocalTimezone
+              ? datetimeInLocalTimezone(startDatetime, displayLocalTimezone)
+              : getTimeInUTCString(startDatetime)
+            }
           </Text>,
         ],
         [
@@ -312,7 +319,10 @@ function BackfillDetail({
             key="backfill_end_date"
             monospace
           >
-            {getTimeInUTCString(endDatetime)}
+            {displayLocalTimezone
+              ? datetimeInLocalTimezone(endDatetime, displayLocalTimezone)
+              : getTimeInUTCString(endDatetime)
+            }
           </Text>,
         ],
         [
@@ -380,6 +390,7 @@ function BackfillDetail({
     );
   }, [
     blockUUID,
+    displayLocalTimezone,
     endDatetime,
     intervalType,
     intervalUnits,

--- a/mage_ai/frontend/components/Backfills/Edit/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Edit/index.tsx
@@ -43,10 +43,13 @@ import {
   UNIT,
 } from '@oracle/styles/units/spacing';
 import { capitalize } from '@utils/string';
-import { getTimeInUTC } from '../../Triggers/utils';
+import { getDateAndTimeObjFromDatetimeString } from '@oracle/components/Calendar/utils';
+import { getDatetimeFromDateAndTime } from '@components//Triggers/utils';
 import { onSuccess } from '@api/utils/response';
 import { parseVariables } from '@components/Sidekick/utils';
 import { selectKeys } from '@utils/hash';
+import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
+import { display } from 'styled-system';
 
 type BackfillEditProps = {
   backfill: BackfillType;
@@ -66,14 +69,13 @@ function BackfillEdit({
   variables,
 }: BackfillEditProps) {
   const router = useRouter();
+  const displayLocalTimezone = shouldDisplayLocalTimezone();
   const [model, setModel] = useState<BackfillType>();
   const {
     block_uuid: blockUUID,
     id: modelID,
     interval_type: intervalType,
     interval_units: intervalUnits,
-    end_datetime: endDatetime,
-    start_datetime: startDatetime,
     name,
   } = model || {};
   const {
@@ -99,27 +101,25 @@ function BackfillEdit({
 
       const startDatetime = modelProp.start_datetime;
       if (startDatetime) {
-        const dateTimeSplit = startDatetime.split(' ');
-        const timePart = dateTimeSplit[1];
-        setDateStart(getTimeInUTC(startDatetime));
-        setTimeStart({
-          hour: timePart.substring(0, 2),
-          minute: timePart.substring(3, 5),
-        });
+        const startDatetimeObj = getDateAndTimeObjFromDatetimeString(
+          startDatetime,
+          { localTimezone: displayLocalTimezone },
+        );
+        setDateStart(startDatetimeObj?.date);
+        setTimeStart(startDatetimeObj.time);
       }
 
       const endDatetime = modelProp.end_datetime;
       if (endDatetime) {
-        const dateTimeSplit = endDatetime.split(' ');
-        const timePart = dateTimeSplit[1];
-        setDateEnd(getTimeInUTC(endDatetime));
-        setTimeEnd({
-          hour: timePart.substring(0, 2),
-          minute: timePart.substring(3, 5),
-        });
+        const endDatetimeObj = getDateAndTimeObjFromDatetimeString(
+          endDatetime,
+          { localTimezone: displayLocalTimezone },
+        );
+        setDateEnd(endDatetimeObj?.date);
+        setTimeEnd(endDatetimeObj?.time);
       }
     }
-  }, [modelProp]);
+  }, [displayLocalTimezone, modelProp]);
 
   const detailsMemo = useMemo(() => {
     const rows = [
@@ -174,7 +174,10 @@ function BackfillEdit({
                 onFocus={() => setShowCalendarStart(true)}
                 placeholder="YYYY-MM-DD HH:MM"
                 value={dateStart
-                  ? `${dateStart.toISOString().split('T')[0]} ${timeStart?.hour}:${timeStart?.minute}`
+                  ? getDatetimeFromDateAndTime(
+                    dateStart,
+                    timeStart,
+                    { localTimezone: displayLocalTimezone })
                   : ''
                 }
               />
@@ -187,6 +190,7 @@ function BackfillEdit({
                 style={{ position: 'relative' }}
               >
                 <Calendar
+                  localTime={displayLocalTimezone}
                   selectedDate={dateStart}
                   selectedTime={timeStart}
                   setSelectedDate={setDateStart}
@@ -219,7 +223,10 @@ function BackfillEdit({
                 onFocus={() => setShowCalendarEnd(true)}
                 placeholder="YYYY-MM-DD HH:MM"
                 value={dateEnd
-                  ? `${dateEnd.toISOString().split('T')[0]} ${timeEnd?.hour}:${timeEnd?.minute}`
+                  ? getDatetimeFromDateAndTime(
+                    dateEnd,
+                    timeEnd,
+                    { localTimezone: displayLocalTimezone })
                   : ''
                 }
               />
@@ -232,6 +239,7 @@ function BackfillEdit({
                 style={{ position: 'relative' }}
               >
                 <Calendar
+                  localTime={displayLocalTimezone}
                   selectedDate={dateEnd}
                   selectedTime={timeEnd}
                   setSelectedDate={setDateEnd}
@@ -325,6 +333,7 @@ function BackfillEdit({
   }, [
     dateEnd,
     dateStart,
+    displayLocalTimezone,
     intervalType,
     intervalUnits,
     name,
@@ -373,11 +382,25 @@ function BackfillEdit({
     } else {
       data.interval_type = intervalType;
       data.interval_units = intervalUnits;
-      data.end_datetime = dateEnd && timeEnd?.hour && timeEnd?.minute
-        ? `${dateEnd.toISOString().split('T')[0]} ${timeEnd?.hour}:${timeEnd?.minute}:00`
+      data.end_datetime = (dateEnd && timeEnd?.hour && timeEnd?.minute)
+        ? getDatetimeFromDateAndTime(
+          dateEnd,
+          timeEnd,
+          {
+            convertToUtc: displayLocalTimezone,
+            includeSeconds: true,
+            localTimezone: displayLocalTimezone,
+          })
         : null;
-      data.start_datetime = dateStart && timeStart?.hour && timeStart?.minute
-        ? `${dateStart.toISOString().split('T')[0]} ${timeStart?.hour}:${timeStart?.minute}:00`
+      data.start_datetime = (dateStart && timeStart?.hour && timeStart?.minute)
+        ? getDatetimeFromDateAndTime(
+          dateStart,
+          timeStart,
+          {
+            convertToUtc: displayLocalTimezone,
+            includeSeconds: true,
+            localTimezone: displayLocalTimezone,
+          })
         : null;
     }
 
@@ -386,6 +409,7 @@ function BackfillEdit({
   }, [
     dateEnd,
     dateStart,
+    displayLocalTimezone,
     intervalType,
     intervalUnits,
     model,
@@ -393,6 +417,7 @@ function BackfillEdit({
     setupType,
     timeEnd,
     timeStart,
+    updateModel,
   ]);
 
   const saveButtonDisabled = useMemo(() => {
@@ -409,8 +434,6 @@ function BackfillEdit({
     intervalType,
     intervalUnits,
     setupType,
-    timeEnd,
-    timeStart,
   ]);
 
   return (

--- a/mage_ai/frontend/components/Backfills/Edit/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Edit/index.tsx
@@ -49,7 +49,6 @@ import { onSuccess } from '@api/utils/response';
 import { parseVariables } from '@components/Sidekick/utils';
 import { selectKeys } from '@utils/hash';
 import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
-import { display } from 'styled-system';
 
 type BackfillEditProps = {
   backfill: BackfillType;

--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -11,8 +11,10 @@ import Text from '@oracle/elements/Text';
 import { Edit } from '@oracle/icons';
 import { RunStatus } from '@interfaces/PipelineRunType';
 import { UNIT } from '@oracle/styles/units/spacing';
+import { datetimeInLocalTimezone } from '@utils/date';
 import { getTimeInUTCString } from '@components/Triggers/utils';
 import { isViewer } from '@utils/session';
+import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
 
 type BackfillsTableProps = {
   pipeline: {
@@ -30,6 +32,7 @@ function BackfillsTable({
   selectedRow,
 }: BackfillsTableProps) {
   const isViewerRole = isViewer();
+  const displayLocalTimezone = shouldDisplayLocalTimezone();
   const pipelineUUID = pipeline?.uuid;
   const columnFlex = [null, 1, null, null, null, 1, 1, null];
   const columns: ColumnType[] = [
@@ -95,21 +98,41 @@ function BackfillsTable({
             {blockUUID ? BACKFILL_TYPE_CODE : BACKFILL_TYPE_DATETIME}
           </Text>,
           <Text default key="runs" monospace>{totalRunCount || 0}</Text>,
-          <Text default key="backfill" monospace>
-            {startDatetime && endDatetime && (
+          <Text default key="backfill" monospace small>
+            {(startDatetime && endDatetime) && (
               <>
-                {getTimeInUTCString(startDatetime)}
+                {displayLocalTimezone
+                  ? datetimeInLocalTimezone(startDatetime, displayLocalTimezone)
+                  : getTimeInUTCString(startDatetime)
+                }
                 &nbsp;-&nbsp;
-                {getTimeInUTCString(endDatetime)}
+                {displayLocalTimezone
+                  ? datetimeInLocalTimezone(endDatetime, displayLocalTimezone)
+                  : getTimeInUTCString(endDatetime)
+                }
               </>
             )}
-            {!(startDatetime && endDatetime) && '-'}
+            {!(startDatetime && endDatetime) && <>&#8212;</>}
           </Text>,
-          <Text default key="started_at" monospace>
-            {startedAt ? getTimeInUTCString(startedAt) : '-'}
+          <Text default key="started_at" monospace small>
+            {startedAt
+              ? (displayLocalTimezone
+                ? datetimeInLocalTimezone(startedAt, displayLocalTimezone)
+                : getTimeInUTCString(startedAt)
+              ): (
+                <>&#8212;</>
+              )
+            }
           </Text>,
-          <Text default key="completed_at" monospace>
-            {completedAt ? getTimeInUTCString(completedAt) : '-'}
+          <Text default key="completed_at" monospace small>
+            {completedAt
+              ? (displayLocalTimezone
+                ? datetimeInLocalTimezone(completedAt, displayLocalTimezone)
+                : getTimeInUTCString(completedAt)
+              ): (
+                <>&#8212;</>
+              )
+            }
           </Text>,
         ];
         if (!isViewerRole) {

--- a/mage_ai/frontend/components/Logs/Table/index.tsx
+++ b/mage_ai/frontend/components/Logs/Table/index.tsx
@@ -28,6 +28,7 @@ import { get, set } from '@storage/localStorage';
 import { getColorsForBlockType } from '@components/CodeBlock/index.style';
 import { getLogScrollPositionLocalStorageKey } from '../utils';
 import { goToWithQuery } from '@utils/routing';
+import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
 import { useWindowSize } from '@utils/sizes';
 
 export const LOG_UUID_PARAM = 'log_uuid';
@@ -57,6 +58,7 @@ function LogsTable({
   setSelectedLog,
   themeContext,
 }: LogsTableProps) {
+  const displayLocalTimezone = shouldDisplayLocalTimezone();
   const { height: windowHeight } = useWindowSize();
   const tableRef = useRef(null);
   const isIntegration = useMemo(
@@ -109,7 +111,7 @@ function LogsTable({
     },
     {
       uuid: 'Date',
-      width: 214,
+      width: displayLocalTimezone ? 202 : 214,
     },
     {
       uuid: 'Block',
@@ -245,8 +247,9 @@ function LogsTable({
             key="log_timestamp"
             monospace
             noWrapping
+            small={displayLocalTimezone}
           >
-            {formatTimestamp(timestamp)}
+            {formatTimestamp(timestamp, { localTimezone: displayLocalTimezone })}
           </Text>
         </Flex>
         <Flex
@@ -283,6 +286,7 @@ function LogsTable({
     );
   }, [
     blockUUIDColWidth,
+    displayLocalTimezone,
     isIntegration,
     onRowClick,
     query,

--- a/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
@@ -45,11 +45,15 @@ import {
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { PipelineHeaderStyle } from './index.style';
 import { ThemeType } from '@oracle/styles/themes/constants';
-import { dateFormatLongFromUnixTimestamp } from '@utils/date';
+import {
+  dateFormatLongFromUnixTimestamp,
+  datetimeInLocalTimezone,
+} from '@utils/date';
 import { find } from '@utils/array';
 import { goToWithQuery } from '@utils/routing';
 import { isMac } from '@utils/os';
 import { onSuccess } from '@api/utils/response';
+import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
 import { useKeyboardContext } from '@context/Keyboard';
 import { useModal } from '@context/Modal';
 
@@ -91,6 +95,7 @@ function KernelStatus({
   updatePipelineMetadata,
 }: KernelStatusProps) {
   const themeContext: ThemeType = useContext(ThemeContext);
+  const displayLocalTimezone = shouldDisplayLocalTimezone();
   const {
     alive,
     usage,
@@ -147,7 +152,11 @@ function KernelStatus({
   } else if (isPipelineUpdating) {
     saveStatus = 'Saving changes...';
   } else if (pipelineLastSaved) {
-    saveStatus = `Last saved ${dateFormatLongFromUnixTimestamp(Number(pipelineLastSaved) / 1000)}`;
+    let lastSavedDate = dateFormatLongFromUnixTimestamp(Number(pipelineLastSaved) / 1000);
+    if (pipeline?.updated_at) {
+      lastSavedDate = datetimeInLocalTimezone(pipeline?.updated_at, displayLocalTimezone);
+    }
+    saveStatus = `Last saved ${lastSavedDate}`;
   } else {
     saveStatus = 'All changes saved';
   }

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -41,12 +41,14 @@ import { PopupContainerStyle } from './Table.style';
 import { ScheduleTypeEnum } from '@interfaces/PipelineScheduleType';
 import { TableContainerStyle } from '@components/shared/Table/index.style';
 import { UNIT } from '@oracle/styles/units/spacing';
+import { datetimeInLocalTimezone } from '@utils/date';
 import { getTimeInUTCString } from '@components/Triggers/utils';
 import { indexBy } from '@utils/array';
 import { isViewer } from '@utils/session';
 import { onSuccess } from '@api/utils/response';
 import { pauseEvent } from '@utils/events';
 import { queryFromUrl } from '@utils/url';
+import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
 
 const SHARED_DATE_FONT_PROPS = {
   monospace: true,
@@ -284,6 +286,7 @@ function PipelineRunsTable({
 }: PipelineRunsTableProps) {
   const router = useRouter();
   const isViewerRole = isViewer();
+  const displayLocalTimezone = shouldDisplayLocalTimezone();
   const deleteButtonRefs = useRef({});
   const [cancelingRunId, setCancelingRunId] = useState<number>(null);
   const [showConfirmationId, setShowConfirmationId] = useState<number>(null);
@@ -479,7 +482,14 @@ function PipelineRunsTable({
                     key="row_completed"
                     muted
                   >
-                    {(completedAt && getTimeInUTCString(completedAt)) || '-'}
+                    {completedAt
+                      ? (displayLocalTimezone
+                        ? datetimeInLocalTimezone(completedAt, displayLocalTimezone)
+                        : getTimeInUTCString(completedAt)
+                      ): (
+                        <>&#8212;</>
+                      )
+                    }
                   </Text>,
                   <NextLink
                     as={`/pipelines/${pipelineUUID}/runs/${id}`}
@@ -548,14 +558,28 @@ function PipelineRunsTable({
                     default
                     key="row_date"
                   >
-                    {(executionDate && getTimeInUTCString(executionDate)) || '-'}
+                    {executionDate
+                      ? (displayLocalTimezone
+                        ? datetimeInLocalTimezone(executionDate, displayLocalTimezone)
+                        : getTimeInUTCString(executionDate)
+                      ): (
+                        <>&#8212;</>
+                      )
+                    }
                   </Text>,
                   <Text
                     {...SHARED_DATE_FONT_PROPS}
                     default
                     key="row_completed"
                   >
-                    {(completedAt && getTimeInUTCString(completedAt)) || '-'}
+                    {completedAt
+                      ? (displayLocalTimezone
+                        ? datetimeInLocalTimezone(completedAt, displayLocalTimezone)
+                        : getTimeInUTCString(completedAt)
+                      ): (
+                        <>&#8212;</>
+                      )
+                    }
                   </Text>,
                   <NextLink
                     as={`/pipelines/${pipelineUUID}/runs/${id}`}

--- a/mage_ai/frontend/components/PipelineRun/Widget/index.tsx
+++ b/mage_ai/frontend/components/PipelineRun/Widget/index.tsx
@@ -19,6 +19,7 @@ import { TAB_URL_PARAM } from '@oracle/components/Tabs';
 import {
   TIME_PERIOD_DISPLAY_MAPPING,
   TimePeriodEnum,
+  dateFormatLong,
   datetimeInLocalTimezone,
 } from '@utils/date';
 import { UNIT } from '@oracle/styles/units/spacing';
@@ -131,7 +132,10 @@ function Widget({
                 passHref
               >
                 <Link danger monospace sameColorAsText small>
-                  Run created on {datetimeInLocalTimezone(createdAt, displayLocalTimezone)}
+                  Run created on&nbsp;
+                  {displayLocalTimezone
+                    ? datetimeInLocalTimezone(createdAt, displayLocalTimezone)
+                    : dateFormatLong(createdAt, { includeSeconds: true, utcFormat: true })}
                 </Link>
               </NextLink>
             </FlexContainer>

--- a/mage_ai/frontend/components/PipelineRun/Widget/index.tsx
+++ b/mage_ai/frontend/components/PipelineRun/Widget/index.tsx
@@ -16,10 +16,15 @@ import {
 } from '@interfaces/PipelineType';
 import { ImageStyle } from '@components/Dashboard/index.style';
 import { TAB_URL_PARAM } from '@oracle/components/Tabs';
-import { TIME_PERIOD_DISPLAY_MAPPING, TimePeriodEnum } from '@utils/date';
+import {
+  TIME_PERIOD_DISPLAY_MAPPING,
+  TimePeriodEnum,
+  datetimeInLocalTimezone,
+} from '@utils/date';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { capitalize, lowercase } from '@utils/string';
 import { queryFromUrl } from '@utils/url';
+import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
 
 const MAX_HEIGHT = UNIT * 40;
 const MIN_HEIGHT = UNIT * 40;
@@ -36,6 +41,7 @@ function Widget({
   const router = useRouter();
   const q = queryFromUrl();
   const timePeriod = q?.[TAB_URL_PARAM] || TimePeriodEnum.TODAY;
+  const displayLocalTimezone = shouldDisplayLocalTimezone();
   const isAllRuns = pipelineType === ALL_PIPELINE_RUNS_TYPE;
   const pipelineTypeLabel = isAllRuns
     ? ALL_PIPELINE_RUNS_TYPE
@@ -125,7 +131,7 @@ function Widget({
                 passHref
               >
                 <Link danger monospace sameColorAsText small>
-                  Run created on {createdAt}
+                  Run created on {datetimeInLocalTimezone(createdAt, displayLocalTimezone)}
                 </Link>
               </NextLink>
             </FlexContainer>

--- a/mage_ai/frontend/components/Triggers/Detail/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Detail/index.tsx
@@ -64,7 +64,7 @@ import {
   getFormattedVariables,
 } from '@components/Sidekick/utils';
 import { convertSeconds, getTriggerApiEndpoint } from '../utils';
-import { dateFormatLong } from '@utils/date';
+import { dateFormatLong, datetimeInLocalTimezone } from '@utils/date';
 import { getModelAttributes } from '@utils/models/dbt';
 import { goToWithQuery } from '@utils/routing';
 import { indexBy } from '@utils/array';
@@ -73,6 +73,7 @@ import { isViewer } from '@utils/session';
 import { onSuccess } from '@api/utils/response';
 import { pauseEvent } from '@utils/events';
 import { queryFromUrl, queryString } from '@utils/url';
+import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
 
 type TriggerDetailProps = {
   errors: ErrorsType;
@@ -95,6 +96,7 @@ function TriggerDetail({
 }: TriggerDetailProps) {
   const router = useRouter();
   const isViewerRole = isViewer();
+  const displayLocalTimezone = shouldDisplayLocalTimezone();
 
   const {
     uuid: pipelineUUID,
@@ -371,12 +373,13 @@ function TriggerDetail({
             monospace
           >
             {nextRunDate
-              ?
-                dateFormatLong(
+              ? (displayLocalTimezone
+                ? datetimeInLocalTimezone(nextRunDate, displayLocalTimezone)
+                : dateFormatLong(
                   nextRunDate,
                   { includeSeconds: true, utcFormat: true },
                 )
-              : 'N/A'
+              ): 'N/A'
             }
           </Text>,
         ],
@@ -399,7 +402,10 @@ function TriggerDetail({
           key="trigger_start_date"
           monospace
         >
-          {startTime}
+          {displayLocalTimezone
+            ? datetimeInLocalTimezone(startTime, displayLocalTimezone)
+            : startTime
+          }
         </Text>,
       ]);
     }

--- a/mage_ai/frontend/components/Triggers/Detail/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Detail/index.tsx
@@ -520,6 +520,7 @@ function TriggerDetail({
     );
   }, [
     description,
+    displayLocalTimezone,
     isActive,
     nextRunDate,
     pipelineSchedule,

--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -383,7 +383,7 @@ function Edit({
       data.event_matchers = eventMatchers;
     } else {
       data.schedule_interval = isCustomInterval ? customInterval : schedule.schedule_interval;
-      data.start_time = date && time?.hour && time?.minute
+      data.start_time = (date && time?.hour && time?.minute)
         ? getDatetimeFromDateAndTime(
           date,
           time,

--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -67,17 +67,17 @@ import {
   convertSeconds,
   convertToSeconds,
   getDatetimeFromDateAndTime,
-  getTimeInUTC,
   getTriggerApiEndpoint,
   getTriggerTypes,
 } from '../utils';
+import { getDateAndTimeObjFromDatetimeString } from '@oracle/components/Calendar/utils';
 import { getFormattedVariables, parseVariables } from '@components/Sidekick/utils';
 import { indexBy, pushUnique, range, removeAtIndex } from '@utils/array';
 import { isEmptyObject, selectKeys } from '@utils/hash';
 import { isNumeric, pluralize } from '@utils/string';
 import { onSuccess } from '@api/utils/response';
+import { padTime } from '@utils/date';
 import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
-import { padTime, utcStringToLocalDate } from '@utils/date';
 
 type EditProps = {
   errors: ErrorsType;
@@ -184,22 +184,12 @@ function Edit({
   useEffect(
     () => {
       if (startTime) {
-        if (displayLocalTimezone) {
-          const localStartTimeDate = utcStringToLocalDate(startTime);
-          setDate(localStartTimeDate);
-          setTime({
-            hour: padTime(String(localStartTimeDate.getHours())),
-            minute: padTime(String(localStartTimeDate.getMinutes())),
-          });
-        } else {
-          const dateTimeSplit = startTime.split(' ');
-          const timePart = dateTimeSplit[1];
-          setDate(getTimeInUTC(startTime));
-          setTime({
-            hour: timePart.substring(0, 2),
-            minute: timePart.substring(3, 5),
-          });
-        }
+        const startDatetimeObj = getDateAndTimeObjFromDatetimeString(
+          startTime,
+          { localTimezone: displayLocalTimezone },
+        );
+        setDate(startDatetimeObj?.date);
+        setTime(startDatetimeObj?.time);
 
         const mt = moment(startTime).utc();
         setLandingTimeData({
@@ -699,7 +689,7 @@ function Edit({
       }}
       placeholder="Description"
       value={description}
-    />
+    />,
   ]), [description]);
 
   const detailsMemo = useMemo(() => {

--- a/mage_ai/frontend/components/Triggers/Table.tsx
+++ b/mage_ai/frontend/components/Triggers/Table.tsx
@@ -37,10 +37,11 @@ import { ICON_SIZE_SMALL } from '@oracle/styles/units/icons';
 import { RunStatus } from '@interfaces/BlockRunType';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { TableContainerStyle } from '@components/shared/Table/index.style';
-import { dateFormatLong } from '@utils/date';
+import { dateFormatLong, datetimeInLocalTimezone } from '@utils/date';
 import { isViewer } from '@utils/session';
 import { onSuccess } from '@api/utils/response';
 import { pauseEvent } from '@utils/events';
+import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
 
 const ICON_SIZE = UNIT * 1.5;
 
@@ -81,6 +82,8 @@ function TriggersTable({
   const [deleteConfirmationOpenIdx, setDeleteConfirmationOpenIdx] = useState<number>(null);
   const [confirmDialogueTopOffset, setConfirmDialogueTopOffset] = useState<number>(0);
   const [confirmDialogueLeftOffset, setConfirmDialogueLeftOffset] = useState<number>(0);
+
+  const displayLocalTimezone = shouldDisplayLocalTimezone();
 
   const [updatePipelineSchedule] = useMutation(
     (pipelineSchedule: PipelineScheduleType) =>
@@ -358,12 +361,15 @@ function TriggersTable({
                   small
                 >
                   {nextRunDate
-                    ?
-                      dateFormatLong(
+                    ? (displayLocalTimezone
+                      ? datetimeInLocalTimezone(nextRunDate, displayLocalTimezone)
+                      : dateFormatLong(
                         nextRunDate,
                         { includeSeconds: true, utcFormat: true },
                       )
-                    : <>&#8212;</>
+                    ): (
+                      <>&#8212;</>
+                    )
                   }
                 </Text>,
                 <Text
@@ -476,8 +482,9 @@ function TriggersTable({
                     default
                     key={`created_at_${idx}`}
                     monospace
+                    small
                   >
-                    {createdAt?.slice(0, 19)}
+                    {datetimeInLocalTimezone(createdAt?.slice(0, 19), displayLocalTimezone)}
                   </Text>,
                 );
               }

--- a/mage_ai/frontend/components/settings/workspace/Preferences.tsx
+++ b/mage_ai/frontend/components/settings/workspace/Preferences.tsx
@@ -211,8 +211,9 @@ function Preferences({
                       <Tooltip
                         block
                         description="Display dates in local timezone. Please note that certain pages
-                          (e.g. Logs and Monitor) or components may still be in UTC time. Dates
-                          in local time will have a timezone offset in the timestamp (e.g. -07:00)."
+                          (e.g. Monitor page) or components (e.g. Pipeline run bar charts) may still
+                          be in UTC time. Dates in local time will have a timezone offset in the
+                          timestamp (e.g. -07:00)."
                         lightBackground
                         muted
                         size={ICON_SIZE_MEDIUM}

--- a/mage_ai/frontend/components/settings/workspace/Preferences.tsx
+++ b/mage_ai/frontend/components/settings/workspace/Preferences.tsx
@@ -21,6 +21,7 @@ import { Edit } from '@oracle/icons';
 import { ICON_SIZE_SMALL } from '@oracle/styles/units/icons';
 import { PADDING_UNITS, UNITS_BETWEEN_SECTIONS } from '@oracle/styles/units/spacing';
 import { onSuccess } from '@api/utils/response';
+import { storeLocalTimezoneSetting } from './utils';
 import { useError } from '@context/Error';
 
 type PreferencesProps = {
@@ -67,6 +68,7 @@ function Preferences({
             fetchProjects();
             setProjectAttributes(p);
             setEditingOpenAIKey(false);
+            storeLocalTimezoneSetting(p?.features?.[FeatureUUIDEnum.LOCAL_TIMEZONE]);
 
             if (onSaveSuccess) {
               onSaveSuccess?.(p);

--- a/mage_ai/frontend/components/settings/workspace/Preferences.tsx
+++ b/mage_ai/frontend/components/settings/workspace/Preferences.tsx
@@ -15,10 +15,11 @@ import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
 import TextInput from '@oracle/elements/Inputs/TextInput';
 import ToggleSwitch from '@oracle/elements/Inputs/ToggleSwitch';
+import Tooltip from '@oracle/components/Tooltip';
 import api from '@api';
 import { ContainerStyle } from './index.style';
 import { Edit } from '@oracle/icons';
-import { ICON_SIZE_SMALL } from '@oracle/styles/units/icons';
+import { ICON_SIZE_MEDIUM, ICON_SIZE_SMALL } from '@oracle/styles/units/icons';
 import { PADDING_UNITS, UNITS_BETWEEN_SECTIONS } from '@oracle/styles/units/spacing';
 import { onSuccess } from '@api/utils/response';
 import { storeLocalTimezoneSetting } from './utils';
@@ -184,7 +185,7 @@ function Preferences({
 
       <Spacing mt={UNITS_BETWEEN_SECTIONS} />
 
-      <Panel noPadding>
+      <Panel noPadding overflowVisible>
         <Spacing p={PADDING_UNITS}>
           <Spacing mb={1}>
             <Headline level={5}>
@@ -201,9 +202,24 @@ function Preferences({
                 alignItems="center"
                 justifyContent="space-between"
               >
-                <Text default monospace>
-                  {k}
-                </Text>
+                <Flex>
+                  <Text default monospace>
+                    {k}
+                  </Text>
+                  {k === FeatureUUIDEnum.LOCAL_TIMEZONE &&
+                    <Spacing ml={1}>
+                      <Tooltip
+                        block
+                        description="Display dates in local timezone. Please note that certain pages
+                          (e.g. Logs and Monitor) or components may still be in UTC time. Dates
+                          in local time will have a timezone offset in the timestamp (e.g. -07:00)."
+                        lightBackground
+                        muted
+                        size={ICON_SIZE_MEDIUM}
+                      />
+                    </Spacing>
+                  }
+                </Flex>
 
                 <Spacing mr={PADDING_UNITS} />
 

--- a/mage_ai/frontend/components/settings/workspace/Preferences.tsx
+++ b/mage_ai/frontend/components/settings/workspace/Preferences.tsx
@@ -190,29 +190,33 @@ function Preferences({
             </Headline>
           </Spacing>
 
-          {Object.entries(projectAttributes?.features || {}).map(([k, v]) => (
-            <FlexContainer
-              alignItems="center"
-              justifyContent="space-between"
+          {Object.entries(projectAttributes?.features || {}).map(([k, v], idx) => (
+            <Spacing
               key={k}
+              mt={idx === 0 ? 0 : '4px'}
             >
-              <Text default monospace>
-                {k}
-              </Text>
+              <FlexContainer
+                alignItems="center"
+                justifyContent="space-between"
+              >
+                <Text default monospace>
+                  {k}
+                </Text>
 
-              <Spacing mr={PADDING_UNITS} />
+                <Spacing mr={PADDING_UNITS} />
 
-              <ToggleSwitch
-                checked={!!v}
-                onCheck={() => setProjectAttributes(prev => ({
-                  ...prev,
-                  features: {
-                    ...projectAttributes?.features,
-                    [k]: !v,
-                  },
-                }))}
-              />
-            </FlexContainer>
+                <ToggleSwitch
+                  checked={!!v}
+                  onCheck={() => setProjectAttributes(prev => ({
+                    ...prev,
+                    features: {
+                      ...projectAttributes?.features,
+                      [k]: !v,
+                    },
+                  }))}
+                />
+              </FlexContainer>
+            </Spacing>
           ))}
         </Spacing>
       </Panel>

--- a/mage_ai/frontend/components/settings/workspace/utils.ts
+++ b/mage_ai/frontend/components/settings/workspace/utils.ts
@@ -1,27 +1,13 @@
-import api from '@api';
-import { FeatureUUIDEnum } from '@interfaces/ProjectType';
 import { LOCAL_STORAGE_KEY_DISPLAY_LOCAL_TIMEZONE } from '@storage/constants';
 import { get, set } from '@storage/localStorage';
 
-export function shouldDisplayLocalTimezone(checkServer?: boolean): null | boolean {
+export function shouldDisplayLocalTimezone(): boolean {
   const displayLocalTimezone = get(LOCAL_STORAGE_KEY_DISPLAY_LOCAL_TIMEZONE, null);
 
-  if (checkServer && displayLocalTimezone === null) {
-    const { data: dataProject } = api.projects.list();
-    const project = dataProject?.projects?.[0];
-    const displayLocalTimezoneFromServer = project?.features?.[FeatureUUIDEnum.LOCAL_TIMEZONE];
-
-    if (typeof displayLocalTimezoneFromServer === 'boolean') {
-      set(LOCAL_STORAGE_KEY_DISPLAY_LOCAL_TIMEZONE, displayLocalTimezoneFromServer);
-    }
-
-    return displayLocalTimezoneFromServer;
-  }
-
-  return displayLocalTimezone;
+  return displayLocalTimezone || false;
 }
 
-export function storeLocalTimezoneSetting(displayLocalTimezone: boolean) {
+export function storeLocalTimezoneSetting(displayLocalTimezone: boolean): boolean {
   if (typeof displayLocalTimezone !== 'undefined') {
     set(LOCAL_STORAGE_KEY_DISPLAY_LOCAL_TIMEZONE, displayLocalTimezone);
   }

--- a/mage_ai/frontend/components/settings/workspace/utils.ts
+++ b/mage_ai/frontend/components/settings/workspace/utils.ts
@@ -1,0 +1,30 @@
+import api from '@api';
+import { FeatureUUIDEnum } from '@interfaces/ProjectType';
+import { LOCAL_STORAGE_KEY_DISPLAY_LOCAL_TIMEZONE } from '@storage/constants';
+import { get, set } from '@storage/localStorage';
+
+export function shouldDisplayLocalTimezone(checkServer?: boolean): null | boolean {
+  const displayLocalTimezone = get(LOCAL_STORAGE_KEY_DISPLAY_LOCAL_TIMEZONE, null);
+
+  if (checkServer && displayLocalTimezone === null) {
+    const { data: dataProject } = api.projects.list();
+    const project = dataProject?.projects?.[0];
+    const displayLocalTimezoneFromServer = project?.features?.[FeatureUUIDEnum.LOCAL_TIMEZONE];
+
+    if (typeof displayLocalTimezoneFromServer === 'boolean') {
+      set(LOCAL_STORAGE_KEY_DISPLAY_LOCAL_TIMEZONE, displayLocalTimezoneFromServer);
+    }
+
+    return displayLocalTimezoneFromServer;
+  }
+
+  return displayLocalTimezone;
+}
+
+export function storeLocalTimezoneSetting(displayLocalTimezone: boolean) {
+  if (typeof displayLocalTimezone !== 'undefined') {
+    set(LOCAL_STORAGE_KEY_DISPLAY_LOCAL_TIMEZONE, displayLocalTimezone);
+  }
+
+  return displayLocalTimezone;
+}

--- a/mage_ai/frontend/interfaces/ProjectType.ts
+++ b/mage_ai/frontend/interfaces/ProjectType.ts
@@ -1,5 +1,6 @@
 export enum FeatureUUIDEnum {
   ADD_NEW_BLOCK_V2 = 'add_new_block_v2',
+  LOCAL_TIMEZONE = 'display_local_timezone',
 }
 
 export enum ProjectTypeEnum {

--- a/mage_ai/frontend/oracle/components/Calendar/index.tsx
+++ b/mage_ai/frontend/oracle/components/Calendar/index.tsx
@@ -14,6 +14,7 @@ export type TimeType = {
 };
 
 type CalendarProps = {
+  localTime?: boolean;
   selectedDate: Date;
   selectedTime: TimeType;
   setSelectedDate: (date: Date) => void;
@@ -22,6 +23,7 @@ type CalendarProps = {
 };
 
 function Calendar({
+  localTime,
   selectedDate,
   selectedTime,
   setSelectedDate,
@@ -40,7 +42,7 @@ function Calendar({
       <Spacing mb={2} />
       <FlexContainer alignItems="center">
         <Text default large>
-          Time (UTC):
+          Time ({localTime ? 'Local' : 'UTC'}):
         </Text>
         <Spacing pr={2} />
         <Select

--- a/mage_ai/frontend/oracle/components/Calendar/utils.ts
+++ b/mage_ai/frontend/oracle/components/Calendar/utils.ts
@@ -1,0 +1,36 @@
+import { TimeType } from './index';
+import { getTimeInUTC } from '@components/Triggers/utils';
+import { padTime, utcStringToLocalDate } from '@utils/date';
+
+export function getDateAndTimeObjFromDatetimeString(
+  datetime: string,
+  opts?: { localTimezone: boolean },
+): {
+  date: Date;
+  time: TimeType;
+} {
+  let dateObj;
+  let timeObj;
+
+  if (opts?.localTimezone) {
+    dateObj = utcStringToLocalDate(datetime);
+    timeObj = {
+      hour: padTime(String(dateObj.getHours())),
+      minute: padTime(String(dateObj.getMinutes())),
+    };
+  } else {
+    // UTC string with "YYYY-MM-DD HH:MM:SS" format
+    const dateTimeSplit = datetime.split(' ');
+    const timePart = dateTimeSplit[1];
+    dateObj = getTimeInUTC(datetime);
+    timeObj = {
+      hour: timePart.substring(0, 2),
+      minute: timePart.substring(3, 5),
+    };
+  }
+
+  return {
+    date: dateObj,
+    time: timeObj,
+  };
+}

--- a/mage_ai/frontend/pages/overview/index.tsx
+++ b/mage_ai/frontend/pages/overview/index.tsx
@@ -20,7 +20,7 @@ import Panel from '@oracle/components/Panel';
 import PipelineRunType from '@interfaces/PipelineRunType';
 import Preferences from '@components/settings/workspace/Preferences';
 import PrivateRoute from '@components/shared/PrivateRoute';
-import ProjectType from '@interfaces/ProjectType';
+import ProjectType, { FeatureUUIDEnum } from '@interfaces/ProjectType';
 import Spacing from '@oracle/elements/Spacing';
 import Spinner from '@oracle/components/Spinner';
 import Text from '@oracle/elements/Text';
@@ -80,6 +80,7 @@ import { goToWithQuery } from '@utils/routing';
 import { groupBy } from '@utils/array';
 import { onSuccess } from '@api/utils/response';
 import { queryFromUrl } from '@utils/url';
+import { storeLocalTimezoneSetting } from '@components/settings/workspace/utils';
 import { useModal } from '@context/Modal';
 
 const SHARED_WIDGET_SPACING_PROPS = {
@@ -223,6 +224,10 @@ function OverviewPage() {
 
   const { data: dataProjects, mutate: fetchProjects } = api.projects.list();
   const project: ProjectType = useMemo(() => dataProjects?.projects?.[0], [dataProjects]);
+  const _ = useMemo(
+    () => storeLocalTimezoneSetting(project?.features?.[FeatureUUIDEnum.LOCAL_TIMEZONE]),
+    [project?.features],
+  );
 
   const [showBrowseTemplates, hideBrowseTemplates] = useModal(() => (
     <ErrorProvider>

--- a/mage_ai/frontend/pages/pipeline-runs/index.tsx
+++ b/mage_ai/frontend/pages/pipeline-runs/index.tsx
@@ -7,6 +7,7 @@ import FlexContainer from '@oracle/components/FlexContainer';
 import Paginate, { MAX_PAGES, ROW_LIMIT } from '@components/shared/Paginate';
 import PipelineRunsTable from '@components/PipelineDetail/Runs/Table';
 import PrivateRoute from '@components/shared/PrivateRoute';
+import ProjectType, { FeatureUUIDEnum } from '@interfaces/ProjectType';
 import Select from '@oracle/elements/Inputs/Select';
 import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
@@ -19,12 +20,20 @@ import {
 import { UNIT } from '@oracle/styles/units/spacing';
 import { goToWithQuery } from '@utils/routing';
 import { queryFromUrl, queryString } from '@utils/url';
+import { storeLocalTimezoneSetting } from '@components/settings/workspace/utils';
 
 function RunListPage() {
   const router = useRouter();
   const [errors, setErrors] = useState<ErrorsType>(null);
   const q = queryFromUrl();
   const page = q?.page ? q.page : 0;
+
+  const { data: dataProjects } = api.projects.list();
+  const project: ProjectType = useMemo(() => dataProjects?.projects?.[0], [dataProjects]);
+  const _ = useMemo(
+    () => storeLocalTimezoneSetting(project?.features?.[FeatureUUIDEnum.LOCAL_TIMEZONE]),
+    [project?.features],
+  );
 
   const pipelineRunsRequestQuery: PipelineRunReqQueryParamsType = {
     _limit: ROW_LIMIT,

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/backfills/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/backfills/index.tsx
@@ -86,7 +86,7 @@ function PipelineBackfills({
   // ]);
 
   const breadcrumbs = useMemo(() => {
-    let asLink = `/pipelines/${pipelineUUID}/backfills`;
+    const asLink = `/pipelines/${pipelineUUID}/backfills`;
 
     const arr = [
       {
@@ -107,6 +107,7 @@ function PipelineBackfills({
 
     return arr;
   }, [
+    pipelineUUID,
     selectedRow,
   ]);
 

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/backfills/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/backfills/index.tsx
@@ -36,7 +36,6 @@ function PipelineBackfills({
   const pipelineUUID = pipeline.uuid;
   const {
     data: dataPipelineRuns,
-    mutate: fetchPipelineRuns,
   } = api.backfills.list({
     _limit: 20,
     _offset: 0,

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -57,7 +57,7 @@ import PipelineType, {
 import PopupMenu from '@oracle/components/PopupMenu';
 import Preferences from '@components/settings/workspace/Preferences';
 import PrivateRoute from '@components/shared/PrivateRoute';
-import ProjectType from '@interfaces/ProjectType';
+import ProjectType, { FeatureUUIDEnum } from '@interfaces/ProjectType';
 import Sidekick from '@components/Sidekick';
 import SidekickHeader from '@components/Sidekick/Header';
 import Spacing from '@oracle/elements/Spacing';
@@ -74,7 +74,6 @@ import { Close } from '@oracle/icons';
 import { ErrorProvider } from '@context/Error';
 import { INTERNAL_OUTPUT_REGEX } from '@utils/models/output';
 import {
-  // LOCAL_STORAGE_KEY_AUTOMATICALLY_NAME_BLOCKS,
   LOCAL_STORAGE_KEY_PIPELINE_EDIT_BEFORE_TAB_SELECTED,
   LOCAL_STORAGE_KEY_PIPELINE_EDIT_BLOCK_OUTPUT_LOGS,
   LOCAL_STORAGE_KEY_PIPELINE_EDIT_HIDDEN_BLOCKS,
@@ -115,6 +114,7 @@ import { goToWithQuery } from '@utils/routing';
 import { ignoreKeys, isEmptyObject } from '@utils/hash';
 import { isJsonString } from '@utils/string';
 import { queryFromUrl } from '@utils/url';
+import { storeLocalTimezoneSetting } from '@components/settings/workspace/utils';
 import { useModal } from '@context/Modal';
 import { useWindowSize } from '@utils/sizes';
 import { utcNowDate } from '@utils/date';
@@ -157,6 +157,10 @@ function PipelineDetailPage({
 
   const { data: dataProject, mutate: fetchProjects } = api.projects.list();
   const project: ProjectType = useMemo(() => dataProject?.projects?.[0], [dataProject]);
+  const _ = useMemo(
+    () => storeLocalTimezoneSetting(project?.features?.[FeatureUUIDEnum.LOCAL_TIMEZONE]),
+    [project?.features],
+  );
 
   const localStorageTabSelectedKey =
     `${LOCAL_STORAGE_KEY_PIPELINE_EDIT_BEFORE_TAB_SELECTED}_${pipelineUUID}`;

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -3,11 +3,8 @@ import { useMemo, useState } from 'react';
 import { useMutation } from 'react-query';
 import { useRouter } from 'next/router';
 
-import Button from '@oracle/elements/Button';
 import DependencyGraph, { DependencyGraphProps } from '@components/DependencyGraph';
 import Divider from '@oracle/elements/Divider';
-import FlexContainer from '@oracle/components/FlexContainer';
-import Headline from '@oracle/elements/Headline';
 import Link from '@oracle/elements/Link';
 import Paginate, { ROW_LIMIT } from '@components/shared/Paginate';
 import PipelineDetailPage from '@components/PipelineDetailPage';
@@ -20,6 +17,7 @@ import PipelineScheduleType, {
 } from '@interfaces/PipelineScheduleType';
 import PipelineTriggerType from '@interfaces/PipelineTriggerType';
 import PrivateRoute from '@components/shared/PrivateRoute';
+import ProjectType, { FeatureUUIDEnum } from '@interfaces/ProjectType';
 import RunPipelinePopup from '@components/Triggers/RunPipelinePopup';
 import RuntimeVariables from '@components/RuntimeVariables';
 import Spacing from '@oracle/elements/Spacing';
@@ -27,13 +25,11 @@ import Spinner from '@oracle/components/Spinner';
 import TagType from '@interfaces/TagType';
 import Text from '@oracle/elements/Text';
 import Toolbar from '@components/shared/Table/Toolbar';
-import Tooltip from '@oracle/components/Tooltip';
 import TriggersTable from '@components/Triggers/Table';
 import api from '@api';
 import { GLOBAL_VARIABLES_UUID } from '@interfaces/PipelineVariableType';
-import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
+import { PADDING_UNITS } from '@oracle/styles/units/spacing';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
-import { PlayButton } from '@oracle/icons';
 import { dateFormatLong } from '@utils/date';
 import { filterQuery, queryFromUrl, queryString } from '@utils/url';
 import { getFormattedVariables } from '@components/Sidekick/utils';
@@ -43,6 +39,7 @@ import { isEmptyObject } from '@utils/hash';
 import { isViewer } from '@utils/session';
 import { onSuccess } from '@api/utils/response';
 import { randomNameGenerator } from '@utils/string';
+import { storeLocalTimezoneSetting } from '@components/settings/workspace/utils';
 import { useModal } from '@context/Modal';
 
 type PipelineSchedulesProp = {
@@ -58,6 +55,13 @@ function PipelineSchedules({
   const isViewerRole = isViewer();
   const pipelineUUID = pipeline.uuid;
   const [errors, setErrors] = useState(null);
+
+  const { data: dataProjects } = api.projects.list();
+  const project: ProjectType = useMemo(() => dataProjects?.projects?.[0], [dataProjects]);
+  const _ = useMemo(
+    () => storeLocalTimezoneSetting(project?.features?.[FeatureUUIDEnum.LOCAL_TIMEZONE]),
+    [project?.features],
+  );
 
   const {
     data: dataGlobalVariables,

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -24,7 +24,7 @@ import PipelineType, {
 } from '@interfaces/PipelineType';
 import Preferences from '@components/settings/workspace/Preferences';
 import PrivateRoute from '@components/shared/PrivateRoute';
-import ProjectType from '@interfaces/ProjectType';
+import ProjectType, { FeatureUUIDEnum } from '@interfaces/ProjectType';
 import Spacing from '@oracle/elements/Spacing';
 import Spinner from '@oracle/components/Spinner';
 import Table, { SortedColumnType } from '@components/shared/Table';
@@ -56,6 +56,7 @@ import { ScheduleStatusEnum } from '@interfaces/PipelineScheduleType';
 import { SortDirectionEnum, SortQueryEnum } from '@components/shared/Table/constants';
 import { TableContainerStyle } from '@components/shared/Table/index.style';
 import { capitalize, capitalizeRemoveUnderscoreLower, randomNameGenerator } from '@utils/string';
+import { datetimeInLocalTimezone } from '@utils/date';
 import { displayErrorFromReadResponse, onSuccess } from '@api/utils/response';
 import { filterQuery, queryFromUrl } from '@utils/url';
 import { get, set } from '@storage/localStorage';
@@ -64,6 +65,7 @@ import { goToWithQuery } from '@utils/routing';
 import { indexBy, sortByKey } from '@utils/array';
 import { isEmptyObject } from '@utils/hash';
 import { pauseEvent } from '@utils/events';
+import { storeLocalTimezoneSetting } from '@components/settings/workspace/utils';
 import { useError } from '@context/Error';
 import { useModal } from '@context/Modal';
 
@@ -132,6 +134,10 @@ function PipelineListPage() {
 
   const { data: dataProjects, mutate: fetchProjects } = api.projects.list();
   const project: ProjectType = useMemo(() => dataProjects?.projects?.[0], [dataProjects]);
+  const displayLocalTimezone = useMemo(
+    () => storeLocalTimezoneSetting(project?.features?.[FeatureUUIDEnum.LOCAL_TIMEZONE]),
+    [project?.features],
+  );
 
   const sortColumnIndexQuery = q?.[SortQueryEnum.SORT_COL_IDX];
   const sortDirectionQuery = q?.[SortQueryEnum.SORT_DIRECTION];
@@ -1174,7 +1180,9 @@ function PipelineListPage() {
                     small
                     title={updatedAt}
                   >
-                    {updatedAt ? updatedAt.slice(0, -3) : <>&#8212;</>}
+                    {updatedAt
+                      ? datetimeInLocalTimezone(updatedAt, displayLocalTimezone)
+                      : <>&#8212;</>}
                   </Text>,
                   <Text
                     key={`pipeline_created_at_${idx}`}
@@ -1182,7 +1190,9 @@ function PipelineListPage() {
                     small
                     title={createdAt}
                   >
-                    {createdAt ? createdAt.slice(0, 16) : <>&#8212;</>}
+                    {createdAt
+                      ? datetimeInLocalTimezone(createdAt.slice(0, 19), displayLocalTimezone)
+                      : <>&#8212;</>}
                   </Text>,
                   tagsEl,
                   <Text

--- a/mage_ai/frontend/pages/triggers/index.tsx
+++ b/mage_ai/frontend/pages/triggers/index.tsx
@@ -5,6 +5,7 @@ import Dashboard from '@components/Dashboard';
 import FlexContainer from '@oracle/components/FlexContainer';
 import Paginate, { ROW_LIMIT } from '@components/shared/Paginate';
 import PrivateRoute from '@components/shared/PrivateRoute';
+import ProjectType, { FeatureUUIDEnum } from '@interfaces/ProjectType';
 import Select from '@oracle/elements/Inputs/Select';
 import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
@@ -18,12 +19,20 @@ import {
 import { UNIT } from '@oracle/styles/units/spacing';
 import { goToWithQuery } from '@utils/routing';
 import { queryFromUrl, queryString } from '@utils/url';
+import { storeLocalTimezoneSetting } from '@components/settings/workspace/utils';
 
 function TriggerListPage() {
   const router = useRouter();
   const q = queryFromUrl();
   const page = q?.page ? q.page : 0;
   const orderByQuery = q?.order_by || SortQueryParamEnum.CREATED_AT;
+
+  const { data: dataProjects } = api.projects.list();
+  const project: ProjectType = useMemo(() => dataProjects?.projects?.[0], [dataProjects]);
+  const _ = useMemo(
+    () => storeLocalTimezoneSetting(project?.features?.[FeatureUUIDEnum.LOCAL_TIMEZONE]),
+    [project?.features],
+  );
 
   const pipelineSchedulesRequestQuery: PipelineScheduleReqQueryParamsType = {
     _limit: ROW_LIMIT,

--- a/mage_ai/frontend/storage/constants.ts
+++ b/mage_ai/frontend/storage/constants.ts
@@ -12,3 +12,5 @@ export const LOCAL_STORAGE_KEY_PIPELINE_EDIT_BLOCK_OUTPUT_LOGS =
 export const LOCAL_STORAGE_KEY_SETUP_AI_LATER = 'setup_ai_later';
 
 export const LOCAL_STORAGE_KEY_AUTO_SCROLL_LOGS = 'auto_scroll_logs';
+
+export const LOCAL_STORAGE_KEY_DISPLAY_LOCAL_TIMEZONE = 'display_local_timezone';

--- a/mage_ai/frontend/utils/date.ts
+++ b/mage_ai/frontend/utils/date.ts
@@ -20,6 +20,7 @@ export const TIME_PERIOD_INTERVAL_MAPPING = {
 
 export const DATE_FORMAT_LONG = 'YYYY-MM-DD HH:mm:ss';
 export const DATE_FORMAT_LONG_NO_SEC = 'YYYY-MM-DD HH:mm';
+export const DATE_FORMAT_LONG_NO_SEC_WITH_OFFSET = 'YYYY-MM-DD HH:mmZ';
 export const DATE_FORMAT_SHORT = 'YYYY-MM-DD';
 export const DATE_FORMAT_FULL = 'MMMM D, YYYY';
 
@@ -63,7 +64,7 @@ export function dateFormatLong(
 export function datetimeInLocalTimezone(
   datetime: string,
   enableLocalTimezoneConversion?: boolean,
-) {
+): string {
   if (enableLocalTimezoneConversion) {
     return moment
       .utc(datetime)
@@ -72,6 +73,15 @@ export function datetimeInLocalTimezone(
   }
 
   return datetime;
+}
+
+export function utcStringToLocalDate(
+  datetime: string,
+): Date {
+  return moment
+    .utc(datetime)
+    .local()
+    .toDate();
 }
 
 export function utcNowDate(opts?: { dateObj?: boolean }): any {

--- a/mage_ai/frontend/utils/date.ts
+++ b/mage_ai/frontend/utils/date.ts
@@ -60,6 +60,20 @@ export function dateFormatLong(
   return momentObj.format(dateFormat);
 }
 
+export function datetimeInLocalTimezone(
+  datetime: string,
+  enableLocalTimezoneConversion?: boolean,
+) {
+  if (enableLocalTimezoneConversion) {
+    return moment
+      .utc(datetime)
+      .local()
+      .format();
+  }
+
+  return datetime;
+}
+
 export function utcNowDate(opts?: { dateObj?: boolean }): any {
   const utcDate: string = dateFormatLong(
     new Date().toISOString(),

--- a/mage_ai/frontend/utils/models/log.ts
+++ b/mage_ai/frontend/utils/models/log.ts
@@ -52,6 +52,17 @@ export function initializeLogs(log: LogType) {
   }));
 }
 
-export function formatTimestamp(timestamp: number) {
-  return timestamp && moment.unix(timestamp).utc().format('YYYY-MM-DD HH:mm:ss.SSS');
+export function formatTimestamp(
+  timestamp: number,
+  opts?: {
+    localTimezone?: boolean;
+  },
+): string {
+  if (!timestamp) {
+    return '';
+  }
+
+  return opts?.localTimezone
+    ? moment.unix(timestamp).local().format()
+    : moment.unix(timestamp).utc().format('YYYY-MM-DD HH:mm:ss.SSS');
 }


### PR DESCRIPTION
# Description
- Add project setting for displaying datetimes in local timezone. The timezone conversions are all done on the frontend. Dates are still stored in config files and the metadata db in UTC time.
- Certain pages (namely a pipeline's "Monitor" page) and components (e.g. the pipeline run completed vertical bar chart on the "Overview" page) are still in UTC time since those dates are parsed from the UTC datetimes on the backend. Will require a separate PR to convert these dates in the graphs to the local timezone.

# How Has This Been Tested?
![image](https://github.com/mage-ai/mage-ai/assets/78053898/cac5d894-3867-4a49-a04f-84f97762dd90)

The dates are in local time (they have a timezone offset):
![pages with dates in local time](https://github.com/mage-ai/mage-ai/assets/78053898/1e9e08d3-e982-4d7f-b6bf-e926af2fe171)



# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
