### PR TITLE
[jk] Check for empty column headers

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
@@ -278,6 +278,19 @@ function CodeOutput({
       if (shape) {
         setDataFrameShape(shape);
       }
+
+      const columnHeadersContainEmptyString = columns?.some(header => header === '');
+      if (columnHeadersContainEmptyString) {
+        return (
+          <Spacing mx={5} my={3}>
+            <Text monospace warning>
+              Block output table could not be rendered due to empty string headers.
+              Please check your data’s column headers for empty strings.
+            </Text>
+          </Spacing>
+        );
+      }
+
       return rows.length >= 1 && (
         <DataTable
           columns={columns}

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -543,6 +543,11 @@ function DataTable({
   rows: rowsProp,
   width,
 }: DataTableProps) {
+  const columnHeadersContainEmptyString = columnsProp?.some(header => header === '');
+  if (columnHeadersContainEmptyString) {
+    return null;
+  }
+
   const numberOfIndexes = useMemo(() => index?.length
     ? (Array.isArray(index[0]) ? index[0].length : 1)
     : 1


### PR DESCRIPTION
# Description
- App was crashing if there were empty strings in the column headers when rendering the DataTable component.
- Prevent table rendering if there are empty string column headers.
- Show warning in block output letting user know they should check their column headers for empty strings.

# How Has This Been Tested?
![image](https://github.com/mage-ai/mage-ai/assets/78053898/b9026ec5-978e-4549-9b3c-3801978354af)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
