### PR TITLE
[xy] Fix extracting update statement from sql.

### DIFF
--- a/mage_ai/data_preparation/models/block/sql/utils/shared.py
+++ b/mage_ai/data_preparation/models/block/sql/utils/shared.py
@@ -503,7 +503,7 @@ def extract_drop_statement_table_names(text: str) -> List[str]:
 
 def extract_update_statement_table_names(text: str) -> List[str]:
     matches = re.findall(
-        r'\bupdate\b\s+([\w.]+)\s+set\s+[\s\S]*?\bwhere\b',
+        r'\bupdate\b\s+([\w.]+)\s+(?:as\s+\w+\s+)?set\s+[\s\S]*?\bwhere\b',
         remove_comments(text),
         re.IGNORECASE,
     )

--- a/mage_ai/tests/data_preparation/models/block/sql/utils/test_shared.py
+++ b/mage_ai/tests/data_preparation/models/block/sql/utils/test_shared.py
@@ -135,6 +135,15 @@ class SQLBlockSharedUtilsTest(DBTestCase):
         expected_result = []
         self.assertEqual(extract_update_statement_table_names(text), expected_result)
 
+        # Test case 4: UPDATE statement with alias
+        text = """
+        UPDATE table_name as x
+        SET column1 = value1, column2 = value2
+        WHERE condition;
+        """
+        expected_result = ['table_name']
+        self.assertEqual(extract_update_statement_table_names(text), expected_result)
+
     def test_interpolate_input(self):
         self.pipeline = Pipeline.create(
             'test pipeline',


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix extracting update statement from sql.
When the UPDATE command uses alias for the table, the UPDATE statement wasn't extracted properly.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with SQL block locally
<img width="525" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/32d7b0c2-2d12-459f-9709-b869ac2f5e1a">


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
