### PR TITLE
[xy] Fix auto generating mage_sources.yml for dbt upstream blocks

### DIFF
--- a/mage_ai/data_preparation/models/block/dbt/block_sql.py
+++ b/mage_ai/data_preparation/models/block/dbt/block_sql.py
@@ -179,7 +179,7 @@ class DBTBlockSQL(DBTBlock):
         if res:
             nodes = [simplejson.loads(node) for node in res]
         else:
-            return None
+            return []
 
         # transform List into dict and remove unnecessary fields
         file_path = self.configuration.get('file_path')

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -985,7 +985,7 @@ class Pipeline:
                 BlockType.DBT != block.type and
                 block.language in [BlockLanguage.SQL, BlockLanguage.PYTHON, BlockLanguage.R] and
                 any(
-                    BlockType.DBT != downstream_block.type
+                    BlockType.DBT == downstream_block.type
                     for downstream_block in block.downstream_blocks
                 )
             )


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix auto generating `mage_sources.yml` for dbt upstream blocks.

The `mage_sources.yml` wasn't auto generated after adding a python block as upstream.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested modifying the upstream blocks for a dbt block. The `mage_source.yml` is auto generated.
<img width="582" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/abc21388-2275-468e-9512-2124f427095d">

<img width="810" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/7f9b2bc3-7b88-47a1-b595-4e7ac9179040">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
