### PR TITLE
[td] Fix block tests not getting output

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -73,7 +73,6 @@ function PipelineSchedules({
 
   const { data: dataClientPage } = api.client_pages.detail('pipeline_schedule:create', {
     'pipelines[]': [pipelineUUID],
-    'pipeline_schedules[]': [],
   }, {}, {
     key: `Triggers/Edit/${pipelineUUID}`,
   });
@@ -199,7 +198,7 @@ function PipelineSchedules({
     const hasVariables = !isEmptyObject(variablesOrig);
 
     return (props: DependencyGraphProps) => {
-      /** 
+      /**
        * Because it's required to specify the DependencyGraph height, we calculate
        * the RuntimeVariables height here instead of within its component.
        * We dynamically calculate the RuntimeVariables height based on the number
@@ -214,7 +213,7 @@ function PipelineSchedules({
         const numVisibleRows = Math.min(maxVisibleRows, numVariables);
         runtimeVariablesHeight = headerRowHeight + (numVisibleRows * rowHeight) + 1;
       }
-   
+
       const dependencyGraphHeight = props.height - runtimeVariablesHeight;
 
       return (

--- a/mage_ai/presenters/pages/loaders/pipeline_schedules.py
+++ b/mage_ai/presenters/pages/loaders/pipeline_schedules.py
@@ -12,6 +12,12 @@ class Loader(BaseLoader):
         query: Dict = None,
         **kwargs,
     ) -> List[PipelineSchedule]:
-        return PipelineSchedule.query.filter(
-            PipelineSchedule.id.in_(ids),
-        ).all()
+        if ids:
+            ids = list(filter(lambda x: x, ids))
+
+        if ids:
+            return PipelineSchedule.query.filter(
+                PipelineSchedule.id.in_(ids),
+            ).all()
+
+        return []


### PR DESCRIPTION
# Description
```
Traceback (most recent call last):

  File "/usr/local/lib/python3.10/site-packages/mage_ai/shared/retry.py", line 34, in retry_func

    return func(*args, **kwargs)

  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/executors/block_executor.py", line 512, in __execute_with_retry

    return self._execute(

  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/executors/block_executor.py", line 976, in _execute

    self.block.run_tests(

  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/models/block/__init__.py", line 2259, in run_tests

    test_function(*outputs)

TypeError: test_output() missing 1 required positional argument: 'output'

@test
def test_output(output, *args) -> None:
    """
    Template code for testing the output of the block.
    """
    assert output is not None, 'The output is undefined'
```


# How Has This Been Tested?

- Ran dynamic and normal block with multiple tests in notebook and triggering pipeline

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
