### PR TITLE
[dy] Hide mage-repo remote

### DIFF
--- a/mage_ai/api/resources/GitBranchResource.py
+++ b/mage_ai/api/resources/GitBranchResource.py
@@ -5,7 +5,7 @@ from github import Auth, Github
 
 from mage_ai.api.errors import ApiError
 from mage_ai.api.resources.GenericResource import GenericResource
-from mage_ai.data_preparation.git import Git, api
+from mage_ai.data_preparation.git import REMOTE_NAME, Git, api
 from mage_ai.data_preparation.preferences import get_preferences
 
 
@@ -283,6 +283,13 @@ class GitBranchResource(GenericResource):
                 args.append(val)
 
             if action_type == 'add_remote':
+                if remote.get('name') == REMOTE_NAME:
+                    error = ApiError.RESOURCE_ERROR
+                    error.update({
+                        'message': f'Remote name {REMOTE_NAME} is reserved, ' +
+                        'please select a different name.',
+                    })
+                    raise ApiError(error)
                 git_manager.add_remote(*args)
             elif action_type == 'remove_remote':
                 git_manager.remove_remote(*args)

--- a/mage_ai/api/resources/GitCustomBranchResource.py
+++ b/mage_ai/api/resources/GitCustomBranchResource.py
@@ -1,5 +1,7 @@
+from typing import Dict, List
+
 from mage_ai.api.resources.GitBranchResource import GitBranchResource
-from mage_ai.data_preparation.git import Git
+from mage_ai.data_preparation.git import REMOTE_NAME, Git
 from mage_ai.data_preparation.sync import AuthType
 
 
@@ -7,3 +9,10 @@ class GitCustomBranchResource(GitBranchResource):
     @classmethod
     def get_git_manager(self, user, setup_repo: bool = False) -> Git:
         return Git.get_manager(auth_type=AuthType.OAUTH, setup_repo=False, user=user)
+
+    def remotes(self, limit: int = None) -> List[Dict]:
+        git_manager = self.get_git_manager(user=self.current_user)
+        remotes = git_manager.remotes(limit=limit, user=self.current_user)
+        # Filter out the remote used by git sync/git integration since it will not work
+        # properly with the version control app.
+        return list(filter(lambda remote: remote.get('name') != REMOTE_NAME, remotes))


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Hide `mage-repo` remote in the version control app, and throw exception if a user tries to create the `mage-repo` remote.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with version-control app


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
