### PR TITLE
Apache Kafka - SASL_PLAINTEXT

### DIFF
--- a/mage_ai/streaming/sources/kafka.py
+++ b/mage_ai/streaming/sources/kafka.py
@@ -15,6 +15,7 @@ from mage_ai.streaming.sources.shared import SerDeConfig, SerializationMethod
 
 class SecurityProtocol(str, Enum):
     SASL_SSL = 'SASL_SSL'
+    SASL_PLAINTEXT = 'SASL_PLAINTEXT'
     SSL = 'SSL'
 
 
@@ -89,6 +90,11 @@ class KafkaSource(BaseSource):
             ] = self.config.ssl_config.check_hostname
         elif self.config.security_protocol == SecurityProtocol.SASL_SSL:
             consumer_kwargs['security_protocol'] = SecurityProtocol.SASL_SSL
+            consumer_kwargs['sasl_mechanism'] = self.config.sasl_config.mechanism
+            consumer_kwargs['sasl_plain_username'] = self.config.sasl_config.username
+            consumer_kwargs['sasl_plain_password'] = self.config.sasl_config.password
+        elif self.config.security_protocol == SecurityProtocol.SASL_PLAINTEXT:
+            consumer_kwargs['security_protocol'] = SecurityProtocol.SASL_PLAINTEXT
             consumer_kwargs['sasl_mechanism'] = self.config.sasl_config.mechanism
             consumer_kwargs['sasl_plain_username'] = self.config.sasl_config.username
             consumer_kwargs['sasl_plain_password'] = self.config.sasl_config.password


### PR DESCRIPTION
# Description
Addition of SASL_PLAINTEXT security protocol support for Apache Kafka Streaming block.
Motivation: Required SASL_PLAINTEXT connectivity to Apache Kafka
Dependencies: None


# How Has This Been Tested?
K8s Deployment on AWS
Instructions:
* Requires Bitnami Helm Apache Kafka Helm Chart deployed on K8s cluster
* MageAI configuration using K8s yaml files (can provide separately)


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
