### PR TITLE
[td] If run in parallel is not on, sequentially run streams

### DIFF
--- a/mage_ai/api/policies/BlockPolicy.py
+++ b/mage_ai/api/policies/BlockPolicy.py
@@ -59,6 +59,7 @@ BlockPolicy.allow_read([
     'description',
     'outputs',
     'pipelines',
+    'runtime',
     'tags',
 ] + BlockPresenter.default_attributes, scopes=[
     OauthScope.CLIENT_PRIVATE,

--- a/mage_ai/api/resources/BlockResource.py
+++ b/mage_ai/api/resources/BlockResource.py
@@ -1,4 +1,5 @@
 import urllib.parse
+from typing import Dict
 
 from mage_ai.api.errors import ApiError
 from mage_ai.api.resources.GenericResource import GenericResource
@@ -30,6 +31,8 @@ from mage_ai.data_preparation.utils.block.convert_content import convert_to_bloc
 from mage_ai.orchestration.db import safe_db_query
 from mage_ai.orchestration.db.models.schedules import PipelineRun
 from mage_ai.settings.repo import get_repo_path
+from mage_ai.shared.array import find
+from mage_ai.shared.hash import merge_dict
 from mage_ai.usage_statistics.logger import UsageStatisticLogger
 
 
@@ -38,7 +41,9 @@ class BlockResource(GenericResource):
     @safe_db_query
     def collection(self, query_arg, meta, user, **kwargs):
         parent_model = kwargs.get('parent_model')
+
         block_dicts_by_uuid = {}
+        data_integration_sets_by_uuid = {}
         sources_destinations_by_block_uuid = {}
 
         if isinstance(parent_model, Pipeline):
@@ -135,6 +140,37 @@ class BlockResource(GenericResource):
                     if tags:
                         block_dict['tags'] = tags
 
+                    if original_block_uuid:
+                        if original_block_uuid not in data_integration_sets_by_uuid:
+                            data_integration_sets_by_uuid[original_block_uuid] = dict(
+                                children={},
+                                controller=None,
+                                controllers={},
+                                original=None,
+                            )
+
+                        data = merge_dict(block_dict, dict(metrics=metrics))
+                        if original:
+                            data_integration_sets_by_uuid[original_block_uuid]['original'] = data
+                        elif child:
+                            if controller:
+                                data_integration_sets_by_uuid[original_block_uuid]['controllers'][
+                                    block_run_block_uuid
+                                ] = data
+                            elif controller_block_uuid:
+                                if controller_block_uuid not in \
+                                        data_integration_sets_by_uuid[original_block_uuid][
+                                            'children'
+                                        ]:
+                                    data_integration_sets_by_uuid[original_block_uuid][
+                                        'children'
+                                    ][controller_block_uuid] = []
+                                data_integration_sets_by_uuid[original_block_uuid][
+                                    'children'
+                                ][controller_block_uuid].append(data)
+                        elif controller:
+                            data_integration_sets_by_uuid[original_block_uuid]['controller'] = data
+
                 # If dynamic child, then it has many other blocks.
                 if is_dynamic_block_child(block):
                     parts = block_run_block_uuid.split(':')
@@ -178,6 +214,106 @@ class BlockResource(GenericResource):
 
                 block_dicts_by_uuid[block_run_block_uuid] = block_dict
 
+            # Replace upstream and downstream blocks that contain the base UUID
+            # of a replicated block (e.g. [block_uuid]) and replace it with the full
+            # replicated block UUID (e.g. [block_uuid]:[replicated_block_uuid])
+            for block_uuid, block_dict in block_dicts_by_uuid.items():
+                for key in [
+                    'downstream_blocks',
+                    'upstream_blocks',
+                ]:
+                    arr = block_dict.get(key) or []
+                    for block_uuid_base in arr:
+                        block = pipeline.get_block(block_uuid_base)
+                        if block.replicated_block and not is_dynamic_block_child(block):
+                            blocks_arr = block_dicts_by_uuid[block_uuid].get(key) or []
+                            block_dicts_by_uuid[block_uuid][key] = \
+                                [uuid for uuid in blocks_arr if uuid != block_uuid_base]
+                            block_dicts_by_uuid[block_uuid][key].append(block.uuid_replicated)
+
+            blocks_to_not_override = {}
+            # Reconstruct the upstream blocks for data integrations if the stream
+            # is not parallel.
+            for original_block_uuid, set_dict in data_integration_sets_by_uuid.items():
+                children = set_dict.get('children') or {}
+                controller = set_dict.get('controller') or {}
+                controllers = set_dict.get('controllers') or {}
+
+                controllers_not_parallel = list(filter(
+                    lambda x: not (x.get('metrics') or {}).get('run_in_parallel'),
+                    controllers.values(),
+                ))
+
+                # Start from the controller that has no downstream block uuids
+                controller_child_end = find(
+                    lambda x: not (x.get('metrics') or {}).get('downstream_block_uuids'),
+                    controllers_not_parallel,
+                )
+
+                def _update_upstream_block_uuids(controller_child: Dict):
+                    uuid = controller_child.get('uuid')
+                    metrics = controller_child.get('metrics') or {}
+                    upstream_block_uuids = metrics.get('upstream_block_uuids') or []
+
+                    for up_block_uuid in upstream_block_uuids:
+                        arr = children.get(up_block_uuid) or []
+
+                        # Set the upstream controller’s children as upstream blocks for the
+                        # current controller child.
+                        block_dicts_by_uuid[uuid]['upstream_blocks'] = [d['uuid'] for d in arr]
+                        blocks_to_not_override[uuid] = True
+
+                        for d_child in arr:
+                            child_uuid = d_child['uuid']
+                            block_dicts_by_uuid[child_uuid]['upstream_blocks'] = [
+                                up_block_uuid,
+                            ]
+                            block_dicts_by_uuid[child_uuid]['downstream_blocks'] = [
+                                uuid,
+                            ]
+                            blocks_to_not_override[child_uuid] = True
+
+                        up_controller = controllers.get(up_block_uuid)
+                        if up_controller:
+                            _update_upstream_block_uuids(up_controller)
+
+                if controller_child_end:
+                    _update_upstream_block_uuids(controller_child_end)
+
+                    controller_child_end_uuid = controller_child_end.get('uuid')
+                    children_end = children.get(controller_child_end_uuid) or []
+
+                    block_dicts_by_uuid[original_block_uuid]['upstream_blocks'] = \
+                        [d['uuid'] for d in children_end]
+                    blocks_to_not_override[original_block_uuid] = True
+
+                    downstream_blocks = block_dicts_by_uuid[original_block_uuid].get(
+                        'downstream_blocks',
+                    ) or []
+                    for down_uuid in downstream_blocks:
+                        blocks_to_not_override[down_uuid] = True
+
+                    for up_uuid in block_dicts_by_uuid[original_block_uuid]['upstream_blocks']:
+                        block_dicts_by_uuid[up_uuid]['upstream_blocks'] = [
+                            controller_child_end_uuid,
+                        ]
+                        block_dicts_by_uuid[up_uuid]['downstream_blocks'] = [
+                            original_block_uuid,
+                        ]
+                        blocks_to_not_override[up_uuid] = True
+
+                controller_child_start = find(
+                    lambda x: not (x.get('metrics') or {}).get('upstream_block_uuids'),
+                    controllers_not_parallel,
+                )
+
+                if controller_child_start:
+                    controller_child_start_uuid = controller_child_start['uuid']
+                    block_dicts_by_uuid[controller_child_start_uuid]['upstream_blocks'] = [
+                        controller.get('uuid'),
+                    ]
+                    blocks_to_not_override[controller_child_start_uuid] = True
+
             for block_uuid, mapping in block_mapping.items():
                 block = pipeline.get_block(block_uuid)
                 if not block:
@@ -199,18 +335,21 @@ class BlockResource(GenericResource):
                     controller = metrics.get('controller')
                     original = metrics.get('original')
 
-                    if original:
-                        # The original block should only have upstreams that are
-                        # child blocks and not controllers.
-                        block_dicts_by_uuid[block_uuid]['upstream_blocks'] = []
+                if original or (controller and not child):
+                    if block_uuid in sources_destinations_by_block_uuid:
+                        if 'tags' not in block_dicts_by_uuid[block_uuid]:
+                            block_dicts_by_uuid[block_uuid] = []
+                        block_dicts_by_uuid[block_uuid]['tags'].append(
+                            sources_destinations_by_block_uuid[block_uuid],
+                        )
 
-                    if original or (controller and not child):
-                        if block_uuid in sources_destinations_by_block_uuid:
-                            if 'tags' not in block_dicts_by_uuid[block_uuid]:
-                                block_dicts_by_uuid[block_uuid] = []
-                            block_dicts_by_uuid[block_uuid]['tags'].append(
-                                sources_destinations_by_block_uuid[block_uuid],
-                            )
+                if block_uuid in blocks_to_not_override:
+                    continue
+
+                if original:
+                    # The original block should only have upstreams that are
+                    # child blocks and not controllers.
+                    block_dicts_by_uuid[block_uuid]['upstream_blocks'] = []
 
                 for ub_uuid in upstream_block_uuids:
                     if ub_uuid in block_dicts_by_uuid[block_uuid]['upstream_blocks']:

--- a/mage_ai/api/resources/BlockResource.py
+++ b/mage_ai/api/resources/BlockResource.py
@@ -268,13 +268,17 @@ class BlockResource(GenericResource):
                     controllers_not_parallel,
                 )
 
-                def _update_upstream_block_uuids(controller_child: Dict):
+                def _update_upstream_block_uuids(
+                    controller_child: Dict,
+                    controllers_inner,
+                    children_inner,
+                ):
                     uuid = controller_child.get('uuid')
                     metrics = controller_child.get('metrics') or {}
                     upstream_block_uuids = metrics.get('upstream_block_uuids') or []
 
                     for up_block_uuid in upstream_block_uuids:
-                        arr = children.get(up_block_uuid) or []
+                        arr = children_inner.get(up_block_uuid) or []
 
                         # Set the upstream controller’s children as upstream blocks for the
                         # current controller child.
@@ -291,12 +295,16 @@ class BlockResource(GenericResource):
                             ]
                             blocks_to_not_override[child_uuid] = True
 
-                        up_controller = controllers.get(up_block_uuid)
+                        up_controller = controllers_inner.get(up_block_uuid)
                         if up_controller:
-                            _update_upstream_block_uuids(up_controller)
+                            _update_upstream_block_uuids(
+                                up_controller,
+                                controllers_inner,
+                                children_inner,
+                            )
 
                 if controller_child_end:
-                    _update_upstream_block_uuids(controller_child_end)
+                    _update_upstream_block_uuids(controller_child_end, controllers, children)
 
                     controller_child_end_uuid = controller_child_end.get('uuid')
                     children_end = children.get(controller_child_end_uuid) or []
@@ -423,7 +431,7 @@ class BlockResource(GenericResource):
 
             # Adjust the runtime for these blocks because it has a start_at
             # but we don’t actually start running the block until later.
-            for original_block_uuid, set_dict in data_integration_sets_by_uuid.items():
+            for set_dict in data_integration_sets_by_uuid.values():
                 children = set_dict.get('children') or {}
                 controller = set_dict.get('controller') or {}
                 controllers = set_dict.get('controllers') or {}

--- a/mage_ai/api/resources/BlockResource.py
+++ b/mage_ai/api/resources/BlockResource.py
@@ -207,8 +207,8 @@ class BlockResource(GenericResource):
                             block_mapping[db_uuid]['uuids'].append(block_run_block_uuid)
 
                 if block.replicated_block:
-                    block_dict['name'] = block.replicated_block
-                    block_dict['description'] = block.uuid
+                    block_dict['name'] = block.uuid
+                    block_dict['description'] = block.replicated_block
 
                 block_dict['tags'] += block.tags()
 

--- a/mage_ai/api/resources/BlockRunResource.py
+++ b/mage_ai/api/resources/BlockRunResource.py
@@ -24,6 +24,7 @@ class BlockRunResource(DatabaseResource):
                 created_at,
                 id,
                 pipeline_run_id,
+                started_at,
                 status,
                 updated_at,
                 pipeline_schedule_id,
@@ -36,6 +37,7 @@ class BlockRunResource(DatabaseResource):
                 created_at=created_at,
                 id=id,
                 pipeline_run_id=pipeline_run_id,
+                started_at=started_at,
                 status=status,
                 updated_at=updated_at,
                 pipeline_schedule_id=pipeline_schedule_id,
@@ -72,6 +74,7 @@ class BlockRunResource(DatabaseResource):
             a.created_at,
             a.id,
             a.pipeline_run_id,
+            a.started_at,
             a.status,
             a.updated_at,
             c.id.label('pipeline_schedule_id'),
@@ -124,6 +127,10 @@ class BlockRunResource(DatabaseResource):
                                 'must be an attribute of the BlockRun model. The sort direction ' +
                                 'is either "asc" (ascending order) or "desc" (descending order).')
         else:
-            initial_results = query.order_by(a.created_at.desc(), a.completed_at.desc())
+            initial_results = query.order_by(
+                a.started_at.desc(),
+                a.created_at.desc(),
+                a.completed_at.desc(),
+            )
 
         return initial_results

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -306,6 +306,11 @@ class Block(SourceMixin):
     def uuid(self) -> str:
         return self.dynamic_block_uuid or self._uuid
 
+    @property
+    def uuid_replicated(self) -> str:
+        if self.replicated_block:
+            return f'{self.uuid}:{self.replicated_block}'
+
     @uuid.setter
     def uuid(self, x) -> None:
         self.dynamic_block_uuid = None

--- a/mage_ai/frontend/components/DependencyGraph/BlockNode/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/BlockNode/index.tsx
@@ -84,7 +84,7 @@ function BlockNode({
   isInProgress,
   isQueued,
   isSuccessful,
-  runtime,
+  runtime: runtimeFromBlockRun,
 }: BlockNodeProps) {
   const themeContext: ThemeType = useContext(ThemeContext);
 
@@ -114,6 +114,7 @@ function BlockNode({
 
   const {
     color,
+    runtime: runtimeFromBlock,
     type,
   } = block;
   const {
@@ -281,14 +282,14 @@ function BlockNode({
           return;
         })}
 
-        {runtime && (
+        {(runtimeFromBlock || runtimeFromBlockRun) && (
           <Spacing mt={1}>
             <Text
               monospace
               muted
               small
             >
-              {getRuntimeText(runtime)}
+              {getRuntimeText(runtimeFromBlock || runtimeFromBlockRun)}
             </Text>
           </Spacing>
         )}

--- a/mage_ai/frontend/components/DependencyGraph/BlockNode/utils.ts
+++ b/mage_ai/frontend/components/DependencyGraph/BlockNode/utils.ts
@@ -93,14 +93,14 @@ export function displayTextForBlock(block: BlockType, pipeline: PipelineType): {
   }
 
   if (block?.replicated_block) {
-    if (name) {
+    if (name && description) {
       displayText = name;
     } else {
-      displayText = block?.replicated_block;
+      displayText = block?.uuid;
     }
 
     if (!description) {
-      subtitle = block?.uuid;
+      subtitle = block?.replicated_block;
     }
   }
 

--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
@@ -38,7 +38,7 @@ export const DEFAULT_SORTABLE_BR_COL_INDEXES = [0, 1, 4];
 export const COL_IDX_TO_BLOCK_RUN_ATTR_MAPPING = {
   0: 'status',
   1: 'block_uuid',
-  4: 'completed_at',
+  5: 'completed_at',
 };
 
 type BlockRunsTableProps = {
@@ -117,7 +117,7 @@ function BlockRunsTable({
   );
 
   const timezoneTooltipProps = displayLocalTimezone ? TIMEZONE_TOOLTIP_PROPS : {};
-  const columnFlex = [1, 2, 2, 1, 1, null, null];
+  const columnFlex = [1, 2, 2, 1, 1, 1, null, null];
   const columns = [
     {
       uuid: 'Status',
@@ -131,6 +131,10 @@ function BlockRunsTable({
     {
       ...timezoneTooltipProps,
       uuid: 'Created at',
+    },
+    {
+      ...timezoneTooltipProps,
+      uuid: 'Started at',
     },
     {
       ...timezoneTooltipProps,
@@ -164,6 +168,7 @@ function BlockRunsTable({
           pipeline_run_id: pipelineRunId,
           pipeline_schedule_id: pipelineScheduleId,
           pipeline_schedule_name: pipelineScheduleName,
+          started_at: startedAt,
           status,
         } = blockRun || {};
         let blockUUID = blockUUIDOrig;
@@ -250,6 +255,22 @@ function BlockRunsTable({
             {displayLocalTimezone
               ? datetimeInLocalTimezone(createdAt, displayLocalTimezone)
               : dateFormatLong(createdAt, { includeSeconds: true })
+            }
+          </Text>,
+          <Text
+            default
+            key={`${id}_started_at`}
+            monospace
+            small
+            title={startedAt ? `UTC: ${startedAt.slice(0, 19)}` : null}
+          >
+            {startedAt
+              ? (displayLocalTimezone
+                ? datetimeInLocalTimezone(startedAt, displayLocalTimezone)
+                : dateFormatLong(startedAt, { includeSeconds: true })
+              ): (
+                <>&#8212;</>
+              )
             }
           </Text>,
           <Text

--- a/mage_ai/frontend/interfaces/BlockRunType.ts
+++ b/mage_ai/frontend/interfaces/BlockRunType.ts
@@ -31,7 +31,6 @@ export default interface BlockRunType {
   pipeline_run_id: number;
   pipeline_schedule_id?: number;
   pipeline_schedule_name?: string;
-  runtime?: number;
   started_at?: string;
   status: RunStatus;
   updated_at?: string;

--- a/mage_ai/frontend/interfaces/BlockRunType.ts
+++ b/mage_ai/frontend/interfaces/BlockRunType.ts
@@ -31,6 +31,7 @@ export default interface BlockRunType {
   pipeline_run_id: number;
   pipeline_schedule_id?: number;
   pipeline_schedule_name?: string;
+  runtime?: number;
   started_at?: string;
   status: RunStatus;
   updated_at?: string;

--- a/mage_ai/frontend/interfaces/BlockType.ts
+++ b/mage_ai/frontend/interfaces/BlockType.ts
@@ -290,6 +290,7 @@ export default interface BlockType {
   priority?: number;
   replicated_block?: string;
   retry_config?: BlockRetryConfigType;
+  runtime?: number;
   status?: StatusTypeEnum;
   tags?: TagEnum[];
   timeout?: number;

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
@@ -59,7 +59,9 @@ function PipelineBlockRuns({
   const [selectedTabSidekick, setSelectedTabSidekick] = useState<TabType>(TABS_SIDEKICK[0]);
   const [errors, setErrors] = useState<ErrorsType>(null);
 
-  const { data: dataBlocks } = api.blocks.pipeline_runs.list(pipelineRunProp?.id);
+  const { data: dataBlocks } = api.blocks.pipeline_runs.list(pipelineRunProp?.id, {}, {
+    refreshInterval: 5000,
+  });
 
   const pipelineUUID = pipelineProp.uuid;
   const { data: dataPipeline } = api.pipelines.detail(pipelineUUID, {

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -1063,10 +1063,11 @@ def run_block(
     ]:
         return {}
 
-    block_run.update(
-        started_at=datetime.now(tz=pytz.UTC),
-        status=BlockRun.BlockRunStatus.RUNNING,
-    )
+    block_run_data = dict(status=BlockRun.BlockRunStatus.RUNNING)
+    if not block_run.started_at or (block_run.metrics and not block_run.metrics.get('controller')):
+        block_run_data['started_at'] = datetime.now(tz=pytz.UTC)
+
+    block_run.update(**block_run_data)
 
     pipeline_scheduler = PipelineScheduler(pipeline_run)
     pipeline = pipeline_scheduler.pipeline

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -589,6 +589,7 @@ class PipelineScheduler:
                 [dict(
                     block_uuid=br.block_uuid,
                     id=br.id,
+                    metrics=br.metrics,
                     status=br.status,
                 ) for br in self.pipeline_run.block_runs],
             )


### PR DESCRIPTION
# Description
- If stream is not parallel, sequentially run a stream and then run the next one after its done.
- Show all dynamic blocks

# How Has This Been Tested?
<img width="932" alt="CleanShot 2023-09-21 at 15 41 18@2x" src="https://github.com/mage-ai/mage-ai/assets/1066980/48f08f4b-a090-4ee0-a0b1-234e2eb76c4d">

<img width="1525" alt="CleanShot 2023-09-21 at 15 57 20@2x" src="https://github.com/mage-ai/mage-ai/assets/1066980/5e9bafdd-1395-409d-8ca2-a24916e4abdd">

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
