### PR TITLE
[ac] Display elapsed time on datetime hover rather than UTC time

### DIFF
--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -124,7 +124,7 @@ function BackfillsTable({
             key="started_at"
             monospace
             small
-            title={startedAt ? utcStringToElapsedTime(startedAt.slice(0, 19)) : null}
+            title={startedAt ? utcStringToElapsedTime(startedAt) : null}
           >
             {startedAt
               ? (displayLocalTimezone
@@ -140,7 +140,7 @@ function BackfillsTable({
             key="completed_at"
             monospace
             small
-            title={completedAt ? utcStringToElapsedTime(completedAt.slice(0, 19)) : null}
+            title={completedAt ? utcStringToElapsedTime(completedAt) : null}
           >
             {completedAt
               ? (displayLocalTimezone

--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -12,7 +12,7 @@ import { Edit } from '@oracle/icons';
 import { RunStatus } from '@interfaces/PipelineRunType';
 import { TIMEZONE_TOOLTIP_PROPS } from '@components/shared/Table/constants';
 import { UNIT } from '@oracle/styles/units/spacing';
-import { datetimeInLocalTimezone } from '@utils/date';
+import { datetimeInLocalTimezone, utcStringToElapsedTime } from '@utils/date';
 import { getTimeInUTCString } from '@components/Triggers/utils';
 import { isViewer } from '@utils/session';
 import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
@@ -124,7 +124,7 @@ function BackfillsTable({
             key="started_at"
             monospace
             small
-            title={startedAt ? `UTC: ${startedAt.slice(0, 19)}` : null}
+            title={startedAt ? utcStringToElapsedTime(startedAt.slice(0, 19)) : null}
           >
             {startedAt
               ? (displayLocalTimezone
@@ -140,7 +140,7 @@ function BackfillsTable({
             key="completed_at"
             monospace
             small
-            title={completedAt ? `UTC: ${completedAt.slice(0, 19)}` : null}
+            title={completedAt ? utcStringToElapsedTime(completedAt.slice(0, 19)) : null}
           >
             {completedAt
               ? (displayLocalTimezone

--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
@@ -264,7 +264,7 @@ function BlockRunsTable({
             key={`${id}_started_at`}
             monospace
             small
-            title={startedAt ? utcStringToElapsedTime(startedAt.slice(0, 19)) : null}
+            title={startedAt ? utcStringToElapsedTime(startedAt) : null}
           >
             {startedAt
               ? (displayLocalTimezone
@@ -280,7 +280,7 @@ function BlockRunsTable({
             key={`${id}_completed_at`}
             monospace
             small
-            title={completedAt ? utcStringToElapsedTime(completedAt.slice(0, 19)) : null}
+            title={completedAt ? utcStringToElapsedTime(completedAt) : null}
           >
             {completedAt
               ? (displayLocalTimezone

--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
@@ -26,7 +26,7 @@ import {
   TIMEZONE_TOOLTIP_PROPS,
 } from '@components/shared/Table/constants';
 import { UNIT } from '@oracle/styles/units/spacing';
-import { dateFormatLong, datetimeInLocalTimezone } from '@utils/date';
+import { dateFormatLong, datetimeInLocalTimezone, utcStringToElapsedTime } from '@utils/date';
 import { getColorsForBlockType } from '@components/CodeBlock/index.style';
 import { indexBy } from '@utils/array';
 import { onSuccess } from '@api/utils/response';
@@ -252,7 +252,7 @@ function BlockRunsTable({
             key={`${id}_created_at`}
             monospace
             small
-            title={createdAt ? `UTC: ${createdAt}` : null}
+            title={createdAt ? utcStringToElapsedTime(createdAt) : null}
           >
             {displayLocalTimezone
               ? datetimeInLocalTimezone(createdAt, displayLocalTimezone)
@@ -264,7 +264,7 @@ function BlockRunsTable({
             key={`${id}_started_at`}
             monospace
             small
-            title={startedAt ? `UTC: ${startedAt.slice(0, 19)}` : null}
+            title={startedAt ? utcStringToElapsedTime(startedAt.slice(0, 19)) : null}
           >
             {startedAt
               ? (displayLocalTimezone
@@ -280,7 +280,7 @@ function BlockRunsTable({
             key={`${id}_completed_at`}
             monospace
             small
-            title={completedAt ? `UTC: ${completedAt.slice(0, 19)}` : null}
+            title={completedAt ? utcStringToElapsedTime(completedAt.slice(0, 19)) : null}
           >
             {completedAt
               ? (displayLocalTimezone

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -510,7 +510,7 @@ function PipelineRunsTable({
                     {...SHARED_DATE_FONT_PROPS}
                     key="row_started_at"
                     muted
-                    title={startedAt ? utcStringToElapsedTime(startedAt.slice(0, 19)) : null}
+                    title={startedAt ? utcStringToElapsedTime(startedAt) : null}
                   >
                     {startedAt
                       ? (displayLocalTimezone
@@ -525,7 +525,7 @@ function PipelineRunsTable({
                     {...SHARED_DATE_FONT_PROPS}
                     key="row_completed_at"
                     muted
-                    title={completedAt ? utcStringToElapsedTime(completedAt.slice(0, 19)) : null}
+                    title={completedAt ? utcStringToElapsedTime(completedAt) : null}
                   >
                     {completedAt
                       ? (displayLocalTimezone
@@ -621,7 +621,7 @@ function PipelineRunsTable({
                     {...SHARED_DATE_FONT_PROPS}
                     default
                     key="row_started_at"
-                    title={startedAt ? utcStringToElapsedTime(startedAt.slice(0, 19)) : null}
+                    title={startedAt ? utcStringToElapsedTime(startedAt) : null}
                   >
                     {startedAt
                       ? (displayLocalTimezone
@@ -636,7 +636,7 @@ function PipelineRunsTable({
                     {...SHARED_DATE_FONT_PROPS}
                     default
                     key="row_completed_at"
-                    title={completedAt ? utcStringToElapsedTime(completedAt.slice(0, 19)) : null}
+                    title={completedAt ? utcStringToElapsedTime(completedAt) : null}
                   >
                     {completedAt
                       ? (displayLocalTimezone

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -43,7 +43,7 @@ import { PopupContainerStyle } from './Table.style';
 import { ScheduleTypeEnum } from '@interfaces/PipelineScheduleType';
 import { TableContainerStyle } from '@components/shared/Table/index.style';
 import { UNIT } from '@oracle/styles/units/spacing';
-import { datetimeInLocalTimezone } from '@utils/date';
+import { datetimeInLocalTimezone, utcStringToElapsedTime } from '@utils/date';
 import { getTimeInUTCString } from '@components/Triggers/utils';
 import { indexBy } from '@utils/array';
 import { isViewer } from '@utils/session';
@@ -510,7 +510,7 @@ function PipelineRunsTable({
                     {...SHARED_DATE_FONT_PROPS}
                     key="row_started_at"
                     muted
-                    title={startedAt ? `UTC: ${startedAt.slice(0, 19)}` : null}
+                    title={startedAt ? utcStringToElapsedTime(startedAt.slice(0, 19)) : null}
                   >
                     {startedAt
                       ? (displayLocalTimezone
@@ -525,7 +525,7 @@ function PipelineRunsTable({
                     {...SHARED_DATE_FONT_PROPS}
                     key="row_completed_at"
                     muted
-                    title={completedAt ? `UTC: ${completedAt.slice(0, 19)}` : null}
+                    title={completedAt ? utcStringToElapsedTime(completedAt.slice(0, 19)) : null}
                   >
                     {completedAt
                       ? (displayLocalTimezone
@@ -606,7 +606,7 @@ function PipelineRunsTable({
                     {...SHARED_DATE_FONT_PROPS}
                     default
                     key="row_date"
-                    title={executionDate ? `UTC: ${executionDate}` : null}
+                    title={executionDate ? utcStringToElapsedTime(executionDate) : null}
                   >
                     {executionDate
                       ? (displayLocalTimezone
@@ -621,7 +621,7 @@ function PipelineRunsTable({
                     {...SHARED_DATE_FONT_PROPS}
                     default
                     key="row_started_at"
-                    title={startedAt ? `UTC: ${startedAt.slice(0, 19)}` : null}
+                    title={startedAt ? utcStringToElapsedTime(startedAt.slice(0, 19)) : null}
                   >
                     {startedAt
                       ? (displayLocalTimezone
@@ -636,7 +636,7 @@ function PipelineRunsTable({
                     {...SHARED_DATE_FONT_PROPS}
                     default
                     key="row_completed_at"
-                    title={completedAt ? `UTC: ${completedAt.slice(0, 19)}` : null}
+                    title={completedAt ? utcStringToElapsedTime(completedAt.slice(0, 19)) : null}
                   >
                     {completedAt
                       ? (displayLocalTimezone

--- a/mage_ai/frontend/components/Triggers/Table.tsx
+++ b/mage_ai/frontend/components/Triggers/Table.tsx
@@ -495,7 +495,7 @@ function TriggersTable({
                     key={`created_at_${idx}`}
                     monospace
                     small
-                    title={createdAt ? utcStringToElapsedTime(createdAt.slice(0, 19)) : null}
+                    title={createdAt ? utcStringToElapsedTime(createdAt) : null}
                   >
                     {datetimeInLocalTimezone(createdAt?.slice(0, 19), displayLocalTimezone)}
                   </Text>,

--- a/mage_ai/frontend/components/Triggers/Table.tsx
+++ b/mage_ai/frontend/components/Triggers/Table.tsx
@@ -42,7 +42,7 @@ import {
   checkIfCustomInterval,
   convertUtcCronExpressionToLocalTimezone,
 } from './utils';
-import { dateFormatLong, datetimeInLocalTimezone } from '@utils/date';
+import { dateFormatLong, datetimeInLocalTimezone, utcStringToElapsedTime } from '@utils/date';
 import { isViewer } from '@utils/session';
 import { onSuccess } from '@api/utils/response';
 import { pauseEvent } from '@utils/events';
@@ -495,7 +495,7 @@ function TriggersTable({
                     key={`created_at_${idx}`}
                     monospace
                     small
-                    title={createdAt ? `UTC: ${createdAt.slice(0, 19)}` : null}
+                    title={createdAt ? utcStringToElapsedTime(createdAt.slice(0, 19)) : null}
                   >
                     {datetimeInLocalTimezone(createdAt?.slice(0, 19), displayLocalTimezone)}
                   </Text>,

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -85,7 +85,7 @@ import {
   randomNameGenerator,
   removeUnderscore,
 } from '@utils/string';
-import { datetimeInLocalTimezone } from '@utils/date';
+import { datetimeInLocalTimezone, utcStringToElapsedTime } from '@utils/date';
 import { displayErrorFromReadResponse, onSuccess } from '@api/utils/response';
 import { filterQuery, queryFromUrl } from '@utils/url';
 import { get, set } from '@storage/localStorage';
@@ -1342,7 +1342,7 @@ function PipelineListPage() {
             key={`pipeline_updated_at_${idx}`}
             monospace
             small
-            title={updatedAt ? `UTC: ${updatedAt}` : null}
+            title={updatedAt ? utcStringToElapsedTime(updatedAt) : null}
           >
             {updatedAt
               ? datetimeInLocalTimezone(updatedAt, displayLocalTimezone)
@@ -1352,7 +1352,7 @@ function PipelineListPage() {
             key={`pipeline_created_at_${idx}`}
             monospace
             small
-            title={createdAt ? `UTC: ${createdAt.slice(0, 19)}` : null}
+            title={createdAt ? utcStringToElapsedTime(createdAt.slice(0, 19)) : null}
           >
             {createdAt
               ? datetimeInLocalTimezone(createdAt.slice(0, 19), displayLocalTimezone)

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -1352,7 +1352,7 @@ function PipelineListPage() {
             key={`pipeline_created_at_${idx}`}
             monospace
             small
-            title={createdAt ? utcStringToElapsedTime(createdAt.slice(0, 19)) : null}
+            title={createdAt ? utcStringToElapsedTime(createdAt) : null}
           >
             {createdAt
               ? datetimeInLocalTimezone(createdAt.slice(0, 19), displayLocalTimezone)

--- a/mage_ai/frontend/utils/date.ts
+++ b/mage_ai/frontend/utils/date.ts
@@ -78,6 +78,37 @@ export function datetimeInLocalTimezone(
   return datetime;
 }
 
+/**
+ * Given a UTC datetime string, find how much time has elapsed between then 
+ * and now. Return the elapsed time in the first matching format:
+ *   - >= 1 year: X year(s) ago
+ *   - >= 1 month: X month(s) ago
+ *   - >= 1 day: X day(s) ago
+ *   - >= 1 hr: X hr(s) Y min(s) ago
+ *   - < 1 hr: X min(s) ago
+ */
+export function utcStringToElapsedTime(datetime: string) {
+  const then = moment.utc(datetime);
+  const now = moment.utc();
+  const duration = moment.duration(now.diff(then));
+
+  let timeDisplay = '';
+  if (duration.years() >= 1) {
+    timeDisplay = `${duration.years()} year${duration.years() > 1 ? 's' : ''} ago`;
+  } else if (duration.months() >= 1) {
+    timeDisplay = `${duration.months()} month${duration.months() > 1 ? 's' : ''} ago`;
+  } else if (duration.days() >= 1) {
+    timeDisplay = `${duration.days()} day${duration.days() > 1 ? 's' : ''} ago`;
+  } else if (duration.hours() >= 1) {
+    timeDisplay = `${duration.hours()} hr${duration.hours() > 1 ? 's' : ''} ` +
+      `${duration.minutes()} min${duration.minutes() > 1 ? 's' : ''} ago`;
+  } else {
+    timeDisplay = `${duration.minutes()} min${duration.minutes() > 1 || duration.minutes() === 0 ? 's' : ''} ago`;
+  }
+
+  return timeDisplay;
+}
+
 export function utcStringToLocalDate(
   datetime: string,
 ): Date {

--- a/mage_ai/frontend/utils/date.ts
+++ b/mage_ai/frontend/utils/date.ts
@@ -1,5 +1,6 @@
 import moment from 'moment';
 
+import { pluralize } from '@utils/string';
 import { rangeSequential } from '@utils/array';
 
 export enum TimePeriodEnum {
@@ -94,16 +95,16 @@ export function utcStringToElapsedTime(datetime: string) {
 
   let timeDisplay = '';
   if (duration.years() >= 1) {
-    timeDisplay = `${duration.years()} year${duration.years() > 1 ? 's' : ''} ago`;
+    timeDisplay = `${pluralize('year', duration.years(), true)} ago`;
   } else if (duration.months() >= 1) {
-    timeDisplay = `${duration.months()} month${duration.months() > 1 ? 's' : ''} ago`;
+    timeDisplay = `${pluralize('month', duration.months(), true)} ago`;
   } else if (duration.days() >= 1) {
-    timeDisplay = `${duration.days()} day${duration.days() > 1 ? 's' : ''} ago`;
+    timeDisplay = `${pluralize('day', duration.days(), true)} ago`;
   } else if (duration.hours() >= 1) {
-    timeDisplay = `${duration.hours()} hr${duration.hours() > 1 ? 's' : ''} ` +
-      `${duration.minutes()} min${duration.minutes() > 1 ? 's' : ''} ago`;
+    timeDisplay = `${pluralize('hr', duration.hours(), true)} ` +
+      `${pluralize('min', duration.minutes(), true)} ago`;
   } else {
-    timeDisplay = `${duration.minutes()} min${duration.minutes() > 1 || duration.minutes() === 0 ? 's' : ''} ago`;
+    timeDisplay = `${pluralize('min', duration.minutes(), true)} ago`;
   }
 
   return timeDisplay;


### PR DESCRIPTION
# Description

Previously, when you hovered over a datetime in a table, we would display a tooltip with the corresponding UTC time:
<img width="283" alt="image" src="https://github.com/mage-ai/mage-ai/assets/8130751/655561a8-c565-4968-a07e-a82d98434f11">

This PR updates the tooltip to instead show the amount of time that has elapsed between the datetime and now based on the following logic ([Airtable Task](https://airtable.com/applEuqJsK4zF5yJK/tbl5bIlFkk2KhCpL4/viwCmaGgcnwD9IqOM/recUepW8SZxtgaFn3?blocks=hide)):
  * If elapsed time >= 1 year, display `X year(s) ago`
  * If elapsed time >= 1 month, display `X month(s) ago`
  * If elapsed time >= 1 day, display `X day(s) ago`
  * If elapsed time >= 1 hr, display `X hr(s) Y min(s) ago`
  * If elapsed time < 1 hr, display `X min(s) ago`

Note that the current implementation always rounds down. If 11 months and 27 days have passed, we show `11 months ago`. In this case, Kai and I decided that we are okay with being loosely accurate because the highly specific UTC time is already there.

# How Has This Been Tested?

To see this change:
1. Go to the Pipelines page: http://localhost:3000/pipelines
2. Hover your cursor over any of the datetime values in the Pipelines table
3. See that the tooltip shows the elapsed time instead of UTC
4. Repeat Steps 1-3 for the Pipeline Runs, Pipeline Detail, Triggers, and Backfill pages

- [x] Tooltip shows the elapsed time
    <img width="202" alt="image" src="https://github.com/mage-ai/mage-ai/assets/8130751/ebee2777-7b97-43b6-afa7-b05324142370">
  <img width="182" alt="image" src="https://github.com/mage-ai/mage-ai/assets/8130751/4007aaf7-4a8f-4666-bc42-f9fe4a8a1be6">

cc: @johnson-mage 