### PR TITLE
[dy] Handle secret key and uuid whitespace

### DIFF
--- a/mage_ai/data_preparation/shared/secrets.py
+++ b/mage_ai/data_preparation/shared/secrets.py
@@ -166,10 +166,7 @@ def get_secret_value(
     if key:
         fernet = Fernet(key)
         if key_uuid:
-            secret = Secret.query.filter(
-                Secret.name == name,
-                Secret.key_uuid == key_uuid,
-            ).one_or_none()
+            secret = Secret.get_secret(name, key_uuid)
 
         if secret:
             try:
@@ -211,10 +208,7 @@ def delete_secret(
         pipeline_uuid=pipeline_uuid,
     )
     if key_uuid:
-        secret = Secret.query.filter(
-            Secret.name == name,
-            Secret.key_uuid == key_uuid,
-        ).one_or_none()
+        secret = Secret.get_secret(name, key_uuid)
 
     if entity == Entity.GLOBAL and not secret:
         secret = Secret.query.filter(
@@ -289,5 +283,8 @@ def _get_encryption_key(
             key_uuid = f.read()
     except Exception:
         key_uuid = None
+
+    if key is not None:
+        key = key.strip()
 
     return key, key_uuid

--- a/mage_ai/orchestration/db/models/secrets.py
+++ b/mage_ai/orchestration/db/models/secrets.py
@@ -1,5 +1,8 @@
-from sqlalchemy import Column, String, Text, UniqueConstraint
+from typing import Optional
 
+from sqlalchemy import Column, String, Text, UniqueConstraint, or_
+
+from mage_ai.orchestration.db import safe_db_query
 from mage_ai.orchestration.db.models.base import BaseModel
 
 
@@ -11,3 +14,14 @@ class Secret(BaseModel):
     repo_name = Column(String(255))
     key_uuid = Column(String(255), nullable=True)
     __table_args__ = (UniqueConstraint('name', 'key_uuid', name='name_key_uuid_uc'),)
+
+    @classmethod
+    @safe_db_query
+    def get_secret(cls, name: str, key_uuid: str) -> Optional['Secret']:
+        return cls.query.filter(
+            cls.name == name,
+            or_(
+                cls.key_uuid == key_uuid,
+                cls.key_uuid == key_uuid.strip(),
+            ),
+        ).one_or_none()

--- a/mage_ai/tests/data_preparation/shared/test_secrets.py
+++ b/mage_ai/tests/data_preparation/shared/test_secrets.py
@@ -2,10 +2,12 @@ import os
 from unittest.mock import patch
 
 from mage_ai.data_preparation.shared.secrets import (
+    _get_encryption_key,
     create_secret,
     delete_secret,
     get_secret_value,
 )
+from mage_ai.orchestration.constants import Entity
 from mage_ai.orchestration.db.models.secrets import Secret
 from mage_ai.tests.base_test import DBTestCase
 
@@ -53,3 +55,17 @@ class SecretTests(DBTestCase):
         )
 
         self.assertEqual(get_secret_value('secret1'), 'real_value')
+
+    @patch('mage_ai.data_preparation.shared.secrets.get_data_dir')
+    def test_key_uuid_with_whitespace(self, mock_data_dir):
+        data_dir = os.path.join(self.repo_path, 'data')
+        mock_data_dir.return_value = data_dir
+
+        _, key_uuid = _get_encryption_key(Entity.GLOBAL)
+
+        create_secret('secret6', 'value')
+
+        with open(os.path.join(data_dir, 'secrets', 'uuid'), 'w') as f:
+            f.write('  ' + key_uuid + '\n ')
+
+        self.assertEqual(get_secret_value('secret6'), 'value')


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

In case there is extra whitespace in the key or uuid files for some reason, we should be able to still retrieve the secrets.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally
- [x] Unit test


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
