### PR TITLE
Fix: S3 path is joined using os.path.join -> Error non posix systems

### DIFF
--- a/mage_ai/data_preparation/executors/pyspark_block_executor.py
+++ b/mage_ai/data_preparation/executors/pyspark_block_executor.py
@@ -1,4 +1,7 @@
+import posixpath
 from contextlib import redirect_stdout
+from typing import Dict
+
 from mage_ai.data_preparation.executors.block_executor import BlockExecutor
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.data_preparation.shared.stream import StreamToLogger
@@ -7,8 +10,6 @@ from mage_ai.services.aws.emr import emr
 from mage_ai.services.aws.emr.resource_manager import EmrResourceManager
 from mage_ai.services.aws.s3 import s3
 from mage_ai.shared.hash import merge_dict
-from typing import Dict
-import os
 
 
 class PySparkBlockExecutor(BlockExecutor):
@@ -45,11 +46,11 @@ class PySparkBlockExecutor(BlockExecutor):
 
     @property
     def spark_script_path(self) -> str:
-        return os.path.join('s3://', self.s3_bucket, self.spark_script_path_key)
+        return posixpath.join('s3://', self.s3_bucket, self.spark_script_path_key)
 
     @property
     def spark_script_path_key(self) -> str:
-        return os.path.join(
+        return posixpath.join(
             self.s3_path_prefix,
             f'scripts/{self.pipeline.uuid}/{self.block_uuid}.py',
         )

--- a/mage_ai/data_preparation/executors/pyspark_pipeline_executor.py
+++ b/mage_ai/data_preparation/executors/pyspark_pipeline_executor.py
@@ -1,4 +1,4 @@
-import os
+import posixpath
 from typing import Dict
 
 from mage_ai.data_preparation.executors.pipeline_executor import PipelineExecutor
@@ -43,11 +43,11 @@ class PySparkPipelineExecutor(PipelineExecutor):
 
     @property
     def spark_script_path(self) -> str:
-        return os.path.join('s3://', self.s3_bucket, self.spark_script_path_key)
+        return posixpath.join('s3://', self.s3_bucket, self.spark_script_path_key)
 
     @property
     def spark_script_path_key(self) -> str:
-        return os.path.join(self.s3_path_prefix, f'scripts/{self.pipeline.uuid}.py')
+        return posixpath.join(self.s3_path_prefix, f'scripts/{self.pipeline.uuid}.py')
 
     def upload_pipeline_execution_script(self, global_vars: Dict = None) -> None:
         execution_script_code = template_env.get_template(

--- a/mage_ai/services/aws/emr/resource_manager.py
+++ b/mage_ai/services/aws/emr/resource_manager.py
@@ -1,4 +1,4 @@
-import os
+import posixpath
 
 from mage_ai.data_preparation.templates.utils import template_env
 from mage_ai.services.aws.s3 import s3
@@ -22,15 +22,15 @@ class EmrResourceManager:
 
     @property
     def bootstrap_script_path(self) -> str:
-        return os.path.join('s3://', self.s3_bucket, self.bootstrap_script_path_key)
+        return posixpath.join('s3://', self.s3_bucket, self.bootstrap_script_path_key)
 
     @property
     def bootstrap_script_path_key(self) -> str:
-        return os.path.join(self.s3_path_prefix, 'scripts/emr_bootstrap.sh')
+        return posixpath.join(self.s3_path_prefix, 'scripts/emr_bootstrap.sh')
 
     @property
     def log_uri(self) -> str:
-        return os.path.join('s3://', self.s3_bucket, self.s3_path_prefix, 'logs')
+        return posixpath.join('s3://', self.s3_bucket, self.s3_path_prefix, 'logs')
 
     def upload_bootstrap_script(self) -> None:
         if self.local_bootstrap_script_path is None:

--- a/mage_integrations/mage_integrations/destinations/delta_lake_s3/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/delta_lake_s3/__init__.py
@@ -1,10 +1,16 @@
-from botocore.config import Config
-from mage_integrations.destinations.delta_lake.base import DeltaLake as BaseDeltaLake, main
-from mage_integrations.destinations.delta_lake.constants import MODE_OVERWRITE
-from mage_integrations.destinations.delta_lake_s3.utils import fix_overwritten_partitions
-from typing import Dict
-import boto3
 import os
+import posixpath
+from typing import Dict
+
+import boto3
+from botocore.config import Config
+
+from mage_integrations.destinations.delta_lake.base import DeltaLake as BaseDeltaLake
+from mage_integrations.destinations.delta_lake.base import main
+from mage_integrations.destinations.delta_lake.constants import MODE_OVERWRITE
+from mage_integrations.destinations.delta_lake_s3.utils import (
+    fix_overwritten_partitions,
+)
 
 
 class DeltaLakeS3(BaseDeltaLake):
@@ -84,7 +90,7 @@ class DeltaLakeS3(BaseDeltaLake):
         }
 
     def build_table_uri(self, stream: str) -> str:
-        return '/'.join([
+        return posixpath.join([
             f"s3://{self.config['bucket']}",
             self.config['object_key_path'],
             self.table_name,


### PR DESCRIPTION
# Description
Resolves #3515 
Used `posixpath.join` instead of `os.path.join` in all cases to force posix like join using forward slash for `s3://` paths.

# How Has This Been Tested?
- [x] Unittests


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
