### PR TITLE
[td] Support Python destination blocks

### DIFF
--- a/mage_ai/data_integrations/utils/scheduler.py
+++ b/mage_ai/data_integrations/utils/scheduler.py
@@ -326,7 +326,7 @@ def __build_block_run_metadata_for_destination(
             ).get(stream_id)
         else:
             # If upstream not a source, convert first.
-            output_file_paths, _schema = convert_block_output_data_for_destination(
+            tup = convert_block_output_data_for_destination(
                 block,
                 chunk_size=MAX_QUERY_STRING_SIZE,
                 data_integration_uuid=data_integration_uuid,
@@ -338,6 +338,8 @@ def __build_block_run_metadata_for_destination(
                 partition=partition,
                 stream=stream_id,
             )
+            if tup:
+                output_file_paths = tup[0]
 
         # Create a child block run in batches.
         # Each batch will be based on number of output files in the output file path.

--- a/mage_ai/data_integrations/utils/scheduler.py
+++ b/mage_ai/data_integrations/utils/scheduler.py
@@ -326,7 +326,7 @@ def __build_block_run_metadata_for_destination(
             ).get(stream_id)
         else:
             # If upstream not a source, convert first.
-            output_file_paths = convert_block_output_data_for_destination(
+            output_file_paths, _schema = convert_block_output_data_for_destination(
                 block,
                 chunk_size=MAX_QUERY_STRING_SIZE,
                 data_integration_uuid=data_integration_uuid,

--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -796,9 +796,7 @@ class BlockExecutor:
                                 if block_dict:
                                     block_run_dicts.append(block_dict)
                         else:
-                            uuids_to_remove = self.block.configuration_data_integration.get(
-                                'inputs_only',
-                            ) or []
+                            uuids_to_remove = self.block.inputs_only_uuids
 
                             up_uuids = self.block.upstream_block_uuids
                             if dynamic_upstream_block_uuids:

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -1115,19 +1115,25 @@ class Block(DataIntegrationMixin):
             # If all the input variables are fetched, there is a chance that a lot of data from
             # an upstream source block is loaded just to be used as inputs for the block’s
             # decorated functions. Only do this for the notebook because
-            block_uuids_to_fetch = None
             if from_notebook and self.is_data_integration():
-                block_uuids_to_fetch = self.upstream_block_uuids_for_inputs
-
-            input_vars, kwargs_vars, upstream_block_uuids = self.fetch_input_variables(
-                input_args,
-                execution_partition,
-                global_vars,
-                dynamic_block_index=dynamic_block_index,
-                dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
-                from_notebook=from_notebook,
-                upstream_block_uuids=block_uuids_to_fetch,
-            )
+                input_vars, kwargs_vars, upstream_block_uuids = \
+                    self.fetch_input_variables_and_catalog(
+                        input_args,
+                        execution_partition,
+                        global_vars,
+                        dynamic_block_index=dynamic_block_index,
+                        dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
+                        from_notebook=from_notebook,
+                    )
+            else:
+                input_vars, kwargs_vars, upstream_block_uuids = self.fetch_input_variables(
+                    input_args,
+                    execution_partition,
+                    global_vars,
+                    dynamic_block_index=dynamic_block_index,
+                    dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
+                    from_notebook=from_notebook,
+                )
 
             outputs_from_input_vars = {}
             if input_args is None:
@@ -1386,6 +1392,7 @@ class Block(DataIntegrationMixin):
         dynamic_upstream_block_uuids: List[str] = None,
         from_notebook: bool = False,
         upstream_block_uuids: List[str] = None,
+        data_integration_settings_mapping: Dict = None,
     ) -> Tuple[List, List, List]:
         return fetch_input_variables(
             self.pipeline,
@@ -1396,6 +1403,7 @@ class Block(DataIntegrationMixin):
             dynamic_block_index,
             dynamic_upstream_block_uuids,
             from_notebook=from_notebook,
+            data_integration_settings_mapping=data_integration_settings_mapping,
         )
 
     def get_analyses(self) -> List:

--- a/mage_ai/data_preparation/models/block/data_integration/mixins.py
+++ b/mage_ai/data_preparation/models/block/data_integration/mixins.py
@@ -2,7 +2,7 @@ import json
 import os
 from datetime import datetime
 from inspect import Parameter, signature
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, Tuple, Union
 
 import aiofiles
 import yaml
@@ -11,6 +11,7 @@ from jinja2 import Template
 from mage_ai.data_preparation.models.block.data_integration.constants import (
     BLOCK_CATALOG_FILENAME,
 )
+from mage_ai.data_preparation.models.block.data_integration.schema import build_schema
 from mage_ai.data_preparation.models.block.data_integration.utils import (
     discover as discover_func,
 )
@@ -19,6 +20,7 @@ from mage_ai.data_preparation.models.block.data_integration.utils import (
 )
 from mage_ai.data_preparation.models.block.data_integration.utils import (
     extract_stream_ids_from_streams,
+    get_streams_from_catalog,
     select_streams_in_catalog,
 )
 from mage_ai.data_preparation.models.constants import (
@@ -46,11 +48,43 @@ class DataIntegrationMixin:
         return {}
 
     @property
+    def inputs_only_uuids(self) -> List[str]:
+        arr = []
+
+        for stream_id, settings in self.data_integration_inputs.items():
+            if settings.get('input_only'):
+                arr.append(stream_id)
+
+        return arr
+
+    @property
+    def data_integration_inputs(self) -> Dict:
+        mapping = {}
+
+        if self.configuration_data_integration:
+            inputs = self.configuration_data_integration.get('inputs')
+            if isinstance(inputs, list):
+                for stream_id in inputs:
+                    mapping[stream_id] = dict(streams=[stream_id])
+            elif isinstance(inputs, dict):
+                mapping.update(inputs)
+
+        return mapping
+
+    @property
+    def uuids_for_inputs(self) -> List[str]:
+        arr = []
+
+        for stream_id, settings in self.data_integration_inputs.items():
+            if settings.get('streams'):
+                arr.append(stream_id)
+
+        return arr
+
+    @property
     def upstream_block_uuids_for_inputs(self) -> List[str]:
         if self.configuration_data_integration:
-            inputs = self.configuration_data_integration.get('inputs') or []
-            inputs_only = self.configuration_data_integration.get('inputs_only') or []
-            inputs_combined = inputs + inputs_only
+            inputs_combined = self.uuids_for_inputs + self.inputs_only_uuids
 
             return [up_uuid for up_uuid in self.upstream_block_uuids if up_uuid in inputs_combined]
 
@@ -180,6 +214,134 @@ class DataIntegrationMixin:
 
         return self._data_integration
 
+    def fetch_input_variables_and_catalog(
+        self,
+        input_vars,
+        execution_partition: str = None,
+        global_vars: Dict = None,
+        dynamic_block_index: int = None,
+        dynamic_upstream_block_uuids: List[str] = None,
+        from_notebook: bool = False,
+    ) -> Tuple[List, List, List]:
+        block_uuids_to_fetch = self.upstream_block_uuids_for_inputs
+
+        catalog_by_upstream_block_uuid = {}
+        data_integration_settings_mapping = {}
+
+        for up_uuid, settings in self.data_integration_inputs.items():
+            input_catalog = settings.get('catalog', False)
+
+            upstream_block = self.pipeline.get_block(up_uuid)
+            if input_catalog and upstream_block.is_source():
+                di_settings = upstream_block.get_data_integration_settings(
+                    dynamic_block_index=dynamic_block_index,
+                    dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
+                    from_notebook=from_notebook,
+                    global_vars=input_vars,
+                    input_vars=input_vars,
+                    partition=execution_partition,
+                )
+
+                catalog = di_settings.get('catalog') or {}
+
+                streams = settings.get('streams')
+                if streams:
+                    catalog['streams'] = get_streams_from_catalog(catalog, streams)
+
+                catalog_by_upstream_block_uuid[up_uuid] = catalog
+                data_integration_settings_mapping[up_uuid] = di_settings
+
+        # Get the output as inputs for this block
+        input_vars_fetched, kwargs_vars, up_block_uuids = self.fetch_input_variables(
+            input_vars,
+            execution_partition,
+            global_vars,
+            dynamic_block_index=dynamic_block_index,
+            dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
+            from_notebook=from_notebook,
+            upstream_block_uuids=block_uuids_to_fetch,
+            data_integration_settings_mapping=data_integration_settings_mapping,
+        )
+
+        if block_uuids_to_fetch and is_debug():
+            uuids = ', '.join(block_uuids_to_fetch)
+            inputs_count = len(input_vars_fetched) if input_vars_fetched else 0
+            print(
+                '[Block.__execute_data_integration_block_code]: Inputs fetched from '
+                f'block UUIDS {uuids}: {inputs_count} inputs fetched.',
+            )
+
+        if self.data_integration_inputs:
+            input_vars_updated = []
+            kwargs_vars_updated = []
+            up_block_uuids_updated = []
+
+            for up_uuid in self.upstream_block_uuids:
+                if up_uuid not in self.data_integration_inputs:
+                    continue
+
+                upstream_block = self.pipeline.get_block(up_uuid)
+                is_source = upstream_block.is_source()
+
+                settings = self.data_integration_inputs.get(up_uuid)
+                input_catalog = settings.get('catalog', False)
+                input_streams = settings.get('streams')
+
+                input_var_to_add = []
+                kwargs_var_to_add = None
+
+                idx = None
+                if up_uuid in up_block_uuids:
+                    idx = up_block_uuids.index(up_uuid)
+
+                if idx is not None and idx < len(kwargs_vars):
+                    kwargs_var_to_add = kwargs_vars[idx]
+
+                input_data = None
+                if input_streams:
+                    if idx is not None:
+                        input_data = input_vars_fetched[idx]
+                    input_var_to_add.append(input_data)
+
+                if input_catalog:
+                    catalog = None
+                    if is_source:
+                        catalog = catalog_by_upstream_block_uuid.get(up_uuid)
+                    elif input_data is None:
+                        input_vars_inner, \
+                            kwargs_vars_inner, \
+                            _up_block_uuids = self.fetch_input_variables(
+                                None,
+                                execution_partition,
+                                global_vars,
+                                dynamic_block_index=dynamic_block_index,
+                                dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
+                                from_notebook=from_notebook,
+                                upstream_block_uuids=[up_uuid],
+                                data_integration_settings_mapping=data_integration_settings_mapping,
+                            )
+
+                        if input_vars_inner:
+                            input_data = input_vars_inner[0]
+
+                        if kwargs_vars_inner and not kwargs_var_to_add:
+                            kwargs_var_to_add = kwargs_vars_inner[0]
+
+                    if input_data is not None:
+                        catalog = build_schema(input_data, up_uuid)
+
+                    input_var_to_add.append(catalog)
+
+                if len(input_var_to_add) == 1:
+                    input_var_to_add = input_var_to_add[0]
+                input_vars_updated.append(input_var_to_add)
+                kwargs_vars_updated.append(kwargs_var_to_add)
+                up_block_uuids_updated.append(up_uuid)
+
+            return input_vars_updated, kwargs_vars_updated, up_block_uuids_updated
+
+        return input_vars_fetched, kwargs_vars, up_block_uuids
+
     def __execute_data_integration_block_code(
         self,
         dynamic_block_index: Union[int, None] = None,
@@ -243,30 +405,16 @@ class DataIntegrationMixin:
             )
             num_inputs = len(input_vars_use or [])
 
-            block_uuids_to_fetch = None
-            if self.is_destination():
-                block_uuids_to_fetch = self.upstream_block_uuids_for_inputs
-
             if num_args > num_inputs:
                 input_vars_fetched, _kwargs_vars, _upstream_block_uuids = \
-                    self.fetch_input_variables(
+                    self.fetch_input_variables_and_catalog(
                         input_vars,
                         partition,
                         global_vars,
                         dynamic_block_index=dynamic_block_index,
                         dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
                         from_notebook=from_notebook,
-                        upstream_block_uuids=block_uuids_to_fetch,
                     )
-
-                if block_uuids_to_fetch and is_debug():
-                    uuids = ', '.join(block_uuids_to_fetch)
-                    inputs_count = len(input_vars_fetched) if input_vars_fetched else 0
-                    print(
-                        '[Block.__execute_data_integration_block_code] inputs fetched from '
-                        f'block UUIDS {uuids}: {inputs_count} inputs fetched.',
-                    )
-
                 input_vars_use = input_vars_fetched
 
             self._data_integration[key] = self.execute_block_function(

--- a/mage_ai/data_preparation/models/block/data_integration/mixins.py
+++ b/mage_ai/data_preparation/models/block/data_integration/mixins.py
@@ -327,7 +327,7 @@ class DataIntegrationMixin:
                         if kwargs_vars_inner and not kwargs_var_to_add:
                             kwargs_var_to_add = kwargs_vars_inner[0]
 
-                    if input_data is not None:
+                    if not catalog and input_data is not None:
                         catalog = build_schema(input_data, up_uuid)
 
                     input_var_to_add.append(catalog)

--- a/mage_ai/data_preparation/models/block/data_integration/schema.py
+++ b/mage_ai/data_preparation/models/block/data_integration/schema.py
@@ -14,7 +14,9 @@ from mage_ai.data_preparation.models.block.data_integration.constants import (
     COLUMN_TYPE_NUMBER,
     COLUMN_TYPE_OBJECT,
     COLUMN_TYPE_STRING,
+    KEY_REPLICATION_METHOD,
     OUTPUT_TYPE_SCHEMA,
+    REPLICATION_METHOD_FULL_TABLE,
     TYPE_OBJECT,
 )
 from mage_ai.shared.column_type_detector import (
@@ -31,6 +33,7 @@ from mage_ai.shared.column_type_detector import (
     ZIP_CODE,
     infer_column_types,
 )
+from mage_ai.shared.hash import merge_dict
 
 COLUMN_TYPE_TO_CONVERTED_TYPE_MAPPING = {
     # Array is not yet detected
@@ -57,7 +60,12 @@ COLUMN_TYPE_TO_CONVERTED_TYPE_MAPPING_PYTHON = {
 }
 
 
-def build_schema(df: pd.DataFrame, stream: str, strict: bool = False) -> Dict:
+def build_schema(
+    df: pd.DataFrame,
+    stream: str,
+    strict: bool = False,
+    schema_override: Dict = None,
+) -> Dict:
     column_types = infer_column_types(df)
 
     properties = {}
@@ -119,11 +127,12 @@ def build_schema(df: pd.DataFrame, stream: str, strict: bool = False) -> Dict:
 
             properties[column] = props
 
-    return dict(
-        schema=dict(
+    return merge_dict({
+        'schema': dict(
             properties=properties,
             type=TYPE_OBJECT,
         ),
-        stream=stream,
-        type=OUTPUT_TYPE_SCHEMA,
-    )
+        'stream': stream,
+        'type': OUTPUT_TYPE_SCHEMA,
+        KEY_REPLICATION_METHOD: REPLICATION_METHOD_FULL_TABLE,
+    }, schema_override)

--- a/mage_ai/data_preparation/models/block/data_integration/utils.py
+++ b/mage_ai/data_preparation/models/block/data_integration/utils.py
@@ -541,8 +541,10 @@ def convert_block_output_data_for_destination(
         )
 
     index_to_get_input = 0
-    if stream in block.upstream_block_uuids_for_inputs:
+    if input_vars_use is not None and stream in block.upstream_block_uuids_for_inputs:
         index_to_get_input = block.upstream_block_uuids_for_inputs.index(stream)
+        if index_to_get_input >= len(input_vars_fetched):
+            index_to_get_input = 0
 
     data = input_vars_fetched[index_to_get_input] if input_vars_fetched else None
 
@@ -732,9 +734,8 @@ def __execute_destination(
             )
 
             if pair:
-                output_file_paths, schema = pair
+                output_file_paths = pair[0]
                 output_file_path = output_file_paths[0]
-                catalog_from_source = dict(streams=[schema])
         else:
             block_for_variable = block
             data_integration_uuid_for_variable = data_integration_uuid

--- a/mage_ai/data_preparation/models/block/utils.py
+++ b/mage_ai/data_preparation/models/block/utils.py
@@ -458,6 +458,7 @@ def output_variables(
     from_notebook: bool = False,
     global_vars: Dict = None,
     input_args: List[Any] = None,
+    data_integration_settings_mapping: Dict = None,
 ) -> List[str]:
     """
     Retrieves the output variables of a block.
@@ -482,9 +483,14 @@ def output_variables(
     """
 
     block = pipeline.get_block(block_uuid)
-    data_integration_settings = None
-    if block:
-        data_integration_settings = block.get_data_integration_settings(
+
+    di_settings = None
+    if data_integration_settings_mapping:
+        di_settings = data_integration_settings_mapping.get(block_uuid) or \
+            data_integration_settings_mapping.get(block.uuid)
+
+    if block and not di_settings:
+        di_settings = block.get_data_integration_settings(
             dynamic_block_index=dynamic_block_index,
             dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
             from_notebook=from_notebook,
@@ -493,8 +499,8 @@ def output_variables(
             partition=execution_partition,
         )
 
-    if block and data_integration_settings:
-        streams = get_selected_streams(data_integration_settings.get('catalog'))
+    if block and di_settings:
+        streams = get_selected_streams(di_settings.get('catalog'))
         output_variables = [s.get('tap_stream_id') for s in streams]
     else:
         all_variables = pipeline.variable_manager.get_variables_by_block(
@@ -561,6 +567,7 @@ def input_variables(
     from_notebook: bool = False,
     global_vars: Dict = None,
     input_args: List[Any] = None,
+    data_integration_settings_mapping: Dict = None,
 ) -> Dict[str, List[str]]:
     """
     Retrieves the input variables from the output variables of upstream blocks.
@@ -586,6 +593,7 @@ def input_variables(
             from_notebook=from_notebook,
             global_vars=global_vars,
             input_args=input_args,
+            data_integration_settings_mapping=data_integration_settings_mapping,
         )
         mapping[block_uuid] = out_vars
 
@@ -601,6 +609,7 @@ def fetch_input_variables(
     dynamic_block_index: int = None,
     dynamic_upstream_block_uuids: List[str] = None,
     from_notebook: bool = False,
+    data_integration_settings_mapping: Dict = None,
 ) -> Tuple[List, List, List]:
     """
     Fetches the input variables for a block.
@@ -638,6 +647,7 @@ def fetch_input_variables(
             from_notebook=from_notebook,
             global_vars=global_vars,
             input_args=input_args,
+            data_integration_settings_mapping=data_integration_settings_mapping,
         )
         keys = input_variables_by_uuid.keys()
         reduce_output_indexes = []
@@ -729,6 +739,7 @@ def fetch_input_variables(
                     from_notebook=from_notebook,
                     global_vars=global_vars,
                     input_args=input_args,
+                    data_integration_settings_mapping=data_integration_settings_mapping,
                 )
 
                 final_value = []

--- a/mage_ai/frontend/components/Logs/Table/index.tsx
+++ b/mage_ai/frontend/components/Logs/Table/index.tsx
@@ -142,6 +142,13 @@ function LogsTable({
       uuid,
     } = logData || {};
 
+    let displayText = message || content;
+    if (Array.isArray(displayText)) {
+      displayText = displayText.join(' ');
+    } else if (typeof displayText === 'object') {
+      displayText = JSON.stringify(displayText);
+    }
+
     let idEl;
     let blockUUID = blockUUIDProp || name.split('.log')[0];
 
@@ -268,10 +275,10 @@ function LogsTable({
             key="log_message"
             monospace
             textOverflow
-            title={message || content}
+            title={displayText}
           >
             <Ansi>
-              {message || content}
+              {displayText}
             </Ansi>
           </Text>
         </Flex>

--- a/mage_ai/server/websocket_server.py
+++ b/mage_ai/server/websocket_server.py
@@ -428,6 +428,13 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
                     pipeline_config=pipeline.get_config_from_yaml(),
                     repo_config=get_repo_config().to_dict(remote=remote_execution),
                     run_incomplete_upstream=run_incomplete_upstream,
+                    # The UI can execute a block and send run_settings to control the behavior
+                    # of the block run while executing it from the notebook.
+                    # E.G.
+                    # run_settings = dict(selected_streams=[
+                    #     'account_v2',
+                    #     'user_with_emails',
+                    # ])
                     run_settings=run_settings,
                     run_tests=run_tests,
                     run_upstream=run_upstream,

--- a/mage_ai/shared/environments.py
+++ b/mage_ai/shared/environments.py
@@ -5,7 +5,7 @@ from mage_ai.shared.constants import ENV_DEV, ENV_PROD, ENV_STAGING, ENV_TEST
 
 
 def is_debug():
-    return int(os.getenv('DEBUG', 0)) == 1
+    return int(os.getenv('DEBUG', 0) or 0) == 1
 
 
 def is_dev():


### PR DESCRIPTION
# Description
- Use Python and decorators to dynamically build destination blocks.
- Control what upstream blocks pass its output data or catalog to destination block as inputs for the decorated functions

# How Has This Been Tested?

```python
import json


@data_integration_destination
def destination(input_only, _, _sp, **kwargs):
    return input_only


@data_integration_config
def config(*args, **kwargs):
    return dict(
        database='dangerous',
        host='host.docker.internal',
        password='postgres',
        port=5432,
        schema='mage_destination_blocks',
        username='postgres',
    )


@data_integration_catalog
def catalog(_, tup, source_postgresql, **kwargs):
    d, c = source_postgresql
    print([sd['stream'] for sd in c['streams']])

    print(len(d))

    for da in d:
        print(da['columns'], len(da['rows']))

    api_data, api_data_catalog = tup

    columns_by_type = {}
    for col, col_type_init in api_data.dtypes.items():
        col_type = str(col_type_init)
        if col_type not in columns_by_type:
            columns_by_type[col_type] = []
        columns_by_type[col_type].append(col)

    properties = {}
    for col in columns_by_type['int64']:
        properties[col] = dict(
            type=[
                'null',
                'number',
            ]
        )

    stream_dict = dict(
        destination_table='api_data_unify_destination_block_python',
        replication_method='FULL_TABLE',
        schema=dict(
            properties=properties,
        ),
        stream='api_data',
    )

    streams = [
        stream_dict,
    ]

    for stream in c['streams']:
        stream_updated = stream.copy()
        stream_updated.pop('metadata', None)
        
        properties_updated = {}
        for col, prop in list(stream_updated['schema']['properties'].items())[:3]:
            properties_updated[col] = prop
        stream_updated['schema']['properties'] = properties_updated
        stream_updated['destination_table'] = '_'.join([
            stream_updated['destination_table'],
            'unify_destination_block_python',
        ])

        streams.append(stream_updated)

    catalog = dict(streams=streams)

    return catalog
```

<img width="2056" alt="CleanShot 2023-09-23 at 19 23 14@2x" src="https://github.com/mage-ai/mage-ai/assets/1066980/5442cc9c-9ee4-4fe3-961f-a7a04afab8a2">

<img width="1165" alt="CleanShot 2023-09-23 at 19 24 07@2x" src="https://github.com/mage-ai/mage-ai/assets/1066980/25d83ada-bb4a-4558-b06f-5e1d9b918823">

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
