### PR TITLE
Improved Slack notification design

### DIFF
--- a/mage_ai/orchestration/notification/sender.py
+++ b/mage_ai/orchestration/notification/sender.py
@@ -58,7 +58,7 @@ class NotificationSender:
         if summary is None:
             return
         if self.config.slack_config is not None and self.config.slack_config.is_valid:
-            send_slack_message(self.config.slack_config, details or summary)
+            send_slack_message(self.config.slack_config, details or summary, title)
 
         if self.config.teams_config is not None and self.config.teams_config.is_valid:
             send_teams_message(self.config.teams_config, summary)

--- a/mage_ai/services/slack/slack.py
+++ b/mage_ai/services/slack/slack.py
@@ -1,10 +1,16 @@
-from mage_ai.services.slack.config import SlackConfig
 import json
+
 import requests
+
+from mage_ai.services.slack.config import SlackConfig
 
 
 def send_slack_message(config: SlackConfig, message: str) -> None:
+    payload = {
+        "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": message}}]
+    }
+
     requests.post(
         config.webhook_url,
-        json.dumps(dict(text=message)),
+        json.dumps(payload),
     )

--- a/mage_ai/services/slack/slack.py
+++ b/mage_ai/services/slack/slack.py
@@ -13,7 +13,7 @@ def send_slack_message(config: SlackConfig, message: str, title: str = None) -> 
                 "type": "header",
                 "text": {
                     "type": "plain_text",
-                    "text": title if title else ":x:  Failed to execute pipeline",
+                    "text": title if title else "Mage Notification",
                 },
             },
             {"type": "divider"},

--- a/mage_ai/services/slack/slack.py
+++ b/mage_ai/services/slack/slack.py
@@ -5,9 +5,20 @@ import requests
 from mage_ai.services.slack.config import SlackConfig
 
 
-def send_slack_message(config: SlackConfig, message: str) -> None:
+def send_slack_message(config: SlackConfig, message: str, title: str = None) -> None:
+    message = message.replace("\\n", "\n")
     payload = {
-        "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": message}}]
+        "blocks": [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": title if title else ":x:  Failed to execute pipeline",
+                },
+            },
+            {"type": "divider"},
+            {"type": "section", "text": {"type": "mrkdwn", "text": message}},
+        ]
     }
 
     requests.post(

--- a/mage_ai/tests/orchestration/notification/test_sender.py
+++ b/mage_ai/tests/orchestration/notification/test_sender.py
@@ -62,9 +62,11 @@ class NotificationSenderTests(DBTestCase):
             f'Open http://localhost:6789/pipelines/test_pipeline/runs/'
             f'{pipeline_run.id} to check pipeline run results and logs.'
         )
+        title = None
         mock_send_slack.assert_called_once_with(
             notification_config.slack_config,
             message,
+            title
         )
 
     @patch('mage_ai.orchestration.notification.sender.send_slack_message')
@@ -85,9 +87,11 @@ class NotificationSenderTests(DBTestCase):
             f'{pipeline_run.id}. Pipeline uuid: test_pipeline. '
             f'Trigger name: {pipeline_run.pipeline_schedule.name}.'
         )
+        title = None
         mock_send_slack.assert_called_once_with(
             notification_config.slack_config,
             message,
+            title
         )
 
     @patch('mage_ai.orchestration.notification.sender.send_teams_message')

--- a/mage_ai/tests/orchestration/notification/test_sender.py
+++ b/mage_ai/tests/orchestration/notification/test_sender.py
@@ -62,7 +62,7 @@ class NotificationSenderTests(DBTestCase):
             f'Open http://localhost:6789/pipelines/test_pipeline/runs/'
             f'{pipeline_run.id} to check pipeline run results and logs.'
         )
-        title = None
+        title = 'Failed to run Mage pipeline test_pipeline'
         mock_send_slack.assert_called_once_with(
             notification_config.slack_config,
             message,
@@ -87,7 +87,7 @@ class NotificationSenderTests(DBTestCase):
             f'{pipeline_run.id}. Pipeline uuid: test_pipeline. '
             f'Trigger name: {pipeline_run.pipeline_schedule.name}.'
         )
-        title = None
+        title = 'Failed to run Mage pipeline test_pipeline'
         mock_send_slack.assert_called_once_with(
             notification_config.slack_config,
             message,


### PR DESCRIPTION
# Description

This PR improves the Slack Notification layout using Slack API Blocks.


# How Has This Been Tested?
I've created a standard "example" project (mage init + mage start) with a Slack connection.

I also supplied an example formated Slack message to the project metadata, as follows:
```yaml
notification_config:
  alert_on:
    - trigger_failure
    - trigger_passed_sla
  message_templates:
    failure:
      title: ":x:  Failed to execute pipeline {pipeline_uuid}"
      details: >
        *Execution time*: {execution_time}\n
        *Pipeline URL*: {pipeline_run_url}\n
        *Trigger name*: {pipeline_schedule_name}\n
  slack_config:
    webhook_url: "{{ env_var('SLACK_WEBHOOK_URL') }}"
```

Then I created a pipeline that raises a `ValueError` on purpose to trigger the Slack notification on failure.

The Slack notification output:
<img width="485" alt="image" src="https://github.com/mage-ai/mage-ai/assets/32077629/49dca25b-7f54-4f97-a81f-a243b4c8aa51">

Note: I've added `title` as a variable to be used in Slack notifications, similar to emails.


cc: @wangxiaoyou1993 
