### PR TITLE
[xy] Fix loading data integration sources.

### DIFF
--- a/mage_ai/data_preparation/templates/data_integrations/utils.py
+++ b/mage_ai/data_preparation/templates/data_integrations/utils.py
@@ -113,7 +113,6 @@ def render_template(
             config_string_parts.append(f'  {key}: {value_use}')
         config_string = '\n'.join(config_string_parts)
 
-
     template_path_with_extension = '.'.join([
         config['template_path'],
         BLOCK_LANGUAGE_TO_FILE_EXTENSION[language],

--- a/mage_ai/shared/strings.py
+++ b/mage_ai/shared/strings.py
@@ -25,7 +25,7 @@ def is_number(s) -> bool:
     try:
         float(s)
         return True
-    except ValueError:
+    except (ValueError, TypeError):
         return False
 
 

--- a/mage_integrations/mage_integrations/sources/twitter_ads/__init__.py
+++ b/mage_integrations/mage_integrations/sources/twitter_ads/__init__.py
@@ -1,15 +1,19 @@
+from typing import List
+
+from singer import catalog as catalog_singer
+
 from mage_integrations.sources.base import Source, main
 from mage_integrations.sources.catalog import Catalog
 from mage_integrations.sources.twitter_ads.tap_twitter_ads import (
-    TwitterAds as TwitterAdsStream,
     build_client,
     check_credentials,
     do_discover,
 )
-from mage_integrations.sources.twitter_ads.tap_twitter_ads.sync import sync as do_sync
 from mage_integrations.sources.twitter_ads.tap_twitter_ads.streams import STREAMS
-from singer import catalog as catalog_singer
-from typing import List
+from mage_integrations.sources.twitter_ads.tap_twitter_ads.streams import (
+    TwitterAds as TwitterAdsStream,
+)
+from mage_integrations.sources.twitter_ads.tap_twitter_ads.sync import sync as do_sync
 
 
 class TwitterAds(Source):


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
1. Couchbase (python, yaml) - 'NoneType' object has no attribute 'items'
2. Datadog (python, yaml) - float() argument must be a string or a real number, not 'dict'
3. Google ads (python, yaml) - float() argument must be a string or a real number, not 'list'
4. Sftp (python, yaml) - float() argument must be a string or a real number, not 'list'
5. Twitter ads (python, yaml) - 'NoneType' object has no attribute 'items'

Except for Couchbase (libssl issue), other sources can be correctly loaded with the fix.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Datadog
- [x] Google ads
- [x] Sftp
- [x] Twitter ads


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
