### PR TITLE
[dy] Fix condition_failed check for dynamic blocks

### DIFF
--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -503,20 +503,16 @@ class PipelineScheduler:
 
             for status, block_uuids in statuses.items():
                 if dynamic_upstream_block_uuids:
-                    if all(
-                        b in block_uuids
-                        for b in dynamic_upstream_block_uuids
-                    ):
-                        block_run.update(status=status)
-                        updated_status = True
+                    upstream_block_uuids = dynamic_upstream_block_uuids
                 else:
                     block = self.pipeline.get_block(block_run.block_uuid)
-                    if any(
-                        b in block_uuids
-                        for b in block.upstream_block_uuids
-                    ):
-                        block_run.update(status=status)
-                        updated_status = True
+                    upstream_block_uuids = block.upstream_block_uuids
+                if any(
+                    b in block_uuids
+                    for b in upstream_block_uuids
+                ):
+                    block_run.update(status=status)
+                    updated_status = True
 
             if not updated_status:
                 not_updated_block_runs.append(block_run)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

The `conditional_failed` check for dynamic blocks was using `all`, but it should be using `any`. If any of the upstream dynamic block uuids are `condition_failed`, then the current dynamic block should be `condition_failed` as well.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with dynamic block

<img width="1645" alt="Screenshot 2023-09-25 at 4 09 42 PM" src="https://github.com/mage-ai/mage-ai/assets/14357209/4f9613d1-2118-4b93-856a-234c7b5e3935">

I'm trying to add a unit test to catch this case in the future, but it may take some time to mock a dynamic pipeline.

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
