### PR TITLE
Set attributes from pubsub message to handler dict

### DIFF
--- a/mage_ai/streaming/sources/google_cloud_pubsub.py
+++ b/mage_ai/streaming/sources/google_cloud_pubsub.py
@@ -96,7 +96,7 @@ class GoogleCloudPubSubSource(BaseSource):
             # self._print(f'Received: {received_message}.')
             handler(dict(
                 data=received_message.message.data.decode(),
-                attributes=received_message.message.attributes))
+                metadata=dict(attributes=received_message.message.attributes)))
             # self._print(f'Handled: {received_message.message.data}.')
             received_message.ack()
 
@@ -141,7 +141,7 @@ class GoogleCloudPubSubSource(BaseSource):
                     # self._print(f'Received: {received_message.message.data}.')
                     message_values.append(
                         dict(data=received_message.message.data.decode(),
-                             attributes=received_message.message.attributes)
+                             metadata=dict(attributes=received_message.message.attributes))
                     )
                     # self._print(f'Batched: {received_message.message.data}.')
                     ack_ids.append(received_message.ack_id)

--- a/mage_ai/streaming/sources/google_cloud_pubsub.py
+++ b/mage_ai/streaming/sources/google_cloud_pubsub.py
@@ -1,12 +1,14 @@
+import os
+from dataclasses import dataclass
+from typing import Callable
+
 from google.api_core import retry
 from google.cloud import pubsub_v1
 from google.oauth2 import service_account
-from dataclasses import dataclass
+
 from mage_ai.shared.config import BaseConfig
 from mage_ai.streaming.constants import DEFAULT_BATCH_SIZE
 from mage_ai.streaming.sources.base import BaseSource
-from typing import Callable
-import os
 
 
 @dataclass
@@ -92,7 +94,9 @@ class GoogleCloudPubSubSource(BaseSource):
         def callback(
                 received_message: pubsub_v1.subscriber.message.Message) -> None:
             # self._print(f'Received: {received_message}.')
-            handler(dict(data=received_message.message.data.decode()))
+            handler(dict(
+                data=received_message.message.data.decode(),
+                attributes=received_message.message.attributes))
             # self._print(f'Handled: {received_message.message.data}.')
             received_message.ack()
 
@@ -136,7 +140,8 @@ class GoogleCloudPubSubSource(BaseSource):
                 for received_message in response.received_messages:
                     # self._print(f'Received: {received_message.message.data}.')
                     message_values.append(
-                        dict(data=received_message.message.data.decode())
+                        dict(data=received_message.message.data.decode(),
+                             attributes=received_message.message.attributes)
                     )
                     # self._print(f'Batched: {received_message.message.data}.')
                     ack_ids.append(received_message.ack_id)


### PR DESCRIPTION
# Description
i implement streaming pipeline using pubsub  but can't read the attributes from the pubsub message,
so i  set the attributes from pubsub message to dict when passing to handler

reference : https://cloud.google.com/python/docs/reference/pubsub/latest/google.cloud.pubsub_v1.subscriber.message.Message

# How Has This Been Tested?
- [x] tested locally
<img width="509" alt="Screenshot 2023-10-11 at 21 56 14" src="https://github.com/mage-ai/mage-ai/assets/26200571/0fef0b94-4a2d-4f43-96b5-0b10c85a1df0">



# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993 @tommydangerous @dy46 @johnson-mage 

