### PR TITLE
[BUG] GCS listdir so it doesnt go recursively listing objects

### DIFF
--- a/mage_ai/data_preparation/storage/gcs_storage.py
+++ b/mage_ai/data_preparation/storage/gcs_storage.py
@@ -36,6 +36,10 @@ class GCSStorage(BaseStorage):
         blobs = self.bucket.list_blobs(prefix=path)
         keys = []
         for blob in blobs:
+            # Avoid finding files recursevively in the dir path.
+            blob_path = blob.name.replace(path, '').split('/')
+            if len(blob_path) > 1 and blob_path[1] != '':
+                continue
             if (suffix is None or blob.name.endswith(suffix)) and blob.name != path:
                 keys.append(blob.name)
         return [k[len(path):].rstrip('/') for k in keys]

--- a/mage_ai/tests/data_preparation/storage/test_gcs_storage.py
+++ b/mage_ai/tests/data_preparation/storage/test_gcs_storage.py
@@ -30,12 +30,19 @@ class TestGCSStorage(TestCase):
         self.assertTrue(self.storage.isdir('your_dirpath/'))
 
     def test_listdir(self):
+        path = 'dirpath'
+
         self.gcs_bucket_mock.list_blobs.return_value = [
-            mock_blob('dirpath/file1.txt'),
-            mock_blob('dirpath/file2.txt'),
+            mock_blob(f'{path}/'),
+            mock_blob(f'{path}/file1.txt'),
+            mock_blob(f'{path}/file2.txt'),
+            mock_blob(f'{path}/depth_0/'),
+            mock_blob(f'{path}/depth_0/file3.txt'),
+            mock_blob(f'{path}/depth_0/depth_1/'),
+            mock_blob(f'{path}/depth_0/depth_1/file4.txt'),
         ]
-        result = self.storage.listdir('dirpath/')
-        self.assertEqual(result, ['file1.txt', 'file2.txt'])
+        result = self.storage.listdir(path)
+        self.assertEqual(result, ['file1.txt', 'file2.txt', 'depth_0'])
 
     def test_path_exists(self):
         self.gcs_bucket_mock.blob.exists = True


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

This MR fixes Google Cloud Storage listdir so it to doesn't list all path objects recursively (it list only depth 1).

This bug impacts running pipelines with multiple blocks with GCS as its block storage.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Unit testing
- [x] Local testing using a real GCS bucket as storage
- [ ] Test on cloud with real pipelines


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
