### PR TITLE
[xy] Support interpolating pipeline variables in streaming configs.

### DIFF
--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -430,6 +430,7 @@ class Pipeline:
             )
             StreamingPipelineExecutor(self).execute(
                 build_block_output_stdout=build_block_output_stdout,
+                global_vars=global_vars,
             )
         else:
             root_blocks = []


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Support interpolating pipeline variables in streaming configs.
Also pass the global vars to transformer kwargs,

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with a streaming pipeline locally

![image](https://github.com/mage-ai/mage-ai/assets/80284865/1d096652-5ba4-456b-a3ef-12403fb3d680)
![image](https://github.com/mage-ai/mage-ai/assets/80284865/86772d23-13c9-4ceb-a776-a1018c84f0ce)
![image](https://github.com/mage-ai/mage-ai/assets/80284865/116ab2e4-5dbc-4e7d-a979-0ea1e2fddaf1)


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code

cc:
<!-- Optionally mention someone to let them know about this pull request -->
