### PR TITLE
[jk] Cron expression syntax err display for triggers in code

### DIFF
--- a/mage_ai/data_preparation/models/triggers/__init__.py
+++ b/mage_ai/data_preparation/models/triggers/__init__.py
@@ -69,6 +69,7 @@ class Trigger(BaseConfig):
 
     @property
     def has_valid_schedule_interval(self) -> bool:
+        # Check if trigger has valid cron expression
         if self.schedule_interval is not None and \
             self.schedule_type == ScheduleType.TIME and \
             self.schedule_interval not in [e.value for e in ScheduleInterval] and \

--- a/mage_ai/data_preparation/models/triggers/__init__.py
+++ b/mage_ai/data_preparation/models/triggers/__init__.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Dict, List
 
 import yaml
+from croniter import croniter
 
 from mage_ai.data_preparation.models.constants import PIPELINES_FOLDER
 from mage_ai.settings.repo import get_repo_path
@@ -65,6 +66,16 @@ class Trigger(BaseConfig):
             self.status = ScheduleStatus(self.status)
         if any(env not in VALID_ENVS for env in self.envs):
             raise Exception(f'Please provide valid env values inside {list(VALID_ENVS)}.')
+
+    @property
+    def has_valid_schedule_interval(self) -> bool:
+        if self.schedule_interval is not None and \
+            self.schedule_type == ScheduleType.TIME and \
+            self.schedule_interval not in [e.value for e in ScheduleInterval] and \
+                not croniter.is_valid(self.schedule_interval):
+            return False
+
+        return True
 
     def to_dict(self) -> Dict:
         return dict(
@@ -146,6 +157,11 @@ def build_triggers(
             trigger_config['pipeline_uuid'] = pipeline_uuid
         try:
             trigger = Trigger.load(config=trigger_config)
+
+            # Add flag to settings so frontend can detect triggers with invalid cron expressions
+            if not trigger.has_valid_schedule_interval:
+                trigger.settings['invalid_schedule_interval'] = True
+
             triggers.append(trigger)
         except Exception as e:
             if raise_exception:

--- a/mage_ai/frontend/interfaces/PipelineScheduleType.ts
+++ b/mage_ai/frontend/interfaces/PipelineScheduleType.ts
@@ -60,6 +60,7 @@ export interface PipelineScheduleSettingsType {
   landing_time_enabled?: boolean;
   skip_if_previous_running?: boolean;
   timeout?: number;
+  invalid_schedule_interval?: boolean; // Used to detect triggers with invalid cron expressions
 }
 
 export const SORT_QUERY_TO_COLUMN_NAME_MAPPING = {

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -63,6 +63,7 @@ function PipelineSchedules({
   const isViewerRole = isViewer();
   const pipelineUUID = pipeline.uuid;
   const [errors, setErrors] = useState<ErrorsType>(null);
+  const [triggerErrors, setTriggerErrors] = useState<ErrorsType>(null);
   const [isCreatingTrigger, setIsCreatingTrigger] = useState<boolean>(false);
 
   const { data: dataProjects } = api.projects.list();
@@ -272,7 +273,7 @@ function PipelineSchedules({
     const triggers = dataPipelineTriggers?.pipeline_triggers || [];
     const triggerWithInvalidCronExpression = triggers.find(({ settings }) => settings?.invalid_schedule_interval);
     if (triggerWithInvalidCronExpression) {
-      setErrors({
+      setTriggerErrors({
         displayMessage: `Schedule interval for Trigger (in code) "${triggerWithInvalidCronExpression?.name}"`
           + ' is invalid. Please check your cron expression’s syntax in the pipeline’s triggers.yaml file.',
       });
@@ -433,7 +434,7 @@ function PipelineSchedules({
     <PipelineDetailPage
       breadcrumbs={breadcrumbs}
       buildSidekick={!isCreatingTrigger && buildSidekick}
-      errors={errors}
+      errors={errors || triggerErrors}
       pageName={PageNameEnum.TRIGGERS}
       pipeline={pipeline}
       setErrors={setErrors}

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -277,6 +277,8 @@ function PipelineSchedules({
         displayMessage: `Schedule interval for Trigger (in code) "${triggerWithInvalidCronExpression?.name}"`
           + ' is invalid. Please check your cron expression’s syntax in the pipeline’s triggers.yaml file.',
       });
+    } else {
+      setTriggerErrors(null);
     }
   }, [dataPipelineTriggers?.pipeline_triggers]);
 


### PR DESCRIPTION
# Description
- Display error popup if trigger in code has syntax error for cron expression. Note that this checks if the cron syntax is invalid, not if the `triggers.yaml` config file has proper yaml syntax. For example, `schedule_interval: */15 * * * *` may not be parsed correctly as yaml because `*/15 * * * *` requires quotes around it.


# How Has This Been Tested?
![cron expression syntax error](https://github.com/mage-ai/mage-ai/assets/78053898/96c487b7-32cb-463d-b7f6-a5083a7b894e)



# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
