### PR TITLE
[jk] Bookmark values minor improvements

### DIFF
--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
@@ -965,7 +965,7 @@ function SchemaTable({
                             });
                           }}
                           pill
-                          secondary
+                          primary
                         >
                           Save
                         </Button>
@@ -1004,7 +1004,7 @@ function SchemaTable({
                               ...prev,
                               [streamUUID]: {
                                 ...prev[streamUUID],
-                                [bookmarkProperty]: e.target.value,
+                                [bookmarkProperty]: e.target.value || null,
                               },
                             }));
                           }}

--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
@@ -116,7 +116,7 @@ function SchemaTable({
   const [destinationTable, setDestinationTable] = useState<string>(destinationTableInit);
   const [isApplyingToAllStreams, setIsApplyingToAllStreams] = useState<boolean>(false);
   const [isApplyingToAllStreamsIdx, setIsApplyingToAllStreamsIdx] = useState<number>(null);
-  const [showBookmarkValuesTable, setShowBookmarkPropertyTable] = useState<boolean>(false);
+  const [showBookmarkValuesTable, setShowBookmarkPropertyTable] = useState<boolean>(!!destination);
   const [bookmarkValues, setBookmarkValues] = useState({ [streamUUID]: bookmarkValuesInit || {} });
 
   const streamUUIDPrev = usePrevious(streamUUID);
@@ -873,15 +873,11 @@ function SchemaTable({
                 Bookmark properties
               </Text>
               <Text default>
-                After each integration pipeline run,
-                the last record that was successfully synchronized
-                will be used as the bookmark.
+                After each integration pipeline run, the last record that was successfully
+                synchronized will be used as the bookmark.
                 The properties listed below will be extracted from the last record and used
                 as the bookmark.
-
-                <br />
-
-                On the next run, the synchronization will start after the bookmarked record.
+                On the next run, the synchronization will start from the bookmarked record.
               </Text>
             </Spacing>
 
@@ -926,11 +922,20 @@ function SchemaTable({
                       <Text bold large>
                         Manually edit bookmark property values
                       </Text>
-                      <Text default>
-                        In order to override the bookmark values for the next sync, you must first select a destination.
-                        Then click the toggle to edit the values for the bookmark properties in the table below.
-                        Click the &#34;Save&#34; button to save your changes.
-                      </Text>
+                      {!destination && (
+                        <Text default>
+                          In order to overwrite the bookmark values for the next sync, you must first select a
+                          destination. Then you will be able to edit the bookmark property values in the
+                          table below. Click the &#34;Save&#34; button to save your changes.
+                        </Text>
+                      )}
+                      {destination && (
+                        <Text default>
+                          This will temporarily overwrite the bookmark value for the next pipeline run. After
+                          editing any bookmark values below, you must click the &#34;Save&#34; button in
+                          the table header in order to persist and save your changes.
+                        </Text>
+                      )}
                     </Spacing>
 
                     <ToggleSwitch
@@ -975,10 +980,10 @@ function SchemaTable({
                       columnFlex={[null, 1]}
                       columns={[
                         {
-                          uuid: 'Bookmark property',
+                          uuid: 'Feature',
                         },
                         {
-                          uuid: 'Value',
+                          uuid: 'Current bookmark value',
                         },
                       ]}
                       rows={bookmarkProperties.map(bookmarkProperty => [
@@ -1004,7 +1009,7 @@ function SchemaTable({
                             }));
                           }}
                           paddingHorizontal={0}
-                          placeholder="Enter value"
+                          placeholder="Enter value (optional)"
                           value={bookmarkValues?.[streamUUID]?.[bookmarkProperty]}
                         />,
                       ])}


### PR DESCRIPTION
# Description
- Make some minor changes to improve UX for bookmark values in data integration pipelines.
- Update explanations.
- Default to making the bookmark property values visible. 
- If user tries to save an empty bookmark value, it will be saved as `null` instead of an empty string. An empty string can cause syncing issues.

# How Has This Been Tested?
Update descriptions:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/a4e4cbcf-9377-4cd4-b109-535a364bfd8e)

![image](https://github.com/mage-ai/mage-ai/assets/78053898/3a1d897f-965e-4d20-abb2-150a2de2e77b)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
