### PR TITLE
Fixed typo and simplified text for empty dashboard

### DIFF
--- a/mage_ai/frontend/components/BlockLayout/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/index.tsx
@@ -569,12 +569,12 @@ function BlockLayout({
           </Spacing>
 
           <Text center default>
-            Build your own dashboard with customizable charts with the exact insights you need.
+            Add customizable charts with the exact insights you need.
           </Text>
 
           {pageBlockLayoutTemplate && (
             <Text center default>
-              Get started with a recommended set of freely define your own.
+              Start with a recommended set or freely define your own.
             </Text>
           )}
         </Spacing>


### PR DESCRIPTION
# Description
Made text changes to the empty state message of the dashboard. Fixed a typo and simplified message.

Fixed typo and tense:
- _Old:_ "Get started with a recommended set OF freely define your own." 
- _New:_ "Start with a recommended set OR freely define your own."

Simplified first sentence
- Made more distinct from H1


# How Has This Been Tested?
Simple text change, reviewed in code.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code