### PR TITLE
[ac] Add total execution time to Pipeline Runs table

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -45,7 +45,7 @@ import { PopupContainerStyle } from './Table.style';
 import { ScheduleTypeEnum } from '@interfaces/PipelineScheduleType';
 import { TableContainerStyle } from '@components/shared/Table/index.style';
 import { UNIT } from '@oracle/styles/units/spacing';
-import { datetimeInLocalTimezone, utcStringToElapsedTime } from '@utils/date';
+import { datetimeInLocalTimezone, timeDifference, utcStringToElapsedTime } from '@utils/date';
 import { getTimeInUTCString } from '@components/Triggers/utils';
 import { indexBy } from '@utils/array';
 import { isViewer } from '@utils/session';
@@ -442,6 +442,9 @@ function PipelineRunsTable({
       uuid: 'Execution date',
     },
     {
+      uuid: 'Execution time',
+    },
+    {
       ...timezoneTooltipProps,
       uuid: 'Started at',
     },
@@ -700,6 +703,22 @@ function PipelineRunsTable({
                         <>&#8212;</>
                       )
                     }
+                  </Text>,
+                  <Text
+                    {...SHARED_DATE_FONT_PROPS}
+                    default
+                    key="row_execution_time"
+                    title={startedAt && completedAt 
+                      ? timeDifference({ endDatetime: completedAt, showFullFormat: true, startDatetime: startedAt })
+                      : null}
+                  >
+                    {startedAt && completedAt 
+                    ? (
+                      timeDifference({ endDatetime: completedAt, startDatetime: startedAt })
+                    ): (
+                      <>&#8212;</>
+                    )
+                  }
                   </Text>,
                   <Text
                     {...SHARED_DATE_FONT_PROPS}

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -442,15 +442,15 @@ function PipelineRunsTable({
       uuid: 'Execution date',
     },
     {
-      uuid: 'Execution time',
-    },
-    {
       ...timezoneTooltipProps,
       uuid: 'Started at',
     },
     {
       ...timezoneTooltipProps,
       uuid: 'Completed at',
+    },
+    {
+      uuid: 'Execution time',
     },
     {
       uuid: 'Block runs',
@@ -623,6 +623,22 @@ function PipelineRunsTable({
                       )
                     }
                   </Text>,
+                  <Text
+                    {...SHARED_DATE_FONT_PROPS}
+                    default
+                    key="row_execution_time"
+                    title={(startedAt && completedAt)
+                      ? timeDifference({ endDatetime: completedAt, showFullFormat: true, startDatetime: startedAt })
+                      : null}
+                  >
+                    {(startedAt && completedAt)
+                      ? (
+                        timeDifference({ endDatetime: completedAt, startDatetime: startedAt })
+                      ): (
+                        <>&#8212;</>
+                      )
+                    }
+                  </Text>,
                   <NextLink
                     as={`/pipelines/${pipelineUUID}/runs/${id}`}
                     href={'/pipelines/[pipeline]/runs/[run]'}
@@ -707,22 +723,6 @@ function PipelineRunsTable({
                   <Text
                     {...SHARED_DATE_FONT_PROPS}
                     default
-                    key="row_execution_time"
-                    title={startedAt && completedAt 
-                      ? timeDifference({ endDatetime: completedAt, showFullFormat: true, startDatetime: startedAt })
-                      : null}
-                  >
-                    {startedAt && completedAt 
-                    ? (
-                      timeDifference({ endDatetime: completedAt, startDatetime: startedAt })
-                    ): (
-                      <>&#8212;</>
-                    )
-                  }
-                  </Text>,
-                  <Text
-                    {...SHARED_DATE_FONT_PROPS}
-                    default
                     key="row_started_at"
                     title={startedAt ? utcStringToElapsedTime(startedAt) : null}
                   >
@@ -745,6 +745,22 @@ function PipelineRunsTable({
                       ? (displayLocalTimezone
                         ? datetimeInLocalTimezone(completedAt, displayLocalTimezone)
                         : getTimeInUTCString(completedAt)
+                      ): (
+                        <>&#8212;</>
+                      )
+                    }
+                  </Text>,
+                  <Text
+                    {...SHARED_DATE_FONT_PROPS}
+                    default
+                    key="row_execution_time"
+                    title={(startedAt && completedAt)
+                      ? timeDifference({ endDatetime: completedAt, showFullFormat: true, startDatetime: startedAt })
+                      : null}
+                  >
+                    {(startedAt && completedAt)
+                      ? (
+                        timeDifference({ endDatetime: completedAt, startDatetime: startedAt })
                       ): (
                         <>&#8212;</>
                       )

--- a/mage_ai/frontend/package.json
+++ b/mage_ai/frontend/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@amplitude/react-amplitude": "^1.0.0",
     "@monaco-editor/react": "^4.4.5",
+    "@types/moment-duration-format": "^2.2.5",
     "@types/react-table": "^7.7.12",
     "@visx/axis": "2.14.0",
     "@visx/curve": "2.1.0",

--- a/mage_ai/frontend/package.json
+++ b/mage_ai/frontend/package.json
@@ -42,6 +42,7 @@
     "jwt-decode": "^3.1.2",
     "local-storage": "^2.0.0",
     "moment": "^2.29.4",
+    "moment-duration-format": "^2.3.2",
     "moment-timezone": "^0.5.43",
     "monaco-themes": "^0.4.2",
     "next": "12.3.4",

--- a/mage_ai/frontend/utils/date.ts
+++ b/mage_ai/frontend/utils/date.ts
@@ -145,7 +145,6 @@ export function timeDifference({
 export function utcStringToElapsedTime(datetime: string) {
   const then = moment.utc(datetime);
   const now = moment.utc();
-  console.log(datetime, then, now);
   const duration = moment.duration(now.diff(then));
 
   let timeDisplay = '';

--- a/mage_ai/frontend/utils/date.ts
+++ b/mage_ai/frontend/utils/date.ts
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import tzMoment from 'moment-timezone';
+import 'moment-duration-format';
 
 import { pluralize } from '@utils/string';
 import { rangeSequential } from '@utils/array';
@@ -96,6 +97,42 @@ export function datetimeInLocalTimezone(
   return datetime;
 }
 
+/** 
+ * Given start and end UTC datetime strings, find the time difference between them 
+ * and return it in the first matching format:
+ *   - >= 1 week: > 1 week
+     - >= 1 day: d,HH:mm:ss.SS
+ *   - < 1 day: HH:mm:ss.SS
+ * If `showFullFormat` is true, we'll return it in a specific, human-readable format.
+ */
+export function timeDifference({
+  startDatetime, 
+  endDatetime,
+  showFullFormat = false,
+}: {
+  startDatetime: string; 
+  endDatetime: string;
+  showFullFormat?: boolean;
+}) {
+  const start = moment.utc(startDatetime);
+  const end = moment.utc(endDatetime);
+  const timeDiff = moment.duration(end.diff(start));
+
+  if (showFullFormat) {
+    return timeDiff.format('Y __, M __, W __, D __, H __, m __, s __, S __');
+  } else if (timeDiff.asWeeks() >= 1) {
+    return '> 1 week';
+  } else if (timeDiff.asDays() >= 1) {
+    return timeDiff.format('d[d],HH:mm:ss.SS', {
+      trim: false,
+    });
+  } else {
+    return timeDiff.format('HH:mm:ss.SS', {
+      trim: false,
+    });
+  }
+}
+
 /**
  * Given a UTC datetime string, find how much time has elapsed between then
  * and now. Return the elapsed time in the first matching format:
@@ -108,7 +145,7 @@ export function datetimeInLocalTimezone(
 export function utcStringToElapsedTime(datetime: string) {
   const then = moment.utc(datetime);
   const now = moment.utc();
-  console.log(datetime, then, now)
+  console.log(datetime, then, now);
   const duration = moment.duration(now.diff(then));
 
   let timeDisplay = '';

--- a/mage_ai/frontend/yarn.lock
+++ b/mage_ai/frontend/yarn.lock
@@ -3785,6 +3785,13 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
   integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
 
+"@types/moment-duration-format@^2.2.5":
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/@types/moment-duration-format/-/moment-duration-format-2.2.5.tgz#8e290780c5f23b69d99d78f456e8a974c65b6fbf"
+  integrity sha512-0ojMdyThftIMXblaNFbIC4RUNUuiKyXP9BwywS6fm6L4Sod78ziFzO+cH2UWReexJo3go3xhkY3CVdcBiryocg==
+  dependencies:
+    moment ">=2.14.0"
+
 "@types/ms@*":
   version "0.7.32"
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.32.tgz#f6cd08939ae3ad886fcc92ef7f0109dacddf61ab"
@@ -9331,7 +9338,7 @@ moment-timezone@^0.5.43:
   dependencies:
     moment "^2.29.4"
 
-moment@^2.29.4:
+moment@>=2.14.0, moment@^2.29.4:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==

--- a/mage_ai/frontend/yarn.lock
+++ b/mage_ai/frontend/yarn.lock
@@ -9319,6 +9319,11 @@ mkdirp@^1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+moment-duration-format@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/moment-duration-format/-/moment-duration-format-2.3.2.tgz#5fa2b19b941b8d277122ff3f87a12895ec0d6212"
+  integrity sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ==
+
 moment-timezone@^0.5.43:
   version "0.5.43"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.43.tgz#3dd7f3d0c67f78c23cd1906b9b2137a09b3c4790"


### PR DESCRIPTION
# Description

This PR adds a new `Execution Time` column in the Pipeline runs table, which displays how long it took each of the pipelines to run ([Airtable](https://airtable.com/applEuqJsK4zF5yJK/tbl5bIlFkk2KhCpL4/viwCmaGgcnwD9IqOM/rec7be6rwQDozAkU9?blocks=hide)).

The execution times are displayed in the first matching time format:
* If execution time ≥ 1 week, display `> 1 week`
* If execution time ≥ 1 day, display in the `d,HH:mm:ss.SS` format (e.g. `2d,12:04:35.12`)
* If execution time < 1 day, display in the `HH:mm:ss.SS` format (e.g. `12:04:35.12`)

When you hover over an execution time, the tooltip displays the execution time in a very specific, human-readable format and could include years / months / weeks / days / hours / minutes / seconds / milliseconds depending on the duration. We use the [`moment-duration-format`](https://www.npmjs.com/package/moment-duration-format) package to easily achieve this format.

# How Has This Been Tested?

- [x] Tested the `timeDifference(...)` function in a code sandbox with various test cases for each if/else branch
- [x] Tested that the `Execution Time` column appears in the Pipeline runs table
- [x] Tested that the execution time shows up correctly when there is a `Started at` and `Completed at` time
- [x] Tested that the execution time shows up as `-` when one of `Started at` or `Completed at` time is not set
    <img width="1792" alt="Screenshot 2023-10-18 at 9 35 03 PM" src="https://github.com/mage-ai/mage-ai/assets/8130751/3986ccff-9a6d-4270-859a-d3fea6c0621b">
- [x] Tested that when you hover over the execution time, the tooltip displays the specific full format 
    <img width="1792" alt="image" src="https://github.com/mage-ai/mage-ai/assets/8130751/8d2b9765-2d8a-48a3-a490-359833c6f391">
- [x] Tested the `Execution Time` column is populated correctly for Pipeline run retry rows
    <img width="1792" alt="image" src="https://github.com/mage-ai/mage-ai/assets/8130751/ded28255-16ce-4fbb-b213-1d960b0e4bc8">

cc: @johnson-mage 