### PR TITLE
Support trailing slash when base path set

### DIFF
--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -176,7 +176,7 @@ def make_app(template_dir: str = None, update_routes: bool = False):
     if template_dir is None:
         template_dir = os.path.join(os.path.dirname(__file__), EXPORTS_FOLDER)
     routes = [
-        (r'/', MainPageHandler),
+        (r'/?', MainPageHandler),
         (r'/files', MainPageHandler),
         (r'/overview', MainPageHandler),
         (r'/pipelines', MainPageHandler),


### PR DESCRIPTION
# Description
When using a base path, an url with trailing slash results in 404 as the path for routing in server.py becomes empty string and not single slash. This can be confusing.
```bash
MAGE_BASE_PATH=mage ./scripts/dev.sh dummy_project
```
- http://localhost:6789/mage - works
- http://localhost:6789/mage/ - does not work

# How Has This Been Tested?
```bash
MAGE_BASE_PATH=mage ./scripts/dev.sh dummy_project
```
- http://localhost:6789/mage - works
- http://localhost:6789/mage/ - also works

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation