### PR TITLE
Removing obsolete code, handle root path

### DIFF
--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -268,11 +268,8 @@ def make_app(template_dir: str = None, update_routes: bool = False):
     if update_routes:
         updated_routes = []
         for route in routes:
-            if route[0] == r'/':
-                updated_routes.append((f'/{ROUTES_BASE_PATH}', *route[1:]))
-            else:
-                updated_routes.append(
-                    (route[0].replace('/', f'/{ROUTES_BASE_PATH}/', 1), *route[1:]))
+            updated_routes.append(
+                (route[0].replace('/', f'/{ROUTES_BASE_PATH}/', 1), *route[1:]))
     else:
         updated_routes = routes
 


### PR DESCRIPTION
# Description
Previous [PR 3530](https://github.com/mage-ai/mage-ai/pull/3530) changed root path to r'/?' from r'/' .
After that I found an `if ... else` code block that used to handle the root path as a special case.
With the mentioned change the special case is not needed, the condition in the `if` never evaluates to `True`, and hence is obsolete.
Removing for cleaner code.

# How Has This Been Tested?
```bash
MAGE_BASE_PATH=mage ./scripts/dev.sh dummy_project
```
- http://localhost:6789/mage - works
- http://localhost:6789/mage/ - works

```bash
./scripts/dev.sh dummy_project
```
- http://localhost:6789 - works
- http://localhost:6789/ - works

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
@dy46 
