### PR TITLE
[xy] Speed up bigquery destination in data integration pipeline.

### DIFF
--- a/mage_integrations/mage_integrations/destinations/bigquery/utils.py
+++ b/mage_integrations/mage_integrations/destinations/bigquery/utils.py
@@ -37,7 +37,7 @@ EMOJI_PATTERN = re.compile(
     u"\u3030"                 # wavy dash
     u"\U00002500-\U00002BEF"  # Chinese characters
     u"\U00010000-\U0010ffff"  # other characters
-    u'\u00a9\u00ae\u2000-\u3300\ud83c\ud000-\udfff\ud83d\ud000-\udfff\ud83e\ud000-\udfff\uD83C-\uDBFF\uDC00-\uDFFF'
+    u'\u00a9\u00ae\u2000-\u3300\ud83c\ud000-\udfff\ud83d\ud000-\udfff\ud83e\ud000-\udfff\uD83C-\uDBFF\uDC00-\uDFFF'     # noqa: E501
     "]+",
     flags=re.UNICODE,  # specify the unicode flag to handle unicode characters properly
 )
@@ -45,7 +45,7 @@ EMOJI_PATTERN = re.compile(
 
 def remove_emoji_code(v: str) -> str:
     if type(v) is str:
-        v = re.sub(r'(\\ud83d(\\ud[0-f][0-f][0-f])?)|(\\ud83c\\ud[0-f][0-f][0-f])|(\\ud83e\\ud[0-f][0-f][0-f])', '', v)
+        v = re.sub(r'(\\ud83d(\\ud[0-f][0-f][0-f])?)|(\\ud83c\\ud[0-f][0-f][0-f])|(\\ud83e\\ud[0-f][0-f][0-f])', '', v)     # noqa: E501
         v = EMOJI_PATTERN.sub(r'', v)
     return v
 
@@ -217,12 +217,17 @@ def convert_json_or_string(value, column_type_dict):
     return value
 
 
-def convert_json_or_string_for_batch_load(value, column_type_dict):
+def convert_json_or_string_for_batch_load(
+    value,
+    column_type_dict,
+    convert_json_to_dict: bool = True,
+):
     column_type = column_type_dict['type']
     if COLUMN_TYPE_OBJECT == column_type:
         value = stringify_object_and_remove_emoji_code(value)
         value = value.replace('\n', '\\n')
-        # value = json.loads(value)
+        if convert_json_to_dict:
+            value = json.loads(value)
     elif COLUMN_TYPE_STRING == column_type:
         if type(value) is not str:
             value = str(value)

--- a/mage_integrations/mage_integrations/destinations/bigquery/utils.py
+++ b/mage_integrations/mage_integrations/destinations/bigquery/utils.py
@@ -1,3 +1,9 @@
+import json
+import re
+from typing import Dict, List
+
+import dateutil.parser
+
 from mage_integrations.destinations.constants import (
     COLUMN_FORMAT_DATETIME,
     COLUMN_TYPE_BOOLEAN,
@@ -5,11 +11,9 @@ from mage_integrations.destinations.constants import (
     COLUMN_TYPE_OBJECT,
     COLUMN_TYPE_STRING,
 )
-from mage_integrations.destinations.sql.utils import convert_column_type as convert_column_type_orig
-from typing import Dict, List
-import dateutil.parser
-import json
-import re
+from mage_integrations.destinations.sql.utils import (
+    convert_column_type as convert_column_type_orig,
+)
 
 EMOJI_PATTERN = re.compile(
     "["
@@ -76,9 +80,11 @@ def convert_array(value: str, column_type_dict: Dict) -> str:
         return f'[{arr_string}]'
 
     if type(value) is list:
-        value_next = [f"CAST('{replace_single_quotes_with_double(v)}' AS {item_type_converted})" for v in value]
+        value_next = [f"CAST('{replace_single_quotes_with_double(v)}' AS {item_type_converted})"
+                      for v in value]
     else:
-        value_next = [f"CAST('{replace_single_quotes_with_double(value)}' AS {item_type_converted})"]
+        value_next = \
+            [f"CAST('{replace_single_quotes_with_double(value)}' AS {item_type_converted})"]
 
     arr_string = ', '.join([str(v) for v in value_next])
 
@@ -160,6 +166,7 @@ def convert_datetime_for_batch_load(value: str) -> str:
 
     return dateutil.parser.parse(final_value).strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
 
+
 def convert_converted_type_to_parameter_type(converted_type):
     """
     https://cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.query.ScalarQueryParameterType
@@ -215,7 +222,7 @@ def convert_json_or_string_for_batch_load(value, column_type_dict):
     if COLUMN_TYPE_OBJECT == column_type:
         value = stringify_object_and_remove_emoji_code(value)
         value = value.replace('\n', '\\n')
-        value = json.loads(value)
+        # value = json.loads(value)
     elif COLUMN_TYPE_STRING == column_type:
         if type(value) is not str:
             value = str(value)
@@ -228,8 +235,10 @@ def remove_duplicate_rows(
     row_data: List[Dict],
     unique_constraints: List[str],
     logger=None,
-    tags: Dict = {}
+    tags: Dict = None,
 ) -> List[Dict]:
+    if tags is None:
+        tags = {}
     if not unique_constraints or len(unique_constraints) == 0:
         return row_data
 
@@ -247,8 +256,8 @@ def remove_duplicate_rows(
         if existing_record:
             if logger:
                 logger.info(
-                    f"Duplicate record found for unique constraints {', '.join(unique_constraints)} "
-                    f"with values {', '.join(values_for_unique_constraints)}: {record}.",
+                    f"Duplicate record found for unique constraints {', '.join(unique_constraints)}"
+                    f" with values {', '.join(values_for_unique_constraints)}: {record}.",
                     tags=tags,
                 )
 
@@ -265,7 +274,8 @@ def remove_duplicate_rows(
                     logger.info(
                         'Replacing previous record with duplicate record because duplicate record '
                         f'has {non_null_values} non-null values, '
-                        f'which is greater than or equal to the previous record {existing_non_null_values} non-null values.',
+                        'which is greater than or equal to the previous record '
+                        f'{existing_non_null_values} non-null values.',
                         tags=tags,
                     )
 
@@ -275,7 +285,8 @@ def remove_duplicate_rows(
                 logger.info(
                     'Skipping duplicate record because previous record has '
                     f'{existing_non_null_values} non-null values, '
-                    f'which is greater than or equal to the duplicate record {non_null_values} non-null values.',
+                    f'which is greater than or equal to the duplicate record {non_null_values} '
+                    'non-null values.',
                     tags=tags,
                 )
         else:

--- a/mage_integrations/mage_integrations/destinations/sql/utils.py
+++ b/mage_integrations/mage_integrations/destinations/sql/utils.py
@@ -226,6 +226,13 @@ def convert_column_to_type(value, column_type) -> str:
     return f"CAST('{value}' AS {column_type})"
 
 
+def build_insert_columns(
+    columns: List[str],
+    column_identifier: str = '',
+):
+    return [f'{column_identifier}{clean_column_name(col)}{column_identifier}' for col in columns]
+
+
 def build_insert_command(
     column_type_mapping: Dict,
     columns: List[str],
@@ -284,6 +291,6 @@ def build_insert_command(
         values.append(vals)
 
     return [
-        [f'{column_identifier}{clean_column_name(col)}{column_identifier}' for col in columns],
+        build_insert_columns(columns, column_identifier=column_identifier),
         values,
     ]

--- a/mage_integrations/mage_integrations/tests/destinations/test_base.py
+++ b/mage_integrations/mage_integrations/tests/destinations/test_base.py
@@ -1,9 +1,9 @@
-from mage_integrations.destinations.base import Destination
-from mage_integrations.destinations.postgresql import PostgreSQL
-from unittest.mock import MagicMock, patch
 import io
 import unittest
+from unittest.mock import MagicMock, patch
 
+from mage_integrations.destinations.base import Destination
+from mage_integrations.destinations.postgresql import PostgreSQL
 
 SAMPLE_RECORD = {
     'id': 2,
@@ -44,6 +44,7 @@ SAMPLE_SCHEMA_ROW = {
 }
 SAMPLE_STREAM_NAME = 'demo_users'
 
+
 def build_test_destination():
     destination = Destination(
         config=dict(database='demo_db'),
@@ -60,6 +61,7 @@ def build_test_destination():
     destination.versions = {}
 
     return destination
+
 
 class BaseDestinationTests(unittest.TestCase):
     def test_templates(self):
@@ -112,6 +114,7 @@ class BaseDestinationTests(unittest.TestCase):
             mock_export_batch_data.assert_called_once_with(
                 [dict(record=SAMPLE_RECORD, stream=SAMPLE_STREAM_NAME)],
                 SAMPLE_STREAM_NAME,
+                tags={'records': 1, 'stream': 'demo_users'},
             )
 
     def test_process_empty_record_data(self):
@@ -169,10 +172,12 @@ class BaseDestinationTests(unittest.TestCase):
 
     def test_process_no_state(self):
         destination = build_test_destination()
-        with self.assertRaises(Exception):
+        with self.assertRaises(Exception) as context:
             destination.process_state(
                 row=SAMPLE_RECORD_ROW
             )
+            self.assertEqual(
+                str(context.exception), 'A state message is missing a state value.')
 
     def test_process_test_connection(self):
         destination = build_test_destination()


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Speed up bigquery destination in data integration pipeline.
* Only run schema creation command, table creation and alter commands for the first subbatch in destination
* Allow maximum batch size to be configured via `maximum_batch_size_mb` key in destination config
* Remove redundant records loop through in bigquery destination when `use_batch_load` is true
* Speed up exporting datetime column to BigQuery by converting records to dataframe and use `pd.to_datetime` to convert datetime column
  * User PARQUET format for most of the cases
  * Use CSV format when there're json columns: https://stackoverflow.com/questions/76983677/json-format-not-supported-when-using-load-table-from-dataframe-bigquery
  * Use load_table_from_json when there's ARRAY type since REPEATED mode is not supported in CSV format

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
Config
```yaml
use_batch_load: true
maximum_batch_size_mb: 500
```

- [x] Tested exporting 50k rows to BigQuery. Time before optimization: 90s. Time after optimization: 20s.
* Load from dataframe (default to parquet): 20s
* Load from dataframe (csv format with schema): 20s
* Load from dataframe (csv format without schema): 41s
* Load from json: 42s


Column type tested
- [x] string
- [x] int
- [x] datetime
- [x] array
- [x] object


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

cc:
<!-- Optionally mention someone to let them know about this pull request -->
