### PR TITLE
[jk] Bulk retry incomplete block runs

### DIFF
--- a/mage_ai/api/resources/PipelineResource.py
+++ b/mage_ai/api/resources/PipelineResource.py
@@ -435,8 +435,10 @@ class PipelineResource(BaseResource):
                 join(b, a.id == b.pipeline_run_id).
                 filter(a.pipeline_uuid == pipeline_uuid).
                 filter(a.status == PipelineRun.PipelineRunStatus.FAILED).
-                filter(b.status != BlockRun.BlockRunStatus.COMPLETED).
-                filter(b.status != BlockRun.BlockRunStatus.CONDITION_FAILED)
+                filter(b.status.not_in([
+                    BlockRun.BlockRunStatus.COMPLETED,
+                    BlockRun.BlockRunStatus.CONDITION_FAILED,
+                ]))
             ).all()
 
             return result

--- a/mage_ai/api/resources/PipelineResource.py
+++ b/mage_ai/api/resources/PipelineResource.py
@@ -434,7 +434,9 @@ class PipelineResource(BaseResource):
                 select(*columns).
                 join(b, a.id == b.pipeline_run_id).
                 filter(a.pipeline_uuid == pipeline_uuid).
-                filter(b.status != BlockRun.BlockRunStatus.COMPLETED)
+                filter(a.status == PipelineRun.PipelineRunStatus.FAILED).
+                filter(b.status != BlockRun.BlockRunStatus.COMPLETED).
+                filter(b.status != BlockRun.BlockRunStatus.CONDITION_FAILED)
             ).all()
 
             return result
@@ -449,7 +451,7 @@ class PipelineResource(BaseResource):
             )
             PipelineRun.batch_update_status(
                 pipeline_run_ids,
-                PipelineRun.PipelineRunStatus.RUNNING,
+                PipelineRun.PipelineRunStatus.INITIAL,
             )
 
         status = payload.get('status')

--- a/mage_ai/frontend/components/PipelineDetailPage/constants.ts
+++ b/mage_ai/frontend/components/PipelineDetailPage/constants.ts
@@ -11,3 +11,6 @@ export enum PageNameEnum {
   SYNCS = 'syncs',
   TRIGGERS = 'triggers',
 }
+
+export const CANCEL_ALL_RUNNING_PIPELINE_RUNS_UUID = 'cancel_all_running_pipeline_runs';
+export const RETRY_INCOMPLETE_BLOCK_RUNS_UUID = 'retry_incomplete_block_runs';

--- a/mage_ai/frontend/components/PipelineDetailPage/constants.ts
+++ b/mage_ai/frontend/components/PipelineDetailPage/constants.ts
@@ -13,4 +13,3 @@ export enum PageNameEnum {
 }
 
 export const CANCEL_ALL_RUNNING_PIPELINE_RUNS_UUID = 'cancel_all_running_pipeline_runs';
-export const RETRY_INCOMPLETE_BLOCK_RUNS_UUID = 'retry_incomplete_block_runs';

--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -917,6 +917,8 @@ function Edit({
                 [minute] [hour] [day(month)] [month] [day(week)]
               </Text>
 
+              <Spacing mb="2px" />
+
               {!customInterval
                 ? null
                 : (

--- a/mage_ai/frontend/components/shared/Header/index.tsx
+++ b/mage_ai/frontend/components/shared/Header/index.tsx
@@ -57,8 +57,8 @@ function Header({
   version: versionProp,
 }: HeaderProps) {
   const [userMenuVisible, setUserMenuVisible] = useState<boolean>(false);
-  const [highlightedMenuIndex, setHighlightedMenuIndex] = useState(null);
-  const [confirmationDialogueOpen, setConfirmationDialogueOpen] = useState(false);
+  const [highlightedMenuIndex, setHighlightedMenuIndex] = useState<number>(null);
+  const [confirmationDialogueOpen, setConfirmationDialogueOpen] = useState<boolean>(false);
   const [confirmationAction, setConfirmationAction] = useState(null);
 
   const menuRef = useRef(null);

--- a/mage_ai/frontend/components/shared/Table/Toolbar/constants.ts
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/constants.ts
@@ -5,8 +5,8 @@ export const POPUP_MENU_WIDTH = UNIT * 40;
 export const POPUP_TOP_OFFSET = 58;
 
 export enum ConfirmDialogueOpenEnum {
-  SECONDARY = 1,
-  DELETE = 2,
+  FIRST = 1,
+  SECOND = 2,
 }
 
 export const SHARED_TOOLTIP_PROPS = {

--- a/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
@@ -379,7 +379,7 @@ function Toolbar({
               greyBorder
               loading={isLoadingExtraAction}
               onClick={openExtraActionConfirmDialogue
-                ? () => setConfirmationDialogueOpenIdx(ConfirmDialogueOpenEnum.SECONDARY)
+                ? () => setConfirmationDialogueOpenIdx(ConfirmDialogueOpenEnum.FIRST)
                 : onExtraActionClick
               }
               smallIcon
@@ -390,7 +390,7 @@ function Toolbar({
           </Tooltip>
           <ClickOutside
             onClickOutside={closeConfirmationDialogue}
-            open={confirmationDialogueOpenIdx === ConfirmDialogueOpenEnum.SECONDARY}
+            open={confirmationDialogueOpenIdx === ConfirmDialogueOpenEnum.FIRST}
           >
             <PopupMenu
               onCancel={closeConfirmationDialogue}
@@ -420,14 +420,14 @@ function Toolbar({
               disabled={disabledActions}
               greyBorder
               loading={isLoadingDelete}
-              onClick={() => setConfirmationDialogueOpenIdx(ConfirmDialogueOpenEnum.DELETE)}
+              onClick={() => setConfirmationDialogueOpenIdx(ConfirmDialogueOpenEnum.SECOND)}
               smallIcon
               uuid="Table/Toolbar/DeleteButton"
             />
           </Tooltip>
           <ClickOutside
             onClickOutside={closeConfirmationDialogue}
-            open={confirmationDialogueOpenIdx === ConfirmDialogueOpenEnum.DELETE}
+            open={confirmationDialogueOpenIdx === ConfirmDialogueOpenEnum.SECOND}
           >
             <PopupMenu
               danger

--- a/mage_ai/frontend/interfaces/PipelineType.ts
+++ b/mage_ai/frontend/interfaces/PipelineType.ts
@@ -44,6 +44,7 @@ export enum PipelineStatusEnum {
   INACTIVE = 'inactive',    // All inactive triggers
   NO_SCHEDULES = 'no_schedules',    // No triggers
   RETRY = 'retry',
+  RETRY_INCOMPLETE_BLOCK_RUNS = 'retry_incomplete_block_runs',
 }
 
 export enum PipelineQueryEnum {

--- a/mage_ai/frontend/interfaces/PipelineType.ts
+++ b/mage_ai/frontend/interfaces/PipelineType.ts
@@ -44,6 +44,7 @@ export enum PipelineStatusEnum {
   INACTIVE = 'inactive',    // All inactive triggers
   NO_SCHEDULES = 'no_schedules',    // No triggers
   RETRY = 'retry',
+  // Retry incomplete block runs for failed pipeline runs specifically
   RETRY_INCOMPLETE_BLOCK_RUNS = 'retry_incomplete_block_runs',
 }
 

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -50,12 +50,13 @@ export type FlyoutMenuProps = {
   disableKeyboardShortcuts?: boolean;
   items: FlyoutMenuItemType[];
   left?: number;
+  multipleConfirmDialogues?: boolean;
   onClickCallback?: () => void;
   open: boolean;
   parentRef: any;
   rightOffset?: number;
   roundedStyle?: boolean;
-  setConfirmationDialogueOpen?: (open: boolean) => void;
+  setConfirmationDialogueOpen?: (open: any) => void;   // "open" arg can be boolean or string (uuid)
   setConfirmationAction?: (action: any) => void;
   topOffset?: number;
   uuid: string;
@@ -67,6 +68,7 @@ function FlyoutMenu({
   disableKeyboardShortcuts,
   items,
   left,
+  multipleConfirmDialogues,
   onClickCallback,
   open,
   parentRef,
@@ -246,7 +248,7 @@ function FlyoutMenu({
                 }
 
                 if (openConfirmationDialogue && !disabled) {
-                  setConfirmationDialogueOpen?.(true);
+                  setConfirmationDialogueOpen?.(multipleConfirmDialogues ? uuid : true);
                   setConfirmationAction?.(() => onClick);
                   onClickCallback?.();
                 } else if (onClick && !disabled) {

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -221,8 +221,8 @@ function PipelineRuns({
   const hasRunningPipeline = useMemo(() => pipelineRuns.some(({ status }) => (
     status === RunStatusEnum.INITIAL || status === RunStatusEnum.RUNNING
   )), [pipelineRuns]);
-  const hasIncompletePipelineRun = useMemo(() => pipelineRuns.some(({ status }) => (
-    status !== RunStatusEnum.COMPLETED
+  const hasFailedPipelineRun = useMemo(() => pipelineRuns.some(({ status }) => (
+    status === RunStatusEnum.FAILED
   )), [pipelineRuns]);
   const selectedRunsArr = useMemo(() => (
     Object.values(selectedRuns || {})
@@ -316,10 +316,10 @@ function PipelineRuns({
     {
       beforeIcon: (
         <Refresh
-          muted={!hasIncompletePipelineRun || hasRunningPipeline}
+          muted={!hasFailedPipelineRun || hasRunningPipeline}
         />
       ),
-      disabled: !hasIncompletePipelineRun || hasRunningPipeline,
+      disabled: !hasFailedPipelineRun || hasRunningPipeline,
       label: () => 'Retry all incomplete block runs',
       onClick: () => updatePipeline({
         pipeline: {
@@ -354,7 +354,7 @@ function PipelineRuns({
       uuid: CANCEL_ALL_RUNNING_PIPELINE_RUNS_UUID,
     },
   ]), [
-    hasIncompletePipelineRun,
+    hasFailedPipelineRun,
     hasRunningPipeline,
     isPipelineRunsTab,
     selectedRunningRunsArr,
@@ -514,10 +514,15 @@ function PipelineRuns({
                         confirmationAction?.();
                         setConfirmationDialogueOpenId(null);
                       }}
-                      subtitle="This includes runs on other pages as well, not just the current page."
+                      subtitle={'This includes runs on other pages as well, not just the current page.' +
+                        (confirmationDialogueOpenId === PipelineStatusEnum.RETRY_INCOMPLETE_BLOCK_RUNS
+                          ? ' Incomplete block runs will be retried for FAILED pipeline runs specifically.'
+                          : ''
+                        )
+                      }
                       title={confirmationDialogueOpenId === CANCEL_ALL_RUNNING_PIPELINE_RUNS_UUID
                         ? 'Are you sure you want to cancel all pipeline runs in progress?'
-                        : 'Are you sure you want to retry all incomplete block runs?'
+                        : 'Are you sure you want to retry all incomplete block runs for any failed pipeline runs?'
                       }
                       width={POPUP_MENU_WIDTH}
                     />

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -216,6 +216,9 @@ function PipelineRuns({
   const hasRunningPipeline = useMemo(() => pipelineRuns.some(({ status }) => (
     status === RunStatusEnum.INITIAL || status === RunStatusEnum.RUNNING
   )), [pipelineRuns]);
+  const hasIncompletePipelineRun = useMemo(() => pipelineRuns.some(({ status }) => (
+    status !== RunStatusEnum.COMPLETED
+  )), [pipelineRuns]);
   const selectedRunsArr = useMemo(() => (
     Object.values(selectedRuns || {})
       .filter((val) => val !== null)
@@ -306,6 +309,17 @@ function PipelineRuns({
       uuid: 'retry_selected',
     },
     {
+      beforeIcon: <Refresh muted={!hasIncompletePipelineRun} />,
+      disabled: !hasIncompletePipelineRun,
+      label: () => 'Retry all incomplete block runs',
+      onClick: () => updatePipeline({
+        pipeline: {
+          status: PipelineStatusEnum.RETRY_INCOMPLETE_BLOCK_RUNS,
+        },
+      }),
+      uuid: 'retry_incomplete_block_runs',
+    },
+    {
       beforeIcon: <AlertTriangle muted={selectedRunningRunsCount === 0} />,
       disabled: selectedRunningRunsCount === 0,
       label: () => `Cancel selected running (${selectedRunningRunsCount})`,
@@ -330,6 +344,7 @@ function PipelineRuns({
       uuid: 'cancel_all_running',
     },
   ]), [
+    hasIncompletePipelineRun,
     hasRunningPipeline,
     isPipelineRunsTab,
     selectedRunningRunsArr,

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -47,7 +47,6 @@ import { OFFSET_PARAM, goToWithQuery } from '@utils/routing';
 import {
   CANCEL_ALL_RUNNING_PIPELINE_RUNS_UUID,
   PageNameEnum,
-  RETRY_INCOMPLETE_BLOCK_RUNS_UUID,
 } from '@components/PipelineDetailPage/constants';
 import { PipelineStatusEnum, PipelineTypeEnum } from '@interfaces/PipelineType';
 import { POPUP_MENU_WIDTH } from '@components/shared/Table/Toolbar/constants';
@@ -315,8 +314,12 @@ function PipelineRuns({
       uuid: 'retry_selected',
     },
     {
-      beforeIcon: <Refresh muted={!hasIncompletePipelineRun} />,
-      disabled: !hasIncompletePipelineRun,
+      beforeIcon: (
+        <Refresh
+          muted={!hasIncompletePipelineRun || hasRunningPipeline}
+        />
+      ),
+      disabled: !hasIncompletePipelineRun || hasRunningPipeline,
       label: () => 'Retry all incomplete block runs',
       onClick: () => updatePipeline({
         pipeline: {
@@ -324,7 +327,7 @@ function PipelineRuns({
         },
       }),
       openConfirmationDialogue: true,
-      uuid: RETRY_INCOMPLETE_BLOCK_RUNS_UUID,
+      uuid: PipelineStatusEnum.RETRY_INCOMPLETE_BLOCK_RUNS,
     },
     {
       beforeIcon: <AlertTriangle muted={selectedRunningRunsCount === 0} />,

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -729,6 +729,14 @@ class PipelineRun(BaseModel):
         return query.all()
 
     @classmethod
+    @safe_db_query
+    def batch_update_status(self, pipeline_run_ids: List[int], status):
+        PipelineRun.query.filter(PipelineRun.id.in_(pipeline_run_ids)).update({
+            PipelineRun.status: status
+        }, synchronize_session=False)
+        db_connection.session.commit()
+
+    @classmethod
     def create(self, create_block_runs: bool = True, **kwargs) -> 'PipelineRun':
         pipeline_run = super().create(**kwargs)
         pipeline_uuid = kwargs.get('pipeline_uuid')


### PR DESCRIPTION
# Description
- Retry all of a pipeline's incomplete block runs from the UI. This includes all block runs that do not have `completed` status.
- Users may not want to create a new pipeline run when retrying failed pipeline runs, so this allows users to keep the same pipeline runs but still retry the failed block runs without having to individually go into each pipeline run to do so.

# How Has This Been Tested?
Retry all incomplete block runs even if the pipeline runs are across diff pages (the failed blocks intentionally had an exception for testing purposes):
![Retry all incomplete block runs](https://github.com/mage-ai/mage-ai/assets/78053898/aabbf243-ad18-45aa-995e-7f6a9058f0ae)

Retry all incomplete block runs (successfully completes):
![retry incomplete block runs (success)](https://github.com/mage-ai/mage-ai/assets/78053898/7747dfe6-5642-4450-ae96-4b8508797c4c)

"Retry all incomplete block runs" option from Actions menu in a pipeline's Pipeline Runs page:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/9df576be-e562-4770-9b56-678f09bf03fc)
Confirm dialogue before proceeding:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/12a52e3d-6ca3-4c0c-b46a-031c13713cc8)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
