### PR TITLE
Fix: Dependency mismatch between mage_ai and mage_integrations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,9 @@ repos:
         args:
           - "--pytest-test-first"
     -   id: requirements-txt-fixer
+        files: 'mage_integrations/requirements.txt'
+        # excluded ./requirements.txt as it uses groups,
+        #which are not handled correctly by requirements-txt-fixer
 - repo: local
   hooks:
   - id: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     -   id: requirements-txt-fixer
         files: 'mage_integrations/requirements.txt'
         # excluded ./requirements.txt as it uses groups,
-        #which are not handled correctly by requirements-txt-fixer
+        # which are not handled correctly by requirements-txt-fixer
 - repo: local
   hooks:
   - id: isort

--- a/mage_integrations/requirements.txt
+++ b/mage_integrations/requirements.txt
@@ -30,7 +30,7 @@ requests_mock==1.10.0
 simple_salesforce
 simplejson==3.17.6
 singer_sdk==0.30.0
-snowflake-connector-python==2.9.0
+snowflake-connector-python==2.7.9
 sshtunnel==0.4.0
 stripe==4.2.0
 terminaltables==3.1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ polars<=0.19.2
 protobuf
 pyarrow==10.0.1
 python-dateutil==2.8.2
-pytz==2022.1
+pytz==2022.2.1
 pyyaml~=6.0
 redis
 requests==2.27.1


### PR DESCRIPTION
# Description
Resolves #3524

- `snowflake-connector-python`
  the production Dockerfile also installs mage-ai after mage-integrations, effectively sets whatever version of the package is 
  needed for mage-ai. If there weren't any error until now, then it should be fine to downgrade.
- `pytz`
  Typically upgrading pytz doesn't change anything. Most packages just define a minimum version anyway

# How Has This Been Tested?
- [x] `pip install -e ./[all] -e ./mage_integrations`
- [x] unittests

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
