### PR TITLE
[td] Renaming block will move the catalog.json and all other files

### DIFF
--- a/mage_ai/data_preparation/models/block/data_integration/mixins.py
+++ b/mage_ai/data_preparation/models/block/data_integration/mixins.py
@@ -88,7 +88,7 @@ class DataIntegrationMixin:
 
             return [up_uuid for up_uuid in self.upstream_block_uuids if up_uuid in inputs_combined]
 
-    def get_catalog_file_path(self) -> str:
+    def get_block_data_integration_settings_directory_path(self, block_uuid: str = None) -> str:
         if not self.pipeline:
             return
 
@@ -96,7 +96,12 @@ class DataIntegrationMixin:
             self.pipeline.repo_path,
             PIPELINES_FOLDER,
             self.pipeline.uuid,
-            self.uuid,
+            block_uuid or self.uuid,
+        )
+
+    def get_catalog_file_path(self, block_uuid: str = None) -> str:
+        return os.path.join(
+            self.get_block_data_integration_settings_directory_path(block_uuid),
             BLOCK_CATALOG_FILENAME,
         )
 

--- a/mage_ai/data_preparation/models/block/data_integration/mixins.py
+++ b/mage_ai/data_preparation/models/block/data_integration/mixins.py
@@ -180,10 +180,67 @@ class DataIntegrationMixin:
                 BlockLanguage.YAML == self.language and \
                 self.content:
 
+            def _block_output(
+                block_uuid: str,
+                parse: str = None,
+                current_block=self,
+                dynamic_block_index=dynamic_block_index,
+                dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
+                from_notebook=from_notebook,
+                global_vars=global_vars,
+                input_vars=input_vars,
+                partition=partition,
+            ) -> Any:
+                data = None
+
+                if not self.fetched_inputs_from_blocks:
+                    input_vars_fetched, _kwargs_vars, _upstream_block_uuids = \
+                        self.fetch_input_variables_and_catalog(
+                            input_vars,
+                            partition,
+                            global_vars,
+                            dynamic_block_index=dynamic_block_index,
+                            dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
+                            from_notebook=from_notebook,
+                        )
+                    self.fetched_inputs_from_blocks = input_vars_fetched
+
+                if block_uuid in self.upstream_block_uuids and \
+                        self.data_integration_inputs and \
+                        block_uuid in self.data_integration_inputs:
+
+                    index = self.upstream_block_uuids.index(block_uuid)
+                    data = self.fetched_inputs_from_blocks[index]
+
+                if parse:
+                    results = {}
+                    exec(f'_parse_func = {parse}', results)
+                    return results['_parse_func'](data)
+
+                return data
+
+            def _get_variable(
+                var_name: str,
+                parse: str = None,
+                global_vars=global_vars,
+            ) -> Any:
+                if not global_vars:
+                    return None
+
+                val = global_vars.get(var_name)
+                if parse:
+                    results = {}
+                    exec(f'_parse_func = {parse}', results)
+                    return results['_parse_func'](val)
+
+                return val
+
             text = Template(self.content).render(
-                variables=lambda x: global_vars.get(x) if global_vars else None,
+                block_output=_block_output,
+                variables=_get_variable,
                 **get_template_vars(),
             )
+
             settings = yaml.safe_load(text)
 
             catalog = self.__get_catalog_from_file()

--- a/mage_ai/data_preparation/models/block/utils.py
+++ b/mage_ai/data_preparation/models/block/utils.py
@@ -636,6 +636,8 @@ def fetch_input_variables(
     input_vars = []
     if input_args is not None:
         input_vars = input_args
+        if upstream_block_uuids:
+            upstream_block_uuids_final = upstream_block_uuids
     elif pipeline is not None:
         input_vars = [None for i in range(len(upstream_block_uuids))]
         input_variables_by_uuid = input_variables(

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -1410,6 +1410,23 @@ class Pipeline:
             if block.replicated_block == old_uuid:
                 block.replicated_block = new_uuid
 
+        # Update the block directory name that is under the pipeline directory.
+        # This block directory contains the catalog.json. For example:
+        # pipelines/[pipeline_uuid]/[block_uuid]/catalog.json
+        if block.is_data_integration():
+            dir_old = block.get_block_data_integration_settings_directory_path(old_uuid)
+            if os.path.isdir(dir_old):
+                dir_new = block.get_block_data_integration_settings_directory_path()
+                filenames = os.listdir(dir_old)
+                if filenames:
+                    os.makedirs(dir_new, exist_ok=True)
+
+                for filename in filenames:
+                    path_old = os.path.join(dir_old, filename)
+                    path_new = os.path.join(dir_new, filename)
+                    shutil.move(path_old, path_new)
+                shutil.rmtree(dir_old)
+
         self.save()
         return block
 


### PR DESCRIPTION
# Description
Update the block directory name that is under the pipeline directory.
This block directory contains the catalog.json. For example:
pipelines/[pipeline_uuid]/[block_uuid]/catalog.json

- Interpolate upstream block output in YAML files
- Add parsing logic to extract value from variables in YAMLfiles


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

```yaml
config:
  database: dangerous
  host: host.docker.internal
  password: "{{ variables('PASSWORD_WTF') }}"
  port: 5432
  schema: mage
  username: postgres
source: >
    {{ variables(
        'SOURCE_WTF',
        'lambda x: x.split(",")[1]'
    ) }}
```

```yaml
config:
  database: dangerous
  host: host.docker.internal
  password: "{{ variables('PASSWORD_WTF') }}"
  port: 5432
  schema: mage
  username: postgres
source: >
    {{ block_output('divine_glitter', 'lambda x: x[1]') }}
```


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
