### PR TITLE
[xy] Fix botocore library pickle error in pipeline scheduler.

### DIFF
--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -16,7 +16,6 @@ from mage_ai.data_integrations.utils.scheduler import (
 from mage_ai.data_preparation.executors.executor_factory import ExecutorFactory
 from mage_ai.data_preparation.logging.logger import DictLogger
 from mage_ai.data_preparation.logging.logger_manager_factory import LoggerManagerFactory
-from mage_ai.data_preparation.models.block import Block
 from mage_ai.data_preparation.models.block.utils import (
     create_block_runs_from_dynamic_block,
     is_dynamic_block,
@@ -693,8 +692,6 @@ class PipelineScheduler:
                 _start_date=start_date,
             )
 
-            data_loader_block = self.pipeline.data_loader
-            data_exporter_block = self.pipeline.data_exporter
             executable_block_runs = [b.id for b in block_runs_to_schedule]
 
             self.logger.info(
@@ -714,8 +711,6 @@ class PipelineScheduler:
                     set(executable_block_runs),
                     tags,
                     runtime_arguments,
-                    data_loader_block,
-                    data_exporter_block,
                     self.pipeline_run.id,
                     variables,
                 )
@@ -733,8 +728,6 @@ class PipelineScheduler:
                 set(executable_block_runs),
                 tags,
                 runtime_arguments,
-                data_loader_block,
-                data_exporter_block,
                 self.pipeline_run.id,
                 variables,
             )
@@ -832,8 +825,6 @@ def run_integration_stream(
     executable_block_runs: Set[int],
     tags: Dict,
     runtime_arguments: Dict,
-    data_loader_block: Block,
-    data_exporter_block: Block,
     pipeline_run_id: int,
     variables: Dict,
 ):
@@ -849,13 +840,15 @@ def run_integration_stream(
         executable_block_runs (Set[int]): A set of executable block run IDs.
         tags (Dict): A dictionary of tags for logging.
         runtime_arguments (Dict): A dictionary of runtime arguments.
-        data_loader_block (Block): The data loader block.
-        data_exporter_block (Block): The data exporter block.
         pipeline_run_id (int): The ID of the pipeline run.
         variables (Dict): A dictionary of variables.
     """
     pipeline_run = PipelineRun.query.get(pipeline_run_id)
     pipeline_scheduler = PipelineScheduler(pipeline_run)
+    pipeline = pipeline_scheduler.pipeline
+    data_loader_block = pipeline.data_loader
+    data_exporter_block = pipeline.data_exporter
+
     tap_stream_id = stream['tap_stream_id']
     destination_table = stream.get('destination_table', tap_stream_id)
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

When setting the `remote_variables_dir` to a s3 bucket, the pipeline scheduler fails to schedule data integration pipeline due to the error below
<img width="692" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/1d5f86d1-ae5e-4f48-8cb9-de7d26da5141">

This PR excludes the block objects from the process args so that they don't need to be pickled when enqueueing the job.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested setting `remote_variables_dir` to a s3 bucket and schedule the data integration pipeline locally. The blocks can be scheduled, enqueued, and executed successfully after the fix.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
