### PR TITLE
[ac] Replace runtime variables card list with table

### DIFF
--- a/mage_ai/frontend/components/RuntimeVariables/index.style.tsx
+++ b/mage_ai/frontend/components/RuntimeVariables/index.style.tsx
@@ -1,28 +1,12 @@
 import styled from 'styled-components';
 
 import dark from '@oracle/styles/themes/dark';
-import { BORDER_RADIUS } from '@oracle/styles/units/borders';
-import { PADDING, UNIT } from '@oracle/styles/units/spacing';
-import { ScrollbarStyledCss } from '@oracle/styles/scrollbars';
+import { PADDING } from '@oracle/styles/units/spacing';
 
-export const ContainerStyle = styled.div`
-  border-bottom: 1px solid ${dark.borders.medium};
-  padding: ${PADDING}px;
-`;
-
-export const CardsStyle = styled.div`
-  ${ScrollbarStyledCss}
-
-  height: 80px;
-
+export const ContainerStyle = styled.div<{ $height: number }>`
   display: flex;
-  overflow-x: scroll;
-`;
-
-export const VariableCardStyle = styled.div`
-  background-color: ${dark.background.output};
-  border-radius: ${BORDER_RADIUS}px;
-  flex-shrink: 0;
-  margin-right: ${UNIT}px;
+  flex-direction: column;
+  height: ${props => props.$height}px;
   padding: ${PADDING}px;
+  border-bottom: 1px solid ${dark.borders.medium};
 `;

--- a/mage_ai/frontend/components/RuntimeVariables/index.tsx
+++ b/mage_ai/frontend/components/RuntimeVariables/index.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 
+import SimpleDataTable from '@oracle/components/Table/SimpleDataTable';
 import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
-import { CardsStyle, ContainerStyle, VariableCardStyle } from './index.style';
-import { LIME_DARK } from '@oracle/styles/colors/main';
+import { ContainerStyle } from './index.style';
 import { ScheduleTypeEnum } from '@interfaces/PipelineScheduleType';
 import { addTriggerVariables, getFormattedVariable } from '@components/Sidekick/utils';
 
 type RuntimeVariablesProps = {
   hasOverride?: boolean;
+  height: number;
   variables: {
     [key: string]: string | number;
   };
@@ -20,6 +21,7 @@ type RuntimeVariablesProps = {
 
 function RuntimeVariables({
   hasOverride,
+  height,
   scheduleType,
   variables,
   variablesOverride,
@@ -36,24 +38,36 @@ function RuntimeVariables({
   addTriggerVariables(variablesArr, scheduleType);
 
   return (
-    <ContainerStyle>
+    <ContainerStyle $height={height}>
       <Spacing mb={2}>
         <Text bold large monospace muted>
           Runtime variables{hasOverride && ' (override)'}
         </Text>
       </Spacing>
-      <CardsStyle noScrollbarTrackBackground>
-        {variables && variablesArr.map(({ uuid, value }) => (
-          <VariableCardStyle>
-            <Text monospace small>
-              {uuid}
-            </Text>
-            <Text color={LIME_DARK} monospace small>
-              {getFormattedVariable(value)}
-            </Text>
-          </VariableCardStyle>
-        ))}
-      </CardsStyle>
+      {variables && (
+        <SimpleDataTable 
+          columnFlexNumbers={[1, 1]}
+          columnHeaders={[
+              {
+                label: 'Variable',
+              },
+              {
+                label: 'Value',
+              },
+            ]}
+          rowGroupData={[
+            {
+              rowData: variablesArr.map(({ uuid, value }) => (
+                {
+                  columnValues: [uuid, value],
+                  uuid,
+                }
+              )),
+            },
+          ]}
+          small
+        />
+      )}
     </ContainerStyle>
   );
 }

--- a/mage_ai/frontend/oracle/components/Table/SimpleDataTable.tsx
+++ b/mage_ai/frontend/oracle/components/Table/SimpleDataTable.tsx
@@ -85,7 +85,8 @@ function SimpleDataTable({
     <TableStyle
       flex={flex}
       height={height}
-      scrollbarBorderRadiusLarge
+      noBorder={noBorder}
+      noScrollbarTrackBackground
     >
       <ColumnHeaderRowStyle noBorder={noBorder}>
         <FlexContainer alignItems="center">

--- a/mage_ai/frontend/oracle/components/Table/index.style.tsx
+++ b/mage_ai/frontend/oracle/components/Table/index.style.tsx
@@ -3,17 +3,19 @@ import styled from 'styled-components';
 import light from '@oracle/styles/themes/light';
 import { BORDER_RADIUS } from '@oracle/styles/units/borders';
 import { UNIT } from '@oracle/styles/units/spacing';
+import { ScrollbarStyledCss } from '@oracle/styles/scrollbars';
 import { transition } from '@oracle/styles/mixins';
 
 export const PADDING_SIZE_UNITS = 1.5;
 
 export const TableStyle = styled.div<any>`
+  ${ScrollbarStyledCss}
+
   overflow-y: auto;
   position: relative;
   width: 100%;
   z-index: 3;
-  border-bottom-left-radius: ${BORDER_RADIUS}px;
-  border-bottom-right-radius: ${BORDER_RADIUS}px;
+  border-radius: ${BORDER_RADIUS}px;
 
   ${props => `
     background-color: ${(props.theme.background || light.background).page};
@@ -21,9 +23,11 @@ export const TableStyle = styled.div<any>`
   ${props => props.height && `
     height: ${props.height}px;
   `}
-
   ${props => props.flex && `
     flex: 1;
+  `}
+  ${props => props.noBorder && `
+    border-radius: 0;
   `}
 `;
 

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -197,25 +197,39 @@ function PipelineSchedules({
   const buildSidekick = useMemo(() => {
     const variablesOverride = selectedSchedule?.variables;
     const hasOverride = !isEmptyObject(variablesOverride);
-
-    const showVariables = hasOverride
-      ? selectedSchedule?.variables
-      : !isEmptyObject(variablesOrig) ? variablesOrig : null;
+    const hasVariables = !isEmptyObject(variablesOrig);
 
     return (props: DependencyGraphProps) => {
-      const dependencyGraphHeight = props.height - (showVariables ? 151 : 80);
+      /** 
+       * Because it's required to specify the DependencyGraph height, we calculate
+       * the RuntimeVariables height here instead of within its component.
+       * We dynamically calculate the RuntimeVariables height based on the number
+       * of visible rows in the runtime variables table at any time.
+       */
+      let runtimeVariablesHeight = 80;
+      if (hasVariables) {
+        const maxVisibleRows = 5;
+        const rowHeight = 44;
+        const numVariables = Object.keys(variablesOrig).length;
+        const numVisibleRows = Math.min(maxVisibleRows, numVariables);
+        // This accounts for title + spacing + table in RuntimeVariables
+        runtimeVariablesHeight = 116 + numVisibleRows * rowHeight;
+      }
+   
+      const dependencyGraphHeight = props.height - runtimeVariablesHeight;
 
       return (
         <>
-          {showVariables && (
+          {hasVariables && (
             <RuntimeVariables
               hasOverride={hasOverride}
+              height={runtimeVariablesHeight}
               scheduleType={selectedSchedule?.schedule_type}
               variables={variablesOrig}
               variablesOverride={variablesOverride}
             />
           )}
-          {!showVariables && (
+          {!hasVariables && (
             <Spacing p={PADDING_UNITS}>
               <Text>
                 This pipeline has no runtime variables.


### PR DESCRIPTION
# Description

Previously, runtime variables were displayed in a horizontally-scrollable card list like so: 
<img width="906" alt="before copy" src="https://github.com/mage-ai/mage-ai/assets/8130751/ab6855b2-30e1-4226-b15d-319d72099689">

Feedback was that "it is hard to see all the runtime variables the way it is now, and you have to scroll a lot too." This PR replaces the card list with a table instead ([Airtable Task](https://airtable.com/applEuqJsK4zF5yJK/tbl5bIlFkk2KhCpL4/viwCmaGgcnwD9IqOM/recrumg67BH0zbgaB?blocks=hide)):
<img width="888" alt="image" src="https://github.com/mage-ai/mage-ai/assets/8130751/d5372b81-8b35-46ce-85b1-76250635a179">
* If there are more than 5 variables, only 5 variables will be visible in the table, and there will be a scrollbar to vertically scroll and see more variables.
* If there are ≤ 5 variables, all variables will be visible in the table, and there will be no scrollbar.


# How Has This Been Tested?

1. Add global variables here: http://localhost:3000/pipelines/example_pipeline/edit?sideview=variables
2. Test when there's no variables
3. Test when there's ≤ 5 variables
4. Test when there's > 5 variables

**Before:**
<img width="1792" alt="before" src="https://github.com/mage-ai/mage-ai/assets/8130751/5013a9dd-5e24-4b2b-9911-e82acf1befa7">


**After**

- [ ] No variables
    <img width="1792" alt="image" src="https://github.com/mage-ai/mage-ai/assets/8130751/e3c78abb-0da8-43c5-b55d-cc2f657ce940">
- [ ] ≤ 5 variables
    <img width="1792" alt="image" src="https://github.com/mage-ai/mage-ai/assets/8130751/cc54b2c2-a1b8-407d-84b1-2b41538f1d41">
- [ ] > 5 variables
    <img width="1792" alt="image" src="https://github.com/mage-ai/mage-ai/assets/8130751/d7f0574a-ef39-4f07-ac3e-d87e94e3f5df">

cc:
<!-- Optionally mention someone to let them know about this pull request -->
