### PR TITLE
[dy] Add always on schedule interval

### DIFF
--- a/docs/orchestration/triggers/configure-triggers-in-code.mdx
+++ b/docs/orchestration/triggers/configure-triggers-in-code.mdx
@@ -29,7 +29,7 @@ Here are the steps to create and configure triggers via code:
     1. Required trigger fields
         1. `name`: Unique identifier of the trigger
         1. `schedule_type`: `time`, `api`, or `event`
-        1. `schedule_interval`: `@once`, `@hourly`, "@daily", `@weekly`, `@monthly`, or Cron syntax(`* * * * *`)
+        1. `schedule_interval`: `@once`, `@hourly`, `@daily`, `@weekly`, `@monthly`, `@always_on`, or Cron syntax(`* * * * *`)
         1. `start_time`: The start time of the trigger (e.g. `2023-01-01`)
     1. Optional trigger fields
         1. `status`: `active` or `inactive`

--- a/docs/orchestration/triggers/schedule-pipelines.mdx
+++ b/docs/orchestration/triggers/schedule-pipelines.mdx
@@ -15,8 +15,11 @@ You can schedule your pipeline to run on these intervals:
 
 - Once
 - Hourly
+- Daily
 - Weekly
 - Monthly
+- Always on
+    - The pipeline will be run as soon as the previous pipeline run is finished
 - Custom schedule using
   [CRON Expression](https://en.wikipedia.org/wiki/Cron#CRON_expression)
 - Every minute using CRON expression: `* * * * *`

--- a/mage_ai/data_preparation/models/triggers/__init__.py
+++ b/mage_ai/data_preparation/models/triggers/__init__.py
@@ -34,6 +34,7 @@ class ScheduleInterval(str, enum.Enum):
     DAILY = '@daily'
     WEEKLY = '@weekly'
     MONTHLY = '@monthly'
+    ALWAYS_ON = '@always_on'
 
 
 @dataclass

--- a/mage_ai/frontend/interfaces/PipelineScheduleType.ts
+++ b/mage_ai/frontend/interfaces/PipelineScheduleType.ts
@@ -24,6 +24,7 @@ export enum ScheduleIntervalEnum {
   DAILY = '@daily',
   WEEKLY = '@weekly',
   MONTHLY = '@monthly',
+  ALWAYS_ON = '@always_on'
 }
 
 export interface SelectedScheduleType {

--- a/mage_ai/orchestration/airflow.py
+++ b/mage_ai/orchestration/airflow.py
@@ -1,8 +1,10 @@
 from datetime import datetime
-from mage_ai.data_preparation.models.pipeline import Pipeline
-from mage_ai.shared.hash import ignore_keys, merge_dict
-from typing import Dict, List, Any
+from typing import Any, Dict, List
+
 import mage_ai
+from mage_ai.data_preparation.models.pipeline import Pipeline
+from mage_ai.data_preparation.models.triggers import ScheduleInterval
+from mage_ai.shared.hash import ignore_keys, merge_dict
 
 
 def create_dag(
@@ -10,9 +12,14 @@ def create_dag(
     pipeline_uuid: str,
     dag_class,
     python_operator_class,
-    dag_settings: Dict[str, Any] = dict(),
-    globals_dict: Dict[str, Any] = dict(),
+    dag_settings: Dict[str, Any] = None,
+    globals_dict: Dict[str, Any] = None,
 ):
+    if dag_settings is None:
+        dag_settings = dict()
+    if globals_dict is None:
+        globals_dict = dict()
+
     pipeline = Pipeline(pipeline_uuid, repo_path=project_path)
 
     tasks = []
@@ -62,7 +69,7 @@ def create_dag(
                 dict(
                     start_date=datetime(2022, 7, 14),
                     description=f'Mage pipeline: {pipeline_uuid}.',
-                    schedule_interval='@once',
+                    schedule_interval=ScheduleInterval.ONCE,
                     catchup=False,
                 ),
                 dag_settings,
@@ -77,10 +84,17 @@ def create_dags(
     project_path: str,
     dag_class,
     python_operator_class,
-    blacklist_pipelines: List[str] = [],
-    dag_settings: Dict[str, Any] = dict(),
-    globals_dict: Dict[str, Any] = dict(),
+    blacklist_pipelines: List[str] = None,
+    dag_settings: Dict[str, Any] = None,
+    globals_dict: Dict[str, Any] = None,
 ):
+    if blacklist_pipelines is None:
+        blacklist_pipelines = []
+    if dag_settings is None:
+        dag_settings = dict()
+    if globals_dict is None:
+        globals_dict = dict()
+
     all_pipeline_uuids = Pipeline.get_all_pipelines(project_path)
     for pipeline_uuid in all_pipeline_uuids:
         if pipeline_uuid not in blacklist_pipelines:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

User request.

Add `@always_on` schedule interval for scheduled triggers. Always on schedules will trigger the new pipeline run as soon as the latest pipeline run is completed. Basically, it should always have 1 pipeline run in progress at all times.

I also replaced schedule interval strings with constants in this PR.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally
- [x] Unit test

![Screenshot 2023-09-27 at 3 46 08 PM](https://github.com/mage-ai/mage-ai/assets/14357209/c7c22e2e-463f-474b-8a80-c52bdf8161e2)


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
