### PR TITLE
[td] Add role permissions API

### DIFF
--- a/mage_ai/api/policies/RolePermissionPolicy.py
+++ b/mage_ai/api/policies/RolePermissionPolicy.py
@@ -1,0 +1,35 @@
+from mage_ai.api.oauth_scope import OauthScope
+from mage_ai.api.operations import constants
+from mage_ai.api.policies.BasePolicy import BasePolicy
+from mage_ai.api.presenters.RolePermissionPresenter import RolePermissionPresenter
+
+
+class RolePermissionPolicy(BasePolicy):
+    pass
+
+
+RolePermissionPolicy.allow_actions([
+    constants.CREATE,
+    constants.DELETE,
+], scopes=[
+    OauthScope.CLIENT_PRIVATE,
+], condition=lambda policy: policy.has_at_least_admin_role())
+
+
+RolePermissionPolicy.allow_read(RolePermissionPresenter.default_attributes + [
+], scopes=[
+    OauthScope.CLIENT_PRIVATE,
+], on_action=[
+    constants.CREATE,
+    constants.DELETE,
+], condition=lambda policy: policy.has_at_least_admin_role())
+
+
+RolePermissionPolicy.allow_write([
+    'role_id',
+    'user_id',
+], scopes=[
+    OauthScope.CLIENT_PRIVATE,
+], on_action=[
+    constants.CREATE,
+], condition=lambda policy: policy.has_at_least_admin_role())

--- a/mage_ai/api/presenters/PermissionPresenter.py
+++ b/mage_ai/api/presenters/PermissionPresenter.py
@@ -33,6 +33,7 @@ PermissionPresenter.register_formats([
         'query_attributes',
         'read_attributes',
         'role',
+        'roles',
         'user_id',
         'write_attributes',
     ],

--- a/mage_ai/api/presenters/RolePermissionPresenter.py
+++ b/mage_ai/api/presenters/RolePermissionPresenter.py
@@ -1,0 +1,11 @@
+from mage_ai.api.presenters.BasePresenter import BasePresenter
+
+
+class RolePermissionPresenter(BasePresenter):
+    default_attributes = [
+        'created_at',
+        'id',
+        'permission_id',
+        'role_id',
+        'updated_at',
+    ]

--- a/mage_ai/api/presenters/RolePresenter.py
+++ b/mage_ai/api/presenters/RolePresenter.py
@@ -8,6 +8,7 @@ class RolePresenter(BasePresenter):
         'id',
         'name',
         'permissions',
+        'role_permissions',
         'updated_at',
     ]
 

--- a/mage_ai/api/resources/RolePermissionResource.py
+++ b/mage_ai/api/resources/RolePermissionResource.py
@@ -1,0 +1,9 @@
+from mage_ai.api.resources.DatabaseResource import DatabaseResource
+from mage_ai.orchestration.db.models.oauth import Role, RolePermission
+
+
+class RolePermissionResource(DatabaseResource):
+    model_class = RolePermission
+
+
+RolePermissionResource.register_parent_model('role_id', Role)

--- a/mage_ai/authentication/permissions/constants.py
+++ b/mage_ai/authentication/permissions/constants.py
@@ -52,6 +52,7 @@ class EntityName(str, Enum):
     Project = 'Project'
     PullRequest = 'PullRequest'
     Role = 'Role'
+    RolePermission = 'RolePermission'
     Scheduler = 'Scheduler'
     SearchResult = 'SearchResult'
     Secret = 'Secret'

--- a/mage_ai/orchestration/db/migrations/README.md
+++ b/mage_ai/orchestration/db/migrations/README.md
@@ -7,6 +7,7 @@ We use alembic to perform DB migrations. alembic tutorial: https://alembic.sqlal
 1. Open the file `mage-ai/mage_ai/orchestration/db/alembic.ini`
 1. Change the value `sqlalchemy.url` to the URL of your database.
     - e.g. `sqlalchemy.url = postgresql+psycopg2://postgres:postgres@host.docker.internal:5432/demo`
+    - e.g. `postgresql://postgres:postgres@host.docker.internal/mage_development`
 
 ## Create migration scripts
 

--- a/mage_ai/orchestration/db/models/oauth.py
+++ b/mage_ai/orchestration/db/models/oauth.py
@@ -154,6 +154,11 @@ class User(BaseModel):
 class Role(BaseModel):
     name = Column(String(255), index=True, unique=True)
     permissions = relationship('Permission', back_populates='role')
+    role_permissions = relationship(
+        'Permission',
+        secondary='role_permission',
+        back_populates='roles',
+    )
     users = relationship('User', secondary='user_role', back_populates='roles_new')
     user_id = Column(Integer, ForeignKey('user.id'), default=None)
     user = relationship(User, back_populates='created_roles')
@@ -331,6 +336,7 @@ class Permission(BaseModel):
     options = Column(JSON, default=None)
 
     role = relationship(Role, back_populates='permissions')
+    roles = relationship(Role, secondary='role_permission', back_populates='role_permissions')
 
     @validates('entity')
     def validate_entity(self, key, value):


### PR DESCRIPTION
# Description
## ~~Permission can belong to many roles~~

~~Add an association table for roles and permissions so that permissions can belong to many roles~~

- ~~role_id~~
- ~~permission_id~~
- ~~user_id~~

### ~~Update role and permission logic to use new association table~~

- ~~Add new association on Role~~
    - `~~role_permissions = relationship('Permission', secondary='role_permission', back_populates='roles')~~`
- ~~Permission~~
    - `~~roles = relationship('Role', secondary='role_permission', back_populates='role_permissions')~~`
- [x]  Add RolePermission to EntityName enum

### ~~RolePermission API~~

- ~~Read~~
    - ~~role_id~~
    - ~~permission_id~~
    - ~~user_id~~
    - ~~id~~
    - ~~created_at~~
    - ~~updated_at~~
- ~~Create~~
    - ~~Write~~
        - ~~role_id~~
        - ~~permission_id~~
        - ~~user_id~~
- ~~Delete~~

### ~~Update APIs to use this new relationship~~

- ~~Roles~~
    - ~~Add `role_permissions`~~
- ~~Permissions~~
    - ~~Add `roles`~~

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
