### PR TITLE
Propagate tags of ECS task definition to task executors

### DIFF
--- a/mage_ai/services/aws/ecs/config.py
+++ b/mage_ai/services/aws/ecs/config.py
@@ -84,6 +84,7 @@ class EcsConfig(BaseConfig):
             count=1,
             networkConfiguration=network_configuration,
             tags=self.tags,
+            propagateTags='TASK_DEFINITION',
         )
         if command is not None:
             task_config['overrides'] = {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Made a simple change that makes any ECS task executor automatically inherit the tags configured in the task definition. Previously there was no way of doing that, or define tags for the executors in general.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Executed a pipeline with blocks that have `executor_tye: ecs`. Before the change: no tags for the newly spawned ECS tasks. After the change: the new tasks have the same tags of the task definition.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 
