### PR TITLE
[xy] Not concat pandas dataframes when not reducing dynamic blocks.

### DIFF
--- a/mage_ai/data_preparation/models/block/utils.py
+++ b/mage_ai/data_preparation/models/block/utils.py
@@ -723,7 +723,10 @@ def fetch_input_variables(
                             val = variable_values[dynamic_block_index]
                             kwargs_vars.append(val)
 
-                if len(final_value) >= 1 and all([type(v) is pd.DataFrame for v in final_value]):
+                if ((upstream_is_dynamic and dynamic_block_index is not None)
+                    or should_reduce) and \
+                        len(final_value) >= 1 and \
+                        all([type(v) is pd.DataFrame for v in final_value]):
                     final_value = pd.concat(final_value)
 
                 if not should_reduce:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Not concat pandas dataframes when not reducing dynamic blocks.
<img width="739" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/5b8091e7-5db2-4fee-93b6-1ce117c6e88f">


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with the following pipeline
<img width="284" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/2fc8776d-2003-4f8e-9910-9b8c5f184234">

Code in still_leaf block
```python
@transformer
def transform(data, *args, **kwargs):
    result = []
    print(data)
    for d in data:
        result.append(pd.DataFrame.from_dict(d))
    return result
```
Before the fix, the list of dataframes get concatenate automatically in the data exporter block.
With the fix, the data exporter block gets the list of dataframes as input. 


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code

cc:
<!-- Optionally mention someone to let them know about this pull request -->
