### PR TITLE
[jk] Add sortable block run columns

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
@@ -34,10 +34,12 @@ import { openSaveFileDialog } from '@components/PipelineDetail/utils';
 import { queryFromUrl } from '@utils/url';
 import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
 
-export const DEFAULT_SORTABLE_BR_COL_INDEXES = [0, 1, 4];
+export const DEFAULT_SORTABLE_BR_COL_INDEXES = [0, 1, 3, 4, 5];
 export const COL_IDX_TO_BLOCK_RUN_ATTR_MAPPING = {
   0: 'status',
   1: 'block_uuid',
+  3: 'created_at',
+  4: 'started_at',
   5: 'completed_at',
 };
 


### PR DESCRIPTION
# Description
- Allow `Created at` and `Started at` columns to be sorted on Block Runs table. Previously, only the `Status`, `Block`, and `Completed at` columns were sortable.

# How Has This Been Tested?
![sortable block run table columns](https://github.com/mage-ai/mage-ai/assets/78053898/8a92ced8-3fba-463e-888b-f06aacd5a028)


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
