### PR TITLE
[jk] Clarify components based on UTC time in Overview page

### DIFF
--- a/mage_ai/frontend/components/PipelineRun/MetricsSummary/index.tsx
+++ b/mage_ai/frontend/components/PipelineRun/MetricsSummary/index.tsx
@@ -5,6 +5,7 @@ import Flex from '@oracle/components/Flex';
 import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
 import Tile from '@oracle/components/Tile';
+import Tooltip from '@oracle/components/Tooltip';
 import dark from '@oracle/styles/themes/dark';
 import { GroupedPipelineRunCountType } from '@interfaces/MonitorStatsType';
 import { MetricsSummaryContainerStyle } from './index.style';
@@ -14,8 +15,10 @@ import {
   PipelineTypeEnum,
 } from '@interfaces/PipelineType';
 import { RunStatus as RunStatusEnum } from '@interfaces/BlockRunType';
+import { SHARED_UTC_TOOLTIP_PROPS } from '@components/PipelineRun/shared/constants';
 import { capitalize } from '@utils/string';
 import { formatNumber } from '@utils/number';
+import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
 import { sortTuplesArrayByFirstItem } from '@utils/array';
 
 type MetricsSummaryProps = {
@@ -25,6 +28,7 @@ type MetricsSummaryProps = {
 function MetricsSummary({
   pipelineRunCountByPipelineType,
 }: MetricsSummaryProps) {
+  const displayLocalTimezone = shouldDisplayLocalTimezone();
   const pipelineRunCounts = useMemo(() => {
     if (!pipelineRunCountByPipelineType) {
       return [];
@@ -48,11 +52,26 @@ function MetricsSummary({
     );
   }, [pipelineRunCountByPipelineType]);
 
+  const utcTooltipEl = useMemo(() => (
+    displayLocalTimezone
+      ? (
+        <Spacing ml="4px">
+          <Tooltip
+            {...SHARED_UTC_TOOLTIP_PROPS}
+            label="Please note that these metrics are based on UTC time."
+          />
+        </Spacing>
+      ) : null
+  ), [displayLocalTimezone]);
+
   return (
     <MetricsSummaryContainerStyle>
-      <Text bold large>
-        Pipeline run metrics
-      </Text>
+      <FlexContainer alignItems="center">
+        <Text bold large>
+          Pipeline run metrics
+        </Text>
+        {utcTooltipEl}
+      </FlexContainer>
 
       <Spacing mb={2} />
 

--- a/mage_ai/frontend/components/PipelineRun/Widget/index.tsx
+++ b/mage_ai/frontend/components/PipelineRun/Widget/index.tsx
@@ -153,7 +153,8 @@ function Widget({
                   Run created on&nbsp;
                   {displayLocalTimezone
                     ? datetimeInLocalTimezone(createdAt, displayLocalTimezone)
-                    : dateFormatLong(createdAt, { includeSeconds: true, utcFormat: true })}
+                    : createdAt
+                  }
                 </Link>
               </NextLink>
             </FlexContainer>

--- a/mage_ai/frontend/components/PipelineRun/Widget/index.tsx
+++ b/mage_ai/frontend/components/PipelineRun/Widget/index.tsx
@@ -1,4 +1,5 @@
 import NextLink from 'next/link';
+import { useMemo } from 'react';
 import { useRouter } from 'next/router';
 
 import Button from '@oracle/elements/Button';
@@ -8,6 +9,7 @@ import PipelineRunType from '@interfaces/PipelineRunType';
 import RowDataTable, { RowStyle } from '@oracle/components/RowDataTable';
 import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
+import Tooltip from '@oracle/components/Tooltip';
 import {
   ALL_PIPELINE_RUNS_TYPE,
   PipelineTypeEnum,
@@ -15,6 +17,7 @@ import {
   PIPELINE_TYPE_LABEL_MAPPING,
 } from '@interfaces/PipelineType';
 import { ImageStyle } from '@components/Dashboard/index.style';
+import { SHARED_UTC_TOOLTIP_PROPS } from '@components/PipelineRun/shared/constants';
 import { TAB_URL_PARAM } from '@oracle/components/Tabs';
 import {
   TIME_PERIOD_DISPLAY_MAPPING,
@@ -53,6 +56,20 @@ function Widget({
     ? ''
     : `(${count})`;
 
+  const utcTooltipEl = useMemo(() => (
+    displayLocalTimezone
+      ? (
+        <Spacing ml="4px">
+          <Tooltip
+            {...SHARED_UTC_TOOLTIP_PROPS}
+            label="The pipeline run failures are displayed in local time."
+            maxWidth={UNIT * 24}
+            widthFitContent={false}
+          />
+        </Spacing>
+      ) : null
+  ), [displayLocalTimezone]);
+
   return (
     <RowDataTable
       footer={
@@ -83,6 +100,7 @@ function Widget({
           <Text bold>
             Latest {isAllRuns ? '' : `${lowercase(pipelineTypeLabel)} `}pipeline run failures {countDisplay}
           </Text>
+          {utcTooltipEl}
         </FlexContainer>
       }
       maxHeight={MAX_HEIGHT}

--- a/mage_ai/frontend/components/PipelineRun/shared/constants.ts
+++ b/mage_ai/frontend/components/PipelineRun/shared/constants.ts
@@ -1,0 +1,7 @@
+import { ICON_SIZE_MEDIUM } from '@oracle/styles/units/icons';
+
+export const SHARED_UTC_TOOLTIP_PROPS = {
+  muted: true,
+  size: ICON_SIZE_MEDIUM,
+  widthFitContent: true,
+};

--- a/mage_ai/frontend/components/settings/workspace/Preferences.tsx
+++ b/mage_ai/frontend/components/settings/workspace/Preferences.tsx
@@ -54,6 +54,11 @@ function Preferences({
     project_uuid: projectUUID,
   } = project || {};
 
+  const isDemoApp = useMemo(() =>
+    typeof window !== 'undefined' && window.location.hostname === 'demo.mage.ai',
+    [],
+  );
+
   useEffect(() => {
     if (!projectAttributes) {
       setProjectAttributes(project);
@@ -267,7 +272,8 @@ function Preferences({
               </FlexContainer>
             :
               <TextInput
-                label="API key"
+                disabled={isDemoApp}
+                label={isDemoApp ? 'Entering API key is disabled on demo' : 'API key'}
                 monospace
                 onChange={e => setProjectAttributes(prev => ({
                   ...prev,

--- a/mage_ai/frontend/pages/overview/index.tsx
+++ b/mage_ai/frontend/pages/overview/index.tsx
@@ -24,6 +24,7 @@ import ProjectType, { FeatureUUIDEnum } from '@interfaces/ProjectType';
 import Spacing from '@oracle/elements/Spacing';
 import Spinner from '@oracle/components/Spinner';
 import Text from '@oracle/elements/Text';
+import Tooltip from '@oracle/components/Tooltip';
 import Widget from '@components/PipelineRun/Widget';
 import api from '@api';
 import dark from '@oracle/styles/themes/dark';
@@ -52,6 +53,7 @@ import { HEADER_HEIGHT } from '@components/shared/Header/index.style';
 import { MonitorStatsEnum, RunCountStatsType } from '@interfaces/MonitorStatsType';
 import { NAV_TAB_PIPELINES } from '@components/CustomTemplates/BrowseTemplates/constants';
 import { RunStatus } from '@interfaces/BlockRunType';
+import { SHARED_UTC_TOOLTIP_PROPS } from '@components/PipelineRun/shared/constants';
 import { TAB_URL_PARAM } from '@oracle/components/Tabs';
 import {
   TIME_PERIOD_DISPLAY_MAPPING,
@@ -224,7 +226,7 @@ function OverviewPage() {
 
   const { data: dataProjects, mutate: fetchProjects } = api.projects.list();
   const project: ProjectType = useMemo(() => dataProjects?.projects?.[0], [dataProjects]);
-  const _ = useMemo(
+  const displayLocalTimezone = useMemo(
     () => storeLocalTimezoneSetting(project?.features?.[FeatureUUIDEnum.LOCAL_TIMEZONE]),
     [project?.features],
   );
@@ -363,6 +365,18 @@ function OverviewPage() {
       onClickCallback={() => setAddButtonMenuOpen(false)}
     />
   ), [addButtonMenuOpen, isLoadingCreatePipeline, newPipelineButtonMenuItems]);
+
+  const utcTooltipEl = useMemo(() => (
+    displayLocalTimezone
+      ? (
+        <Spacing ml="4px">
+          <Tooltip
+            {...SHARED_UTC_TOOLTIP_PROPS}
+            label="Please note that these counts are based on UTC time."
+          />
+        </Spacing>
+      ) : null
+  ), [displayLocalTimezone]);
 
   const pageBlockLayoutTemplate = useMemo(() => {
     const name0 = 'Pipelines';
@@ -602,9 +616,9 @@ def d(df):
           <Spacing mx={3} my={2}>
             <Headline level={4}>
               {timePeriod === TimePeriodEnum.TODAY &&
-                `${capitalize(TimePeriodEnum.TODAY)}: ${selectedDateRange}`}
+                `${capitalize(TimePeriodEnum.TODAY)} (UTC): ${selectedDateRange}`}
               {timePeriod !== TimePeriodEnum.TODAY &&
-                `${capitalize(TIME_PERIOD_DISPLAY_MAPPING[timePeriod])}: ${selectedDateRange}`}
+                `${capitalize(TIME_PERIOD_DISPLAY_MAPPING[timePeriod])} (UTC): ${selectedDateRange}`}
             </Headline>
 
             <Spacing mt={2}>
@@ -623,9 +637,12 @@ def d(df):
 
             <Spacing mt={2}>
               <Spacing ml={2}>
-                <Text bold large>
-                  {isValidatingMonitorStats ? '--' : totalPipelineRunCount} total pipeline runs
-                </Text>
+                <FlexContainer alignItems="center">
+                  <Text bold large>
+                    {isValidatingMonitorStats ? '--' : totalPipelineRunCount} total pipeline runs
+                  </Text>
+                  {utcTooltipEl}
+                </FlexContainer>
               </Spacing>
               <Spacing mt={1}>
                 <BarStackChart


### PR DESCRIPTION
# Description
- Even with the `display_local_timezone` setting enabled, the metrics on the Overview page are still calculated based on pipeline run creation dates in UTC time. This PR adds tooltips to the Overview page to make it clear that the metrics and pipeline run counts are still based on UTC time.
- Disable inputting OpenAI API key on mage demo app (demo.mage.ai).

# How Has This Been Tested?
![image](https://github.com/mage-ai/mage-ai/assets/78053898/a0245bb2-69ae-46f0-b7f8-ab78fe4cb36f)

![image](https://github.com/mage-ai/mage-ai/assets/78053898/11f38f48-ca0c-46ec-9fe1-7931fbc38dc0)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
