### PR TITLE
[jk] Only show Execute pipeline action for streaming pipelines

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/index.tsx
@@ -150,7 +150,7 @@ function FileHeaderMenu({
         onClick: () => cancelPipeline(),
         uuid: 'Cancel pipeline',
       });
-    } else {
+    } else if (pipeline?.type === PipelineTypeEnum.STREAMING) {
       items.push({
         label: () => 'Execute pipeline',
         onClick: () => executePipeline(),
@@ -164,6 +164,7 @@ function FileHeaderMenu({
     executePipeline,
     interruptKernel,
     isPipelineExecuting,
+    pipeline?.type,
     restartKernel,
     setMessages,
   ]);


### PR DESCRIPTION
# Description
- Hide the `Execute pipeline` action item from the "Run" menu dropdown on the Pipeline Editor page for non-streaming pipelines.
- Context: We used to show the "Pipeline execution" section (see screenshot below for what it looks like) in the Sidekick of the Pipeline Editor for all pipeline types (integration, standard, and streaming) and allow users to execute the pipeline directly from the Pipeline Editor, but this caused inconsistencies and issues from executing the pipeline there and running a pipeline by creating a trigger (e.g. clicking the `Run @once` button on the Triggers list page). As a result, we started only showing the Pipeline execution for streaming pipelines since it is still needed for streaming pipelines specifically.
![image](https://github.com/mage-ai/mage-ai/assets/78053898/2a283234-99d8-4eb5-b4c0-fa1f5b2f5bd5)
- In this PR, we are removing the `Execute pipeline` action from the Run menu dropdown in the non-streaming (standard and integration) pipelines for consistency. Instead of "executing the pipeline", users can execute a block with all upstream blocks in the Pipeline Editor if they want to test out their pipeline directly from the Pipeline Editor.
![image](https://github.com/mage-ai/mage-ai/assets/78053898/44b5bb34-2444-45a0-ac2c-0cba4e5d94d9)

# How Has This Been Tested?
Confirmed `Execute pipeline` menu item no longer appears in integration and standard pipelines:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/65f79921-988f-4e29-a358-a96af7a91be1)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
