### PR TITLE
[xy] Allow specifying credentials info in bigquery source and dest.

### DIFF
--- a/mage_integrations/mage_integrations/connections/bigquery/__init__.py
+++ b/mage_integrations/mage_integrations/connections/bigquery/__init__.py
@@ -20,7 +20,12 @@ class BigQuery(Connection):
         self.path_to_credentials_json_file = path_to_credentials_json_file
         self.location = location
 
-        if self.credentials_info is None and self.path_to_credentials_json_file is not None:
+        if self.credentials_info is not None:
+            if isinstance(self.credentials_info, dict):
+                self.credentials_info = service_account.Credentials.from_service_account_info(
+                    self.credentials_info,
+                )
+        elif self.path_to_credentials_json_file is not None:
             self.credentials_info = service_account.Credentials.from_service_account_file(
                 self.path_to_credentials_json_file,
             )

--- a/mage_integrations/mage_integrations/destinations/bigquery/README.md
+++ b/mage_integrations/mage_integrations/destinations/bigquery/README.md
@@ -14,6 +14,22 @@ You must enter the following credentials when configuring this destination:
 | `location` | (Optional) BigQuery location of dataset, the BigQuery client will infer a location by default. | us-west1
 | `disable_update_column_types` | If `false` and an existing column has a different column type than the schema, the existing column type will be altered to match the column type in the schema. | `false` (default value) |
 | `use_batch_load` | (In beta) Instruct the BigQuery destination to use BigQuery load jobs instead of the query API. If you encounter any issues with batch loading, let us know in the [community slack](https://www.mage.ai/chat). | `true` (default value) |
+| `credential_info` | An alternative to specify the Google service account credentials. | Structure is shown below |
+
+
+`credential_info` structure:
+```yaml
+auth_provider_x509_cert_url: str
+auth_uri: str
+client_email: str
+client_id: str
+client_x509_cert_url: str
+private_key: str
+private_key_id: str
+project_id: str
+token_uri: str
+type: str
+```
 
 ### Optional Configs
 

--- a/mage_integrations/mage_integrations/destinations/bigquery/README.md
+++ b/mage_integrations/mage_integrations/destinations/bigquery/README.md
@@ -14,10 +14,10 @@ You must enter the following credentials when configuring this destination:
 | `location` | (Optional) BigQuery location of dataset, the BigQuery client will infer a location by default. | us-west1
 | `disable_update_column_types` | If `false` and an existing column has a different column type than the schema, the existing column type will be altered to match the column type in the schema. | `false` (default value) |
 | `use_batch_load` | (In beta) Instruct the BigQuery destination to use BigQuery load jobs instead of the query API. If you encounter any issues with batch loading, let us know in the [community slack](https://www.mage.ai/chat). | `true` (default value) |
-| `credential_info` | An alternative to specify the Google service account credentials. | Structure is shown below |
+| `credentials_info` | An alternative to specify the Google service account credentials. | Structure is shown below |
 
 
-`credential_info` structure:
+`credentials_info` structure:
 ```yaml
 auth_provider_x509_cert_url: str
 auth_uri: str

--- a/mage_integrations/mage_integrations/destinations/bigquery/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/bigquery/__init__.py
@@ -70,6 +70,7 @@ class BigQuery(Destination):
 
     def build_connection(self) -> BigQueryConnection:
         return BigQueryConnection(
+            credentials_info=self.config.get('credentials_info'),
             path_to_credentials_json_file=self.config.get('path_to_credentials_json_file'),
             location=self.config.get('location'),
         )

--- a/mage_integrations/mage_integrations/sources/bigquery/README.md
+++ b/mage_integrations/mage_integrations/sources/bigquery/README.md
@@ -10,10 +10,10 @@ You must enter the following credentials when configuring this source:
 | --- | --- | --- |
 | `path_to_credentials_json_file` | Google service account credential json file. If Mage is running on GCP, you can leave this value null and then Mage will use the instance service account to authenticate. | `/path/to/service_account_credentials.json` |
 | `dataset` | BigQuery dataset you want to read data from. | `example_dataset` |
-| `credential_info` | An alternative to specify the Google service account credentials. | Structure is shown below | 
+| `credentials_info` | An alternative to specify the Google service account credentials. | Structure is shown below | 
 
 
-`credential_info` structure:
+`credentials_info` structure:
 ```yaml
 auth_provider_x509_cert_url: str
 auth_uri: str

--- a/mage_integrations/mage_integrations/sources/bigquery/README.md
+++ b/mage_integrations/mage_integrations/sources/bigquery/README.md
@@ -10,6 +10,22 @@ You must enter the following credentials when configuring this source:
 | --- | --- | --- |
 | `path_to_credentials_json_file` | Google service account credential json file. If Mage is running on GCP, you can leave this value null and then Mage will use the instance service account to authenticate. | `/path/to/service_account_credentials.json` |
 | `dataset` | BigQuery dataset you want to read data from. | `example_dataset` |
+| `credential_info` | An alternative to specify the Google service account credentials. | Structure is shown below | 
+
+
+`credential_info` structure:
+```yaml
+auth_provider_x509_cert_url: str
+auth_uri: str
+client_email: str
+client_id: str
+client_x509_cert_url: str
+private_key: str
+private_key_id: str
+project_id: str
+token_uri: str
+type: str
+```
 
 ### Optional Configs
 

--- a/mage_integrations/mage_integrations/sources/bigquery/__init__.py
+++ b/mage_integrations/mage_integrations/sources/bigquery/__init__.py
@@ -14,6 +14,7 @@ class BigQuery(Source):
 
     def build_connection(self) -> BigQueryConnection:
         return BigQueryConnection(
+            credentials_info=self.config.get('credentials_info'),
             path_to_credentials_json_file=self.config.get('path_to_credentials_json_file'),
         )
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Allow specifying credentials info in bigquery source and dest.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with BigQuery source and BigQuery destination locally

Example source config
```
credentials_info:
  type: service_account
  project_id: project-id
  private_key_id: 123456789abcdefg
  private_key: |
    -----BEGIN PRIVATE KEY-----
    keydata
    -----END PRIVATE KEY-----
  client_email: test@projet-id.iam.gserviceaccount.com
  client_id: "123456789"
  auth_uri: https://accounts.google.com/o/oauth2/auth
  token_uri: https://oauth2.googleapis.com/token
  auth_provider_x509_cert_url: https://www.googleapis.com/oauth2/v1/certs
  client_x509_cert_ur": url
dataset: test_dataset
```

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
