### PR TITLE
[xy] Support multiple kafka topics in kafka source

### DIFF
--- a/docs/streaming/destinations/kafka.mdx
+++ b/docs/streaming/destinations/kafka.mdx
@@ -48,22 +48,17 @@ or dictionaries with a specific format as messages:
 
 ```
 message = {
-    'data': {
-      'key': <Any>,
-      'value': <Any>
-    }
+    'data': <Any>,
     'metadata': <Optional[Dict]>
 }
 ```
 
-If the data contains no dictionary it will be written to the database as value with the current time value and no key (list types will be written as seperate messages).
+If the data contains no dictionary it will be written to the database as value with the current time value and no key.
 Otherwise, every dictionary message contains at least some data in a `data` field. 
 The following messages are valid:
 
 ```python
-message_1 = {'data': {'bees': 23, 'ants': 30}}
-message_2 = {'data': 23}  # implicit for {None: 23}
-message_3 = {'data': [23, 30]}  # implicit for {None: 23} and {None: 30}
+message = {'data': {'bees': 23, 'ants': 30}}
 ```
 
 Kafka supports [structuring and partitioning](https://kafka-python.readthedocs.io/en/master/apidoc/KafkaProducer.html#kafka.KafkaProducer.send) your data. 
@@ -71,7 +66,8 @@ The Kafka data exporter can create these elements if the messages received conta
 
 ```python
 message['metadata'] = {
-    'topic': str
+    'dest_topic': str
+    'key': str
     'time': int
 }
 ```
@@ -81,11 +77,12 @@ The following message shows the configuration of all possible elements data and 
 ```python
 message = {
     'data': {
-      'bees': 23, 
-      'ants': 30
+        'bees': 23,
+        'ants': 30,
     },
     'metadata': {
-        'topic': 'census',
+        'dest_topic': 'census',
+        'key': 'key',
         'time': 1693396630163,  # timestamp with ms precision
     }
 }
@@ -102,6 +99,3 @@ topic: topic_name
 ```
 
 - The default time timestamp is the current time of execution.
-
-If the `data` part of the message is a dictionary it taken for the keys and values. 
-Otherwise only the values are assigned with empty keys.

--- a/docs/streaming/sources/kafka.mdx
+++ b/docs/streaming/sources/kafka.mdx
@@ -8,6 +8,7 @@ title: "Kafka"
 connector_type: kafka
 bootstrap_server: "localhost:9092"
 topic: topic_name
+topics: topic_name1, topic_name2  # Optional. Used for specifying multiple topics.
 consumer_group: unique_consumer_group
 include_metadata: false
 api_version: "0.10.2"

--- a/docs/streaming/sources/kafka.mdx
+++ b/docs/streaming/sources/kafka.mdx
@@ -50,14 +50,13 @@ If `include_metadata` is set to true, the kafka data loader returns these elemen
 
 ```python
 message = {
-    "data": {
-      "bees": {"location": "klamath", "scientist": "anderson", "count": 23}
-    },
+    "data": {"location": "klamath", "scientist": "anderson", "count": 23},
     "metadata": {
-      "topic": "census",
+      "key": "bees",
       "partition": 0,
       "offset": 6,
-      "time": 1693396630163  # timestamp with ms precision (Wed Aug 30 2023 11:57:10 GMT+0)
+      "time": 1693396630163,  # timestamp with ms precision (Wed Aug 30 2023 11:57:10 GMT+0)
+      "topic": "census",
     }}
 ```
 

--- a/mage_ai/streaming/sinks/kafka.py
+++ b/mage_ai/streaming/sinks/kafka.py
@@ -1,12 +1,10 @@
 import json
 import time
-from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List
 
 from kafka import KafkaProducer
-
 from mage_ai.shared.config import BaseConfig
 from mage_ai.streaming.constants import DEFAULT_BATCH_SIZE, DEFAULT_TIMEOUT_MS
 from mage_ai.streaming.sinks.base import BaseSink
@@ -103,27 +101,12 @@ class KafkaSink(BaseSink):
             data = message
             metadata = {}
 
-        if isinstance(data, dict):
-            for key, value in data.items():
-                self.producer.send(
-                    topic=metadata.get('topic', self.config.topic),
-                    value=value,
-                    key=key,
-                    timestamp_ms=metadata.get('time'),
-                )
-        elif isinstance(data, Iterable):
-            for value in data:
-                self.producer.send(
-                    topic=metadata.get('topic', self.config.topic),
-                    value=value,
-                    timestamp_ms=metadata.get('time'),
-                )
-        else:  # data is scalar
-            self.producer.send(
-                topic=metadata.get('topic', self.config.topic),
-                value=data,
-                timestamp_ms=metadata.get('time'),
-            )
+        self.producer.send(
+            topic=metadata.get('dest_topic', self.config.topic),
+            value=data,
+            key=metadata.get('key'),
+            timestamp_ms=metadata.get('time'),
+        )
 
     def batch_write(self, messages: List[Dict]):
         if not messages:

--- a/mage_ai/streaming/sinks/kafka.py
+++ b/mage_ai/streaming/sinks/kafka.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import Dict, List
 
 from kafka import KafkaProducer
+
 from mage_ai.shared.config import BaseConfig
 from mage_ai.streaming.constants import DEFAULT_BATCH_SIZE, DEFAULT_TIMEOUT_MS
 from mage_ai.streaming.sinks.base import BaseSink

--- a/mage_ai/streaming/sources/kafka.py
+++ b/mage_ai/streaming/sources/kafka.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import Callable, Dict, List
 
 from kafka import KafkaConsumer
+
 from mage_ai.shared.config import BaseConfig
 from mage_ai.streaming.constants import DEFAULT_BATCH_SIZE, DEFAULT_TIMEOUT_MS
 from mage_ai.streaming.sources.base import BaseSource

--- a/mage_ai/streaming/sources/kafka.py
+++ b/mage_ai/streaming/sources/kafka.py
@@ -1,12 +1,11 @@
 import importlib
 import json
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
-from typing import Callable, Dict
+from typing import Callable, Dict, List
 
 from kafka import KafkaConsumer
-
 from mage_ai.shared.config import BaseConfig
 from mage_ai.streaming.constants import DEFAULT_BATCH_SIZE, DEFAULT_TIMEOUT_MS
 from mage_ai.streaming.sources.base import BaseSource
@@ -38,7 +37,6 @@ class SSLConfig:
 class KafkaConfig(BaseConfig):
     bootstrap_server: str
     consumer_group: str
-    topic: str
     api_version: str = '0.10.2'
     batch_size: int = DEFAULT_BATCH_SIZE
     timeout_ms: int = DEFAULT_TIMEOUT_MS
@@ -47,6 +45,8 @@ class KafkaConfig(BaseConfig):
     ssl_config: SSLConfig = None
     sasl_config: SASLConfig = None
     serde_config: SerDeConfig = None
+    topic: str = None
+    topics: List = field(default_factory=list)
 
     @classmethod
     def parse_config(self, config: Dict) -> Dict:
@@ -66,6 +66,9 @@ class KafkaSource(BaseSource):
     config_class = KafkaConfig
 
     def init_client(self):
+        if not self.config.topic and not self.config.topics:
+            raise Exception('Please specify topic or topics in the Kafka config.')
+
         self._print('Start initializing consumer.')
         # Initialize kafka consumer
         consumer_kwargs = dict(
@@ -89,7 +92,12 @@ class KafkaSource(BaseSource):
             consumer_kwargs['sasl_plain_username'] = self.config.sasl_config.username
             consumer_kwargs['sasl_plain_password'] = self.config.sasl_config.password
 
-        self.consumer = KafkaConsumer(self.config.topic, **consumer_kwargs)
+        if self.config.topic:
+            topics = [self.config.topic]
+        else:
+            topics = self.config.topics
+
+        self.consumer = KafkaConsumer(*topics, **consumer_kwargs)
         self._print('Finish initializing consumer.')
 
         self.schema_class = None
@@ -132,14 +140,13 @@ class KafkaSource(BaseSource):
     def _convert_message(self, message):
         if self.config.include_metadata:
             message = {
-                'data': {
-                    message.key.decode(): self.__deserialize_message(message.value)
-                },
+                'data': self.__deserialize_message(message.value),
                 'metadata': {
-                    'topic': message.topic,
+                    'key': message.key.decode() if message.key else None,
                     'partition': message.partition,
                     'offset': message.offset,
                     'time': int(message.timestamp),
+                    'topic': message.topic,
                 },
             }
         else:
@@ -227,5 +234,5 @@ class KafkaSource(BaseSource):
     def __print_message(self, message):
         self._print(
             f'Receive message {message.partition}:{message.offset}: '
-            f'v={message.value}, time={time.time()}'
+            f'key={message.key}, value={message.value}, time={time.time()}'
         )


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Support multiple kafka topics in kafka source

Example config
```
connector_type: kafka
bootstrap_server: "kafka:9093"
consumer_group: unique_consumer_group
include_metadata: true
topics: ['test', 'test2']
```

This PR also moves the key to the metadata. Example record
```python
{
   "data":{
      "title":"test_title",
      "director":"Bennett Miller",
      "year":"2011",
      "rating":0.9114357818630547
   },
   "metadata":{
      "key": None,
      "partition": 0,
      "offset": 18759,
      "time": 1695061975118,
      "topic": "test"
   }
}
```

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested multiple topics in local kafka pipeline
<img width="526" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/97cad633-3d93-464a-8680-3f6b6ff6477c">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
