### PR TITLE
[td] Fix overwriting runtime variables for dbt block

### DIFF
--- a/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
+++ b/mage_ai/data_preparation/models/block/dbt/utils/__init__.py
@@ -1046,8 +1046,8 @@ def build_command_line_arguments(
     test_execution: bool = False,
 ) -> Tuple[str, List[str], Dict]:
     variables = merge_dict(
-        variables or {},
         get_global_variables(block.pipeline.uuid) if block.pipeline else {},
+        variables or {},
     )
     dbt_command = (block.configuration or {}).get('dbt', {}).get('command', 'run')
 


### PR DESCRIPTION
# Description
Can’t overwrite runtime variables for dbt blocks.


# How Has This Been Tested?

## Overwrite

<img width="732" alt="CleanShot 2023-09-19 at 00 27 22@2x" src="https://github.com/mage-ai/mage-ai/assets/1066980/aff058bc-a975-4f14-b752-32bf6ac05859">

<img width="941" alt="CleanShot 2023-09-19 at 00 27 49@2x" src="https://github.com/mage-ai/mage-ai/assets/1066980/0548fe57-47dd-469c-b7f4-f844a63abbfc">


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
