### PR TITLE
[xy] Prioritize using remote_variables_dir for variable manager.

### DIFF
--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -89,7 +89,7 @@ class Pipeline:
             self.repo_config = repo_config
         self.variable_manager = VariableManager.get_manager(
             self.repo_path,
-            self.variables_dir,
+            self.remote_variables_dir or self.variables_dir,
         )
 
     @property
@@ -134,7 +134,11 @@ class Pipeline:
 
     @property
     def remote_variables_dir(self):
-        return self.repo_config.remote_variables_dir
+        remote_variables_dir = self.repo_config.remote_variables_dir
+        if remote_variables_dir == 's3://bucket/path_prefix':
+            # Filter out default value
+            return None
+        return remote_variables_dir
 
     @property
     def version(self):

--- a/mage_ai/data_preparation/templates/main/metadata.yaml
+++ b/mage_ai/data_preparation/templates/main/metadata.yaml
@@ -1,7 +1,7 @@
 project_type: main
 
 variables_dir: ~/.mage_data
-remote_variables_dir: s3://bucket/path_prefix
+# remote_variables_dir: s3://bucket/path_prefix
 
 variables_retention_period: '90d'
 

--- a/mage_ai/data_preparation/templates/repo/metadata.yaml
+++ b/mage_ai/data_preparation/templates/repo/metadata.yaml
@@ -1,7 +1,7 @@
 project_type: standalone
 
 variables_dir: ~/.mage_data
-remote_variables_dir: s3://bucket/path_prefix
+# remote_variables_dir: s3://bucket/path_prefix
 
 variables_retention_period: '90d'
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Prioritize using remote_variables_dir for variable manager.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested setting both variables_dir and remote_variables_dir in project metadata.yaml
```yaml
variables_dir: /home/src/mage_data
remote_variables_dir: s3://mage-feature-sets/mage_variables/
```
The block output variables are stored in s3 bucket. Other local data (cache, secret key, local database) are stored in local variables_dir.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
