### PR TITLE
[dy] Add git sync on executor start env var

### DIFF
--- a/mage_ai/data_preparation/preferences.py
+++ b/mage_ai/data_preparation/preferences.py
@@ -18,6 +18,7 @@ GIT_AUTH_TYPE_VAR = 'GIT_AUTH_TYPE'
 GIT_BRANCH_VAR = 'GIT_BRANCH'
 GIT_SYNC_ON_PIPELINE_RUN_VAR = 'GIT_SYNC_ON_PIPELINE_RUN'
 GIT_SYNC_ON_START_VAR = 'GIT_SYNC_ON_START'
+GIT_SYNC_ON_EXECUTOR_START_VAR = 'GIT_SYNC_ON_EXECUTOR_START'
 
 
 class Preferences:
@@ -56,6 +57,7 @@ class Preferences:
                 branch=os.getenv(GIT_BRANCH_VAR),
                 sync_on_pipeline_run=bool(int(os.getenv(GIT_SYNC_ON_PIPELINE_RUN_VAR) or 0)),
                 sync_on_start=bool(int(os.getenv(GIT_SYNC_ON_START_VAR) or 0)),
+                sync_on_executor_start=bool(int(os.getenv(GIT_SYNC_ON_EXECUTOR_START_VAR) or 0)),
             )
         project_sync_config = project_preferences.get('sync_config', dict())
         if user:

--- a/mage_ai/data_preparation/sync/__init__.py
+++ b/mage_ai/data_preparation/sync/__init__.py
@@ -23,6 +23,7 @@ class GitConfig(BaseConfig):
     branch: str = 'main'
     sync_on_pipeline_run: bool = False
     sync_on_start: bool = False
+    sync_on_executor_start: bool = False
     auth_type: AuthType = None
     # User settings moved to UserGitConfig, these will be used for Git syncs
     username: str = ''


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Add `GIT_SYNC_ON_EXECUTOR_START` environment variable. This will tell mage to run a git sync on the `mage run` command before executing the block or pipeline.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally on k8s pod


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
