### PR TITLE
Redshift: Use TIMESTAMPTZ column type for datetimes

### DIFF
--- a/mage_integrations/mage_integrations/destinations/redshift/utils.py
+++ b/mage_integrations/mage_integrations/destinations/redshift/utils.py
@@ -1,11 +1,14 @@
+import json
+from typing import Dict, List
+
 from mage_integrations.destinations.constants import (
     COLUMN_FORMAT_DATETIME,
     COLUMN_TYPE_OBJECT,
-    COLUMN_TYPE_STRING
+    COLUMN_TYPE_STRING,
 )
-from mage_integrations.destinations.sql.utils import convert_column_type as convert_column_type_orig
-from typing import Dict, List
-import json
+from mage_integrations.destinations.sql.utils import (
+    convert_column_type as convert_column_type_orig,
+)
 
 
 def convert_array(v: List, column_type_dict: Dict):
@@ -19,6 +22,7 @@ def convert_column_type(
 ) -> str:
     if COLUMN_TYPE_OBJECT == column_type:
         return 'VARCHAR(65535)'
-    if COLUMN_TYPE_STRING == column_type and COLUMN_FORMAT_DATETIME == column_settings.get('format'):
-        return 'TIMESTAMPTZ'
+    elif COLUMN_TYPE_STRING == column_type:
+        if COLUMN_FORMAT_DATETIME == column_settings.get('format'):
+            return 'TIMESTAMPTZ'
     return convert_column_type_orig(column_type, column_settings, **kwargs)

--- a/mage_integrations/mage_integrations/destinations/redshift/utils.py
+++ b/mage_integrations/mage_integrations/destinations/redshift/utils.py
@@ -1,4 +1,8 @@
-from mage_integrations.destinations.constants import COLUMN_TYPE_OBJECT
+from mage_integrations.destinations.constants import (
+    COLUMN_FORMAT_DATETIME,
+    COLUMN_TYPE_OBJECT,
+    COLUMN_TYPE_STRING
+)
 from mage_integrations.destinations.sql.utils import convert_column_type as convert_column_type_orig
 from typing import Dict, List
 import json
@@ -15,4 +19,6 @@ def convert_column_type(
 ) -> str:
     if COLUMN_TYPE_OBJECT == column_type:
         return 'VARCHAR(65535)'
+    if COLUMN_TYPE_STRING == column_type and COLUMN_FORMAT_DATETIME == column_settings.get('format'):
+        return 'TIMESTAMPTZ'
     return convert_column_type_orig(column_type, column_settings, **kwargs)


### PR DESCRIPTION
# Description
Extend the column type mapping for the Redshift data integration destination by adding support for the [TIMESTAMPTZ](https://docs.aws.amazon.com/redshift/latest/dg/r_Datetime_types.html#r_Datetime_types-timestamptz) type.


# How Has This Been Tested?
Created a new Redshift cluster and a new data integration pipeline that retrieves data from an external API and stores the records in Redshift.

Following statement was executed (extracted from logs)
```sql
CREATE TABLE IF NOT EXISTS mage.api (id VARCHAR(255), last_updated TIMESTAMPTZ, _mage_created_at TIMESTAMPTZ, _mage_updated_at TIMESTAMPTZ, CONSTRAINT uniquemage_api_id UNIQUE (id))
```

Screenshot of the generated table schema and exported content
![image](https://github.com/mage-ai/mage-ai/assets/316612/6b6be2b4-fe73-4363-8c35-bbf752c5efd8)


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc: @wangxiaoyou1993 
