### PR TITLE
[xy] Fix zmq context destroy issue.

### DIFF
--- a/mage_ai/api/presenters/KernelPresenter.py
+++ b/mage_ai/api/presenters/KernelPresenter.py
@@ -1,4 +1,5 @@
 from inspect import isawaitable
+
 from mage_ai.api.presenters.BasePresenter import BasePresenter
 
 
@@ -32,6 +33,7 @@ class KernelPresenter(BasePresenter):
                     # depending on configured KernelManager class
                     res = await res
                 kernel_response['usage'] = res.get('content')
+                control_channel.stop()
             except Exception:
                 pass
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix zmq context destroy issue.
![image](https://github.com/mage-ai/mage-ai/assets/80284865/b5f88fdc-92f1-47e5-b29a-15cb72178c6b)

This warning shows when the zmq context is deleted while the channel is still running: https://github.com/jupyter/jupyter_client/blob/main/jupyter_client/client.py#L119-L121

If the ZMQ context is not destroy successfully, it could cause memory leak.
<img width="1057" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/0925ef07-b40b-4918-9046-d7675d580d21">
<img width="1055" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/ba387fa4-ff1e-4184-aa3a-83160e3d0e6f">


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested on locally and on cloud. The warning of the `traitlets:Could not destroy zmq context for <jupyter_client.blocking.client.BlockingKernelClient` doesn't continue showing.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code


<!-- Optionally mention someone to let them know about this pull request -->
