### PR TITLE
fix: have api middlware set status codes if api key or oauth token error

### DIFF
--- a/mage_ai/api/middleware.py
+++ b/mage_ai/api/middleware.py
@@ -79,8 +79,10 @@ class OAuthMiddleware(RequestHandler):
             self.request.__setattr__('oauth_client', oauth_client)
             if not oauth_client:
                 self.request.__setattr__('error', ApiError.INVALID_API_KEY)
+                self.set_status(ApiError.INVALID_API_KEY['code'])
             elif oauth_client.client_id != OAUTH2_APPLICATION_CLIENT_ID:
                 self.request.__setattr__('error', ApiError.INVALID_API_KEY)
+                self.set_status(ApiError.INVALID_API_KEY['code'])
             else:
                 should_check = False
                 oauth_token = None
@@ -108,8 +110,11 @@ class OAuthMiddleware(RequestHandler):
                         else:
                             self.request.__setattr__(
                                 'error', ApiError.EXPIRED_OAUTH_TOKEN)
+                            self.set_status(ApiError.EXPIRED_OAUTH_TOKEN['code'])
                     else:
                         self.request.__setattr__(
                             'error', ApiError.INVALID_OAUTH_TOKEN)
+                        self.set_status(ApiError.INVALID_OAUTH_TOKEN['code'])
         else:
             self.request.__setattr__('error', ApiError.INVALID_API_KEY)
+            self.set_status(ApiError.INVALID_API_KEY['code'])


### PR DESCRIPTION
# Description

So I was creating and updating sessions using the API. I noticed that while response bodies would contain error details, the actual HTTP status_code would still be OK 200. For easier error handling for adopters, I desired to see actual 401 'token expired' http responses.

Error responses should therefore use the correct status_code according to `api/errors.py` which can be done in the existing api middleware class.

# How Has This Been Tested?

1. I updated the code in this PR, at every point where an API http response is set to error, the corresponding status_code is also set on the response.
2. I set the `MAGE_ACCESS_TOKEN_EXPIRY_TIME` environment variable to a very short value (120) to trigger token expiration
3. I attempted API calls with the expired session token in the header. 
4. I observed the response status_code to be the integer 401 instead of 200.

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:

@tommydangerous 