### PR TITLE
[jk] Reorder upstream blocks

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -1740,10 +1740,16 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
             self.color = data['color']
             self.__update_pipeline_block()
 
-        if 'upstream_blocks' in data and set(data['upstream_blocks']) != set(
-            self.upstream_block_uuids
+        check_upstream_block_order = kwargs.get('check_upstream_block_order', False)
+        if 'upstream_blocks' in data and (
+            (check_upstream_block_order and
+                data['upstream_blocks'] != self.upstream_block_uuids) or
+            set(data['upstream_blocks']) != set(self.upstream_block_uuids)
         ):
-            self.__update_upstream_blocks(data['upstream_blocks'])
+            self.__update_upstream_blocks(
+                data['upstream_blocks'],
+                check_upstream_block_order=check_upstream_block_order,
+            )
 
         if 'callback_blocks' in data and set(data['callback_blocks']) != set(
             self.callback_block_uuids
@@ -2428,11 +2434,16 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
             language=self.language,
         )
 
-    def __update_upstream_blocks(self, upstream_blocks) -> None:
+    def __update_upstream_blocks(
+        self,
+        upstream_blocks,
+        check_upstream_block_order: bool = False,
+    ) -> None:
         if self.pipeline is None:
             return
         self.pipeline.update_block(
             self,
+            check_upstream_block_order=check_upstream_block_order,
             upstream_block_uuids=upstream_blocks,
             widget=BlockType.CHART == self.type,
         )

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -1018,6 +1018,7 @@ class Pipeline:
             if block_uuid in block_configs_by_uuids:
                 block_config = block_configs_by_uuids[block_uuid]
 
+                # Sort upstream_blocks order based on new block order
                 upstream_blocks = block_config['upstream_blocks']
                 if len(upstream_blocks) > 1:
                     upstream_blocks_reordered = upstream_blocks.copy()

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -1002,21 +1002,38 @@ class Pipeline:
 
         min_length = min(len(uuids_new), len(uuids_old))
 
-        # If there are no blocks or the order has changed
+        # If there are no blocks or the order has not changed
         if min_length == 0 or uuids_new[:min_length] == uuids_old[:min_length]:
             return False
 
         block_configs_by_uuids = index_by(lambda x: x['uuid'], self.block_configs)
+        new_indexes_by_uuid = {uuid: index for index, uuid in enumerate(uuids_new)}
 
         block_configs = []
         blocks_by_uuid = {}
 
         for block_uuid in uuids_new:
+            upstream_blocks = None
+            upstream_blocks_reordered = None
             if block_uuid in block_configs_by_uuids:
-                block_configs.append(block_configs_by_uuids[block_uuid])
+                block_config = block_configs_by_uuids[block_uuid]
+
+                upstream_blocks = block_config['upstream_blocks']
+                if len(upstream_blocks) > 1:
+                    upstream_blocks_reordered = upstream_blocks.copy()
+                    upstream_blocks_reordered.sort(key=lambda uuid: new_indexes_by_uuid[uuid])
+
+                block_configs.append(block_config)
 
             if block_uuid in self.blocks_by_uuid:
-                blocks_by_uuid[block_uuid] = self.blocks_by_uuid[block_uuid]
+                block = self.blocks_by_uuid[block_uuid]
+                if upstream_blocks_reordered is not None and \
+                        upstream_blocks != upstream_blocks_reordered:
+                    block.update(
+                        dict(upstream_blocks=upstream_blocks_reordered),
+                        check_upstream_block_order=True,
+                    )
+                blocks_by_uuid[block_uuid] = block
 
         self.block_configs = block_configs
         self.blocks_by_uuid = blocks_by_uuid
@@ -1199,6 +1216,7 @@ class Pipeline:
         self,
         block: Block,
         callback_block_uuids: List[str] = None,
+        check_upstream_block_order: bool = False,
         conditional_block_uuids: List[str] = None,
         upstream_block_uuids: List[str] = None,
         widget: bool = False,
@@ -1239,7 +1257,9 @@ class Pipeline:
 
             curr_upstream_block_uuids = set(block.upstream_block_uuids)
             new_upstream_block_uuids = set(upstream_block_uuids)
-            if curr_upstream_block_uuids != new_upstream_block_uuids:
+            if curr_upstream_block_uuids != new_upstream_block_uuids or \
+                (check_upstream_block_order and
+                    block.upstream_block_uuids != upstream_block_uuids):
                 # Only set upstream block’s downstream to the current block if current block
                 # is not an extension block and not a callback/conditional block
                 if not is_extension and not is_callback and not is_conditional:

--- a/mage_ai/tests/data_preparation/models/test_block.py
+++ b/mage_ai/tests/data_preparation/models/test_block.py
@@ -606,3 +606,48 @@ def test_output(output, *args) -> None:
         output = block._execute_block(dict(), from_notebook=True)
         self.assertIsNotNone(block.module)
         self.assertEqual(len(output), 1)
+
+    def test_update_upstream_blocks_order(self):
+        pipeline = Pipeline.create(
+            'test pipeline 8',
+            repo_path=self.repo_path,
+        )
+        Block.create(
+            'test_data_loader_1',
+            'data_loader',
+            self.repo_path,
+            pipeline=pipeline,
+        )
+        Block.create(
+            'test_data_loader_2',
+            'data_loader',
+            self.repo_path,
+            pipeline=pipeline,
+        )
+        block3 = Block.create(
+            'test_transformer',
+            'transformer',
+            self.repo_path,
+            pipeline=pipeline,
+            upstream_block_uuids=['test_data_loader_1', 'test_data_loader_2'],
+        )
+        self.assertEqual(
+            block3.upstream_block_uuids[0],
+            'test_data_loader_1',
+        )
+        self.assertEqual(
+            block3.upstream_block_uuids[1],
+            'test_data_loader_2',
+        )
+        block3.update(
+            dict(upstream_blocks=['test_data_loader_2', 'test_data_loader_1']),
+            check_upstream_block_order=True,
+        )
+        self.assertEqual(
+            block3.upstream_block_uuids[0],
+            'test_data_loader_2',
+        )
+        self.assertEqual(
+            block3.upstream_block_uuids[1],
+            'test_data_loader_1',
+        )


### PR DESCRIPTION
# Description
- Reorder a block's `upstream_blocks` based on the pipeline's block order when reordering the blocks in the pipeline.
- Users can reorder blocks in a pipeline by dragging them before or after another block in the Pipeline Editor. Now when reordering the blocks, this will also automatically update the upstream blocks order for a block based on the pipeline's block order.

# How Has This Been Tested?
![upstream block reorder](https://github.com/mage-ai/mage-ai/assets/78053898/a141dd0e-f9fa-4834-8a89-bdc075bee6cf)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
