### PR TITLE
[jk] Pipeline runs table (for individual pipelines) updates

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -349,6 +349,10 @@ function PipelineRunsTable({
     },
     {
       ...timezoneTooltipProps,
+      uuid: 'Started at',
+    },
+    {
+      ...timezoneTooltipProps,
       uuid: 'Completed at',
     },
     {
@@ -433,6 +437,7 @@ function PipelineRunsTable({
                 pipeline_schedule_id: pipelineScheduleId,
                 pipeline_schedule_name: pipelineScheduleName,
                 pipeline_uuid: pipelineUUID,
+                started_at: startedAt,
                 status,
               } = pipelineRun;
               deleteButtonRefs.current[id] = createRef();
@@ -481,7 +486,22 @@ function PipelineRunsTable({
                   </Text>,
                   <Text
                     {...SHARED_DATE_FONT_PROPS}
-                    key="row_completed"
+                    key="row_started_at"
+                    muted
+                    title={startedAt ? `UTC: ${startedAt.slice(0, 19)}` : null}
+                  >
+                    {startedAt
+                      ? (displayLocalTimezone
+                        ? datetimeInLocalTimezone(startedAt, displayLocalTimezone)
+                        : getTimeInUTCString(startedAt)
+                      ): (
+                        <>&#8212;</>
+                      )
+                    }
+                  </Text>,
+                  <Text
+                    {...SHARED_DATE_FONT_PROPS}
+                    key="row_completed_at"
                     muted
                     title={completedAt ? `UTC: ${completedAt.slice(0, 19)}` : null}
                   >
@@ -574,7 +594,22 @@ function PipelineRunsTable({
                   <Text
                     {...SHARED_DATE_FONT_PROPS}
                     default
-                    key="row_completed"
+                    key="row_started_at"
+                    title={startedAt ? `UTC: ${startedAt.slice(0, 19)}` : null}
+                  >
+                    {startedAt
+                      ? (displayLocalTimezone
+                        ? datetimeInLocalTimezone(startedAt, displayLocalTimezone)
+                        : getTimeInUTCString(startedAt)
+                      ): (
+                        <>&#8212;</>
+                      )
+                    }
+                  </Text>,
+                  <Text
+                    {...SHARED_DATE_FONT_PROPS}
+                    default
+                    key="row_completed_at"
                     title={completedAt ? `UTC: ${completedAt.slice(0, 19)}` : null}
                   >
                     {completedAt

--- a/mage_ai/frontend/components/shared/Table/Toolbar/constants.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/constants.tsx
@@ -1,3 +1,5 @@
+import { BORDER_RADIUS } from '@oracle/styles/units/borders';
+import { Search } from '@oracle/icons';
 import { UNIT } from '@oracle/styles/units/spacing';
 
 export const BUTTON_PADDING = `${UNIT * 1.5}px`;
@@ -13,4 +15,14 @@ export const SHARED_TOOLTIP_PROPS = {
   autoHide: true,
   size: null,
   widthFitContent: true,
+};
+
+export const SEARCH_INPUT_PROPS = {
+  afterIconSize: UNIT * 1.5,
+  beforeIcon: <Search />,
+  borderRadius: BORDER_RADIUS,
+  defaultColor: true,
+  fullWidth: true,
+  greyBorder: true,
+  maxWidth: UNIT * 40,
 };

--- a/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
@@ -13,15 +13,15 @@ import Text from '@oracle/elements/Text';
 import TextInput from '@oracle/elements/Inputs/TextInput';
 import ToggleMenu from '@oracle/components/ToggleMenu';
 import Tooltip from '@oracle/components/Tooltip';
-import { BORDER_RADIUS } from '@oracle/styles/units/borders';
 import {
   BUTTON_PADDING,
   ConfirmDialogueOpenEnum,
   POPUP_MENU_WIDTH,
   POPUP_TOP_OFFSET,
+  SEARCH_INPUT_PROPS,
   SHARED_TOOLTIP_PROPS,
 } from './constants';
-import { Close, Ellipsis, Filter, Group, Search, Trash } from '@oracle/icons';
+import { Close, Ellipsis, Filter, Group, Trash } from '@oracle/icons';
 import { FlyoutMenuItemType } from '@oracle/components/FlyoutMenu';
 import { SHARED_BUTTON_PROPS } from '@components/shared/AddButton';
 import { UNIT } from '@oracle/styles/units/spacing';
@@ -457,18 +457,12 @@ function Toolbar({
           <Spacing ml={BUTTON_PADDING} />
           <Flex flex={1}>
             <TextInput
+              {...SEARCH_INPUT_PROPS}
               afterIcon={searchValue ? <Close /> : null}
               afterIconClick={() => {
                 onSearchChange('');
                 searchInputRef?.current?.focus();
               }}
-              afterIconSize={UNIT * 1.5}
-              beforeIcon={<Search />}
-              borderRadius={BORDER_RADIUS}
-              defaultColor
-              fullWidth
-              greyBorder
-              maxWidth={UNIT * 40}
               onChange={e => onSearchChange(e.target.value)}
               paddingVertical={9}
               placeholder={searchPlaceholder ? searchPlaceholder : null}

--- a/mage_ai/frontend/interfaces/PipelineRunType.ts
+++ b/mage_ai/frontend/interfaces/PipelineRunType.ts
@@ -124,6 +124,7 @@ export default interface PipelineRunType {
   pipeline_schedule_token?: string;
   pipeline_schedule_type?: ScheduleTypeEnum;
   pipeline_uuid?: string;
+  started_at?: string;
   status?: RunStatusEnum;
   updated_at?: string;
   variables?: Obj;

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -135,8 +135,9 @@ function PipelineSchedules({
     }), {})
   ), [globalVariables]);
 
+  const randomTriggerName = randomNameGenerator();
   const pipelineOnceSchedulePayload = useMemo(() => ({
-    name: randomNameGenerator(),
+    name: randomTriggerName,
     schedule_interval: ScheduleIntervalEnum.ONCE,
     schedule_type: ScheduleTypeEnum.TIME,
     start_time: dateFormatLong(
@@ -144,7 +145,7 @@ function PipelineSchedules({
       { dayAgo: true, utcFormat: true },
     ),
     status: ScheduleStatusEnum.ACTIVE,
-  }), []);
+  }), [randomTriggerName]);
   const [showModal, hideModal] = useModal(() => (
     <RunPipelinePopup
       initialPipelineSchedulePayload={pipelineOnceSchedulePayload}


### PR DESCRIPTION
# Description
- Add `Started at` column to Pipeline Runs table.
- Add search input for searching pipeline run variables on Pipeline Runs page for individual pipelines.

# How Has This Been Tested?
"Started at" column included in Pipeline Runs table:
<img width="1424" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/8a49713e-889d-41a0-a566-decdc08d0981">

Searching for substring in key or value in pipeline runs' variables:
![search pipeline run variables](https://github.com/mage-ai/mage-ai/assets/78053898/81b22b6e-f704-45d3-b9da-098d9ed96f4a)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
