### PR TITLE
[dy] Throw exception if a variable is not defined in jinja for sql blocks

### DIFF
--- a/mage_ai/data_preparation/models/block/sql/druid.py
+++ b/mage_ai/data_preparation/models/block/sql/druid.py
@@ -1,9 +1,10 @@
+from typing import Dict, List
+
 from mage_ai.data_preparation.models.block.sql.utils.shared import (
     create_upstream_block_tables as create_upstream_block_tables_orig,
-    interpolate_input,
 )
+from mage_ai.data_preparation.models.block.sql.utils.shared import interpolate_input
 from mage_ai.io.config import ConfigKey
-from typing import Dict, List
 
 
 def create_upstream_block_tables(
@@ -16,6 +17,7 @@ def create_upstream_block_tables(
     query: str = None,
     dynamic_block_index: int = None,
     dynamic_upstream_block_uuids: List[str] = None,
+    variables: Dict = None,
 ):
     create_upstream_block_tables_orig(
         loader,

--- a/mage_ai/data_preparation/models/block/sql/utils/shared.py
+++ b/mage_ai/data_preparation/models/block/sql/utils/shared.py
@@ -2,7 +2,7 @@ import re
 from os import path
 from typing import Callable, Dict, List, Tuple, Union
 
-from jinja2 import Template
+from jinja2 import StrictUndefined, Template
 from pandas import DataFrame
 
 from mage_ai.data_preparation.models.block.sql.constants import (
@@ -228,7 +228,7 @@ def interpolate_input(
 def interpolate_vars(query, global_vars=None):
     if global_vars is None:
         global_vars = dict()
-    return Template(query).render(**global_vars)
+    return Template(query, undefined=StrictUndefined).render(**global_vars)
 
 
 def table_name_parts(


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Throw exception in sql blocks if there is a jinja variable in the sql block that is not passed in when interpolating the variables. 

Fixes issue https://github.com/mage-ai/mage-ai/issues/3288

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
