### PR TITLE
[td] Fix raw SQL alias

### DIFF
--- a/mage_ai/data_preparation/models/block/sql/__init__.py
+++ b/mage_ai/data_preparation/models/block/sql/__init__.py
@@ -433,8 +433,6 @@ def execute_sql_code(
             )
             query_string = interpolate_vars(query_string, global_vars=global_vars)
 
-            print(query_string)
-
             schema = schema or loader.default_schema()
 
             if use_raw_sql:

--- a/mage_ai/data_preparation/models/block/sql/__init__.py
+++ b/mage_ai/data_preparation/models/block/sql/__init__.py
@@ -433,6 +433,8 @@ def execute_sql_code(
             )
             query_string = interpolate_vars(query_string, global_vars=global_vars)
 
+            print(query_string)
+
             schema = schema or loader.default_schema()
 
             if use_raw_sql:

--- a/mage_ai/data_preparation/models/block/sql/utils/shared.py
+++ b/mage_ai/data_preparation/models/block/sql/utils/shared.py
@@ -174,11 +174,21 @@ def interpolate_input(
 
             match = 1
             while match is not None:
-                match = re.search(
+                match = None
+
+                for pattern in [
                     r'{}[\n\r\s]+as[\n\r\s]+'.format(variable_pattern),
-                    query,
-                    re.IGNORECASE,
-                )
+                    r'{}[\n\r\s]+["|\'].+["|\']'.format(variable_pattern),
+                    r'{}[\n\r\s]+\S+[\n\r\s]+ON'.format(variable_pattern),
+                ]:
+                    if match:
+                        continue
+
+                    match = re.search(
+                        pattern,
+                        query,
+                        re.IGNORECASE,
+                    )
 
                 if not match:
                     continue

--- a/mage_ai/data_preparation/models/block/sql/utils/shared.py
+++ b/mage_ai/data_preparation/models/block/sql/utils/shared.py
@@ -208,7 +208,7 @@ def interpolate_input(
                 ])
 
             replace_with = f"""(
-    {upstream_query}
+{upstream_query.strip()}
 ) AS {table_name}"""
 
         query = re.sub(

--- a/mage_ai/data_preparation/models/block/sql/utils/shared.py
+++ b/mage_ai/data_preparation/models/block/sql/utils/shared.py
@@ -171,6 +171,32 @@ def interpolate_input(
                 has_create_or_insert_statement(upstream_block_content):
 
             upstream_query = interpolate_input(upstream_block, upstream_block_content)
+
+            match = 1
+            while match is not None:
+                match = re.search(
+                    r'{}[\n\r\s]+as[\n\r\s]+'.format(variable_pattern),
+                    query,
+                    re.IGNORECASE,
+                )
+
+                if not match:
+                    continue
+
+                si, ei = match.span()
+                substring = query[si:ei]
+
+                si, ei = match.span()
+                query = ''.join([
+                    query[:si],
+                    re.sub(
+                        variable_pattern,
+                        f'({upstream_query})',
+                        substring,
+                    ),
+                    query[ei:],
+                ])
+
             replace_with = f"""(
     {upstream_query}
 ) AS {table_name}"""

--- a/mage_ai/tests/data_preparation/models/block/sql/utils/test_shared.py
+++ b/mage_ai/tests/data_preparation/models/block/sql/utils/test_shared.py
@@ -1,0 +1,202 @@
+from mage_ai.data_preparation.models.block import Block
+from mage_ai.data_preparation.models.block.sql.utils.shared import interpolate_input
+from mage_ai.data_preparation.models.constants import BlockLanguage, BlockType
+from mage_ai.data_preparation.models.pipeline import Pipeline
+from mage_ai.tests.base_test import DBTestCase
+
+
+class SQLBlockSharedUtilsTest(DBTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.pipeline = Pipeline.create(
+            'test pipeline',
+            repo_path=self.repo_path,
+        )
+
+        configuration = dict(
+            data_provider='data_provider',
+            data_provider_database='data_provider_database',
+            data_provider_schema='data_provider_schema',
+            use_raw_sql=True,
+        )
+        shared_props = dict(
+            configuration=configuration,
+            language=BlockLanguage.SQL,
+            pipeline=self.pipeline,
+        )
+
+        data_loader_1 = Block(
+            'data_loader_1',
+            'data_loader_1',
+            BlockType.DATA_LOADER,
+            **shared_props,
+            content="""
+WITH
+test AS (
+SELECT 1 AS id2, 2 AS "with"
+)
+
+SELECT
+id as unique_id,split_part(name, ' ', 1) AS "first           name----1!"
+, name AS last_name
+FROM "mage"."account_v6"
+INNER JOIN test
+ON 1 = 1
+""",
+        )
+
+        data_loader_2 = Block(
+            'data_loader_2',
+            'data_loader_2',
+            BlockType.DATA_LOADER,
+            **shared_props,
+            content="""
+SELECT
+id AS unique_id
+, name AS first_name
+, type AS last_name
+FROM "mage"."account_v6" AS "on"
+""",
+        )
+
+        data_exporter = Block(
+            'data_exporter',
+            'data_exporter',
+            BlockType.DATA_EXPORTER,
+            **shared_props,
+            content="""
+SELECT
+a.*
+FROM {{df_1}} AS "a"
+
+INNER JOIN {{ df_2 }} AS b
+ON a.unique_id = b.unique_id
+
+INNER JOIN {{ df_2 }}
+on 1 = 1
+
+INNER JOIN {{ df_2 }} c
+ON 1 = 1
+
+INNER JOIN {{ df_2 }} AS d
+ON 1 = 1
+
+INNER JOIN {{ df_2 }} as e
+ON 1 = 1
+
+INNER JOIN {{ df_2 }} AS "f"
+ON 1 = 1
+
+INNER JOIN {{ df_2 }} as "g"
+ON 1 = 1
+
+INNER JOIN {{ df_2 }} "on"
+ON 1 = 1
+"""
+        )
+
+        self.pipeline.add_block(data_loader_1)
+        self.pipeline.add_block(data_loader_2)
+        self.pipeline.add_block(data_exporter, [
+            data_loader_1.uuid,
+            data_loader_2.uuid,
+        ])
+
+    def test_interpolate_input(self):
+        data_exporter = self.pipeline.get_block('data_exporter')
+
+        query_string = interpolate_input(
+            data_exporter,
+            data_exporter.content,
+        )
+
+        self.assertEqual(query_string.strip(), """
+SELECT
+a.*
+FROM (
+WITH
+test AS (
+SELECT 1 AS id2, 2 AS "with"
+)
+
+SELECT
+id as unique_id,split_part(name, ' ', 1) AS "first           name----1!"
+, name AS last_name
+FROM "mage"."account_v6"
+INNER JOIN test
+ON 1 = 1
+) AS "a"
+
+INNER JOIN (
+SELECT
+id AS unique_id
+, name AS first_name
+, type AS last_name
+FROM "mage"."account_v6" AS "on"
+) AS b
+ON a.unique_id = b.unique_id
+
+INNER JOIN (
+SELECT
+id AS unique_id
+, name AS first_name
+, type AS last_name
+FROM "mage"."account_v6" AS "on"
+) AS test_pipeline_data_loader_2_v1
+on 1 = 1
+
+INNER JOIN (
+SELECT
+id AS unique_id
+, name AS first_name
+, type AS last_name
+FROM "mage"."account_v6" AS "on"
+) c
+ON 1 = 1
+
+INNER JOIN (
+SELECT
+id AS unique_id
+, name AS first_name
+, type AS last_name
+FROM "mage"."account_v6" AS "on"
+) AS d
+ON 1 = 1
+
+INNER JOIN (
+SELECT
+id AS unique_id
+, name AS first_name
+, type AS last_name
+FROM "mage"."account_v6" AS "on"
+) as e
+ON 1 = 1
+
+INNER JOIN (
+SELECT
+id AS unique_id
+, name AS first_name
+, type AS last_name
+FROM "mage"."account_v6" AS "on"
+) AS "f"
+ON 1 = 1
+
+INNER JOIN (
+SELECT
+id AS unique_id
+, name AS first_name
+, type AS last_name
+FROM "mage"."account_v6" AS "on"
+) as "g"
+ON 1 = 1
+
+INNER JOIN (
+SELECT
+id AS unique_id
+, name AS first_name
+, type AS last_name
+FROM "mage"."account_v6" AS "on"
+) "on"
+ON 1 = 1
+""".strip())


### PR DESCRIPTION
# Description
If you wrote this:

```
SELECT *
FROM {{ df_1 }} AS a
```

Mage automatically adds an alias on top of the user defined alias.

This fix will only automatically add the alias if an alias isn’t defined.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Unit test to test interpolation of query with alias


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
