### PR TITLE
[td] Only create 4 default permissions

### DIFF
--- a/mage_ai/orchestration/db/models/oauth.py
+++ b/mage_ai/orchestration/db/models/oauth.py
@@ -435,12 +435,17 @@ class Permission(BaseModel):
         ).all()
         new_permissions = []
         if len(permissions) == 0:
-            for access in [a.value for a in Permission.Access]:
+            for permission_access in [
+                Permission.Access.OWNER,
+                Permission.Access.ADMIN,
+                Permission.Access.EDITOR,
+                Permission.Access.VIEWER,
+            ]:
                 new_permissions.append(
                     self.create(
                         entity=entity,
                         entity_id=entity_id,
-                        access=access,
+                        access=permission_access.value,
                         commit=False,
                     )
                 )


### PR DESCRIPTION
# Description
Only create the first 4 permissions by default since the other permission access is for when requiring user permissions.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [ ] Test A
- [ ] Test B


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
