### PR TITLE
[ac] Update Markdown blocks documentation with image support

### DIFF
--- a/docs/guides/blocks/markdown-blocks.mdx
+++ b/docs/guides/blocks/markdown-blocks.mdx
@@ -64,7 +64,7 @@ Links: [Mage homepage](https://www.mage.ai)
 | Text3 | TextC | TextIII |
 
 
-#### Code block
+#### Code blocks
 ```
 {
   "firstName": "John",
@@ -73,7 +73,21 @@ Links: [Mage homepage](https://www.mage.ai)
 }
 ```
 
+#### Checkboxes
+
 - [x] Todo 1 checked
 - [ ] Todo 2 unchecked
 - [ ] Todo 3 unchecked
----
+
+
+#### Images
+
+Images are supported with the typical image markdown syntax:
+```
+![](https://images.photowall.com/products/57215/golden-retriever-puppy.jpg?h=699&q=85)
+```
+or with the `<img>` HTML tag syntax:
+```
+<img src="https://images.photowall.com/products/57215/golden-retriever-puppy.jpg?h=699&q=85" alt="drawing" width="200"/>
+```
+With the `<img>` syntax, you can create customizable image sizes with `width` and `height` attributes.


### PR DESCRIPTION
# Description

This PR updates the [Mage Markdown blocks documentation](https://docs.mage.ai/guides/blocks/markdown-blocks) with the new `<img>` syntax support added in #3692.

# How Has This Been Tested?
- [x] Tested via Markdown preview in VSCode
  <img width="835" alt="Screenshot 2023-10-11 at 9 46 36 PM" src="https://github.com/mage-ai/mage-ai/assets/8130751/565df2c7-be14-423b-88bd-50bf44358ec7">

cc: @johnson-mage @wangxiaoyou1993 