### PR TITLE
[dy] Fix postgres db connection url parsing

### DIFF
--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -761,7 +761,9 @@ class Pipeline:
         return merge_dict(self.to_dict_base(), data)
 
     async def update(self, data, update_content=False):
-        from mage_ai.orchestration.db.utils import transfer_related_models_for_pipeline
+        from mage_ai.orchestration.db.models.utils import (
+            transfer_related_models_for_pipeline,
+        )
 
         old_uuid = None
         should_update_block_cache = False

--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -57,14 +57,15 @@ try:
 except SQLAlchemyError:
     engine.dispose()
     username, password = get_user_info_from_db_connection_url(db_connection_url)
-    db_connection_url = db_connection_url.replace(
-        password,
-        quote_plus(password),
-    )
-    engine = create_engine(
-        db_connection_url,
-        **db_kwargs,
-    )
+    if password:
+        db_connection_url = db_connection_url.replace(
+            password,
+            quote_plus(password),
+        )
+        engine = create_engine(
+            db_connection_url,
+            **db_kwargs,
+        )
 
 session_factory = sessionmaker(bind=engine)
 

--- a/mage_ai/orchestration/db/models/utils.py
+++ b/mage_ai/orchestration/db/models/utils.py
@@ -1,0 +1,23 @@
+from mage_ai.orchestration.db import db_connection, safe_db_query
+from mage_ai.orchestration.db.models.schedules import (
+    Backfill,
+    PipelineRun,
+    PipelineSchedule,
+)
+
+
+@safe_db_query
+def transfer_related_models_for_pipeline(old_uuid: str, new_uuid: str):
+    # Migrate pipeline schedules
+    PipelineSchedule.query.filter(PipelineSchedule.pipeline_uuid == old_uuid).update({
+        PipelineSchedule.pipeline_uuid: new_uuid
+    }, synchronize_session=False)
+    # Migrate pipeline runs (block runs have foreign key ref to PipelineRun id)
+    PipelineRun.query.filter(PipelineRun.pipeline_uuid == old_uuid).update({
+        PipelineRun.pipeline_uuid: new_uuid
+    }, synchronize_session=False)
+    # Migrate backfills
+    Backfill.query.filter(Backfill.pipeline_uuid == old_uuid).update({
+        Backfill.pipeline_uuid: new_uuid
+    }, synchronize_session=False)
+    db_connection.session.commit()

--- a/mage_ai/orchestration/db/utils.py
+++ b/mage_ai/orchestration/db/utils.py
@@ -1,23 +1,21 @@
-from mage_ai.orchestration.db import db_connection, safe_db_query
-from mage_ai.orchestration.db.models.schedules import (
-    Backfill,
-    PipelineRun,
-    PipelineSchedule,
-)
+from typing import Optional, Tuple
 
 
-@safe_db_query
-def transfer_related_models_for_pipeline(old_uuid: str, new_uuid: str):
-    # Migrate pipeline schedules
-    PipelineSchedule.query.filter(PipelineSchedule.pipeline_uuid == old_uuid).update({
-        PipelineSchedule.pipeline_uuid: new_uuid
-    }, synchronize_session=False)
-    # Migrate pipeline runs (block runs have foreign key ref to PipelineRun id)
-    PipelineRun.query.filter(PipelineRun.pipeline_uuid == old_uuid).update({
-        PipelineRun.pipeline_uuid: new_uuid
-    }, synchronize_session=False)
-    # Migrate backfills
-    Backfill.query.filter(Backfill.pipeline_uuid == old_uuid).update({
-        Backfill.pipeline_uuid: new_uuid
-    }, synchronize_session=False)
-    db_connection.session.commit()
+def get_user_info_from_db_connection_url(url: str) -> Optional[Tuple[str, str]]:
+    """
+    Attempt to parse db connection url to get username and password. urllib.parse
+    does not work for all cases.
+
+    Args:
+        url (str): db connection url usually in the form of
+            "scheme://username:password@host:port/dbname?options"
+
+    Returns:
+        Tuple[str, str]: tuple of username, password
+    """
+    try:
+        prefix = '@'.join(url.split('@')[0:-1])
+        user_info = prefix.split('://', 1)[1]
+        return user_info.split(':', 1)
+    except Exception:
+        return None

--- a/mage_ai/orchestration/db/utils.py
+++ b/mage_ai/orchestration/db/utils.py
@@ -1,7 +1,9 @@
 from typing import Optional, Tuple
 
 
-def get_user_info_from_db_connection_url(url: str) -> Optional[Tuple[str, str]]:
+def get_user_info_from_db_connection_url(
+    url: str,
+) -> Tuple[Optional[str], Optional[str]]:
     """
     Attempt to parse db connection url to get username and password. urllib.parse
     does not work for all cases.
@@ -18,4 +20,4 @@ def get_user_info_from_db_connection_url(url: str) -> Optional[Tuple[str, str]]:
         user_info = prefix.split('://', 1)[1]
         return user_info.split(':', 1)
     except Exception:
-        return None
+        return None, None

--- a/mage_ai/tests/orchestration/db/test_utils.py
+++ b/mage_ai/tests/orchestration/db/test_utils.py
@@ -1,0 +1,19 @@
+from unittest import TestCase
+
+from mage_ai.orchestration.db.utils import get_user_info_from_db_connection_url
+
+
+class DBUtilsTest(TestCase):
+    def test_parse_db_connection_url(self):
+        url = 'postgresql+psycopg2://postgres:passw0rd@postgres-db:5432/postgres'
+        username, password = get_user_info_from_db_connection_url(url)
+
+        self.assertEqual(username, 'postgres')
+        self.assertEqual(password, 'passw0rd')
+
+    def test_parse_db_connection_url_symbols(self):
+        url = 'postgresql+psycopg2://postgres:&^*@%@%*%^^$$*#^*^#@$&$#^##%&%#&%@%^*!@*^@!%@postgres-db:5432/postgres'  # noqa: E501
+        username, password = get_user_info_from_db_connection_url(url)
+
+        self.assertEqual(username, 'postgres')
+        self.assertEqual(password, '&^*@%@%*%^^$$*#^*^#@$&$#^##%&%#&%@%^*!@*^@!%')


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes https://github.com/mage-ai/mage-ai/issues/3307. The `urllib.parse` function doesn't work for some cases, so I wrote a custom function to parse the db connection url.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with various db connection urls
- [x] Unit tests


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
