### PR TITLE
[jk] Run dbt command in yaml dbt blocks

### DIFF
--- a/mage_ai/data_preparation/models/block/dbt/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/__init__.py
@@ -292,7 +292,7 @@ class DBTBlock(Block):
 
             snapshot = dbt_command == 'snapshot'
 
-            if is_sql and from_notebook:
+            if from_notebook:
                 subprocess.run(
                     cmds,
                     preexec_fn=os.setsid,  # os.setsid doesn't work on Windows
@@ -300,7 +300,7 @@ class DBTBlock(Block):
                     stderr=subprocess.STDOUT,
                 )
 
-                if not snapshot:
+                if is_sql and not snapshot:
                     df = query_from_compiled_sql(
                         self,
                         dbt_profile_target,

--- a/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
@@ -4,6 +4,7 @@ import { useMutation } from 'react-query';
 
 import AddChartMenu from './AddChartMenu';
 import BlockType, {
+  BlockLanguageEnum,
   BlockTypeEnum,
 } from '@interfaces/BlockType';
 import Button from '@oracle/elements/Button';
@@ -138,6 +139,7 @@ function CommandButtons({
   const {
     all_upstream_blocks_executed: upstreamBlocksExecuted = true,
     color: blockColor,
+    language,
     metadata,
     type,
     uuid,
@@ -415,7 +417,13 @@ function CommandButtons({
               }}
               small
             >
-              {metadata?.dbt?.block?.snapshot ? 'Run snapshot' : 'Compile & preview'}
+              {metadata?.dbt?.block?.snapshot
+                ? 'Run snapshot'
+                : (language === BlockLanguageEnum.YAML
+                  ? 'Run command'
+                  : 'Compile & preview'
+                )
+              }
             </Button>
           )}
           <ClickOutside


### PR DESCRIPTION
# Description
- Clicking the `Compile & preview` button wouldn't do anything in the YAML dbt blocks on the Pipeline Editor page (which could confuse users expecting something to happen), so this PR updates the button label and runs the dbt command entered in the block.
- **Note:** This update may be obsolete or require additional testing once this [PR (Streamline DBT block)](https://github.com/mage-ai/mage-ai/pull/3497) is merged.

# How Has This Been Tested?
![run yaml dbt block](https://github.com/mage-ai/mage-ai/assets/78053898/0b48fbcf-caf1-41bb-824f-ba74e94ad6aa)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
