### PR TITLE
Fix: timestamp out of range on windows

### DIFF
--- a/mage_ai/tests/api/operations/test_sessions.py
+++ b/mage_ai/tests/api/operations/test_sessions.py
@@ -13,7 +13,7 @@ from mage_ai.tests.factory import create_user
 
 
 class SessionOperationTests(BaseApiTestCase):
-    @freeze_time(datetime(3333, 12, 12))
+    @freeze_time(datetime(3000, 1, 1))
     async def test_execute_create(self):
         password = 'password'
         user = create_user(password=password)
@@ -35,7 +35,7 @@ class SessionOperationTests(BaseApiTestCase):
             encode_token(access_token.token, access_token.expires),
         )
 
-    @freeze_time(datetime(3333, 12, 12))
+    @freeze_time(datetime(3000, 1, 1))
     async def test_execute_create_with_disable_notebook_edits(self):
         password = 'password'
         user = create_user(password=password)


### PR DESCRIPTION
# Description
Fixes #3517 

# How Has This Been Tested?
- [x] Unittest `mage_ai/tests/api/operations/test_sessions.py::SessionOperationTests.text_execute_create`
- [x] Ran unittest on Windows `mage_ai/tests/api/operations/test_sessions.py::SessionOperationTests.test_execute_create_with_disable_notebook_edits`

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
