### PR TITLE
[xy] Speed up io mssql export method

### DIFF
--- a/docs/integrations/databases/MicrosoftSQLServer.mdx
+++ b/docs/integrations/databases/MicrosoftSQLServer.mdx
@@ -116,6 +116,7 @@ def export_data_to_mssql(df: DataFrame, **kwargs) -> None:
             table_name,
             index=False,  # Specifies whether to include index in exported table
             if_exists='replace',  # Specify resolution policy if table name already exists
+            fast_execute=True,  # Use fast_executemany option to speed up bulk inserting rows
         )
 ```
 

--- a/mage_ai/io/druid.py
+++ b/mage_ai/io/druid.py
@@ -1,9 +1,12 @@
-from mage_ai.io.base import ExportWritePolicy, QUERY_ROW_LIMIT
+from typing import IO, Any, Dict, List, Union
+
+from pandas import DataFrame, Series
+from pydruid.db.api import Connection
+from pydruid.db.api import Cursor as CursorParent
+
+from mage_ai.io.base import QUERY_ROW_LIMIT, ExportWritePolicy
 from mage_ai.io.config import BaseConfigLoader, ConfigKey
 from mage_ai.io.sql import BaseSQL
-from pandas import DataFrame, Series
-from pydruid.db.api import Connection, Cursor as CursorParent
-from typing import Dict, List, Union, Any, IO
 
 WRITE_NOT_SUPPORTED_EXCEPTION = Exception('write operations are not supported.')
 
@@ -138,7 +141,8 @@ class Druid(BaseSQL):
                          db_dtypes: List[str],
                          dtypes: List[str],
                          full_table_name: str,
-                         buffer: Union[IO, None] = None) -> None:
+                         buffer: Union[IO, None] = None,
+                         **kwargs) -> None:
         raise WRITE_NOT_SUPPORTED_EXCEPTION
 
     def export(self,

--- a/mage_ai/io/mssql.py
+++ b/mage_ai/io/mssql.py
@@ -4,6 +4,7 @@ import numpy as np
 import pyodbc
 import simplejson
 from pandas import DataFrame, Series
+from sqlalchemy import create_engine
 
 from mage_ai.io.base import QUERY_ROW_LIMIT
 from mage_ai.io.config import BaseConfigLoader, ConfigKey
@@ -21,6 +22,7 @@ class MSSQL(BaseSQL):
         user: str,
         schema: str = None,
         port: int = 1433,
+        verbose: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(
@@ -30,24 +32,25 @@ class MSSQL(BaseSQL):
             password=password,
             schema=schema,
             port=port,
+            verbose=verbose,
             **kwargs
         )
 
-    def _enforce_limit(self, query: str, limit: int = QUERY_ROW_LIMIT) -> str:
-        # MSSQL doesn't support WITH statements in subqueries, so if the user uses a WITH
-        # statement in their query, it would break if we tried to enforce a limit.
-        return query
-
-    @classmethod
-    def with_config(cls, config: BaseConfigLoader) -> 'MSSQL':
-        return cls(
-            database=config[ConfigKey.MSSQL_DATABASE],
-            schema=config[ConfigKey.MSSQL_SCHEMA],
-            driver=config[ConfigKey.MSSQL_DRIVER],
-            host=config[ConfigKey.MSSQL_HOST],
-            password=config[ConfigKey.MSSQL_PASSWORD],
-            port=config[ConfigKey.MSSQL_PORT],
-            user=config[ConfigKey.MSSQL_USER],
+    @property
+    def connection_string(self):
+        driver = self.settings['driver']
+        server = self.settings['server']
+        database = self.settings['database']
+        username = self.settings['user']
+        password = self.settings['password']
+        return (
+            f'DRIVER={{{driver}}};'
+            f'SERVER={server};'
+            f'DATABASE={database};'
+            f'UID={username};'
+            f'PWD={password};'
+            'ENCRYPT=yes;'
+            'TrustServerCertificate=yes;'
         )
 
     def default_schema(self) -> str:
@@ -55,21 +58,9 @@ class MSSQL(BaseSQL):
 
     def open(self) -> None:
         with self.printer.print_msg('Opening connection to MSSQL database'):
-            driver = self.settings['driver']
-            server = self.settings['server']
-            database = self.settings['database']
-            username = self.settings['user']
-            password = self.settings['password']
-            connection_string = (
-                f'DRIVER={{{driver}}};'
-                f'SERVER={server};'
-                f'DATABASE={database};'
-                f'UID={username};'
-                f'PWD={password};'
-                'ENCRYPT=yes;'
-                'TrustServerCertificate=yes;'
+            self._ctx = pyodbc.connect(
+                self.connection_string,
             )
-            self._ctx = pyodbc.connect(connection_string)
 
     def build_create_schema_command(
         self,
@@ -107,8 +98,19 @@ class MSSQL(BaseSQL):
         dtypes: List[str],
         full_table_name: str,
         buffer: Union[IO, None] = None,
+        schema_name: str = None,
+        table_name: str = None,
         **kwargs,
     ) -> None:
+        if kwargs.get('fast_executemany', True) and schema_name and table_name:
+            engine = create_engine(
+                f'mssql+pyodbc://?odbc_connect={self.connection_string}',
+                fast_executemany=True,
+            )
+            # if_exists and index logic is already handled in the base class's export method
+            df.to_sql(table_name, engine, schema=schema_name, if_exists='append', index=False)
+            return
+
         def serialize_obj(val):
             if type(val) is dict:
                 return simplejson.dumps(
@@ -199,3 +201,20 @@ class MSSQL(BaseSQL):
             print(f'Invalid datatype provided: {dtype}')
 
         return 'char(255)'
+
+    @classmethod
+    def with_config(cls, config: BaseConfigLoader) -> 'MSSQL':
+        return cls(
+            database=config[ConfigKey.MSSQL_DATABASE],
+            schema=config[ConfigKey.MSSQL_SCHEMA],
+            driver=config[ConfigKey.MSSQL_DRIVER],
+            host=config[ConfigKey.MSSQL_HOST],
+            password=config[ConfigKey.MSSQL_PASSWORD],
+            port=config[ConfigKey.MSSQL_PORT],
+            user=config[ConfigKey.MSSQL_USER],
+        )
+
+    def _enforce_limit(self, query: str, limit: int = QUERY_ROW_LIMIT) -> str:
+        # MSSQL doesn't support WITH statements in subqueries, so if the user uses a WITH
+        # statement in their query, it would break if we tried to enforce a limit.
+        return query

--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -268,6 +268,7 @@ class Postgres(BaseSQL):
         allow_reserved_words: bool = False,
         unique_conflict_method: str = None,
         unique_constraints: List[str] = None,
+        **kwargs,
     ) -> None:
         if unique_constraints and unique_conflict_method:
             use_insert_command = True

--- a/mage_ai/io/sql.py
+++ b/mage_ai/io/sql.py
@@ -105,7 +105,8 @@ class BaseSQL(BaseSQLConnection):
         db_dtypes: List[str],
         dtypes: List[str],
         full_table_name: str,
-        buffer: Union[IO, None] = None
+        buffer: Union[IO, None] = None,
+        **kwargs,
     ) -> None:
         raise Exception('Subclasses must override this method.')
 
@@ -215,6 +216,7 @@ class BaseSQL(BaseSQLConnection):
         allow_reserved_words: bool = False,
         unique_conflict_method: str = None,
         unique_constraints: List[str] = None,
+        **kwargs,
     ) -> None:
         """
         Exports dataframe to the connected database from a Pandas data frame. If table doesn't
@@ -324,6 +326,9 @@ class BaseSQL(BaseSQLConnection):
                         allow_reserved_words=allow_reserved_words,
                         unique_conflict_method=unique_conflict_method,
                         unique_constraints=unique_constraints,
+                        schema_name=schema_name,
+                        table_name=table_name,
+                        **kwargs,
                     )
             self.conn.commit()
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Speed up io mssql export method.
pyodbc library is slow on bulk inserting rows.
Tested using pyodbc + fast_executemany=True option, the performance didn't improve a lot.
Tested using sqlalchemy + fast_executemany=True + df.to_sql, the performance drastically improved.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested exporting a dataframe with 120k rows and 30 columns.
Original time (pyodbc): 120s
Use sqlalchemy engine (fast_executemany=True) + df.to_sql: 20s


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
