### PR TITLE
[ac] Add up/down arrow keyboard shortcut for navigating b/w pipeline runs

### DIFF
--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -163,6 +163,7 @@ function BackfillDetail({
           pipelineRuns={pipelineRuns}
           selectedRun={selectedRun}
           setErrors={setErrors}
+          setSelectedRun={setSelectedRun}
         />
         <Spacing p={2}>
           <Paginate

--- a/mage_ai/frontend/components/Triggers/Detail/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Detail/index.tsx
@@ -167,6 +167,7 @@ function TriggerDetail({
           pipelineRuns={pipelineRuns}
           selectedRun={selectedRun}
           setErrors={setErrors}
+          setSelectedRun={setSelectedRun}
         />
         <Spacing p={2}>
           <Paginate

--- a/mage_ai/frontend/components/shared/Table/constants.ts
+++ b/mage_ai/frontend/components/shared/Table/constants.ts
@@ -21,3 +21,6 @@ export const TIMEZONE_TOOLTIP_PROPS = {
   fitTooltipContentWidth: true,
   tooltipMessage: `Timezone: ${LOCAL_TIMEZONE}`,
 };
+
+export const getTableRowUuid = 
+  ({ uuid, rowIndex }: { uuid: string, rowIndex: number }) => `${uuid}-row-${rowIndex}`;

--- a/mage_ai/frontend/components/shared/Table/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/index.tsx
@@ -23,6 +23,7 @@ import {
   MENU_WIDTH,
   SortDirectionEnum,
   SortQueryEnum,
+  getTableRowUuid,
 } from './constants';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { SortAscending, SortDescending } from '@oracle/icons';
@@ -418,10 +419,12 @@ function Table({
         }
       };
 
+      const uuidRow = getTableRowUuid({ rowIndex, uuid });
       rowEl = (
         <TableRowStyle
           highlightOnHover={highlightRowOnHover}
-          key={`${uuid}-row-${rowIndex}`}
+          id={uuidRow}
+          key={uuidRow}
           noHover={!(linkProps || onClickRow || renderExpandedRowWithObject)}
           // @ts-ignore
           onClick={(e) => {
@@ -716,7 +719,7 @@ function Table({
                     {els}
                   </>
                 </TableStyle>
-              </div>
+              </div>,
             );
           } else {
             acc.push(
@@ -753,7 +756,7 @@ function Table({
       }, []);
     } else if (!!renderExpandedRowWithObject && selectedRowIndexInternal !== null) {
       const rowsBefore = rowEls?.slice(0, selectedRowIndexInternal + 1);
-      const rowsAfter = rowEls?.slice(selectedRowIndexInternal + 1, rowEls?.length)
+      const rowsAfter = rowEls?.slice(selectedRowIndexInternal + 1, rowEls?.length);
 
       return (
         <>

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -415,6 +415,7 @@ function PipelineRuns({
         allowBulkSelect={pipeline?.type !== PipelineTypeEnum.STREAMING}
         allowDelete
         deletePipelineRun={deletePipelineRun}
+        disableKeyboardNav={showActionsMenu}
         emptyMessage={variableSearchText
           ? 'No runs on this page match your search.'
           : undefined
@@ -442,6 +443,7 @@ function PipelineRuns({
     pipelineRuns,
     selectedRun,
     selectedRuns,
+    showActionsMenu,
     variableSearchText,
   ]);
 

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -429,6 +429,7 @@ function PipelineRuns({
         selectedRun={selectedRun}
         selectedRuns={selectedRuns}
         setErrors={setErrors}
+        setSelectedRun={setSelectedRun}
         setSelectedRuns={setSelectedRuns}
       />
       {paginationEl}


### PR DESCRIPTION
# Description

This PR addresses the following user feedback:

>  I often want to view the "Run details" tab for multiple runs, and clicking each individual run's row is cumbersome. Would love to be able to just use the UP or DOWN arrow to iterate through them quickly to find the run that I'm after.

When you're on a page with a pipeline runs table and rows are selectable, you can click on a row to select it. Once a row is selected, you can use the keyboard up arrow (↑) to navigate to the previous run and the keyboard down arrow (↓) to go to next run in the table on the current page. 
* If the first run is selected and you click the ↑ arrow, we loop to the last run in the table on the current page.
* If the last run is selected and you click the ↓ arrow, we loop to the first run in the table on the current page.
* We automatically scroll the table such that the selected row is in view.
* We don't yet enable navigation between runs on different pages of a table via keyboard shortcuts.

# How Has This Been Tested?

- [x] Select a row in the Pipeline Runs table and see it's selected
- [x] Press the ↑ arrow and see that the previous row is selected (when the current selection is not the first row)
- [x] Press the ↑ arrow and see that the last row is selected (when the current selection is the first row)
- [x] Press the ↓ arrow and see that the next row is selected (when the current selection is not the last row)
- [x] Press the ↓ arrow and see that the first row is selected (when the current selection is the last row)
- [x] Check that keyboard navigation is disabled when an action menu is open
- [x] Check that pressing other keyboard shortcuts (e.g. left/right arrows) don't do anything
- [x] Check that you can navigate interchangeably with the up/down arrows and clicking on rows

- [x] Test all above on Pipeline Runs page

  https://github.com/mage-ai/mage-ai/assets/8130751/32d26be0-cef3-40ca-8377-c6c4eb70ccb9

- [x] Test all above on Triggers Detail page

    https://github.com/mage-ai/mage-ai/assets/8130751/725bc077-7cdb-4c8a-87c8-91c040db6dd4

- [x] Test all above on Backfills Detail page

    https://github.com/mage-ai/mage-ai/assets/8130751/34480fa7-9d52-46b9-beee-dc9b88988444

cc: @johnson-mage 