### PR TITLE
[jk] Update wording for empty pipeline template state

### DIFF
--- a/mage_ai/frontend/components/CustomTemplates/BrowseTemplates/index.tsx
+++ b/mage_ai/frontend/components/CustomTemplates/BrowseTemplates/index.tsx
@@ -538,7 +538,8 @@ function BrowseTemplates({
                 <br />
 
                 <Text>
-                  Add a new template by clicking the button above.
+                  Add a new template by right-clicking a pipeline row from the
+                  Pipelines page and selecting &#34;Create template&#34;.
                 </Text>
               </Spacing>
             )}


### PR DESCRIPTION
# Description
- Update wording for empty pipeline template state since there is no button in the UI for creating a new pipeline template directly from the pipeline templates page.

# How Has This Been Tested?
![image](https://github.com/mage-ai/mage-ai/assets/78053898/cb7a5834-c15c-4fbb-a6f9-cfdf5afd83c4)

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
