### PR TITLE
[xy] Support Kafka SASL_SSL SCRAM-SHA-512 authentication.

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -431,7 +431,7 @@ class Block(DataIntegrationMixin):
 
                     text = Template(content).render(
                         block_output=_block_output,
-                        variables=lambda x, p, v=variables: get_variable_for_template(
+                        variables=lambda x, p=None, v=variables: get_variable_for_template(
                             x,
                             parse=p,
                             variables=v,

--- a/mage_ai/streaming/sinks/kafka.py
+++ b/mage_ai/streaming/sinks/kafka.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import Dict, List
 
 from kafka import KafkaProducer
+
 from mage_ai.shared.config import BaseConfig
 from mage_ai.streaming.constants import DEFAULT_BATCH_SIZE, DEFAULT_TIMEOUT_MS
 from mage_ai.streaming.sinks.base import BaseSink

--- a/mage_ai/streaming/sinks/kafka.py
+++ b/mage_ai/streaming/sinks/kafka.py
@@ -5,7 +5,6 @@ from enum import Enum
 from typing import Dict, List
 
 from kafka import KafkaProducer
-
 from mage_ai.shared.config import BaseConfig
 from mage_ai.streaming.constants import DEFAULT_BATCH_SIZE, DEFAULT_TIMEOUT_MS
 from mage_ai.streaming.sinks.base import BaseSink
@@ -88,6 +87,9 @@ class KafkaSink(BaseSink):
             kwargs['sasl_mechanism'] = self.config.sasl_config.mechanism
             kwargs['sasl_plain_username'] = self.config.sasl_config.username
             kwargs['sasl_plain_password'] = self.config.sasl_config.password
+
+            if self.config.ssl_config is not None and self.config.ssl_config.cafile:
+                kwargs['ssl_cafile'] = self.config.ssl_config.cafile
 
         self.producer = KafkaProducer(**kwargs)
         self._print('Finish initializing producer.')

--- a/mage_ai/streaming/sources/kafka.py
+++ b/mage_ai/streaming/sources/kafka.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import Callable, Dict, List
 
 from kafka import KafkaConsumer
+
 from mage_ai.shared.config import BaseConfig
 from mage_ai.streaming.constants import DEFAULT_BATCH_SIZE, DEFAULT_TIMEOUT_MS
 from mage_ai.streaming.sources.base import BaseSource

--- a/mage_ai/streaming/sources/kafka.py
+++ b/mage_ai/streaming/sources/kafka.py
@@ -6,7 +6,6 @@ from enum import Enum
 from typing import Callable, Dict, List
 
 from kafka import KafkaConsumer
-
 from mage_ai.shared.config import BaseConfig
 from mage_ai.streaming.constants import DEFAULT_BATCH_SIZE, DEFAULT_TIMEOUT_MS
 from mage_ai.streaming.sources.base import BaseSource
@@ -14,8 +13,8 @@ from mage_ai.streaming.sources.shared import SerDeConfig, SerializationMethod
 
 
 class SecurityProtocol(str, Enum):
-    SASL_SSL = 'SASL_SSL'
     SASL_PLAINTEXT = 'SASL_PLAINTEXT'
+    SASL_SSL = 'SASL_SSL'
     SSL = 'SSL'
 
 
@@ -93,6 +92,9 @@ class KafkaSource(BaseSource):
             consumer_kwargs['sasl_mechanism'] = self.config.sasl_config.mechanism
             consumer_kwargs['sasl_plain_username'] = self.config.sasl_config.username
             consumer_kwargs['sasl_plain_password'] = self.config.sasl_config.password
+
+            if self.config.ssl_config is not None and self.config.ssl_config.cafile:
+                consumer_kwargs['ssl_cafile'] = self.config.ssl_config.cafile
         elif self.config.security_protocol == SecurityProtocol.SASL_PLAINTEXT:
             consumer_kwargs['security_protocol'] = SecurityProtocol.SASL_PLAINTEXT
             consumer_kwargs['sasl_mechanism'] = self.config.sasl_config.mechanism


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Support Kafka SASL_SSL SCRAM-SHA-512 authentication and add an option to use cafile. 
Ref: https://stackoverflow.com/questions/57290708/setting-python-kafkaproducer-sasl-mechanism-property

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with kafka pipeline locally
```yaml
security_protocol: "SASL_SSL"
sasl_config:
  mechanism: "SCRAM-SHA-512"
  username: username
  password: password
ssl_config:
  cafile: "pemfilename.pem"
```


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code


cc:
<!-- Optionally mention someone to let them know about this pull request -->
