### PR TITLE
[jk] Use local time on Block runs page

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
@@ -22,11 +22,13 @@ import { ResponseTypeEnum } from '@api/constants';
 import { Save, Logs } from '@oracle/icons';
 import { SortDirectionEnum, SortQueryEnum } from '@components/shared/Table/constants';
 import { UNIT } from '@oracle/styles/units/spacing';
+import { dateFormatLong, datetimeInLocalTimezone } from '@utils/date';
 import { getColorsForBlockType } from '@components/CodeBlock/index.style';
 import { indexBy } from '@utils/array';
 import { onSuccess } from '@api/utils/response';
 import { openSaveFileDialog } from '@components/PipelineDetail/utils';
 import { queryFromUrl } from '@utils/url';
+import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
 
 export const DEFAULT_SORTABLE_BR_COL_INDEXES = [0, 1, 4];
 export const COL_IDX_TO_BLOCK_RUN_ATTR_MAPPING = {
@@ -52,6 +54,7 @@ function BlockRunsTable({
   setErrors,
   sortableColumnIndexes,
 }: BlockRunsTableProps) {
+  const displayLocalTimezone = shouldDisplayLocalTimezone();
   const themeContext = useContext(ThemeContext);
   const [blockOutputDownloadProgress, setBlockOutputDownloadProgress] = useState<string>(null);
   const [blockRunIdDownloading, setBlockRunIdDownloading] = useState<number>(null);
@@ -236,7 +239,10 @@ function BlockRunsTable({
             monospace
             small
           >
-            {createdAt}
+            {displayLocalTimezone
+              ? datetimeInLocalTimezone(createdAt, displayLocalTimezone)
+              : dateFormatLong(createdAt, { includeSeconds: true })
+            }
           </Text>,
           <Text
             default
@@ -244,7 +250,14 @@ function BlockRunsTable({
             monospace
             small
           >
-            {completedAt?.slice(0, 19) || '-'}
+            {completedAt
+              ? (displayLocalTimezone
+                ? datetimeInLocalTimezone(completedAt, displayLocalTimezone)
+                : dateFormatLong(completedAt, { includeSeconds: true })
+              ): (
+                <>&#8212;</>
+              )
+            }
           </Text>,
           <Button
             default

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
@@ -36,9 +36,11 @@ import { PageNameEnum } from '@components/PipelineDetailPage/constants';
 import { PADDING_UNITS } from '@oracle/styles/units/spacing';
 import { SortDirectionEnum, SortQueryEnum } from '@components/shared/Table/constants';
 import { TabType } from '@oracle/components/Tabs/ButtonTabs';
+import { datetimeInLocalTimezone } from '@utils/date';
 import { onSuccess } from '@api/utils/response';
 import { pauseEvent } from '@utils/events';
 import { queryFromUrl, queryString } from '@utils/url';
+import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
 
 const MAX_COLUMNS = 40;
 
@@ -51,6 +53,7 @@ function PipelineBlockRuns({
   pipeline: pipelineProp,
   pipelineRun: pipelineRunProp,
 }: PipelineBlockRunsProps) {
+  const displayLocalTimezone = shouldDisplayLocalTimezone();
   const router = useRouter();
   const q = queryFromUrl();
   const page = q?.page ? q.page : 0;
@@ -226,7 +229,10 @@ function PipelineBlockRuns({
           },
         },
         {
-          label: () => pipelineRunExecutionDate,
+          label: () => (displayLocalTimezone
+            ? datetimeInLocalTimezone(pipelineRunExecutionDate, displayLocalTimezone)
+            : pipelineRunExecutionDate
+          ),
         },
       ]}
       buildSidekick={props => buildTableSidekick({


### PR DESCRIPTION
# Description
- Display dates in local timezone on Block Runs page.

# How Has This Been Tested?
<img width="1398" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/a0d688a2-5d8a-4fb4-9399-af70d4476c2c">

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
