### PR TITLE
[td] Validate permissions for specific entity IDs

### DIFF
--- a/mage_ai/authentication/permissions/constants.py
+++ b/mage_ai/authentication/permissions/constants.py
@@ -193,3 +193,8 @@ ATTRIBUTE_OPERATION_TYPE_TO_PERMISSION_ACCESS_MAPPING = {
     'read': PermissionAccess.READ,
     'write': PermissionAccess.WRITE,
 }
+
+ENTITY_NAME_ENTITY_ID_ATTRIBUTE_NAME_MAPPING = {
+    EntityName.Block: 'uuid',
+    EntityName.Pipeline: 'uuid',
+}

--- a/mage_ai/frontend/components/Permissions/PermissionDetail.tsx
+++ b/mage_ai/frontend/components/Permissions/PermissionDetail.tsx
@@ -62,6 +62,7 @@ import { displayName } from '@utils/models/user';
 import { indexBy, sortByKey } from '@utils/array';
 import { isEmptyObject, selectKeys } from '@utils/hash';
 import { onSuccess } from '@api/utils/response';
+import { pauseEvent } from '@utils/events';
 
 const ICON_SIZE = 2 * UNIT;
 
@@ -491,7 +492,10 @@ function PermissionDetail({
 
   const hasUsers = useMemo(() => users?.length >= 1, [users]);
 
-  const buildTable = useCallback((objectsArray: RoleType[]) => (
+  const buildTable = useCallback((
+    objectsArray: RoleType[],
+    enableClickRow?: boolean,
+  ) => (
     <Table
       columnFlex={[null, 1]}
       columns={[
@@ -503,7 +507,9 @@ function PermissionDetail({
               <Checkbox
                 checked={checked}
                 key="checkbox"
-                onClick={() => {
+                onClick={(e) => {
+                  pauseEvent(e);
+
                   if (checked) {
                     setObjectAttributes({
                       rolesMapping: {},
@@ -523,6 +529,15 @@ function PermissionDetail({
           uuid: 'Role',
         },
       ]}
+      onClickRow={enableClickRow
+        ? (rowIndex: number) => {
+          const object = objectsArray[rowIndex];
+          if (object && typeof window !== 'undefined') {
+            window.open(`/settings/workspace/roles/${object?.id}`, '_blank').focus();
+          }
+        }
+        : null
+      }
       rows={objectsArray?.map((object) => {
         const {
           name,
@@ -534,7 +549,9 @@ function PermissionDetail({
           <Checkbox
             checked={checked}
             key="checkbox"
-            onClick={() => {
+            onClick={(e) => {
+              pauseEvent(e);
+
               const mapping = { ...rolesMapping };
 
               if (checked) {
@@ -560,7 +577,10 @@ function PermissionDetail({
     setObjectAttributes,
   ]);
 
-  const buildTableUsers = useCallback((objectArray: UserType[]) => (
+  const buildTableUsers = useCallback((
+    objectArray: UserType[],
+    enableClickRow?: boolean,
+  ) => (
     <Table
       columnFlex={[1, 1, 1]}
       columns={[
@@ -574,6 +594,15 @@ function PermissionDetail({
           uuid: 'Last name',
         },
       ]}
+      onClickRow={enableClickRow
+        ? (rowIndex: number) => {
+          const object = objectArray[rowIndex];
+          if (object && typeof window !== 'undefined') {
+            window.open(`/settings/workspace/users/${object?.id}`, '_blank').focus();
+          }
+        }
+        : null
+      }
       rows={objectArray?.map(({
         first_name: firstName,
         last_name: lastName,
@@ -603,12 +632,12 @@ function PermissionDetail({
     rolesAll,
   ]);
 
-  const rolesMemo = useMemo(() => buildTable(roles), [
+  const rolesMemo = useMemo(() => buildTable(roles, true), [
     buildTable,
     roles,
   ]);
 
-  const usersMemo = useMemo(() => buildTableUsers(users), [
+  const usersMemo = useMemo(() => buildTableUsers(users, true), [
     buildTableUsers,
     users,
   ]);

--- a/mage_ai/frontend/components/Roles/RoleDetail.tsx
+++ b/mage_ai/frontend/components/Roles/RoleDetail.tsx
@@ -41,6 +41,7 @@ import { displayNames } from '@utils/models/permission';
 import { indexBy, sortByKey } from '@utils/array';
 import { isEmptyObject, selectKeys } from '@utils/hash';
 import { onSuccess } from '@api/utils/response';
+import { pauseEvent } from '@utils/events';
 
 const ICON_SIZE = 2 * UNIT;
 
@@ -209,7 +210,9 @@ function RoleDetail({
     },
   );
 
-  const { data: dataPermissions } = api.permissions.list({}, {}, {
+  const { data: dataPermissions } = api.permissions.list({
+    _limit: 1000,
+  }, {}, {
     pauseFetch: !role,
   });
   const permissionsAll: PermissionType[] = useMemo(() => sortByKey(
@@ -287,9 +290,12 @@ function RoleDetail({
     hasUsers,
   ]);
 
-  const buildTable = useCallback((permissionsArray: PermissionType[]) => (
+  const buildTable = useCallback((
+    permissionsArray: PermissionType[],
+    enableClickRow?: boolean,
+  ) => (
     <Table
-      columnFlex={[null, 2, 1, 1, 6]}
+      columnFlex={[null, null, 2, 1, 1, 6]}
       columns={[
         {
           label: () => {
@@ -299,7 +305,9 @@ function RoleDetail({
               <Checkbox
                 checked={checked}
                 key="checkbox"
-                onClick={() => {
+                onClick={(e) => {
+                  pauseEvent(e);
+
                   if (checked) {
                     setObjectAttributes({
                       permissionsMapping: {},
@@ -316,6 +324,9 @@ function RoleDetail({
           uuid: 'actions',
         },
         {
+          uuid: 'ID',
+        },
+        {
           uuid: 'Entity',
         },
         {
@@ -329,6 +340,15 @@ function RoleDetail({
           uuid: 'Access',
         },
       ]}
+      onClickRow={enableClickRow
+        ? (rowIndex: number) => {
+          const object = permissionsArray[rowIndex];
+          if (object && typeof window !== 'undefined') {
+            window.open(`/settings/workspace/permissions/${object?.id}`, '_blank').focus();
+          }
+        }
+        : null
+      }
       rows={permissionsArray?.map((permission) => {
         const {
           access,
@@ -346,7 +366,9 @@ function RoleDetail({
           <Checkbox
             checked={checked}
             key="checkbox"
-            onClick={() => {
+            onClick={(e) => {
+              pauseEvent(e);
+
               const mapping = { ...permissionsMapping };
 
               if (checked) {
@@ -360,6 +382,9 @@ function RoleDetail({
               });
             }}
           />,
+          <Text default key="id" monospace>
+            {id}
+          </Text>,
           <Text key="entityName" monospace>
             {entityName || entity}
           </Text>,
@@ -398,7 +423,10 @@ function RoleDetail({
     setObjectAttributes,
   ]);
 
-  const buildTableUsers = useCallback((objectArray: UserType[]) => (
+  const buildTableUsers = useCallback((
+    objectArray: UserType[],
+    enableClickRow?: boolean,
+  ) => (
     <Table
       columnFlex={[null, 1, 1, 1]}
       columns={[
@@ -410,7 +438,9 @@ function RoleDetail({
               <Checkbox
                 checked={checked}
                 key="checkbox"
-                onClick={() => {
+                onClick={(e) => {
+                  pauseEvent(e);
+
                   if (checked) {
                     setObjectAttributes({
                       usersMapping: {},
@@ -436,6 +466,15 @@ function RoleDetail({
           uuid: 'Last name',
         },
       ]}
+      onClickRow={enableClickRow
+        ? (rowIndex: number) => {
+          const object = objectArray[rowIndex];
+          if (object && typeof window !== 'undefined') {
+            window.open(`/settings/workspace/users/${object?.id}`, '_blank').focus();
+          }
+        }
+        : null
+      }
       rows={objectArray?.map((object) => {
         const {
           first_name: firstName,
@@ -449,7 +488,9 @@ function RoleDetail({
           <Checkbox
             checked={checked}
             key="checkbox"
-            onClick={() => {
+            onClick={(e) => {
+              pauseEvent(e);
+
               const mapping = { ...usersMapping };
 
               if (checked) {
@@ -491,12 +532,12 @@ function RoleDetail({
     usersAll,
   ]);
 
-  const permissionsMemo = useMemo(() => buildTable(permissions), [
+  const permissionsMemo = useMemo(() => buildTable(permissions, true), [
     buildTable,
     permissions,
   ]);
 
-  const usersMemo = useMemo(() => buildTableUsers(users), [
+  const usersMemo = useMemo(() => buildTableUsers(users, true), [
     buildTableUsers,
     users,
   ]);

--- a/mage_ai/frontend/components/users/UserDetail.tsx
+++ b/mage_ai/frontend/components/users/UserDetail.tsx
@@ -42,6 +42,7 @@ import { getUser } from '@utils/session';
 import { indexBy, sortByKey } from '@utils/array';
 import { isEmptyObject, selectKeys } from '@utils/hash';
 import { onSuccess } from '@api/utils/response';
+import { pauseEvent } from '@utils/events';
 
 const ICON_SIZE = 2 * UNIT;
 
@@ -298,7 +299,10 @@ function UserDetail({
     setAfterHidden,
   ]);
 
-  const buildTable = useCallback((objectsArray: RoleType[]) => (
+  const buildTable = useCallback((
+    objectsArray: RoleType[],
+    enableClickRow?: boolean,
+  ) => (
     <Table
       columnFlex={[null, 1]}
       columns={[
@@ -310,7 +314,9 @@ function UserDetail({
               <Checkbox
                 checked={checked}
                 key="checkbox"
-                onClick={() => {
+                onClick={(e) => {
+                  pauseEvent(e);
+
                   if (checked) {
                     setObjectAttributes({
                       rolesMapping: {},
@@ -330,6 +336,15 @@ function UserDetail({
           uuid: 'Role',
         },
       ]}
+      onClickRow={enableClickRow
+        ? (rowIndex: number) => {
+          const object = objectsArray[rowIndex];
+          if (object && typeof window !== 'undefined') {
+            window.open(`/settings/workspace/roles/${object?.id}`, '_blank').focus();
+          }
+        }
+        : null
+      }
       rows={objectsArray?.map((object) => {
         const {
           name,
@@ -341,7 +356,9 @@ function UserDetail({
           <Checkbox
             checked={checked}
             key="checkbox"
-            onClick={() => {
+            onClick={(e) => {
+              pauseEvent(e);
+
               const mapping = { ...rolesMapping };
 
               if (checked) {
@@ -367,10 +384,16 @@ function UserDetail({
     setObjectAttributes,
   ]);
 
-  const buildTablePermissions = useCallback((objectArray: PermissionType[]) => (
+  const buildTablePermissions = useCallback((
+    objectArray: PermissionType[],
+    enableClickRow?: boolean,
+  ) => (
    <Table
-      columnFlex={[2, 1, 1, 6]}
+      columnFlex={[null, 2, 1, 1, 6]}
       columns={[
+        {
+          uuid: 'ID',
+        },
         {
           uuid: 'Entity',
         },
@@ -385,17 +408,30 @@ function UserDetail({
           uuid: 'Access',
         },
       ]}
+      onClickRow={enableClickRow
+        ? (rowIndex: number) => {
+          const object = objectArray[rowIndex];
+          if (object && typeof window !== 'undefined') {
+            window.open(`/settings/workspace/permissions/${object?.id}`, '_blank').focus();
+          }
+        }
+        : null
+      }
       rows={objectArray?.map(({
         access,
         entity,
         entity_id: entityID,
         entity_name: entityName,
         entity_type: entityType,
+        id,
       }) => {
         const accessDisplayNames = access ? displayNames(access) : [];
         const accessDisplayNamesCount = accessDisplayNames?.length || 0;
 
         return [
+          <Text default key="id" monospace>
+            {id}
+          </Text>,
           <Text key="entityName" monospace>
             {entityName || entity}
           </Text>,
@@ -436,12 +472,12 @@ function UserDetail({
     rolesAll,
   ]);
 
-  const rolesMemo = useMemo(() => buildTable(roles), [
+  const rolesMemo = useMemo(() => buildTable(roles, true), [
     buildTable,
     roles,
   ]);
 
-  const permissionsMemo = useMemo(() => buildTablePermissions(permissions), [
+  const permissionsMemo = useMemo(() => buildTablePermissions(permissions, true), [
     buildTablePermissions,
     permissions,
   ]);

--- a/mage_ai/tests/api/endpoints/test_variables.py
+++ b/mage_ai/tests/api/endpoints/test_variables.py
@@ -4,6 +4,7 @@ from mage_ai.data_preparation.variable_manager import (
     get_global_variables,
     set_global_variable,
 )
+from mage_ai.shared.utils import clean_name
 from mage_ai.tests.api.endpoints.mixins import (
     BaseAPIEndpointTest,
     build_create_endpoint_tests,
@@ -16,8 +17,8 @@ from mage_ai.tests.api.endpoints.mixins import (
 class VariableAPIEndpointTest(BaseAPIEndpointTest):
     def setUp(self):
         super().setUp()
-        self.variable_uuid = self.faker.unique.name().replace(' ', '_')
-        self.variable_value = self.faker.unique.name().replace(' ', '_')
+        self.variable_uuid = clean_name(self.faker.unique.name())
+        self.variable_value = clean_name(self.faker.unique.name())
         set_global_variable(
             self.pipeline.uuid,
             self.variable_uuid,
@@ -70,8 +71,8 @@ build_create_endpoint_tests(
     resource_parent='pipelines',
     get_resource_parent_id=lambda self: self.pipeline.uuid,
     build_payload=lambda self: dict(
-        name=self.faker.unique.name().replace(' ', '_'),
-        value=self.faker.unique.name().replace(' ', '_'),
+        name=clean_name(self.faker.unique.name()),
+        value=clean_name(self.faker.unique.name()),
     ),
     assert_before_create_count=lambda self: len(
         get_global_variables(self.pipeline.uuid).values(),
@@ -90,7 +91,7 @@ build_update_endpoint_tests(
     get_resource_parent_id=lambda self: self.pipeline.uuid,
     build_payload=lambda self: dict(
         name=self.variable_uuid,
-        value=self.faker.unique.name().replace(' ', '_'),
+        value=clean_name(self.faker.unique.name()),
     ),
     get_model_before_update=lambda self: get_global_variable(
         self.pipeline.uuid,

--- a/mage_ai/tests/api/policies/permissions/mixins.py
+++ b/mage_ai/tests/api/policies/permissions/mixins.py
@@ -1,0 +1,43 @@
+from typing import Dict, List, Union
+
+from mage_ai.api.policies.BasePolicy import BasePolicy
+from mage_ai.api.resources.GenericResource import GenericResource
+from mage_ai.authentication.permissions.constants import EntityName, PermissionAccess
+from mage_ai.orchestration.db.models.oauth import Permission, RolePermission, User
+
+ENTITY_NAME = EntityName.Pipeline
+
+
+class PermissionsMixin:
+    def build_policy(
+        self,
+        entity_name: EntityName = None,
+        current_user=None,
+    ):
+        class CustomTestWithPermissionsResource(GenericResource):
+            model_class = User
+
+        class CustomTestWithPermissionsPolicy(BasePolicy):
+            @classmethod
+            def entity_name_uuid(self):
+                return entity_name or ENTITY_NAME
+
+        model = dict(id=(current_user or self.user).id)
+        resource = CustomTestWithPermissionsResource(model, self.user)
+
+        return CustomTestWithPermissionsPolicy(resource, self.user)
+
+    def create_permission(
+        self,
+        accesses: List[PermissionAccess],
+        entity_name: EntityName = None,
+        entity_id: Union[int, str] = None,
+        options: Dict = None,
+    ):
+        permission = Permission.create(
+            access=Permission.add_accesses(accesses),
+            entity_name=entity_name or ENTITY_NAME,
+            entity_id=entity_id,
+            options=options,
+        )
+        RolePermission.create(permission_id=permission.id, role_id=self.role.id)

--- a/mage_ai/tests/api/policies/permissions/test_base_policy_with_permissions.py
+++ b/mage_ai/tests/api/policies/permissions/test_base_policy_with_permissions.py
@@ -37,7 +37,7 @@ class TestSuite(str, Enum):
 class BasePolicyWithPermissionsTest(BaseApiTestCase, BootstrapMixin, PermissionsMixin):
     def setUp(self):
         super().setUp()
-        self.role = Role.create(name=self.faker.unique.name())
+        self.role = Role.create(name=secrets.token_urlsafe())
         UserRole.create(role_id=self.role.id, user_id=self.user.id)
 
 

--- a/mage_ai/tests/api/policies/permissions/test_base_policy_with_permissions.py
+++ b/mage_ai/tests/api/policies/permissions/test_base_policy_with_permissions.py
@@ -1,6 +1,6 @@
 import secrets
 from enum import Enum
-from typing import Dict, List
+from typing import Any, Callable, Dict, List, Union
 from unittest.mock import patch
 
 from mage_ai.api.constants import (
@@ -12,26 +12,17 @@ from mage_ai.api.constants import (
 )
 from mage_ai.api.errors import ApiError
 from mage_ai.api.operations.constants import OperationType
-from mage_ai.api.policies.BasePolicy import BasePolicy
-from mage_ai.api.resources.GenericResource import GenericResource
 from mage_ai.authentication.permissions.constants import (
     EntityName,
     PermissionAccess,
     PermissionCondition,
 )
-from mage_ai.orchestration.db.models.oauth import (
-    Permission,
-    Role,
-    RolePermission,
-    User,
-    UserRole,
-)
+from mage_ai.orchestration.db.models.oauth import Permission, Role, User, UserRole
 from mage_ai.shared.array import find
 from mage_ai.shared.hash import index_by, merge_dict
 from mage_ai.tests.api.mixins import BootstrapMixin
 from mage_ai.tests.api.operations.test_base import BaseApiTestCase
-
-ENTITY_NAME = EntityName.Pipeline
+from mage_ai.tests.api.policies.permissions.mixins import PermissionsMixin
 
 
 class TestSuite(str, Enum):
@@ -43,45 +34,11 @@ class TestSuite(str, Enum):
     UNAUTHORIZED_WITH_NO_PERMISSIONS = 'UNAUTHORIZED_WITH_NO_PERMISSIONS'
 
 
-@patch('mage_ai.api.policies.BasePolicy.REQUIRE_USER_AUTHENTICATION', 1)
-@patch('mage_ai.api.policies.BasePolicy.REQUIRE_USER_PERMISSIONS', 1)
-class BasePolicyWithPermissionsTest(BaseApiTestCase, BootstrapMixin):
-    def bootstrap(self):
-        super().bootstrap()
-
-        self.role = Role.create(name=secrets.token_urlsafe())
+class BasePolicyWithPermissionsTest(BaseApiTestCase, BootstrapMixin, PermissionsMixin):
+    def setUp(self):
+        super().setUp()
+        self.role = Role.create(name=self.faker.unique.name())
         UserRole.create(role_id=self.role.id, user_id=self.user.id)
-
-    def build_policy(
-        self,
-        entity_name: EntityName = None,
-        current_user=None,
-    ):
-        class CustomTestWithPermissionsResource(GenericResource):
-            model_class = User
-
-        class CustomTestWithPermissionsPolicy(BasePolicy):
-            @classmethod
-            def entity_name_uuid(self):
-                return entity_name or ENTITY_NAME
-
-        model = dict(id=(current_user or self.user).id)
-        resource = CustomTestWithPermissionsResource(model, self.user)
-
-        return CustomTestWithPermissionsPolicy(resource, self.user)
-
-    def create_permission(
-        self,
-        accesses: List[PermissionAccess],
-        entity_name: EntityName = None,
-        options: Dict = None,
-    ):
-        permission = Permission.create(
-            access=Permission.add_accesses(accesses),
-            entity_name=entity_name or ENTITY_NAME,
-            options=options,
-        )
-        RolePermission.create(permission_id=permission.id, role_id=self.role.id)
 
 
 operations = [
@@ -109,17 +66,19 @@ for entity_name in [
             access,
             operation_type,
             current_user=None,
+            entity_name=entity_name,
+            get_entity_id: Callable[[Any], Union[int, str]] = None,
             permission_options: Dict = None,
             test_suites: List[TestSuite] = None,
-            entity_name=entity_name,
         ):
             @patch('mage_ai.api.policies.BasePolicy.REQUIRE_USER_AUTHENTICATION', 1)
             @patch('mage_ai.api.policies.BasePolicy.REQUIRE_USER_PERMISSIONS', 1)
             async def _test_action(
                 self,
                 access=access,
-                entity_name=entity_name,
                 current_user=current_user,
+                entity_name=entity_name,
+                get_entity_id=get_entity_id,
                 operation_type=operation_type,
                 permission_options=permission_options,
                 test_suites=test_suites,
@@ -143,6 +102,7 @@ for entity_name in [
                 self.create_permission(
                     [access],
                     entity_name=entity_name,
+                    entity_id=get_entity_id(self) if get_entity_id else None,
                     options=permission_options,
                 )
 
@@ -320,6 +280,36 @@ for entity_name in [
                         test_suites=test_suites,
                     ),
                 )
+
+        if operation in [
+            OperationType.DELETE,
+            OperationType.DETAIL,
+            OperationType.UPDATE,
+        ]:
+            method_name = f'test_authorize_action_{operation}_for_{entity_name}_and_entity_id'
+            method_name = f'{method_name}_with_access_{operation_access}'
+            setattr(
+                BasePolicyWithPermissionsTest,
+                method_name,
+                build_test_action(
+                    access=operation_access,
+                    get_entity_id=lambda self: self.user.id,
+                    operation_type=operation,
+                ),
+            )
+
+            method_name = f'test_authorize_action_{operation}_for_{entity_name}_and_entity_id'
+            method_name = f'{method_name}_with_access_{operation_access}_unauthorized'
+            setattr(
+                BasePolicyWithPermissionsTest,
+                method_name,
+                build_test_action(
+                    access=operation_access,
+                    get_entity_id=lambda self: f'not_{self.user.id}',
+                    operation_type=operation,
+                    test_suites=[TestSuite.INVERSE],
+                ),
+            )
 
         for access_all in [
             PermissionAccess.ALL,
@@ -724,7 +714,6 @@ for entity_name in [
                 return _test_attribute
 
             attribute_uuid = 'id'
-
             attributes = [attribute_uuid]
 
             options = {}

--- a/mage_ai/tests/api/policies/permissions/test_permissions_with_entity_id.py
+++ b/mage_ai/tests/api/policies/permissions/test_permissions_with_entity_id.py
@@ -1,0 +1,15 @@
+from unittest.mock import patch
+
+from mage_ai.tests.api.mixins import BootstrapMixin
+from mage_ai.tests.api.operations.test_base import BaseApiTestCase
+from mage_ai.tests.api.policies.permissions.mixins import PermissionsMixin
+
+
+@patch('mage_ai.api.policies.BasePolicy.REQUIRE_USER_AUTHENTICATION', 1)
+@patch('mage_ai.api.policies.BasePolicy.REQUIRE_USER_PERMISSIONS', 1)
+class PermissionsWithEntityIDTest(BaseApiTestCase, BootstrapMixin, PermissionsMixin):
+    def test_authorized(self):
+        pass
+
+    def test_unauthorized(self):
+        pass


### PR DESCRIPTION
# Description
If a permission has an entity ID, then use the permissions only on that entity.


# How Has This Been Tested?
- [x] Added unit test


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
