### PR TITLE
[jk] Support local timezone for cron expressions

### DIFF
--- a/mage_ai/frontend/components/Triggers/Detail/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Detail/index.tsx
@@ -63,7 +63,12 @@ import {
   getFormattedVariable,
   getFormattedVariables,
 } from '@components/Sidekick/utils';
-import { convertSeconds, getTriggerApiEndpoint } from '../utils';
+import {
+  checkIfCustomInterval,
+  convertSeconds,
+  convertUtcCronExpressionToLocalTimezone,
+  getTriggerApiEndpoint,
+} from '../utils';
 import { dateFormatLong, datetimeInLocalTimezone } from '@utils/date';
 import { getModelAttributes } from '@utils/models/dbt';
 import { goToWithQuery } from '@utils/routing';
@@ -116,6 +121,11 @@ function TriggerDetail({
     tags,
     variables: scheduleVariablesInit = {},
   } = pipelineSchedule || {};
+
+  const isCustomInterval = useMemo(
+    () => checkIfCustomInterval(scheduleInterval),
+    [scheduleInterval],
+  );
 
   const q = queryFromUrl();
 
@@ -354,7 +364,10 @@ function TriggerDetail({
             key="trigger_frequency"
             monospace
           >
-            {scheduleInterval.replace('@', '')}
+            {(displayLocalTimezone && isCustomInterval)
+              ? convertUtcCronExpressionToLocalTimezone(scheduleInterval)
+              : scheduleInterval.replace('@', '')
+            }
           </Text>,
         ],
         [
@@ -522,6 +535,7 @@ function TriggerDetail({
     description,
     displayLocalTimezone,
     isActive,
+    isCustomInterval,
     nextRunDate,
     pipelineSchedule,
     scheduleInterval,

--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -934,19 +934,23 @@ function Edit({
                 )
               }
 
-              <Text bold inline small warning>
-                Note:&nbsp;
-              </Text>
-              <Text inline small>
-                If you have the display_local_timezone setting enabled, the local cron expression
-                above will match your local timezone only
-                <br />
-                if the minute and hour values are single
-                values without any special characters, such as the comma, hyphen, or slash.
-                <br />
-                You can still use cron expressions with special characters for the minute/hour
-                values, but it will be based in UTC time.
-              </Text>
+              {displayLocalTimezone && (
+                <>
+                  <Text bold inline small warning>
+                    Note:&nbsp;
+                  </Text>
+                  <Text inline small>
+                    If you have the display_local_timezone setting enabled, the local cron expression
+                    above will match your local timezone only
+                    <br />
+                    if the minute and hour values are single
+                    values without any special characters, such as the comma, hyphen, or slash.
+                    <br />
+                    You can still use cron expressions with special characters for the minute/hour
+                    values, but it will be based in UTC time.
+                  </Text>
+                </>
+              )}
             </Spacing>
           </div>,
         ],

--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -267,8 +267,7 @@ function Edit({
     () => {
       if (pipelineSchedule && !schedule) {
         setEventMatchers(pipelineSchedule.event_matchers);
-        const custom = pipelineSchedule?.schedule_interval &&
-          !Object.values(ScheduleIntervalEnum).includes(pipelineSchedule?.schedule_interval as ScheduleIntervalEnum);
+        const custom = checkIfCustomInterval(pipelineSchedule?.schedule_interval);
 
         if (custom) {
           const customIntervalInit = displayLocalTimezone

--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -64,6 +64,7 @@ import {
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
 import {
   TIME_UNIT_TO_SECONDS,
+  checkIfCustomInterval,
   convertSeconds,
   convertToSeconds,
   convertUtcCronExpressionToLocalTimezone,
@@ -247,8 +248,7 @@ function Edit({
   );
 
   const isCustomInterval = useMemo(
-    () => scheduleInterval &&
-      !Object.values(ScheduleIntervalEnum).includes(scheduleInterval as ScheduleIntervalEnum),
+    () => checkIfCustomInterval(scheduleInterval),
     [scheduleInterval],
   );
   const readableCronExpression = useMemo(() => (

--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -933,6 +933,20 @@ function Edit({
                   </Text>
                 )
               }
+
+              <Text bold inline small warning>
+                Note:&nbsp;
+              </Text>
+              <Text inline small>
+                If you have the display_local_timezone setting enabled, the local cron expression
+                above will match your local timezone only
+                <br />
+                if the minute and hour values are single
+                values without any special characters, such as the comma, hyphen, or slash.
+                <br />
+                You can still use cron expressions with special characters for the minute/hour
+                values, but it will be based in UTC time.
+              </Text>
             </Spacing>
           </div>,
         ],

--- a/mage_ai/frontend/components/Triggers/Table.tsx
+++ b/mage_ai/frontend/components/Triggers/Table.tsx
@@ -38,6 +38,10 @@ import { ICON_SIZE_SMALL } from '@oracle/styles/units/icons';
 import { RunStatus } from '@interfaces/BlockRunType';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { TableContainerStyle } from '@components/shared/Table/index.style';
+import {
+  checkIfCustomInterval,
+  convertUtcCronExpressionToLocalTimezone,
+} from './utils';
 import { dateFormatLong, datetimeInLocalTimezone } from '@utils/date';
 import { isViewer } from '@utils/session';
 import { onSuccess } from '@api/utils/response';
@@ -245,6 +249,7 @@ function TriggersTable({
                 tags,
               } = pipelineSchedule;
               const isActive = ScheduleStatusEnum.ACTIVE === status;
+              const isCustomInterval = checkIfCustomInterval(scheduleInterval);
               const finalPipelineUUID = pipelineUUID || triggerPipelineUUID;
               deleteButtonRefs.current[id] = createRef();
 
@@ -352,7 +357,10 @@ function TriggersTable({
               if (!disableActions) {
                 rows.push(
                   <Text default key={`trigger_frequency_${idx}`} monospace>
-                    {scheduleInterval}
+                    {(displayLocalTimezone && isCustomInterval)
+                      ? convertUtcCronExpressionToLocalTimezone(scheduleInterval)
+                      : scheduleInterval
+                    }
                   </Text>,
                 );
               }

--- a/mage_ai/frontend/components/Triggers/utils.ts
+++ b/mage_ai/frontend/components/Triggers/utils.ts
@@ -6,12 +6,18 @@ import { DATE_FORMAT_LONG_NO_SEC_WITH_OFFSET, dateFormatLong } from '@utils/date
 import { DEFAULT_PORT } from '@api/utils/url';
 import {
   PipelineScheduleFilterQueryEnum,
+  ScheduleIntervalEnum,
   ScheduleTypeEnum,
 } from '@interfaces/PipelineScheduleType';
 import { TimeType } from '@oracle/components/Calendar';
 import { getDayRangeForCurrentMonth } from '@utils/date';
 import { ignoreKeys } from '@utils/hash';
 import { rangeSequential } from '@utils/array';
+
+export const checkIfCustomInterval = (
+  scheduleInterval: string,
+) => !!scheduleInterval &&
+  !Object.values(ScheduleIntervalEnum).includes(scheduleInterval as ScheduleIntervalEnum);
 
 export function createBlockStatus(blockRuns: BlockRunType[]) {
   return blockRuns?.reduce(

--- a/mage_ai/frontend/components/Triggers/utils.ts
+++ b/mage_ai/frontend/components/Triggers/utils.ts
@@ -234,8 +234,6 @@ function calculateCronValueWithOffset(
 ): CronValueWithOffsetType {
   let currentIndex = range.indexOf(timeUnitValue);
   let additionalOffsetForGreaterTimeUnit = 0;
-  console.log('------------');
-  console.log('range:', range);
   if (timeOffset < 0) {
     for (let i = 0; i > timeOffset; i--) {
       if (currentIndex === 0) {
@@ -247,7 +245,6 @@ function calculateCronValueWithOffset(
     }
   } else if (timeOffset > 0) {
     for (let i = 0; i < timeOffset; i++) {
-      console.log('currentIndex:', currentIndex);
       if (currentIndex === range.length - 1) {
         currentIndex = 0;
         additionalOffsetForGreaterTimeUnit += 1;

--- a/mage_ai/frontend/utils/date.ts
+++ b/mage_ai/frontend/utils/date.ts
@@ -1,5 +1,7 @@
 import moment from 'moment';
 
+import { rangeSequential } from '@utils/array';
+
 export enum TimePeriodEnum {
   TODAY = 'today',
   WEEK = 'week',
@@ -203,6 +205,15 @@ export function getDateRange(
   }
 
   return dateRange;
+}
+
+export function getDayRangeForCurrentMonth() {
+  const currentDate = new Date();
+  const monthNumber = String(currentDate.getMonth() + 1).padStart(2, '0');
+  const year = currentDate.getFullYear();
+  const daysInMonth = moment(`${year}-${monthNumber}`, 'YYYY-MM').daysInMonth();
+
+  return rangeSequential(daysInMonth, 1);
 }
 
 export function padTime(time: string) {


### PR DESCRIPTION
# Description
- The cron expressions for triggers with custom interval schedules are still being used to schedule pipeline runs in UTC time, even though a user may have enabled the `display_local_timezone` setting. This caused some confusion since a user may enter a cron expression like `0 10 * * 1-5` (human readable: "At 10:00 AM, Monday through Friday") and expect their pipeline to run based on local time. However, the pipeline would run at 10 AM UTC.
- The local timezone setting displays dates in local time all on the frontend, so in order to make the cron expressions match up with local time, this PR converts the local cron expression to a UTC cron expression in the background and continues to store the cron expressions in the database the same as before, but now users don't need to do any time conversions for the cron expressions manually.
- There are limitations on the cron expression conversion. It only supports single values for the minute and hour values (no special characters). A note has been added to the Edit Trigger page so users are aware.

# How Has This Been Tested?
![local cron expression](https://github.com/mage-ai/mage-ai/assets/78053898/c83167ca-0440-4378-9091-fa6a551145b5)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
