### PR TITLE
[dy] Fix DISABLE_NOTEBOOK_EDIT_ACCESS variable

### DIFF
--- a/mage_ai/api/policies/BasePolicy.py
+++ b/mage_ai/api/policies/BasePolicy.py
@@ -400,9 +400,7 @@ class BasePolicy(UserPermissionMixIn, ResultSetMixIn):
             not REQUIRE_USER_AUTHENTICATION and
             not DISABLE_NOTEBOOK_EDIT_ACCESS and
             action in [OperationType.CREATE, OperationType.DELETE, OperationType.UPDATE]
-        ) or \
-                (not DISABLE_NOTEBOOK_EDIT_ACCESS and self.is_owner()):
-
+        ):
             return True
 
         config = self.__class__.action_rule(action)

--- a/mage_ai/api/policies/BasePolicy.py
+++ b/mage_ai/api/policies/BasePolicy.py
@@ -401,7 +401,7 @@ class BasePolicy(UserPermissionMixIn, ResultSetMixIn):
             not DISABLE_NOTEBOOK_EDIT_ACCESS and
             action in [OperationType.CREATE, OperationType.DELETE, OperationType.UPDATE]
         ) or \
-                self.is_owner():
+                (not DISABLE_NOTEBOOK_EDIT_ACCESS and self.is_owner()):
 
             return True
 
@@ -498,7 +498,7 @@ class BasePolicy(UserPermissionMixIn, ResultSetMixIn):
             )
 
     async def authorize_attributes(self, read_or_write, attrbs, **kwargs):
-        if self.is_owner():
+        if not REQUIRE_USER_AUTHENTICATION or self.is_owner():
             return True
 
         for attrb in attrbs:

--- a/mage_ai/settings/__init__.py
+++ b/mage_ai/settings/__init__.py
@@ -19,7 +19,7 @@ except ValueError:
     DISABLE_NOTEBOOK_EDIT_ACCESS = 1 if os.getenv('DISABLE_NOTEBOOK_EDIT_ACCESS') else 0
 
 
-def is_disable_pipeline_edit_access(disable_notebook_edit_access_override: int = None):
+def is_disable_pipeline_edit_access(disable_notebook_edit_access_override: int = None) -> bool:
     value = DISABLE_NOTEBOOK_EDIT_ACCESS
     if disable_notebook_edit_access_override is not None:
         value = disable_notebook_edit_access_override

--- a/mage_ai/settings/__init__.py
+++ b/mage_ai/settings/__init__.py
@@ -1,5 +1,9 @@
 import os
 
+# If you add a new environment variable, make sure to check if it should be added to
+# the `MAGE_SETTINGS_ENVIRONMENT_VARIABLES` list at the bottom of this file. Also, update
+# the environment variable documentation at docs/development/variables/environment-variables.mdx
+
 DEBUG = os.getenv('DEBUG', False)
 HIDE_ENV_VAR_VALUES = int(os.getenv('HIDE_ENV_VAR_VALUES', 1) or 1) == 1
 QUERY_API_KEY = 'api_key'
@@ -116,5 +120,6 @@ MAGE_SETTINGS_ENVIRONMENT_VARIABLES = [
     'SENTRY_TRACES_SAMPLE_RATE',
     'MAGE_PUBLIC_HOST',
     'ACTIVE_DIRECTORY_DIRECTORY_ID',
-    'SCHEDULER_TRIGGER_INTERVAL'
+    'SCHEDULER_TRIGGER_INTERVAL',
+    'REQUIRE_USER_PERMISSIONS',
 ]


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

the `DISABLE_NOTEBOOK_EDIT_ACCESS` variable was not working properly if user authentication was not enabled.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally
- [x] Unit tests


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
