### PR TITLE
[jk] YAML block language display

### DIFF
--- a/mage_ai/api/policies/BlockPolicy.py
+++ b/mage_ai/api/policies/BlockPolicy.py
@@ -50,7 +50,9 @@ BlockPolicy.allow_read([
     constants.UPDATE,
 ], condition=lambda policy: policy.has_at_least_editor_role_and_pipeline_edit_access())
 
-BlockPolicy.allow_read(BlockPresenter.default_attributes + [], scopes=[
+BlockPolicy.allow_read(BlockPresenter.default_attributes + [
+    'configuration',
+], scopes=[
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.DELETE,
@@ -83,6 +85,7 @@ BlockPolicy.allow_write([
     'configuration',
     'content',
     'converted_from',
+    'defaults',
     'extension_uuid',
     'has_callback',
     'language',

--- a/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
@@ -364,15 +364,11 @@ function ConfigureBlock({
               const selected = language === v;
 
               if (
-                (
-                  (!isCustomBlock || isUpdatingBlock)
-                  && !selected
-                  && (
-                    (!isDataIntegration || BlockLanguageEnum.R === v)
-                      || (!isDataIntegration || BlockLanguageEnum.SQL === v)
-                  )
-                ) || (
-                  !isDataIntegration && BlockLanguageEnum.YAML === v
+                (!isCustomBlock || isUpdatingBlock)
+                && !selected
+                && (
+                  (!isDataIntegration || BlockLanguageEnum.R === v)
+                    || (!isDataIntegration || BlockLanguageEnum.SQL === v)
                 )
               ) {
                 return acc;

--- a/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
@@ -364,12 +364,14 @@ function ConfigureBlock({
               const selected = language === v;
 
               if (
-                (!isCustomBlock || isUpdatingBlock)
-                && !selected
-                && (
-                  (!isDataIntegration || BlockLanguageEnum.R === v)
-                    || (!isDataIntegration || BlockLanguageEnum.SQL === v)
-                )
+                (
+                  (!isCustomBlock || isUpdatingBlock)
+                  && !selected
+                  && (
+                    (!isDataIntegration || BlockLanguageEnum.R === v)
+                      || (!isDataIntegration || BlockLanguageEnum.SQL === v)
+                  )
+                ) || (isCustomBlock && BlockLanguageEnum.YAML === v)
               ) {
                 return acc;
               }


### PR DESCRIPTION
# Description
- Show `YAML` in "Language" row of ConfigureBlock modal when adding new yaml block (it wasn't appearing in streaming pipeline data loader/exporter blocks or DBT yaml blocks).
- Update block policy for creating/deleting blocks.


# How Has This Been Tested?
## The following issues no longer appeared:
Missing language in modal:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/a6eba764-4d65-494d-adc4-a769ef5048bd)
![image](https://github.com/mage-ai/mage-ai/assets/78053898/406ab9a3-6ec8-4266-b398-c2831a4ae6d0)

Block policy errors when creating and deleting blocks:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/ad9ebcf9-3dee-4f23-98f3-fccfa19b008a)
![image](https://github.com/mage-ai/mage-ai/assets/78053898/a25d5286-a803-4959-ac44-16f71024d99e)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
