### PR TITLE
Fix: dtype int is not always casted as int64

### DIFF
--- a/mage_ai/data_cleaner/column_types/column_type_detector.py
+++ b/mage_ai/data_cleaner/column_types/column_type_detector.py
@@ -1,13 +1,15 @@
 # flake8: noqa
+import re
+
+import numpy as np
+import pandas as pd
+
 from mage_ai.data_cleaner.column_types.constants import NUMBER_TYPES, ColumnType
-from mage_ai.shared.multi import run_parallel_multiple_args
 from mage_ai.data_cleaner.transformer_actions.constants import (
     CONSTANT_IMPUTATION_DEFAULTS,
     INVALID_VALUE_PLACEHOLDERS,
 )
-import numpy as np
-import pandas as pd
-import re
+from mage_ai.shared.multi import run_parallel_multiple_args
 
 DATETIME_MATCHES_THRESHOLD = 0.5
 MAXIMUM_WORD_LENGTH_FOR_CATEGORY_FEATURES = 40
@@ -176,7 +178,7 @@ def infer_object_type(series, column_name, kwargs):
             else:
                 clean_series = clean_series.str.replace(r'\.0*', '', regex=True)
                 try:
-                    clean_series.astype(int)
+                    clean_series.astype(np.int64)
                     return ColumnType.NUMBER
                 except OverflowError:
                     if clean_series_nunique <= kwargs.get('category_cardinality_threshold', 255):

--- a/mage_ai/data_cleaner/shared/utils.py
+++ b/mage_ai/data_cleaner/shared/utils.py
@@ -1,11 +1,13 @@
+import re
+from typing import Any, List, Union
+
+import numpy as np
+import pandas as pd
+from pandas.core.indexes.frozen import FrozenList
+
 from mage_ai.data_cleaner.column_types.constants import NUMBER_TYPES, ColumnType
 from mage_ai.data_cleaner.transformer_actions.constants import CURRENCY_SYMBOLS
 from mage_ai.shared.custom_types import FrozenDict
-from pandas.core.indexes.frozen import FrozenList
-from typing import Any, List, Union
-import pandas as pd
-import numpy as np
-import re
 
 COLUMN_NAME_QUOTE_CHARS = '+=-*&^%$! ?~|<>(){}[],.'
 LIST_SPLIT = re.compile(r'\s*,\s*')
@@ -42,7 +44,7 @@ def clean_series(series, column_type, dropna=True):
             series_cleaned = series_cleaned.str.replace(' ', '')
         if column_type == ColumnType.NUMBER:
             try:
-                series_cleaned = series_cleaned.astype(int)
+                series_cleaned = series_cleaned.astype(np.int64)
             except ValueError:
                 series_cleaned = series_cleaned.astype(float)
         else:

--- a/mage_ai/data_preparation/models/widget/utils.py
+++ b/mage_ai/data_preparation/models/widget/utils.py
@@ -1,11 +1,9 @@
-from .constants import (
-    AggregationFunction,
-    VARIABLE_NAME_X,
-    VARIABLE_NAME_Y,
-)
-from mage_ai.shared.parsers import encode_complex
 import numpy as np
 import pandas as pd
+
+from mage_ai.shared.parsers import encode_complex
+
+from .constants import VARIABLE_NAME_X, VARIABLE_NAME_Y, AggregationFunction
 
 
 def clean_series(series, column_type=None, dropna=True):
@@ -17,7 +15,7 @@ def clean_series(series, column_type=None, dropna=True):
 
     if column_type is int:
         try:
-            series_cleaned = series_cleaned.astype(float).astype(int)
+            series_cleaned = series_cleaned.astype(float).astype(np.int64)
         except ValueError:
             series_cleaned = series_cleaned.astype(float)
     elif column_type is float:
@@ -111,7 +109,7 @@ def build_x_y(df, group_by_columns, metrics):
     ).values
 
     y_values = []
-    for idx, metric in enumerate(metrics):
+    for _idx, metric in enumerate(metrics):
         y_values.append([g[build_metric_name(metric)] for g in metrics_per_group])
 
     data[VARIABLE_NAME_Y] = y_values

--- a/mage_ai/tests/data_cleaner/statistics/test_calculator.py
+++ b/mage_ai/tests/data_cleaner/statistics/test_calculator.py
@@ -114,7 +114,7 @@ class StatisticsCalculatorTest(TestCase):
         self.assertEqual(data['zip_code/invalid_value_rate'], 1 / 6)
 
         self.assertEqual(data['id/invalid_values'], [])
-        self.assertTrue((data['id/invalid_indices'] == np.array([]).astype(int)).all())
+        self.assertTrue((data['id/invalid_indices'] == np.array([]).astype(np.int64)).all())
         self.assertEqual(data['id/invalid_value_count'], 0)
         self.assertEqual(data['id/invalid_value_rate'], 0 / 6)
 

--- a/mage_ai/tests/data_cleaner/transformer_actions/test_column.py
+++ b/mage_ai/tests/data_cleaner/transformer_actions/test_column.py
@@ -1,11 +1,16 @@
 from datetime import datetime as dt
-from mage_ai.data_cleaner.transformer_actions.column import (
+from random import seed
+
+import numpy as np
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from mage_ai.data_cleaner.transformer_actions.column import (  # expand_column,
     add_column,
+    clean_column_names,
     count,
     count_distinct,
-    clean_column_names,
     diff,
-    # expand_column,
     first,
     fix_syntax_errors,
     last,
@@ -15,10 +20,6 @@ from mage_ai.data_cleaner.transformer_actions.column import (
     shift_up,
 )
 from mage_ai.tests.base_test import TestCase
-from pandas.testing import assert_frame_equal
-from random import seed
-import numpy as np
-import pandas as pd
 
 TEST_DATAFRAME = pd.DataFrame(
     [
@@ -933,7 +934,7 @@ class ColumnTests(TestCase):
             ],
             columns=['group_id', 'amount', 'average_amount'],
         )
-        df_new['average_amount'] = df_new['average_amount'].astype(int)
+        df_new['average_amount'] = df_new['average_amount'].astype(np.int64)
         assert_frame_equal(df_new, df_expected)
 
     def test_count(self):
@@ -1859,20 +1860,20 @@ class ColumnTests(TestCase):
             ],
         )
 
-        df_new1['sold'] = df_new1['sold'].astype(int)
-        df_new1['curr_profit'] = df_new1['curr_profit'].astype(int)
-        df_new2['sold'] = df_new2['sold'].astype(int)
-        df_new3['sold'] = df_new3['sold'].astype(int)
-        df_new3['curr_profit'] = df_new3['curr_profit'].astype(int)
-        df_new4['sold'] = df_new4['sold'].astype(int)
-        df_new4['curr_profit'] = df_new4['curr_profit'].astype(int)
-        df_new5['sold'] = df_new5['sold'].astype(int)
-        df_new5['curr_profit'] = df_new5['curr_profit'].astype(int)
-        df_new6['sold'] = df_new6['sold'].astype(int)
-        df_new7['sold'] = df_new7['sold'].astype(int)
-        df_new7['curr_profit'] = df_new7['curr_profit'].astype(int)
-        df_new8['sold'] = df_new8['sold'].astype(int)
-        df_new8['curr_profit'] = df_new8['curr_profit'].astype(int)
+        df_new1['sold'] = df_new1['sold'].astype(np.int64)
+        df_new1['curr_profit'] = df_new1['curr_profit'].astype(np.int64)
+        df_new2['sold'] = df_new2['sold'].astype(np.int64)
+        df_new3['sold'] = df_new3['sold'].astype(np.int64)
+        df_new3['curr_profit'] = df_new3['curr_profit'].astype(np.int64)
+        df_new4['sold'] = df_new4['sold'].astype(np.int64)
+        df_new4['curr_profit'] = df_new4['curr_profit'].astype(np.int64)
+        df_new5['sold'] = df_new5['sold'].astype(np.int64)
+        df_new5['curr_profit'] = df_new5['curr_profit'].astype(np.int64)
+        df_new6['sold'] = df_new6['sold'].astype(np.int64)
+        df_new7['sold'] = df_new7['sold'].astype(np.int64)
+        df_new7['curr_profit'] = df_new7['curr_profit'].astype(np.int64)
+        df_new8['sold'] = df_new8['sold'].astype(np.int64)
+        df_new8['curr_profit'] = df_new8['curr_profit'].astype(np.int64)
 
         assert_frame_equal(df_new1, df_expected1)
         assert_frame_equal(df_new2, df_expected2)
@@ -1883,7 +1884,7 @@ class ColumnTests(TestCase):
         assert_frame_equal(df_new7, df_new7.dropna(axis=0))
         assert_frame_equal(df_new8, df_expected8)
 
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, 'Require a valid strategy or value'):
             _ = impute(df.copy(), action_invalid)
 
     def test_impute_random_edge(self):
@@ -1908,7 +1909,7 @@ class ColumnTests(TestCase):
             action_arguments=['sold', 'curr_profit'],
             action_options={'strategy': 'random'},
         )
-        with self.assertRaises(Exception):
+        with self.assertRaises(KeyError):
             _ = impute(df.copy(), action)
 
     def test_impute_constant(self):
@@ -1992,7 +1993,7 @@ class ColumnTests(TestCase):
             ],
         )
         df_new = impute(df, action).reset_index(drop=True)
-        df_new['group_id'] = df_new['group_id'].astype(int)
+        df_new['group_id'] = df_new['group_id'].astype(np.int64)
         df_new['price'] = df_new['price'].astype(float)
         df_new['group_churned_at'] = df_new['group_churned_at'].astype(np.datetime64)
         assert_frame_equal(df_new, df_expected)
@@ -2061,7 +2062,7 @@ class ColumnTests(TestCase):
             ],
         )
         df_new = impute(df, action).reset_index(drop=True)
-        df_new['zip_code'] = df_new['zip_code'].astype(int)
+        df_new['zip_code'] = df_new['zip_code'].astype(np.int64)
         assert_frame_equal(df_new, df_expected)
 
     def test_impute_sequential_two_idx(self):
@@ -2146,8 +2147,8 @@ class ColumnTests(TestCase):
             ],
         )
         df_new = impute(df, action).reset_index(drop=True)
-        df_new['group_id'] = df_new['group_id'].astype(int)
-        df_new['order_count'] = df_new['order_count'].astype(int)
+        df_new['group_id'] = df_new['group_id'].astype(np.int64)
+        df_new['order_count'] = df_new['order_count'].astype(np.int64)
         assert_frame_equal(df_new, df_expected)
 
     def test_impute_lists(self):
@@ -2569,7 +2570,7 @@ class ColumnTests(TestCase):
             ],
         )
         df_new = median(df, action)
-        df_new['median_amount'] = df_new['median_amount'].astype(int)
+        df_new['median_amount'] = df_new['median_amount'].astype(np.int64)
         df_expected = pd.DataFrame(
             [
                 [1, 1000, 1050],

--- a/mage_ai/tests/data_cleaner/transformer_actions/test_custom_actions.py
+++ b/mage_ai/tests/data_cleaner/transformer_actions/test_custom_actions.py
@@ -1,8 +1,9 @@
+import numpy as np
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
 from mage_ai.data_cleaner.transformer_actions.custom_action import execute_custom_action
 from mage_ai.tests.base_test import TestCase
-from pandas.testing import assert_frame_equal
-import pandas as pd
-import numpy as np
 
 
 class CustomActionTests(TestCase):
@@ -69,7 +70,7 @@ if type(x) is str else x)
             series_cleaned = series_cleaned.str.replace(" ", "")
             if column_type == ColumnType.NUMBER:
                 try:
-                    series_cleaned = series_cleaned.astype(int)
+                    series_cleaned = series_cleaned.astype(np.int64)
                 except ValueError:
                     series_cleaned = series_cleaned.astype(float)
             else:
@@ -173,7 +174,7 @@ if type(x) is str else x)
             series_cleaned = series_cleaned.str.replace(" ", "")
             if column_type == ColumnType.NUMBER:
                 try:
-                    series_cleaned = series_cleaned.astype(int)
+                    series_cleaned = series_cleaned.astype(np.int64)
                 except ValueError:
                     series_cleaned = series_cleaned.astype(float)
             else:

--- a/mage_ai/tests/data_cleaner/transformer_actions/test_row.py
+++ b/mage_ai/tests/data_cleaner/transformer_actions/test_row.py
@@ -676,7 +676,7 @@ class RowTests(TestCase):
             ],
         )
         for column in df.columns:
-            with self.assertRaises((SyntaxError, pd.errors.UndefinedVariableError)):
+            with self.assertRaisesRegex(Exception, ''):
                 action = dict(action_code=f'{column} == False')
                 filter_rows(df, action, original_df=df)
 

--- a/mage_ai/tests/data_cleaner/transformer_actions/test_row.py
+++ b/mage_ai/tests/data_cleaner/transformer_actions/test_row.py
@@ -1,15 +1,15 @@
-from mage_ai.data_cleaner.transformer_actions.base import BaseAction
-from mage_ai.data_cleaner.transformer_actions.row import (
-    drop_duplicates,
-    # explode,
-    filter_rows,
-    sort_rows,
-    remove_row,
-)
-from mage_ai.tests.base_test import TestCase
-from pandas.testing import assert_frame_equal
 import numpy as np
 import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from mage_ai.data_cleaner.transformer_actions.base import BaseAction
+from mage_ai.data_cleaner.transformer_actions.row import (  # explode,
+    drop_duplicates,
+    filter_rows,
+    remove_row,
+    sort_rows,
+)
+from mage_ai.tests.base_test import TestCase
 
 
 class RowTests(TestCase):
@@ -325,7 +325,7 @@ class RowTests(TestCase):
         assert_frame_equal(df_new3, df_expected2)
         assert_frame_equal(df_new4, df_expected3)
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(TypeError):
             _ = filter_rows(df, action_invalid, original_df=df).reset_index(drop=True)
 
     def test_filter_rows_multi_condition(self):
@@ -395,11 +395,11 @@ class RowTests(TestCase):
         df_new3 = filter_rows(df, action3, original_df=df).reset_index(drop=True)
         df_new4 = filter_rows(df, action4, original_df=df).reset_index(drop=True)
         df_new5 = filter_rows(df, action5, original_df=df).reset_index(drop=True)
-        df_new['value'] = df_new['value'].astype(int)
-        df_new['inventory'] = df_new['inventory'].astype(int)
+        df_new['value'] = df_new['value'].astype(np.int64)
+        df_new['inventory'] = df_new['inventory'].astype(np.int64)
         df_new2['brand'] = df_new2['brand'].astype(str)
-        df_new2['inventory'] = df_new2['inventory'].astype(int)
-        df_new4['value'] = df_new4['value'].astype(int)
+        df_new2['inventory'] = df_new2['inventory'].astype(np.int64)
+        df_new4['value'] = df_new4['value'].astype(np.int64)
         df_new4['brand'] = df_new4['brand'].astype(str)
         df_new4['discounted'] = df_new4['discounted'].astype(bool)
         assert_frame_equal(df_expected, df_new)
@@ -447,7 +447,7 @@ class RowTests(TestCase):
             ],
             columns=['value', 'brand', 'discounted', 'inventory'],
         )
-        df_new['value'] = df_new['value'].astype(int)
+        df_new['value'] = df_new['value'].astype(np.int64)
         assert_frame_equal(df_expected, df_new)
 
     def test_filter_row_dirty_columns(self):
@@ -520,11 +520,11 @@ class RowTests(TestCase):
         df_new3 = filter_rows(df, action3, original_df=df).reset_index(drop=True)
         df_new4 = filter_rows(df, action4, original_df=df).reset_index(drop=True)
         df_new5 = filter_rows(df, action5, original_df=df).reset_index(drop=True)
-        df_new['Val ue'] = df_new['Val ue'].astype(int)
-        df_new['invVe nTory'] = df_new['invVe nTory'].astype(int)
+        df_new['Val ue'] = df_new['Val ue'].astype(np.int64)
+        df_new['invVe nTory'] = df_new['invVe nTory'].astype(np.int64)
         df_new2['bra  23423  nd'] = df_new2['bra  23423  nd'].astype(str)
-        df_new2['invVe nTory'] = df_new2['invVe nTory'].astype(int)
-        df_new4['Val ue'] = df_new4['Val ue'].astype(int)
+        df_new2['invVe nTory'] = df_new2['invVe nTory'].astype(np.int64)
+        df_new4['Val ue'] = df_new4['Val ue'].astype(np.int64)
         df_new4['bra  23423  nd'] = df_new4['bra  23423  nd'].astype(str)
         df_new4['dis>>> ??cou nted'] = df_new4['dis>>> ??cou nted'].astype(bool)
         assert_frame_equal(df_expected, df_new)
@@ -574,7 +574,7 @@ class RowTests(TestCase):
         df_new['e e e e e  e e e'] = df_new['e e e e e  e e e'].astype(float)
         df_new2['e e e e e  e e e'] = df_new2['e e e e e  e e e'].astype(float)
         df_new[' kas22d fe ($)'] = df_new[' kas22d fe ($)'].astype(float)
-        df_new2[' kas22d fe ($)'] = df_new2[' kas22d fe ($)'].astype(int)
+        df_new2[' kas22d fe ($)'] = df_new2[' kas22d fe ($)'].astype(np.int64)
         assert_frame_equal(df_expected, df_new)
         assert_frame_equal(df_expected2, df_new2)
 
@@ -635,7 +635,7 @@ class RowTests(TestCase):
         assert_frame_equal(df_new3, df_expected2)
         assert_frame_equal(df_new4, df_expected3)
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(TypeError):
             _ = filter_rows(df, action_invalid, original_df=df).reset_index(drop=True)
 
     def test_original_df_column_name_padding(self):
@@ -654,8 +654,8 @@ class RowTests(TestCase):
         )
         action = dict(action_code='(col != null) and (orig_col != null)')
         df_new = filter_rows(df, action, original_df=df)
-        df_new['col'] = df_new['col'].astype(int)
-        df_new['orig_col'] = df_new['orig_col'].astype(int)
+        df_new['col'] = df_new['col'].astype(np.int64)
+        df_new['orig_col'] = df_new['orig_col'].astype(np.int64)
         assert_frame_equal(df_new, df_expected)
 
     def test_valid_columns_names(self):
@@ -676,7 +676,7 @@ class RowTests(TestCase):
             ],
         )
         for column in df.columns:
-            with self.assertRaises(Exception):
+            with self.assertRaises((SyntaxError, pd.errors.UndefinedVariableError)):
                 action = dict(action_code=f'{column} == False')
                 filter_rows(df, action, original_df=df)
 


### PR DESCRIPTION
# Description
Resolves #3516 
made sure `np.int64` is used

# How Has This Been Tested?
- [x] Unittests

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
