### PR TITLE
[dy] Fix passing in logger for alternative block execution methods

### DIFF
--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -312,10 +312,15 @@ def execute_custom_code():
         pass
 
     if run_incomplete_upstream or run_upstream:
-        block.run_upstream_blocks(global_vars=global_vars, incomplete_only=run_incomplete_upstream)
+        block.run_upstream_blocks(
+            global_vars=global_vars,
+            include_logger=True,
+            incomplete_only=run_incomplete_upstream,
+        )
 
     logger = logging.getLogger('{block_uuid}_test')
     logger.setLevel('INFO')
+    global_vars['logger'] = logger
     block_output = block.execute_with_callback(
         custom_code=code,
         from_notebook=True,

--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -313,14 +313,15 @@ def execute_custom_code():
 
     if run_incomplete_upstream or run_upstream:
         block.run_upstream_blocks(
+            from_notebook=True,
             global_vars=global_vars,
-            include_logger=True,
             incomplete_only=run_incomplete_upstream,
         )
 
     logger = logging.getLogger('{block_uuid}_test')
     logger.setLevel('INFO')
-    global_vars['logger'] = logger
+    if 'logger' not in global_vars:
+        global_vars['logger'] = logger
     block_output = block.execute_with_callback(
         custom_code=code,
         from_notebook=True,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

The logger was not getting passed in as a keyword argument properly when executing upstream blocks from the notebook. This PR changes the execution code to include a logger as a keyword argument for the upstream blocks.

Also, pass in the logger win `block.run_tests`.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested executing a block normally
- [x] Tested executing a block with upstream blocks
- [x] Tested executing a block and tests


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
