### PR TITLE
Fix: paths include posix like forward slash in many instances, which will not work on non-posix systems

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
         types: [python]
     -   id: name-tests-test
         types: [python]
+        exclude: "base_test"
         args:
           - "--pytest-test-first"
     -   id: requirements-txt-fixer

--- a/mage_ai/cluster_manager/aws/emr_cluster_manager.py
+++ b/mage_ai/cluster_manager/aws/emr_cluster_manager.py
@@ -64,7 +64,7 @@ class EmrClusterManager(ClusterManager):
 
         # Get cluster information and update cluster url in sparkmagic config
         home_dir = str(Path.home())
-        sparkmagic_config_path = os.path.join(home_dir, '.sparkmagic/config.json')
+        sparkmagic_config_path = os.path.join(home_dir, '.sparkmagic', 'config.json')
         with open(sparkmagic_config_path) as f:
             fcontent = f.read()
 

--- a/mage_ai/data_preparation/git/__init__.py
+++ b/mage_ai/data_preparation/git/__init__.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import uuid
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Callable, Dict, List
 from urllib.parse import urlparse, urlsplit, urlunsplit
 
@@ -15,7 +16,7 @@ from mage_ai.orchestration.db.models.oauth import User
 from mage_ai.settings.repo import get_repo_path
 from mage_ai.shared.logger import VerboseFunctionExec
 
-DEFAULT_SSH_KEY_DIRECTORY = os.path.expanduser('~/.ssh')
+DEFAULT_SSH_KEY_DIRECTORY = os.path.expanduser(os.path.join('~', '.ssh'))
 DEFAULT_KNOWN_HOSTS_FILE = os.path.join(DEFAULT_SSH_KEY_DIRECTORY, 'known_hosts')
 REMOTE_NAME = 'mage-repo'
 
@@ -546,7 +547,7 @@ class Git:
             self.repo.config_writer().set_value(
                 'user', 'email', self.git_config.email).release()
         self.repo.config_writer('global').set_value(
-            'safe', 'directory', self.repo_path).release()
+            'safe', 'directory', Path(self.repo_path).as_posix()).release()
 
     def __pip_install(self) -> None:
         requirements_file = os.path.join(

--- a/mage_ai/data_preparation/models/variable.py
+++ b/mage_ai/data_preparation/models/variable.py
@@ -84,7 +84,7 @@ class Variable:
 
     @property
     def variable_path(self):
-        return os.path.join(self.variable_dir_path, f'{self.uuid}')
+        return os.path.join(self.variable_dir_path, self.uuid)
 
     @classmethod
     def dir_path(self, pipeline_path, block_uuid):

--- a/mage_ai/io/io_config.py
+++ b/mage_ai/io/io_config.py
@@ -1,7 +1,7 @@
 import os
-import pathlib
 from enum import Enum
-from typing import Any, Mapping, Union
+from pathlib import Path
+from typing import Any, Mapping, Optional, Union
 
 import yaml
 
@@ -26,7 +26,7 @@ class IOConfig:
 
     def __init__(
         self,
-        filepath: Union[os.PathLike, str] = './default_repo/io_config.yaml'
+        filepath: Optional[Union[os.PathLike, str]] = None
     ) -> None:
         """
         Initializes IO Configuration loader
@@ -34,7 +34,7 @@ class IOConfig:
         Args:
             filepath (os.PathLike): Path to IO configuration file.
         """
-        self.filepath = pathlib.Path(filepath)
+        self.filepath = Path(filepath) if filepath else Path('default_repo', 'io_config.yaml')
 
     def use(self, profile: str) -> Mapping[str, Any]:
         """

--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -32,7 +32,7 @@ elif not db_connection_url:
     else:
         if is_test():
             db_connection_url = f'sqlite:///{TEST_DB}'
-        elif os.path.exists('mage_ai/orchestration/db/'):
+        elif os.path.exists(os.path.join('mage_ai', 'orchestration', 'db')):
             # For local dev environment
             db_connection_url = 'sqlite:///mage_ai/orchestration/db/mage-ai.db'
         elif os.path.exists('mage-ai.db'):

--- a/mage_ai/server/docs_server.py
+++ b/mage_ai/server/docs_server.py
@@ -6,7 +6,7 @@ from mage_ai.settings.repo import get_repo_path
 
 
 def get_dbt_target_path():
-    return os.path.join(get_repo_path(), 'dbt/target')
+    return os.path.join(get_repo_path(), 'dbt', 'target')
 
 
 def run_docs_server():

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -194,7 +194,7 @@ def make_app(template_dir: str = None, update_routes: bool = False):
         (
             r'/_next/static/(.*)',
             tornado.web.StaticFileHandler,
-            {'path': os.path.join(template_dir, '_next/static')},
+            {'path': os.path.join(template_dir, '_next', 'static')},
         ),
         (
             r'/fonts/(.*)',

--- a/mage_ai/settings/repo.py
+++ b/mage_ai/settings/repo.py
@@ -9,9 +9,9 @@ which can cause circular import errors.
 """
 
 if is_test():
-    DEFAULT_MAGE_DATA_DIR = './'
+    DEFAULT_MAGE_DATA_DIR = '.'
 else:
-    DEFAULT_MAGE_DATA_DIR = '~/.mage_data'
+    DEFAULT_MAGE_DATA_DIR = os.path.join('~', '.mage_data')
 MAGE_DATA_DIR_ENV_VAR = 'MAGE_DATA_DIR'
 REPO_PATH_ENV_VAR = 'MAGE_REPO_PATH'
 

--- a/mage_ai/tests/base_test.py
+++ b/mage_ai/tests/base_test.py
@@ -23,7 +23,7 @@ else:
         @classmethod
         def setUpClass(self):
             super().setUpClass()
-            self.repo_path = os.getcwd() + '/test'
+            self.repo_path = os.path.join(os.getcwd(), 'test')
             set_repo_path(self.repo_path)
             if not os.path.exists(self.repo_path):
                 os.mkdir(self.repo_path)
@@ -51,7 +51,7 @@ class DBTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         super().setUpClass()
-        self.repo_path = os.getcwd() + '/test'
+        self.repo_path = os.path.join(os.getcwd(), 'test')
         set_repo_path(self.repo_path)
         if not os.path.exists(self.repo_path):
             os.mkdir(self.repo_path)
@@ -83,7 +83,7 @@ class TestCase(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         super().setUpClass()
-        self.repo_path = os.getcwd() + '/test'
+        self.repo_path = os.path.join(os.getcwd(), 'test')
         set_repo_path(self.repo_path)
         if not os.path.exists(self.repo_path):
             os.mkdir(self.repo_path)

--- a/mage_ai/tests/data_preparation/models/test_block.py
+++ b/mage_ai/tests/data_preparation/models/test_block.py
@@ -19,10 +19,14 @@ class BlockTest(DBTestCase):
     def test_create(self):
         block1 = Block.create('test_transformer', 'transformer', self.repo_path)
         block2 = Block.create('test data loader', BlockType.DATA_LOADER, self.repo_path)
-        self.assertTrue(os.path.exists(f'{self.repo_path}/transformers/test_transformer.py'))
-        self.assertTrue(os.path.exists(f'{self.repo_path}/transformers/__init__.py'))
-        self.assertTrue(os.path.exists(f'{self.repo_path}/data_loaders/test_data_loader.py'))
-        self.assertTrue(os.path.exists(f'{self.repo_path}/data_loaders/__init__.py'))
+        self.assertTrue(os.path.exists(os.path.join(
+            self.repo_path, 'transformers', 'test_transformer.py')))
+        self.assertTrue(os.path.exists(os.path.join(
+            self.repo_path, 'transformers', '__init__.py')))
+        self.assertTrue(os.path.exists(os.path.join(
+            self.repo_path, 'data_loaders', 'test_data_loader.py')))
+        self.assertTrue(os.path.exists(os.path.join(
+            self.repo_path, 'data_loaders', '__init__.py')))
         self.assertEqual(block1.name, 'test_transformer')
         self.assertEqual(block1.uuid, 'test_transformer')
         self.assertEqual(block1.type, 'transformer')
@@ -277,7 +281,12 @@ def incorrect_function(df1):
             ''')
         asyncio.run(block1.execute())
         asyncio.run(block2.execute())
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(
+            Exception,
+            'Block test_transformer may have too many upstream dependencies. It expected to have' +
+            ' 1 arguments, but received 2. Confirm that the @transformer method declaration has ' +
+            'the correct number of arguments.'
+        ):
             asyncio.run(block3.execute())
 
         with open(block3.file_path, 'w') as file:
@@ -286,7 +295,12 @@ def incorrect_function(df1):
 def incorrect_function(df1, df2, df3):
     return df1
             ''')
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(
+            Exception,
+            'Block test_transformer may have too many upstream dependencies. It expected to have' +
+            ' 1 arguments, but received 2. Confirm that the @transformer method declaration has ' +
+            'the correct number of arguments.'
+        ):
             asyncio.run(block3.execute())
 
     def test_sensor_block_args_execution(self):
@@ -383,7 +397,7 @@ def on_failure_callback(**kwargs):
     print('FAILED')
             ''')
 
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, 'failed'):
             block1.execute_with_callback()
             mock_print.assert_called_with('FAILED')
 

--- a/mage_ai/tests/data_preparation/models/test_file.py
+++ b/mage_ai/tests/data_preparation/models/test_file.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from mage_ai.data_preparation.models.errors import FileNotInProjectError
 from mage_ai.data_preparation.models.file import ensure_file_is_in_project
@@ -26,7 +27,7 @@ class FileTest(TestCase):
         self.assertIsNone(ensure_file_is_in_project(file_path))
 
     def test_ensure_file_is_in_project_absolute_file_path_not_in_project(self):
-        file_path = os.path.join('/other/path', 'file.txt')
+        file_path = str(Path(os.path.join('/', 'other', 'path', 'file.txt')).absolute())
         with self.assertRaises(FileNotInProjectError):
             ensure_file_is_in_project(file_path)
 

--- a/mage_ai/tests/data_preparation/models/test_pipeline.py
+++ b/mage_ai/tests/data_preparation/models/test_pipeline.py
@@ -24,8 +24,10 @@ class PipelineTest(DBTestCase):
         self.assertEqual(pipeline.uuid, 'test_pipeline')
         self.assertEqual(pipeline.name, 'test pipeline')
         self.assertEqual(pipeline.blocks_by_uuid, dict())
-        self.assertTrue(os.path.exists(f'{self.repo_path}/pipelines/test_pipeline/__init__.py'))
-        self.assertTrue(os.path.exists(f'{self.repo_path}/pipelines/test_pipeline/metadata.yaml'))
+        self.assertTrue(os.path.exists(os.path.join(
+            self.repo_path, 'pipelines', 'test_pipeline', '__init__.py')))
+        self.assertTrue(os.path.exists(os.path.join(
+            self.repo_path, 'pipelines', 'test_pipeline', 'metadata.yaml')))
 
     @freeze_time('2023-08-01 08:08:24')
     def test_add_block(self):

--- a/mage_ai/tests/data_preparation/test_repo_manager.py
+++ b/mage_ai/tests/data_preparation/test_repo_manager.py
@@ -69,7 +69,7 @@ class RepoManagerTest(DBTestCase):
     def test_variables_dir_expanduser(self):
         dir_name = uuid.uuid4().hex
         metadata_dict = dict(
-            variables_dir=f'~/{dir_name}',
+            variables_dir=os.path.join('~', dir_name),
         )
         test_repo_path = os.path.join(self.repo_path, 'repo_manager_test')
         os.makedirs(test_repo_path, exist_ok=True)
@@ -78,9 +78,9 @@ class RepoManagerTest(DBTestCase):
         test = RepoConfig(repo_path=test_repo_path)
         self.assertEqual(
             test.variables_dir,
-            os.path.expanduser(os.path.join(f'~/{dir_name}', 'repo_manager_test'))
+            os.path.expanduser(os.path.join('~', dir_name, 'repo_manager_test'))
         )
-        test_dir = os.path.expanduser(f'~/{dir_name}')
+        test_dir = os.path.expanduser(os.path.join('~', dir_name))
         shutil.rmtree(test_dir)
 
     def test_set_project_uuid_from_metadata(self):

--- a/mage_integrations/mage_integrations/tests/sources/test_base.py
+++ b/mage_integrations/mage_integrations/tests/sources/test_base.py
@@ -1,15 +1,16 @@
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from singer.schema import Schema
+
 from mage_integrations.sources.base import Source
 from mage_integrations.sources.catalog import Catalog, CatalogEntry
 from mage_integrations.sources.intercom import Intercom
 from mage_integrations.sources.postgresql import PostgreSQL
 from mage_integrations.sources.stripe import Stripe
-from singer.schema import Schema
-from unittest.mock import MagicMock, patch
-import os
-import unittest
-import json
-import sys
-
 
 ABSOLUTE_PATH = os.path.abspath(os.path.dirname(__file__))
 
@@ -29,12 +30,14 @@ def build_sample_streams_catalog_entries():
 
 def build_sample_streams_list():
     with open(os.path.join(
-            ABSOLUTE_PATH,
-            'samples/demo_table_stream.json',
-        ), 'r') as f1, open(os.path.join(
-            ABSOLUTE_PATH,
-            'samples/demo_users_stream.json',
-            ), 'r') as f2:
+        ABSOLUTE_PATH,
+        'samples',
+        'demo_table_stream.json',
+    ), 'r') as f1, open(os.path.join(
+        ABSOLUTE_PATH,
+        'samples',
+        'demo_users_stream.json',
+    ), 'r') as f2:
         demo_table_stream = json.load(f1)
         demo_users_stream = json.load(f2)
 
@@ -219,7 +222,7 @@ class BaseSourceTests(unittest.TestCase):
 
     def test_process_stream(self):
         source = Source()
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, ''):
             source.process_stream(
                 CatalogEntry(
                     replication_method='INVALID_METHOD',
@@ -252,7 +255,7 @@ class BaseSourceTests(unittest.TestCase):
             with patch.object(source, 'load_data') as mock_load_data:
                 source.sync_stream(stream)
                 mock_get_bookmark_props.assert_called_with(stream)
-                mock_load_data.assert_called_once() 
+                mock_load_data.assert_called_once()
 
     def test_write_records(self):
         source = Source(
@@ -371,7 +374,7 @@ class BaseSourceTests(unittest.TestCase):
                 'tap_stream_id': 'demo_users',
             },
         )
-    
+
     def test_load_schemas_from_folder(self):
         # Testing with Stripe source, since not all of the
         # integration sources have "schemas" folders.

--- a/scripts/install_other_dependencies.py
+++ b/scripts/install_other_dependencies.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import subprocess
 
-
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--path', type=str)
@@ -13,8 +12,8 @@ if __name__ == '__main__':
 
     dirs = os.listdir(path)
     if 'dbt' in dirs:
-        for dir_path in os.listdir(f'{path}/dbt'):
-            dbt_dir = f'{path}/dbt/{dir_path}'
+        for dir_path in os.listdir(os.path.join(path, 'dbt')):
+            dbt_dir = os.path.join(path, 'dbt', dir_path)
             if os.path.isdir(dbt_dir):
                 dbt_dirs.append(dbt_dir)
 


### PR DESCRIPTION
# Description
Resolves #3518

replaced many instances. There are probably more.
WHen using paths as names (e.g. uuids for blocks) this should probably be handled more strict. e.g. always use forward slash in these cases. Also rather use posixpath instead of manually doing some concatenating of strings to form a path.

Fixed gitconfig for windows users. Running unittest on windows will not destroy the .gitconfig anymore.

# How Has This Been Tested?
- [x] Unittest


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
