### PR TITLE
[xy] Fix adding dbt block with mage_secret_var.

### DIFF
--- a/mage_ai/data_preparation/models/block/dbt/block_sql.py
+++ b/mage_ai/data_preparation/models/block/dbt/block_sql.py
@@ -165,17 +165,18 @@ class DBTBlockSQL(DBTBlock):
             List[DBTBlockSQL]: THe upstream dbt graph as DBTBlocksSQL objects
         """
         # Get upstream nodes via dbt list
-        args = [
-            'list',
-            '--project-dir', self.project_path,
-            '--profiles-dir', self.project_path,
-            '--select', '+' + Path(self.configuration.get('file_path')).stem,
-            '--output', 'json',
-            '--output-keys', 'unique_id original_file_path depends_on',
-            '--resource-type', 'model',
-            '--resource-type', 'snapshot'
-        ]
-        res, _success = DBTCli(args).invoke()
+        with Profiles(self.project_path, self.pipeline.variables) as profiles:
+            args = [
+                'list',
+                '--project-dir', self.project_path,
+                '--profiles-dir', str(profiles.profiles_dir),
+                '--select', '+' + Path(self.configuration.get('file_path')).stem,
+                '--output', 'json',
+                '--output-keys', 'unique_id original_file_path depends_on',
+                '--resource-type', 'model',
+                '--resource-type', 'snapshot'
+            ]
+            res, _success = DBTCli(args).invoke()
         if res:
             nodes = [simplejson.loads(node) for node in res]
         else:

--- a/mage_ai/data_preparation/models/block/dbt/dbt_cli.py
+++ b/mage_ai/data_preparation/models/block/dbt/dbt_cli.py
@@ -106,11 +106,14 @@ class DBTCli:
         EVENT_MANAGER.loggers = []
         EVENT_MANAGER.add_logger(dbt_logger)
 
-        with adapter_management():
-            task = self.__parsed_args.cls.from_args(args=self.__parsed_args)
-            self.__result = task.run()
-            self.__success = task.interpret_results(self.__result)
-        os.chdir(self.__cwd)
+        try:
+            with adapter_management():
+                task = self.__parsed_args.cls.from_args(args=self.__parsed_args)
+                self.__result = task.run()
+                self.__success = task.interpret_results(self.__result)
+        finally:
+            # Always change back the directory
+            os.chdir(self.__cwd)
         return self.__result, self.__success
 
     def to_pandas(self) -> Tuple[Optional[pd.DataFrame], Any, bool]:

--- a/mage_ai/data_preparation/shared/secrets.py
+++ b/mage_ai/data_preparation/shared/secrets.py
@@ -29,10 +29,12 @@ def get_secrets_dir(
     Returns:
         str: /path/to/secrets/directory
     """
-    secrets_dir = os.path.abspath(os.path.join(get_data_dir(), DEFAULT_MAGE_SECRETS_DIR))
+    secrets_dir = os.path.join(get_data_dir(), DEFAULT_MAGE_SECRETS_DIR)
     # Use expanduser path if the secrets dir hasn't been created yet
     if not os.path.exists(secrets_dir):
         secrets_dir = os.path.expanduser(secrets_dir)
+
+    secrets_dir = os.path.abspath(secrets_dir)
 
     if entity == Entity.GLOBAL:
         return secrets_dir


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix adding dbt block with mage_secret_var.

When using syntax `{{mage_secret_var('secret_var_name')}}` in the profiles.yml, Mage throws exception on adding new dbt block.


> Hi
> We recently attempted to upgrade from 0.9.8 to 0.9.34 (big gap as there was an connection string issue preventing us updating) and we now get an error when attempting to add DBT models to a pipeline: Runtime Error Could not run dbt existing DBT pipelines continue to run. From the stack trace the error is:
> dbt.exceptions.DbtProfileError: Runtime Error
>   Compilation Error
>     Could not render {{mage_secret_var('insights-db-database')}}: 'mage_secret_var' is undefined
> mage_secret_var is working when pipelines are executed, it's only adding a new DBT block that is causing this.
> 

This PR fixes this issue by interpolating the profiles.yaml file before running the dbt list command.

This PR also makes sure the path is changed to the original directory path after running dbt command. Otherwise, there'll be issue of finding the secret key path.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested by using `{{mage_secret_var('db_name')}` in profiles.yaml and adding a new dbt block locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
