### PR TITLE
[dy] Fix how table name is parsed for sql blocks

### DIFF
--- a/mage_ai/data_preparation/models/block/sql/utils/shared.py
+++ b/mage_ai/data_preparation/models/block/sql/utils/shared.py
@@ -249,7 +249,9 @@ def table_name_parts(
                 table_name: database.schema.table
         ```
     2. Use the upstream block's table name
-    3. Use the `data_provider_schema` from the upstream block's configuration if it exists
+    3. Use the `data_provider_schema` from the upstream block's configuration if it exists and
+       the current block's `data_provider` and `data_provider_profile` are the same as the upstream
+       block's `data_provider` and `data_provider_profile`.
     4. Use the `data_provider_schema` from the current block's configuration
 
     Args:

--- a/mage_ai/data_preparation/models/block/sql/utils/shared.py
+++ b/mage_ai/data_preparation/models/block/sql/utils/shared.py
@@ -274,21 +274,29 @@ def table_name_parts(
 
     if full_table_name:
         parts = full_table_name.split('.')
-        if len(parts) == 3:
-            database, schema, table = parts
-        elif len(parts) == 2:
-            schema, table = parts
-        elif len(parts) == 1:
-            table = parts[0]
+    else:
+        parts = upstream_block.table_name.split('.')
 
-    if not table:
-        table = upstream_block.table_name
+    if len(parts) == 3:
+        database, schema, table = parts
+    elif len(parts) == 2:
+        if no_schema:
+            database, table = parts
+        else:
+            schema, table = parts
+    elif len(parts) == 1:
+        table = parts[0]
 
     if not schema and not no_schema:
         upstream_configuration = upstream_block.configuration
-        if upstream_configuration and \
-            configuration.get('data_provider') == upstream_configuration.get('data_provider') and \
-                upstream_configuration.get('data_provider_schema'):
+        if (
+            upstream_configuration
+            and configuration.get('data_provider')
+            == upstream_configuration.get('data_provider')
+            and configuration.get('data_provider_profile')
+            == upstream_configuration.get('data_provider_profile')
+            and upstream_configuration.get('data_provider_schema')
+        ):
             schema = upstream_block.configuration.get('data_provider_schema')
         else:
             schema = configuration.get('data_provider_schema')


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

This PR fixes 2 issues related to schema/table name parsing when creating the upstream block table.

The first issue is that when the `data_provider` was the same for the current block and the upstream block, the schema name was being taken from the upstream block even if the `data_provider_profile` was different. 

The second issue is that the table_name from the upstream block can potentially be `database_name.table_name`, and the `table_name_parts` function was not accounting for that and just using the entire string as the table name.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with postgres and mysql blocks


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
