### PR TITLE
[xy] Allow configuring EMR cluster spark properties

### DIFF
--- a/mage_ai/services/aws/emr/config.py
+++ b/mage_ai/services/aws/emr/config.py
@@ -1,8 +1,9 @@
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict
 
 from mage_ai.shared.config import BaseConfig
+from mage_ai.shared.hash import merge_dict
 
 DEFAULT_DRIVER_MEMORY = '32000M'
 DEFAULT_INSTANCE_TYPE = 'r5.4xlarge'
@@ -28,8 +29,10 @@ class EmrConfig(BaseConfig):
     master_security_group: str = None
     slave_security_group: str = None
     master_instance_type: str = DEFAULT_INSTANCE_TYPE
+    master_spark_properties: Dict = field(default_factory=dict)
     slave_instance_count: int = 1
     slave_instance_type: str = DEFAULT_INSTANCE_TYPE
+    slave_spark_properties: Dict = field(default_factory=dict)
     scaling_policy: EmrScalingPocliy = None
 
     def get_instances_config(
@@ -51,7 +54,7 @@ class EmrConfig(BaseConfig):
                     Configurations=[
                         {
                             'Classification': 'spark-defaults',
-                            'Properties': {
+                            'Properties': merge_dict({
                                 'spark.driver.memory': self.__driver_memory(
                                     self.master_instance_type,
                                 ),
@@ -59,7 +62,7 @@ class EmrConfig(BaseConfig):
                                 'spark.executor.memory': self.__driver_memory(
                                     self.master_instance_type,
                                 ),
-                            },
+                            }, self.master_spark_properties),
                         },
                     ],
                 ),
@@ -72,7 +75,7 @@ class EmrConfig(BaseConfig):
                     Configurations=[
                         {
                             'Classification': 'spark-defaults',
-                            'Properties': {
+                            'Properties': merge_dict({
                                 'spark.driver.memory': self.__driver_memory(
                                     self.slave_instance_type,
                                 ),
@@ -80,7 +83,7 @@ class EmrConfig(BaseConfig):
                                 'spark.executor.memory': self.__driver_memory(
                                     self.slave_instance_type,
                                 ),
-                            },
+                            }, self.slave_spark_properties),
                         },
                     ],
                 ),

--- a/mage_ai/services/aws/emr/config.py
+++ b/mage_ai/services/aws/emr/config.py
@@ -27,7 +27,9 @@ class EmrConfig(BaseConfig):
     ec2_key_name: str = None
     master_security_group: str = None
     slave_security_group: str = None
+    master_instance_count: int = 1
     master_instance_type: str = DEFAULT_INSTANCE_TYPE
+    slave_instance_count: int = 1
     slave_instance_type: str = DEFAULT_INSTANCE_TYPE
     scaling_policy: EmrScalingPocliy = None
 
@@ -46,7 +48,7 @@ class EmrConfig(BaseConfig):
                     Market=market,
                     InstanceRole='MASTER',
                     InstanceType=self.master_instance_type,
-                    InstanceCount=1,
+                    InstanceCount=self.master_instance_count,
                     Configurations=[
                         {
                             'Classification': 'spark-defaults',
@@ -67,7 +69,7 @@ class EmrConfig(BaseConfig):
                     Market=market,
                     InstanceRole='CORE',
                     InstanceType=self.slave_instance_type,
-                    InstanceCount=1,
+                    InstanceCount=self.slave_instance_count,
                     Configurations=[
                         {
                             'Classification': 'spark-defaults',

--- a/mage_ai/services/aws/emr/config.py
+++ b/mage_ai/services/aws/emr/config.py
@@ -27,7 +27,6 @@ class EmrConfig(BaseConfig):
     ec2_key_name: str = None
     master_security_group: str = None
     slave_security_group: str = None
-    master_instance_count: int = 1
     master_instance_type: str = DEFAULT_INSTANCE_TYPE
     slave_instance_count: int = 1
     slave_instance_type: str = DEFAULT_INSTANCE_TYPE
@@ -48,7 +47,7 @@ class EmrConfig(BaseConfig):
                     Market=market,
                     InstanceRole='MASTER',
                     InstanceType=self.master_instance_type,
-                    InstanceCount=self.master_instance_count,
+                    InstanceCount=1,
                     Configurations=[
                         {
                             'Classification': 'spark-defaults',


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Allow configuring core instance count for EMR cluster

Example config:
```yaml
emr_config:
  master_instance_type: 'r5.4xlarge'
  master_spark_properties:
    spark.driver.memory: 400M
    spark.executor.cores: '8'
  slave_instance_count: 2
  slave_instance_type: 'r5.4xlarge'
  slave_spark_properties:
    spark.driver.memory: 400M
    spark.executor.cores: '8'
```

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with pyspark kernel locally
![image](https://github.com/mage-ai/mage-ai/assets/80284865/0407ea59-cde0-49f5-927e-06262b03e8c2)


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
