### PR TITLE
[td] Support custom render function in charts

### DIFF
--- a/docs/visualizations/dashboards.mdx
+++ b/docs/visualizations/dashboards.mdx
@@ -342,7 +342,93 @@ def some_columns(data_from_data_source, **kwargs) -> List:
 
 ### `@render`
 
-*Coming soon...*
+Define a function that returns a Base64 string representation of a JPEG/JPG image,
+PNG image, or a complete HTML string (with html and body tags).
+
+#### Render JPEG or JPG
+
+```python
+import base64
+import io
+import matplotlib.pyplot as plt
+
+
+# render_type can be 'jpeg' or 'jpg'
+@render(render_type='jpeg')
+def r(*args, **kwargs):
+    # creating the dataset
+    data = {'C':20, 'C++':15, 'Java':30,
+            'Python':35}
+    courses = list(data.keys())
+    values = list(data.values())
+
+    fig = plt.figure(figsize = (10, 5))
+
+    # creating the bar plot
+    plt.bar(courses, values, color ='maroon',
+            width = 0.4)
+
+    plt.xlabel("Courses offered")
+    plt.ylabel("No. of students enrolled")
+    plt.title("Students enrolled in different courses")
+    plt.show()
+
+    my_stringIObytes = io.BytesIO()
+    plt.savefig(my_stringIObytes, format='jpg')
+    my_stringIObytes.seek(0)
+    my_base64_jpgData = base64.b64encode(my_stringIObytes.read()).decode()
+
+    plt.close()
+
+    return my_base64_jpgData
+```
+
+#### Render PNG
+
+```python
+import base64
+import io
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+@render(render_type='png')
+def r(*args, **kwargs):
+    t = np.arange(0.0, 2.0, 0.01)
+    s = 1 + np.sin(2*np.pi*t)
+    plt.plot(t, s)
+
+    plt.xlabel('time (s)')
+    plt.ylabel('voltage (mV)')
+    plt.title('About as simple as it gets, folks')
+    plt.grid(True)
+    plt.show()
+
+    my_stringIObytes = io.BytesIO()
+    plt.savefig(my_stringIObytes, format='png')
+    my_stringIObytes.seek(0)
+    my_base64_jpgData = base64.b64encode(my_stringIObytes.read()).decode()
+
+    plt.close()
+
+    return my_base64_jpgData
+```
+
+#### Render HTML
+
+```python
+import plotly.graph_objects as go
+
+
+@render(render_type='html')
+def r(*args, **kwargs):
+    fig = go.Figure(
+        data=[go.Bar(y=[2, 1, 3])],
+        layout_title_text="A Figure Displaying Itself"
+    )
+
+    return fig.to_html(full_html=False)
+```
 
 ---
 

--- a/mage_ai/api/resources/BlockLayoutItemResource.py
+++ b/mage_ai/api/resources/BlockLayoutItemResource.py
@@ -8,6 +8,7 @@ from mage_ai.api.errors import ApiError
 from mage_ai.api.resources.GenericResource import GenericResource
 from mage_ai.data_preparation.models.block import Block
 from mage_ai.data_preparation.models.constants import BlockType
+from mage_ai.data_preparation.models.widget.constants import ChartType
 from mage_ai.data_preparation.variable_manager import get_global_variables
 from mage_ai.presenters.charts.data_sources.block import ChartDataSourceBlock
 from mage_ai.presenters.charts.data_sources.block_runs import ChartDataSourceBlockRuns
@@ -59,14 +60,16 @@ class BlockLayoutItemResource(GenericResource):
         block_type = block_config.get('type')
 
         if BlockType.CHART == block_type:
-            data_source_config = block_config.get('data_source')
+            data_source_config = block_config.get('data_source') or {}
             if data_source_override:
                 if data_source_config:
                     data_source_config.update(data_source_override)
                 else:
                     data_source_config = data_source_override
 
-            if data_source_config:
+            configuration_to_use = configuration_override or block_config.get('configuration')
+
+            if data_source_config or ChartType.CUSTOM == configuration_to_use.get('chart_type'):
                 data_source_type = data_source_config.get('type')
                 pipeline_uuid = data_source_config.get('pipeline_uuid')
 
@@ -74,7 +77,7 @@ class BlockLayoutItemResource(GenericResource):
                     block_config.get('name') or file_path or uuid,
                     block_uuid,
                     block_type,
-                    configuration=configuration_override or block_config.get('configuration'),
+                    configuration=configuration_to_use,
                     **extract(block_config, [
                         'language',
                     ]),

--- a/mage_ai/data_preparation/models/widget/constants.py
+++ b/mage_ai/data_preparation/models/widget/constants.py
@@ -1,6 +1,6 @@
 from enum import Enum
-from dateutil.relativedelta import relativedelta
 
+from dateutil.relativedelta import relativedelta
 
 VARIABLE_NAME_BUCKETS = 'buckets'
 VARIABLE_NAME_GROUP_BY = 'group_by'
@@ -36,6 +36,7 @@ class TimeInterval(str, Enum):
 
 class ChartType(str, Enum):
     BAR_CHART = 'bar chart'
+    CUSTOM = 'custom'
     HISTOGRAM = 'histogram'
     LINE_CHART = 'line chart'
     PIE_CHART = 'pie chart'

--- a/mage_ai/frontend/components/BlockLayout/BlockLayoutItem/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/BlockLayoutItem/index.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 
 import BlockLayoutItemDetail from '../BlockLayoutItemDetail';
-import BlockLayoutItemType from '@interfaces/BlockLayoutItemType';
+import BlockLayoutItemType, { RenderTypeEnum } from '@interfaces/BlockLayoutItemType';
 import Button from '@oracle/elements/Button';
 import ChartController from '@components/ChartBlock/ChartController';
 import Flex from '@oracle/components/Flex';
@@ -142,6 +142,39 @@ function BlockLayoutItem({
   }) => {
     if (!data) {
       return null;
+    }
+
+    const renderData = data?.render;
+    if (renderData) {
+      const renderType = data?.render_type;
+
+      if (RenderTypeEnum.JPEG === renderType) {
+        return (
+          <img
+            height={heightArg}
+            src={`data:image/jpeg;base64,${renderData}`}
+            width={widthArg}
+          />
+        );
+      } else if (RenderTypeEnum.PNG === renderType) {
+        return (
+          <img
+            height={heightArg}
+            src={`data:image/png;base64,${renderData}`}
+            width={widthArg}
+          />
+        );
+      } else if (RenderTypeEnum.HTML === renderType) {
+        return (
+          <iframe
+            srcdoc={renderData}
+            style={{
+              height: heightArg,
+              width: widthArg,
+            }}
+          />
+        );
+      }
     }
 
     return (

--- a/mage_ai/frontend/components/BlockLayout/BlockLayoutItem/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/BlockLayoutItem/index.tsx
@@ -148,7 +148,7 @@ function BlockLayoutItem({
     if (renderData) {
       const renderType = data?.render_type;
 
-      if (RenderTypeEnum.JPEG === renderType) {
+      if (RenderTypeEnum.JPEG === renderType || RenderTypeEnum.JPG === renderType) {
         return (
           <img
             height={heightArg}
@@ -167,6 +167,7 @@ function BlockLayoutItem({
       } else if (RenderTypeEnum.HTML === renderType) {
         return (
           <iframe
+            // @ts-ignore
             srcdoc={renderData}
             style={{
               height: heightArg,

--- a/mage_ai/frontend/components/BlockLayout/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/index.tsx
@@ -32,7 +32,7 @@ import TripleLayout from '@components/TripleLayout';
 import api from '@api';
 import { ASIDE_HEADER_HEIGHT } from '@components/TripleLayout/index.style';
 import { Add } from '@oracle/icons';
-import { CHART_TYPES } from '@interfaces/ChartBlockType';
+import { ChartTypeEnum, CHART_TYPES } from '@interfaces/ChartBlockType';
 import {
   PADDING_UNITS,
   UNIT,
@@ -690,7 +690,7 @@ function BlockLayout({
           primary
           value={objectAttributes?.configuration?.chart_type || ''}
         >
-          {CHART_TYPES.map(val => (
+          {CHART_TYPES.concat(ChartTypeEnum.CUSTOM).map(val => (
             <option key={val} value={val}>
               {capitalize(val)}
             </option>
@@ -1050,12 +1050,10 @@ function BlockLayout({
               {
                 label: () => 'Back to dashboard',
                 onClick: () => setSelectedBlockItem(null),
-                uuid: 'Back to dashboard',
               },
               {
                 bold: true,
                 label: () => selectedBlockItem?.name || selectedBlockItem?.uuid,
-                uuid: 'Detail',
               },
             ]}
           />

--- a/mage_ai/frontend/components/BlockLayout/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/index.tsx
@@ -1050,10 +1050,12 @@ function BlockLayout({
               {
                 label: () => 'Back to dashboard',
                 onClick: () => setSelectedBlockItem(null),
+                uuid: 'Back to dashboard',
               },
               {
                 bold: true,
                 label: () => selectedBlockItem?.name || selectedBlockItem?.uuid,
+                uuid: 'Detail',
               },
             ]}
           />

--- a/mage_ai/frontend/interfaces/BlockLayoutItemType.ts
+++ b/mage_ai/frontend/interfaces/BlockLayoutItemType.ts
@@ -13,6 +13,7 @@ export enum DataSourceEnum {
 export enum RenderTypeEnum {
   HTML = 'html',
   JPEG = 'jpeg',
+  JPG = 'jpg',
   PNG = 'png',
 }
 

--- a/mage_ai/frontend/interfaces/BlockLayoutItemType.ts
+++ b/mage_ai/frontend/interfaces/BlockLayoutItemType.ts
@@ -10,6 +10,12 @@ export enum DataSourceEnum {
   PIPELINE_SCHEDULES = 'pipeline_schedules',
 }
 
+export enum RenderTypeEnum {
+  HTML = 'html',
+  JPEG = 'jpeg',
+  PNG = 'png',
+}
+
 export const DATA_SOURCES = [
   DataSourceEnum.BLOCK,
   DataSourceEnum.BLOCK_RUNS,
@@ -41,6 +47,8 @@ export default interface BlockLayoutItemType {
   configuration?: ConfigurationType;
   data?: {
     columns?: string[];
+    render?: string;
+    render_type?: RenderTypeEnum;
     x?: string[];
     y?: number[][];
   };

--- a/mage_ai/frontend/interfaces/ChartBlockType.ts
+++ b/mage_ai/frontend/interfaces/ChartBlockType.ts
@@ -41,6 +41,7 @@ export const VARIABLE_NAMES = [
 
 export enum ChartTypeEnum {
   BAR_CHART = 'bar chart',
+  CUSTOM = 'custom',
   HISTOGRAM = 'histogram',
   LINE_CHART = 'line chart',
   PIE_CHART = 'pie chart',

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -1171,8 +1171,8 @@ function PipelineListPage() {
                   <Text
                     default
                     key={`pipeline_description_${idx}`}
+                    preWrap
                     title={description}
-                    width={UNIT * 90}
                   >
                     {description}
                   </Text>,


### PR DESCRIPTION
# Description

Create a custom render logic for chart block. You can render HTML, JPEG, PNG, etc.

# How Has This Been Tested?
<img width="2056" alt="CleanShot 2023-09-15 at 15 44 53@2x" src="https://github.com/mage-ai/mage-ai/assets/1066980/da96de39-4f5d-4051-868b-5a37d9d63864">


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
