### PR TITLE
[jk] Flyout menu overflow

### DIFF
--- a/mage_ai/frontend/components/CodeEditor/index.tsx
+++ b/mage_ai/frontend/components/CodeEditor/index.tsx
@@ -206,7 +206,6 @@ function CodeEditor({
     onSave,
     selected,
     setMounted,
-    setSelected,
     setTextareaFocused,
     shortcutsProp,
     tabSize,
@@ -283,6 +282,7 @@ function CodeEditor({
    * re-add the keyboard shortcuts when the upstream or downstream connections change.
    * Including shortcutsProp in the dependency array may lead to unnecessary re-renders.
    */
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [block?.downstream_blocks, block?.upstream_blocks]);
 
   useEffect(

--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
@@ -203,6 +203,10 @@ function AddNewBlocks({
   const blockTemplatesByBlockType = useMemo(() => groupBlockTemplates(
     blockTemplates,
     addNewBlock,
+    {
+      'data_integrations/destinations/base': true,
+      'data_integrations/sources/base': true,
+    },
   ), [
     addNewBlock,
     blockTemplates,

--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/utils.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/utils.tsx
@@ -135,6 +135,7 @@ export const getNonPythonMenuItems = (
 export function groupBlockTemplates(
   blockTemplates: BlockTemplateType[],
   addNewBlock,
+  uuidsToHideTooltips?: { [key: string]: boolean },
 ) {
   const mapping = {};
 
@@ -162,7 +163,7 @@ export function groupBlockTemplates(
       };
     }
 
-    const newItem = {
+    const newItem: FlyoutMenuItemType = {
       label: () => name,
       onClick: () => addNewBlock({
         config: {
@@ -175,9 +176,12 @@ export function groupBlockTemplates(
         language,
         type: blockType,
       }),
-      tooltip: () => description,
       uuid: path,
     };
+
+    if (!uuidsToHideTooltips?.[path]) {
+      newItem.tooltip = () => description;
+    }
 
     if (groups?.length >= 1) {
       const obj = {

--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/v2/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/v2/index.tsx
@@ -63,7 +63,7 @@ import {
 } from '@utils/hooks/keyboardShortcuts/constants';
 import { LOCAL_STORAGE_KEY_SETUP_AI_LATER } from '@storage/constants';
 import { PipelineTypeEnum } from '@interfaces/PipelineType';
-import { DataIntegrationTypeEnum } from '@interfaces/BlockTemplateType';
+import { DataIntegrationTypeEnum, TemplateTypeEnum } from '@interfaces/BlockTemplateType';
 import { UNITS_BETWEEN_SECTIONS, UNIT } from '@oracle/styles/units/spacing';
 import { capitalize } from '@utils/string';
 import { get, set } from '@storage/localStorage';
@@ -375,13 +375,13 @@ function AddNewBlocksV2({
         {
           isGroupingTitle: true,
           label: () => 'Data integrations',
-          uuid: `${BlockTypeEnum.DATA_LOADER}/Data integrations/group`,
+          uuid: `${BlockTypeEnum.DATA_LOADER}/${TemplateTypeEnum.DATA_INTEGRATION}/group`,
         },
         {
           // @ts-ignore
           items: itemsDataLoaderSource,
           label: () => capitalize(DataIntegrationTypeEnum.SOURCES),
-          uuid: `${BlockTypeEnum.DATA_LOADER}/Data integrations/${DataIntegrationTypeEnum.SOURCES}`,
+          uuid: `${BlockTypeEnum.DATA_LOADER}/${TemplateTypeEnum.DATA_INTEGRATION}/${DataIntegrationTypeEnum.SOURCES}`,
         },
       ]);
     }
@@ -400,13 +400,13 @@ function AddNewBlocksV2({
         {
           isGroupingTitle: true,
           label: () => 'Data integrations',
-          uuid: `${BlockTypeEnum.DATA_EXPORTER}/Data integrations/group`,
+          uuid: `${BlockTypeEnum.DATA_EXPORTER}/${TemplateTypeEnum.DATA_INTEGRATION}/group`,
         },
         {
           // @ts-ignore
           items: itemsDataExporterDestination,
           label: () => capitalize(DataIntegrationTypeEnum.DESTINATIONS),
-          uuid: `${BlockTypeEnum.DATA_EXPORTER}/Data integrations/${DataIntegrationTypeEnum.DESTINATIONS}`,
+          uuid: `${BlockTypeEnum.DATA_EXPORTER}/${TemplateTypeEnum.DATA_INTEGRATION}/${DataIntegrationTypeEnum.DESTINATIONS}`,
         },
       ]);
     }
@@ -700,6 +700,10 @@ function AddNewBlocksV2({
             increasedZIndex={BUTTON_INDEX_TEMPLATES === buttonMenuOpenIndex}
           >
             <FlyoutMenuWrapper
+              customSubmenuHeights={{
+                [`${BlockTypeEnum.DATA_EXPORTER}/${TemplateTypeEnum.DATA_INTEGRATION}/${DataIntegrationTypeEnum.DESTINATIONS}`]: 504,
+                [`${BlockTypeEnum.DATA_LOADER}/${TemplateTypeEnum.DATA_INTEGRATION}/${DataIntegrationTypeEnum.SOURCES}`]: 504,
+              }}
               disableKeyboardShortcuts
               items={itemsTemplates}
               onClickCallback={closeButtonMenu}

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.style.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.style.tsx
@@ -6,6 +6,7 @@ import {
   BORDER_STYLE,
   BORDER_WIDTH,
 } from '@oracle/styles/units/borders';
+import { ScrollbarStyledCss } from '@oracle/styles/scrollbars';
 import { UNIT } from '@oracle/styles/units/spacing';
 
 type LinkProps = {
@@ -16,13 +17,23 @@ type LinkProps = {
   largePadding?: boolean;
 };
 
-export const FlyoutMenuContainerStyle = styled.div<any>`
+export const FlyoutMenuContainerStyle = styled.div<{
+  maxHeight?: number;
+  roundedStyle?: boolean;
+  width?: number;
+}>`
+  ${ScrollbarStyledCss}
   position: absolute;
   max-height: ${UNIT * 58}px;
 
   ${props => props.width && `
     min-width: 0px;
     width: ${props.width}px;
+  `}
+
+  ${({ maxHeight }) => maxHeight && `
+    max-height: ${maxHeight}px;
+    overflow: auto;
   `}
 
   ${props => `

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -47,6 +47,7 @@ export type FlyoutMenuItemType = {
 
 export type FlyoutMenuProps = {
   alternateBackground?: boolean;
+  customSubmenuHeights?: { [key: string]: number };
   disableKeyboardShortcuts?: boolean;
   items: FlyoutMenuItemType[];
   left?: number;
@@ -65,6 +66,7 @@ export type FlyoutMenuProps = {
 
 function FlyoutMenu({
   alternateBackground,
+  customSubmenuHeights,
   disableKeyboardShortcuts,
   items,
   left,
@@ -169,8 +171,17 @@ function FlyoutMenu({
   ) => {
     depth += 1;
 
+    const hasCustomHeight = customSubmenuHeights?.hasOwnProperty(uuid);
+    const submenuHeight = hasCustomHeight
+      ? customSubmenuHeights?.[uuid]
+      : null;
+    const customHeightOffset = hasCustomHeight
+      ? customSubmenuHeights?.[uuid] - 36
+      : 0;
+
     return (
       <FlyoutMenuContainerStyle
+        maxHeight={submenuHeight}
         roundedStyle={roundedStyle}
         style={{
           display: (visible || submenuVisible[uuid]) ? null : 'none',
@@ -191,7 +202,7 @@ function FlyoutMenu({
                   ? submenuTopOffset2
                   : submenuTopOffset3)
               ) || 0)
-          ),
+          ) - customHeightOffset,
         }}
         width={width}
       >


### PR DESCRIPTION
# Description
- If there were too many items in the flyout menu, it would extend beyond the view of the window and make scrolling it an unideal UX. This issue was apparent in the standard pipeline editor for data integration sources and destinations when adding a new block.
- This PR sets a height on the long list of items in the flyout menu and makes it scrollable, and also repositions the flyout submenu so the items are within view.

# How Has This Been Tested?
Before (excessively long menu):
![image](https://github.com/mage-ai/mage-ai/assets/78053898/4ad425a1-22b4-4ea2-a7f6-00e368b3ca55)

After:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/19149dc0-4f29-414e-9071-9d990691df4e)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
