### PR TITLE
Locking Polars version to 0.19.2

### DIFF
--- a/mage_integrations/mage_integrations/tests/sources/api/test_api.py
+++ b/mage_integrations/mage_integrations/tests/sources/api/test_api.py
@@ -252,23 +252,23 @@ class ApiTest(unittest.TestCase):
             self.assertTrue(catalog.to_dict() == csv_catalog_example())
             mock_build_connection.assert_called()
 
-    # def test_api_xlsx(self):
-    #     source = Api(config=dict(
-    #         url='https://docs.google.com/spreadsheets/d/e/2PACX-1vTLcLUBAJAWf-8NQSjlbB3E4LR6DWk5QIZC-KtRb1j2CXXcgY6mE6vOJAW8PoJ1BAOgjXYpE4tY1LAD/pub?output=xlsx', # noqa
-    #         has_header=True
-    #     ))
-    #     api_connection = MagicMock()
+    def test_api_xlsx(self):
+        source = Api(config=dict(
+            url='https://docs.google.com/spreadsheets/d/e/2PACX-1vTLcLUBAJAWf-8NQSjlbB3E4LR6DWk5QIZC-KtRb1j2CXXcgY6mE6vOJAW8PoJ1BAOgjXYpE4tY1LAD/pub?output=xlsx', # noqa
+            has_header=True
+        ))
+        api_connection = MagicMock()
 
-    #     with patch.object(
-    #         source,
-    #         'test_connection',
-    #         return_value=api_connection
-    #     ) as mock_build_connection:
-    #         source.test_connection()
+        with patch.object(
+            source,
+            'test_connection',
+            return_value=api_connection
+        ) as mock_build_connection:
+            source.test_connection()
 
-    #         catalog = source.discover()
-    #         self.assertTrue(catalog.to_dict() == csv_catalog_example())
-    #         mock_build_connection.assert_called()
+            catalog = source.discover()
+            self.assertTrue(catalog.to_dict() == csv_catalog_example())
+            mock_build_connection.assert_called()
 
     def test_api_json(self):
         source = Api(config=dict(

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ ldap3==2.9.1
 newrelic==8.8.0
 numpy>=1.21.0
 pandas>=1.3.0
-polars==0.19.2
+polars<=0.19.2
 protobuf
 pyarrow==10.0.1
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ ldap3==2.9.1
 newrelic==8.8.0
 numpy>=1.21.0
 pandas>=1.3.0
-polars
+polars==0.19.2
 protobuf
 pyarrow==10.0.1
 python-dateutil==2.8.2


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Polar newest version (0.19.3) seems to alter the behavior of the `read_excel` function, used in Data Integrations API Source. Locking to 0.19.2 resolves this issue

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have added unit tests that prove my fix is effective or that my feature works


cc:
@wangxiaoyou1993 
