### PR TITLE
[td] Allow writing of interaction UUID on create

### DIFF
--- a/mage_ai/api/policies/InteractionPolicy.py
+++ b/mage_ai/api/policies/InteractionPolicy.py
@@ -47,6 +47,7 @@ InteractionPolicy.allow_write([
     'content',
     'inputs',
     'layout',
+    'uuid',
     'variables',
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,


### PR DESCRIPTION
# Description
Fixes bug when trying to create interaction. The UUID is the file path and name.

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
