### PR TITLE
Bugfix: Remove lower-casing from postgres unique-constraints

### DIFF
--- a/mage_ai/io/base.py
+++ b/mage_ai/io/base.py
@@ -286,8 +286,10 @@ class BaseSQLDatabase(BaseIO):
         """
         return query_string.strip(' \n\t')
 
-    def _clean_column_name(self, column_name: str, allow_reserved_words: bool = False) -> str:
-        col_new = re.sub(r'\W', '_', column_name.lower())
+    def _clean_column_name(self, column_name: str, allow_reserved_words: bool = False, perform_lower_casing: bool = True) -> str:
+        if perform_lower_casing:
+            column_name = column_name.lower()
+        col_new = re.sub(r'\W', '_', column_name)
         if not allow_reserved_words and col_new.upper() in SQL_RESERVED_WORDS:
             col_new = f'_{col_new}'
         return col_new

--- a/mage_ai/io/base.py
+++ b/mage_ai/io/base.py
@@ -286,7 +286,12 @@ class BaseSQLDatabase(BaseIO):
         """
         return query_string.strip(' \n\t')
 
-    def _clean_column_name(self, column_name: str, allow_reserved_words: bool = False, perform_lower_casing: bool = True) -> str:
+    def _clean_column_name(
+        self,
+        column_name: str,
+        allow_reserved_words: bool = False,
+        perform_lower_casing: bool = True
+    ) -> str:
         if perform_lower_casing:
             column_name = column_name.lower()
         col_new = re.sub(r'\W', '_', column_name)

--- a/mage_ai/io/base.py
+++ b/mage_ai/io/base.py
@@ -290,9 +290,9 @@ class BaseSQLDatabase(BaseIO):
         self,
         column_name: str,
         allow_reserved_words: bool = False,
-        perform_lower_casing: bool = True
+        lower_casing: bool = True
     ) -> str:
-        if perform_lower_casing:
+        if lower_casing:
             column_name = column_name.lower()
         col_new = re.sub(r'\W', '_', column_name)
         if not allow_reserved_words and col_new.upper() in SQL_RESERVED_WORDS:

--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -332,10 +332,16 @@ class Postgres(BaseSQL):
             ]
 
             unique_constraints = \
-                [f'"{self._clean_column_name(col, allow_reserved_words=allow_reserved_words, perform_lower_casing=False)}"'
+                [f'"{
+                    self._clean_column_name(
+                        col, allow_reserved_words=allow_reserved_words, perform_lower_casing=False)
+                }"'
                  for col in unique_constraints]
             columns_cleaned = \
-                [f'"{self._clean_column_name(col, allow_reserved_words=allow_reserved_words, perform_lower_casing=False)}"'
+                [f'"{
+                    self._clean_column_name(
+                        col, allow_reserved_words=allow_reserved_words, perform_lower_casing=False)
+                }"'
                  for col in columns]
 
             commands.append(f"ON CONFLICT ({', '.join(unique_constraints)})")

--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -20,6 +20,7 @@ class Postgres(BaseSQL):
     """
     Handles data transfer between a PostgreSQL database and the Mage app.
     """
+
     def __init__(
         self,
         dbname: str,
@@ -331,10 +332,10 @@ class Postgres(BaseSQL):
             ]
 
             unique_constraints = \
-                [f'"{self._clean_column_name(col, allow_reserved_words=allow_reserved_words)}"'
+                [f'"{self._clean_column_name(col, allow_reserved_words=allow_reserved_words, perform_lower_casing=False)}"'
                  for col in unique_constraints]
             columns_cleaned = \
-                [f'"{self._clean_column_name(col, allow_reserved_words=allow_reserved_words)}"'
+                [f'"{self._clean_column_name(col, allow_reserved_words=allow_reserved_words, perform_lower_casing=False)}"'
                  for col in columns]
 
             commands.append(f"ON CONFLICT ({', '.join(unique_constraints)})")

--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -332,16 +332,10 @@ class Postgres(BaseSQL):
             ]
 
             unique_constraints = \
-                [f'"{
-                    self._clean_column_name(
-                        col, allow_reserved_words=allow_reserved_words, perform_lower_casing=False)
-                }"'
+                [f'"{self._clean_column_name(col, allow_reserved_words, lower_casing=False)}"'
                  for col in unique_constraints]
             columns_cleaned = \
-                [f'"{
-                    self._clean_column_name(
-                        col, allow_reserved_words=allow_reserved_words, perform_lower_casing=False)
-                }"'
+                [f'"{self._clean_column_name(col, allow_reserved_words, lower_casing=False)}"'
                  for col in columns]
 
             commands.append(f"ON CONFLICT ({', '.join(unique_constraints)})")


### PR DESCRIPTION
# Description
Since lower-casing isn't performed on the columns inserted, this fix will ensure they both aren't changed. Then, it will be up to the user of the function to completely clean any wrong columns.

_Perhaps_ it would be appropriate to entirely align the use of `_clean_column_name` across the function, but this should work.

# How Has This Been Tested?
```py
from mage_ai.io.postgres import Postgres
c = Postgres()

# Old behaviour
print(c._clean_column_name('Domain'))  # '_domain'
print(c._clean_column_name('Domain', allow_reserved_words=True))  # 'domain'

# Added behaviour
print(c._clean_column_name('Domain'), perform_lower_casing=False))  # '_Domain'
print(c._clean_column_name('Domain'), allow_reserved_words=True, perform_lower_casing=False))  # 'Domain'
```

I have also used this to insert data with preserved casing in my own Mage pipelines.


# Checklist
- [ ] ~~The PR is tagged with proper labels (bug, enhancement, feature, documentation)~~ (no access)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
  - Just run the above block on the branch, should be enough
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
