### PR TITLE
[td] 0.9.34

### DIFF
--- a/mage_ai/server/constants.py
+++ b/mage_ai/server/constants.py
@@ -12,4 +12,4 @@ DATAFRAME_OUTPUT_SAMPLE_COUNT = 10
 # Dockerfile depends on it because it runs ./scripts/install_mage.sh and uses
 # the last line to determine the version to install.
 VERSION = \
-'0.9.33'
+'0.9.34'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     name='mage-ai',
     # NOTE: when you change this, change the value of VERSION in the following file:
     # mage_ai/server/constants.py
-    version='0.9.33',
+    version='0.9.34',
     author='Mage',
     author_email='eng@mage.ai',
     description='Mage is a tool for building and deploying data pipelines.',


### PR DESCRIPTION
# Description
If policy check fails when using permissions, check to see if the same rule config exists with override_permissions
If it does, execute that lambda and if it passes, don’t raise an error. If it doesn’t pass, raise an error

Set an API resource class attribute as enabled/disabled by default to support future API endpoints that are added without requiring the end user to add new permissions to access the API.
allow_actions
override_permissions
Set new resource attributes returned from an API endpoint as enabled/disabled by default to support future attributes without requiring the end user to add new permissions to access the API.
allow_read
override_permissions
allow_write
allow_query


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [ ] Test A
- [ ] Test B


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
