### PR TITLE
[td] Don’t show empty images

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
@@ -384,7 +384,6 @@ function CodeOutput({
           });
         }
 
-
         if (data === null) {
           return;
         } else if (typeof data === 'string' && data.match(INTERNAL_OUTPUT_REGEX)) {
@@ -458,7 +457,7 @@ function CodeOutput({
               </OutputRowStyle>
             );
           }
-        } else if (dataType === DataTypeEnum.IMAGE_PNG) {
+        } else if (dataType === DataTypeEnum.IMAGE_PNG && data?.length >= 1) {
           displayElement = (
             <div style={{ backgroundColor: 'white' }}>
               <img


### PR DESCRIPTION
# Description
Don’t show images from output with empty data.

Fixes:

![image](https://github.com/mage-ai/mage-ai/assets/1066980/8bd8d3d9-0896-4c52-8389-a1b764287a75)


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

<img width="1089" alt="CleanShot 2023-10-03 at 14 50 42@2x" src="https://github.com/mage-ai/mage-ai/assets/1066980/c2a87d11-d431-41db-a277-f3fc1cfacaf5">

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
