### PR TITLE
[dy] Fix git config preserve when .preferences.yaml file doesn't exist

### DIFF
--- a/mage_ai/data_preparation/sync/git_sync.py
+++ b/mage_ai/data_preparation/sync/git_sync.py
@@ -1,3 +1,4 @@
+import os
 from typing import Union
 
 from mage_ai.data_preparation.git import Git
@@ -10,15 +11,17 @@ from mage_ai.shared.logger import VerboseFunctionExec
 class PreserveGitConfig:
     def __init__(self):
         self.preferences_file_path = get_preferences().preferences_file_path
-        self.initial_preferences = ''
+        self.initial_preferences = None
 
     def __enter__(self):
-        with open(self.preferences_file_path, 'r', encoding='utf-8') as f:
-            self.initial_preferences = f.read()
+        if os.path.exists(self.preferences_file_path):
+            with open(self.preferences_file_path, 'r', encoding='utf-8') as f:
+                self.initial_preferences = f.read()
 
     def __exit__(self, exc_type, exc_value, exc_tb):
-        with open(self.preferences_file_path, 'w', encoding='utf-8') as f:
-            f.write(self.initial_preferences)
+        if self.initial_preferences is not None:
+            with open(self.preferences_file_path, 'w', encoding='utf-8') as f:
+                f.write(self.initial_preferences)
 
 
 class GitSync(BaseSync):

--- a/mage_ai/tests/data_preparation/sync/test_git_sync.py
+++ b/mage_ai/tests/data_preparation/sync/test_git_sync.py
@@ -1,0 +1,80 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from mage_ai.data_preparation.sync import GitConfig
+from mage_ai.data_preparation.sync.git_sync import GitSync
+from mage_ai.tests.base_test import DBTestCase
+
+
+class GitSyncTest(DBTestCase):
+    @patch('mage_ai.data_preparation.git.Git')
+    def test_run_git_sync_data(self, mock_git_manager):
+        git_manager_instance_mock = MagicMock()
+        mock_git_manager.return_value = git_manager_instance_mock
+
+        git_sync = GitSync(GitConfig(branch='dev'))
+        git_sync.git_manager = git_manager_instance_mock
+
+        with open(os.path.join(self.repo_path, '.preferences.yaml'), 'w') as f:
+            f.write('test: 123\n')
+
+        git_sync.sync_data()
+
+        git_manager_instance_mock.reset_hard.called_once_with(branch='dev')
+        git_manager_instance_mock.submodules_update.not_called()
+
+        with open(os.path.join(self.repo_path, '.preferences.yaml'), 'r') as f:
+            preferences = yaml.safe_load(f)
+            self.assertEqual(preferences['test'], 123)
+
+    @patch('mage_ai.data_preparation.git.Git')
+    def test_run_git_sync_data_submodules(self, mock_git_manager):
+        git_manager_instance_mock = MagicMock()
+        mock_git_manager.return_value = git_manager_instance_mock
+
+        git_sync = GitSync(GitConfig(branch='dev', sync_submodules=True))
+        git_sync.git_manager = git_manager_instance_mock
+
+        with open(os.path.join(self.repo_path, '.preferences.yaml'), 'w') as f:
+            f.write('test: 123\n')
+
+        git_sync.sync_data()
+
+        git_manager_instance_mock.reset_hard.called_once_with(branch='dev')
+        git_manager_instance_mock.submodules_update.called_once()
+
+        with open(os.path.join(self.repo_path, '.preferences.yaml'), 'r') as f:
+            preferences = yaml.safe_load(f)
+            self.assertEqual(preferences['test'], 123)
+
+    @patch('mage_ai.data_preparation.git.Git')
+    def test_run_git_sync_data_with_no_preferences(self, mock_git_manager):
+        git_manager_instance_mock = MagicMock()
+        mock_git_manager.return_value = git_manager_instance_mock
+
+        git_sync = GitSync(GitConfig(branch='dev'))
+        git_sync.git_manager = git_manager_instance_mock
+
+        preferences_file_path = os.path.join(self.repo_path, '.preferences.yaml')
+        if os.path.exists(preferences_file_path):
+            os.remove(preferences_file_path)
+
+        git_sync.sync_data()
+
+        git_manager_instance_mock.reset_hard.called_once_with(branch='dev')
+
+        self.assertFalse(os.path.exists(preferences_file_path))
+
+    @patch('mage_ai.data_preparation.git.Git')
+    def test_run_git_reset(self, mock_git_manager):
+        git_manager_instance_mock = MagicMock()
+        mock_git_manager.return_value = git_manager_instance_mock
+
+        git_sync = GitSync(GitConfig(branch='dev'))
+        git_sync.git_manager = git_manager_instance_mock
+
+        git_sync.reset()
+
+        git_manager_instance_mock.clone.called_once_with(sync_submodules=False)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

In a previous PR, I made a change to preserve the `.preferences.yaml` file between git sync operations. However, it's possible that the file won't exist in some cases, so this PR adds a check for that.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally
- [x] Added unit tests


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
