### PR TITLE
[dy] Add activity to status endpoint when requested

### DIFF
--- a/mage_ai/api/middleware.py
+++ b/mage_ai/api/middleware.py
@@ -18,8 +18,8 @@ from mage_ai.shared.array import find
 
 
 class OAuthMiddleware(RequestHandler):
-    def initialize(self, bypass_oauth_check: bool = False) -> None:
-        self.bypass_oauth_check = bypass_oauth_check
+    def initialize(self, **kwargs) -> None:
+        self.bypass_oauth_check = kwargs.get('bypass_oauth_check', False)
 
     def prepare(self):
         self.request.__setattr__('current_user', None)

--- a/mage_ai/api/policies/StatusPolicy.py
+++ b/mage_ai/api/policies/StatusPolicy.py
@@ -15,7 +15,12 @@ StatusPolicy.allow_actions([
     OauthScope.CLIENT_PUBLIC,
 ])
 
-StatusPolicy.allow_read(StatusPresenter.default_attributes, scopes=[
+StatusPolicy.allow_read(StatusPresenter.default_attributes + [
+    'last_user_request',
+    'last_scheduler_activity',
+    'active_pipeline_run_count',
+    'active_block_run_count',
+], scopes=[
     OauthScope.CLIENT_PRIVATE,
     OauthScope.CLIENT_PUBLIC,
 ], on_action=[

--- a/mage_ai/api/policies/StatusPolicy.py
+++ b/mage_ai/api/policies/StatusPolicy.py
@@ -16,10 +16,9 @@ StatusPolicy.allow_actions([
 ])
 
 StatusPolicy.allow_read(StatusPresenter.default_attributes + [
-    'last_user_request',
-    'last_scheduler_activity',
     'active_pipeline_run_count',
-    'active_block_run_count',
+    'last_scheduler_activity',
+    'last_user_request',
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
     OauthScope.CLIENT_PUBLIC,

--- a/mage_ai/api/presenters/StatusPresenter.py
+++ b/mage_ai/api/presenters/StatusPresenter.py
@@ -13,3 +13,11 @@ class StatusPresenter(BasePresenter):
         'project_type',
         'project_uuid',
     ]
+
+
+StatusPresenter.register_format(
+    'with_activity_details',
+    StatusPresenter.default_attributes + [
+        'last_user_request',
+    ],
+)

--- a/mage_ai/api/presenters/StatusPresenter.py
+++ b/mage_ai/api/presenters/StatusPresenter.py
@@ -18,8 +18,8 @@ class StatusPresenter(BasePresenter):
 StatusPresenter.register_format(
     'with_activity_details',
     StatusPresenter.default_attributes + [
-        'last_user_request',
-        'last_scheduler_activity',
         'active_pipeline_run_count',
+        'last_scheduler_activity',
+        'last_user_request',
     ],
 )

--- a/mage_ai/api/presenters/StatusPresenter.py
+++ b/mage_ai/api/presenters/StatusPresenter.py
@@ -19,5 +19,7 @@ StatusPresenter.register_format(
     'with_activity_details',
     StatusPresenter.default_attributes + [
         'last_user_request',
+        'last_scheduler_activity',
+        'active_pipeline_run_count',
     ],
 )

--- a/mage_ai/api/resources/StatusResource.py
+++ b/mage_ai/api/resources/StatusResource.py
@@ -70,6 +70,7 @@ class StatusResource(GenericResource):
         display_format = meta.get('_format')
         if 'with_activity_details' == display_format:
             from mage_ai.server.server import latest_user_activity
+
             project_schedules = PipelineSchedule.repo_query.all()
             project_schedule_ids = [schedule.id for schedule in project_schedules]
             project_pipeline_runs = PipelineRun.query.filter(
@@ -81,18 +82,13 @@ class StatusResource(GenericResource):
             if sorted_pipeline_runs.count() > 0:
                 last_scheduler_activity = sorted_pipeline_runs[0].updated_at
             active_pipeline_run_count = project_pipeline_runs.filter(
-                PipelineRun.status.in_(
-                    [
-                        PipelineRun.PipelineRunStatus.INITIAL,
-                        PipelineRun.PipelineRunStatus.RUNNING,
-                    ]
-                )
+                PipelineRun.status == PipelineRun.PipelineRunStatus.RUNNING
             ).count()
 
             activity_details = {
-                'last_user_request': latest_user_activity.latest_activity,
-                'last_scheduler_activity': last_scheduler_activity,
                 'active_pipeline_run_count': active_pipeline_run_count,
+                'last_scheduler_activity': last_scheduler_activity,
+                'last_user_request': latest_user_activity.latest_activity,
             }
 
             status = merge_dict(status, activity_details)

--- a/mage_ai/api/resources/StatusResource.py
+++ b/mage_ai/api/resources/StatusResource.py
@@ -34,7 +34,6 @@ class StatusResource(GenericResource):
             GCP_PROJECT_ID,
             KUBE_NAMESPACE,
         )
-        from mage_ai.server.server import latest_user_activity
 
         instance_type = None
         project_type = get_project_type()
@@ -70,6 +69,7 @@ class StatusResource(GenericResource):
 
         display_format = meta.get('_format')
         if 'with_activity_details' == display_format:
+            from mage_ai.server.server import latest_user_activity
             project_schedules = PipelineSchedule.repo_query.all()
             project_schedule_ids = [schedule.id for schedule in project_schedules]
             project_pipeline_runs = PipelineRun.query.filter(

--- a/mage_ai/api/resources/StatusResource.py
+++ b/mage_ai/api/resources/StatusResource.py
@@ -61,4 +61,5 @@ class StatusResource(GenericResource):
             'project_type': project_type,
             'project_uuid': get_project_uuid(),
         }
+
         return self.build_result_set([status], user, **kwargs)

--- a/mage_ai/server/api/base.py
+++ b/mage_ai/server/api/base.py
@@ -1,11 +1,13 @@
+import json
+import traceback
+
+import dateutil.parser
+import simplejson
+import tornado.web
+
 from mage_ai.api.middleware import OAuthMiddleware
 from mage_ai.shared.parsers import encode_complex
 from mage_ai.shared.strings import camel_to_snake_case
-import dateutil.parser
-import json
-import simplejson
-import tornado.web
-import traceback
 
 META_KEY_LIMIT = '_limit'
 META_KEY_OFFSET = '_offset'
@@ -95,7 +97,15 @@ class BaseHandler(tornado.web.RequestHandler):
 
 
 class BaseApiHandler(BaseHandler, OAuthMiddleware):
-    pass
+    def initialize(self, **kwargs) -> None:
+        super().initialize(**kwargs)
+        self.is_health_check = kwargs.get('is_health_check', False)
+
+    def prepare(self):
+        from mage_ai.server.server import latest_user_activity
+        if not self.is_health_check:
+            latest_user_activity.update_latest_activity()
+        super().prepare()
 
 
 class BaseDetailHandler(BaseHandler):

--- a/mage_ai/server/api/v1.py
+++ b/mage_ai/server/api/v1.py
@@ -69,8 +69,9 @@ class ApiListHandler(BaseApiHandler):
         self,
         resource: str,
         bypass_oauth_check: bool = False,
+        is_health_check: bool = False,
     ):
-        super().initialize(bypass_oauth_check=bypass_oauth_check)
+        super().initialize(bypass_oauth_check=bypass_oauth_check, is_health_check=is_health_check)
         self.resource = resource
 
     async def get(self):

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -5,9 +5,11 @@ import shutil
 import stat
 import traceback
 import webbrowser
+from datetime import datetime
 from time import sleep
 from typing import Union
 
+import pytz
 import tornado.ioloop
 import tornado.web
 from tornado import autoreload
@@ -94,6 +96,17 @@ BASE_PATH_TEMPLATE_EXPORTS_FOLDER = 'frontend_dist_base_path_template'
 BASE_PATH_PLACEHOLDER = 'CLOUD_NOTEBOOK_BASE_PATH_PLACEHOLDER_'
 
 logger = Logger().new_server_logger(__name__)
+
+
+class ActivityTracker:
+    def __init__(self):
+        self.latest_activity = None
+
+    def update_latest_activity(self):
+        self.latest_activity = datetime.now(tz=pytz.UTC)
+
+
+latest_user_activity = ActivityTracker()
 
 
 class MainPageHandler(tornado.web.RequestHandler):
@@ -241,7 +254,11 @@ def make_app(template_dir: str = None, update_routes: bool = False):
         (
             r'/api/status(?:es)?',
             ApiListHandler,
-            {'resource': 'statuses', 'bypass_oauth_check': True},
+            {
+                'resource': 'statuses',
+                'bypass_oauth_check': True,
+                'is_health_check': True,
+            },
         ),
         (
             r'/api/(?P<resource>\w+)/(?P<pk>[\w\%2f\.]+)/(?P<child>\w+)/(?P<child_pk>[\w\%2f\.]+)',


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Added a `with_activity_details` format to return activity details for the server. This will be used to determine if a workspace should terminated based on user configured settings.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested that the user activity is updated properly
- [x] Tested that calling the endpoint with `with_activity_details` flag returns the expected values


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
