### PR TITLE
[jk] Detach block from shared pipelines

### DIFF
--- a/mage_ai/api/policies/BlockPolicy.py
+++ b/mage_ai/api/policies/BlockPolicy.py
@@ -79,6 +79,7 @@ BlockPolicy.allow_read([
 
 BlockPolicy.allow_write([
     'block_action_object',
+    'block_uuid_to_remove',
     'catalog',
     'color',
     'config',

--- a/mage_ai/api/policies/BlockPolicy.py
+++ b/mage_ai/api/policies/BlockPolicy.py
@@ -80,6 +80,8 @@ BlockPolicy.allow_read([
 BlockPolicy.allow_write([
     'block_action_object',
     'block_uuid_to_remove',
+    'callback_blocks',
+    'conditional_blocks',
     'catalog',
     'color',
     'config',

--- a/mage_ai/api/policies/BlockPolicy.py
+++ b/mage_ai/api/policies/BlockPolicy.py
@@ -79,9 +79,6 @@ BlockPolicy.allow_read([
 
 BlockPolicy.allow_write([
     'block_action_object',
-    'block_uuid_to_remove',
-    'callback_blocks',
-    'conditional_blocks',
     'catalog',
     'color',
     'config',

--- a/mage_ai/api/resources/BlockResource.py
+++ b/mage_ai/api/resources/BlockResource.py
@@ -650,46 +650,6 @@ class BlockResource(GenericResource):
                 replicated_block=replicated_block,
             )
 
-        async def _create_callback(resource):
-            # Replace existing block in pipeline with newly created copy of that block
-            block_uuid_to_remove = payload.get('block_uuid_to_remove')
-            if pipeline and block_uuid_to_remove is not None:
-                callback_blocks = payload.get('callback_blocks')
-                if callback_blocks:
-                    callbacks_by_uuid = pipeline.callbacks_by_uuid
-                    for callback_uuid in callback_blocks:
-                        callback_block = callbacks_by_uuid.get(callback_uuid)
-                        if callback_block:
-                            existing_upstream_block_uuids = \
-                                [b.uuid for b in callback_block.upstream_blocks]
-                            callback_block.update(
-                                dict(upstream_blocks=existing_upstream_block_uuids + [block.uuid])
-                            )
-
-                conditional_blocks = payload.get('conditional_blocks')
-                if conditional_blocks:
-                    conditionals_by_uuid = pipeline.conditionals_by_uuid
-                    for conditional_uuid in conditional_blocks:
-                        conditional_block = conditionals_by_uuid.get(conditional_uuid)
-                        if conditional_block:
-                            existing_upstream_block_uuids = \
-                                [b.uuid for b in conditional_block.upstream_blocks]
-                            conditional_block.update(
-                                dict(upstream_blocks=existing_upstream_block_uuids + [block.uuid])
-                            )
-
-                block_to_remove = Block.get_block(
-                    block_uuid_to_remove,
-                    block_uuid_to_remove,
-                    block_type,
-                    language=language,
-                    pipeline=pipeline,
-                )
-                cache.remove_pipeline(block_to_remove, pipeline.uuid)
-                block_to_remove.delete()
-
-        self.on_create_callback = _create_callback
-
         return self(block, user, **kwargs)
 
     @classmethod

--- a/mage_ai/api/resources/BlockResource.py
+++ b/mage_ai/api/resources/BlockResource.py
@@ -653,7 +653,7 @@ class BlockResource(GenericResource):
         async def _create_callback(resource):
             # Replace existing block in pipeline with newly created copy of that block
             block_uuid_to_remove = payload.get('block_uuid_to_remove')
-            if block_uuid_to_remove is not None:
+            if pipeline and block_uuid_to_remove is not None:
                 block_to_remove = Block.get_block(
                     block_uuid_to_remove,
                     block_uuid_to_remove,
@@ -661,6 +661,7 @@ class BlockResource(GenericResource):
                     language=language,
                 )
                 block_to_remove.pipeline = pipeline
+                cache.remove_pipeline(block_to_remove, pipeline.uuid)
                 block_to_remove.delete()
 
         self.on_create_callback = _create_callback

--- a/mage_ai/api/resources/BlockResource.py
+++ b/mage_ai/api/resources/BlockResource.py
@@ -650,6 +650,21 @@ class BlockResource(GenericResource):
                 replicated_block=replicated_block,
             )
 
+        async def _create_callback(resource):
+            # Replace existing block in pipeline with newly created copy of that block
+            block_uuid_to_remove = payload.get('block_uuid_to_remove')
+            if block_uuid_to_remove is not None:
+                block_to_remove = Block.get_block(
+                    block_uuid_to_remove,
+                    block_uuid_to_remove,
+                    block_type,
+                    language=language,
+                )
+                block_to_remove.pipeline = pipeline
+                block_to_remove.delete()
+
+        self.on_create_callback = _create_callback
+
         return self(block, user, **kwargs)
 
     @classmethod

--- a/mage_ai/api/resources/BlockResource.py
+++ b/mage_ai/api/resources/BlockResource.py
@@ -654,13 +654,37 @@ class BlockResource(GenericResource):
             # Replace existing block in pipeline with newly created copy of that block
             block_uuid_to_remove = payload.get('block_uuid_to_remove')
             if pipeline and block_uuid_to_remove is not None:
+                callback_blocks = payload.get('callback_blocks')
+                if callback_blocks:
+                    callbacks_by_uuid = pipeline.callbacks_by_uuid
+                    for callback_uuid in callback_blocks:
+                        callback_block = callbacks_by_uuid.get(callback_uuid)
+                        if callback_block:
+                            existing_upstream_block_uuids = \
+                                [b.uuid for b in callback_block.upstream_blocks]
+                            callback_block.update(
+                                dict(upstream_blocks=existing_upstream_block_uuids + [block.uuid])
+                            )
+
+                conditional_blocks = payload.get('conditional_blocks')
+                if conditional_blocks:
+                    conditionals_by_uuid = pipeline.conditionals_by_uuid
+                    for conditional_uuid in conditional_blocks:
+                        conditional_block = conditionals_by_uuid.get(conditional_uuid)
+                        if conditional_block:
+                            existing_upstream_block_uuids = \
+                                [b.uuid for b in conditional_block.upstream_blocks]
+                            conditional_block.update(
+                                dict(upstream_blocks=existing_upstream_block_uuids + [block.uuid])
+                            )
+
                 block_to_remove = Block.get_block(
                     block_uuid_to_remove,
                     block_uuid_to_remove,
                     block_type,
                     language=language,
+                    pipeline=pipeline,
                 )
-                block_to_remove.pipeline = pipeline
                 cache.remove_pipeline(block_to_remove, pipeline.uuid)
                 block_to_remove.delete()
 

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -2842,6 +2842,7 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
         old_uuid = self.uuid
         # This has to be here
         old_file_path = self.file_path
+        block_content = self.content
 
         new_uuid = clean_name(name)
         self.name = name
@@ -2872,7 +2873,7 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
                 file the same. Without detaching a block, the existing block file is simply renamed.
                 """
                 with open(new_file_path, 'w') as f:
-                    f.write(self.content)
+                    f.write(block_content)
             else:
                 os.rename(old_file_path, new_file_path)
 

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -2867,6 +2867,10 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
             os.makedirs(parent_dir, exist_ok=True)
 
             if detach:
+                """"
+                Detaching a block creates a copy of the block file while keeping the existing block
+                file the same. Without detaching a block, the existing block file is simply renamed.
+                """
                 with open(new_file_path, 'w') as f:
                     f.write(self.content)
             else:

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -2100,7 +2100,8 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
 
     def update(self, data, **kwargs) -> 'Block':
         if 'name' in data and data['name'] != self.name:
-            self.__update_name(data['name'])
+            detach = kwargs.get('detach', False)
+            self.__update_name(data['name'], detach=detach)
 
         if (
             'type' in data
@@ -2828,7 +2829,11 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
         return custom_code
 
     # TODO: Update all pipelines that use this block
-    def __update_name(self, name) -> None:
+    def __update_name(
+        self,
+        name: str,
+        detach: bool = False,
+    ) -> None:
         """
         1. Rename block file
         2. Update the folder of variable
@@ -2861,16 +2866,35 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
             parent_dir = os.path.dirname(new_file_path)
             os.makedirs(parent_dir, exist_ok=True)
 
-            os.rename(old_file_path, new_file_path)
+            if detach:
+                with open(new_file_path, 'w') as f:
+                    f.write(self.content)
+            else:
+                os.rename(old_file_path, new_file_path)
 
         if self.pipeline is not None:
             self.pipeline.update_block_uuid(self, old_uuid, widget=BlockType.CHART == self.type)
 
             cache = BlockCache()
-            cache.move_pipelines(self, dict(
-                type=self.type,
-                uuid=old_uuid,
-            ))
+            if detach:
+                """"
+                New block added to pipeline, so it must be added to the block cache.
+                Old block no longer in pipeline, so it must be removed from block cache.
+                """
+                cache.add_pipeline(self, self.pipeline)
+                old_block = self.get_block(
+                    old_uuid,
+                    old_uuid,
+                    self.type,
+                    language=self.language,
+                    pipeline=self.pipeline,
+                )
+                cache.remove_pipeline(old_block, self.pipeline.uuid)
+            else:
+                cache.move_pipelines(self, dict(
+                    type=self.type,
+                    uuid=old_uuid,
+                ))
 
     def __update_pipeline_block(self, widget=False) -> None:
         if self.pipeline is None:

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -970,7 +970,10 @@ class Pipeline:
 
                         cache_block_action_object = await BlockActionObjectCache.initialize_cache()
                         cache_block_action_object.update_block(block, remove=True)
-                        block.update(extract(block_data, ['name']))
+                        block.update(
+                            extract(block_data, ['name']),
+                            detach=block_data.get('detach', False)
+                        )
                         cache_block_action_object.update_block(block)
                         block_uuid_mapping[block_data.get('uuid')] = block.uuid
                         should_save_async = should_save_async or True

--- a/mage_ai/frontend/components/BlockSettings/index.tsx
+++ b/mage_ai/frontend/components/BlockSettings/index.tsx
@@ -128,6 +128,7 @@ function BlockSettings({
     type: blockType,
     uuid: blockUUID,
   } = block;
+  const isDbtBlock = useMemo(() => BlockTypeEnum.DBT === blockType, [blockType]);
   const currentBlockIndex = pipeline?.blocks?.findIndex(({ uuid }) => uuid === blockUUID);
   const blockWithUpdatedContent = useMemo(
     () => pipeline?.blocks?.[currentBlockIndex],
@@ -372,47 +373,49 @@ function BlockSettings({
                     Shared by {blockPipelinesCount} pipelines
                   </Text>
                 </Flex>
-                <Tooltip
-                  appearBefore
-                  block
-                  label="Duplicates block so it is no longer shared with any other
-                    pipelines (detaches other pipeline associations)"
-                  lightBackground
-                  maxWidth={UNIT * 30}
-                  size={null}
-                >
-                  <Button
-                    {...SHARED_BUTTON_PROPS}
-                    afterIcon={<DiamondDetached size={ICON_SIZE_SMALL} />}
-                    iconOnly={false}
-                    onClick={() => addNewBlockAtIndex(
-                      {
-                        ...ignoreKeys(blockWithUpdatedContent, [
-                          'all_upstream_blocks_executed',
-                          'callback_blocks',
-                          'conditional_blocks',
-                          'downstream_blocks',
-                          'executor_config',
-                          'executor_type',
-                          'name',
-                          'outputs',
-                          'retry_config',
-                          'status',
-                          'tags',
-                          'timeout',
-                        ]),
-                        block_uuid_to_remove: blockUUID,
-                      },
-                      currentBlockIndex,
-                      setSelectedBlock,
-                      undefined,
-                      true,
-                    )}
-                    padding={null}
+                {!isDbtBlock && (
+                  <Tooltip
+                    appearBefore
+                    block
+                    label="Duplicates block so it is no longer shared with any other
+                      pipelines (detaches other pipeline associations)"
+                    lightBackground
+                    maxWidth={UNIT * 30}
+                    size={null}
                   >
-                    Detach
-                  </Button>
-                </Tooltip>
+                    <Button
+                      {...SHARED_BUTTON_PROPS}
+                      afterIcon={<DiamondDetached size={ICON_SIZE_SMALL} />}
+                      iconOnly={false}
+                      onClick={() => addNewBlockAtIndex(
+                        {
+                          ...ignoreKeys(blockWithUpdatedContent, [
+                            'all_upstream_blocks_executed',
+                            'callback_blocks',
+                            'conditional_blocks',
+                            'downstream_blocks',
+                            'executor_config',
+                            'executor_type',
+                            'name',
+                            'outputs',
+                            'retry_config',
+                            'status',
+                            'tags',
+                            'timeout',
+                          ]),
+                          block_uuid_to_remove: blockUUID,
+                        },
+                        currentBlockIndex,
+                        setSelectedBlock,
+                        undefined,
+                        true,
+                      )}
+                      padding={null}
+                    >
+                      Detach
+                    </Button>
+                  </Tooltip>
+                )}
               </FlexContainer>
             </BannerStyle>
           </Spacing>
@@ -436,7 +439,8 @@ function BlockSettings({
 
                 <Button
                   {...SHARED_BUTTON_PROPS}
-                  afterIcon={<Edit size={ICON_SIZE_SMALL} />}
+                  afterIcon={isDbtBlock ? null : <Edit size={ICON_SIZE_SMALL} />}
+                  disabled={isDbtBlock}
                   onClick={() => showUpdateBlockModal(block, blockName)}
                 >
                   <Text bold>
@@ -774,7 +778,7 @@ function BlockSettings({
           </Spacing>
         )}
 
-        {BlockTypeEnum.DBT === blockType && (
+        {isDbtBlock && (
           <Spacing mb={UNITS_BETWEEN_SECTIONS} px={PADDING_UNITS}>
             <Headline level={5}>
               dbt settings

--- a/mage_ai/frontend/components/BlockSettings/index.tsx
+++ b/mage_ai/frontend/components/BlockSettings/index.tsx
@@ -373,7 +373,7 @@ function BlockSettings({
                     Shared by {blockPipelinesCount} pipelines
                   </Text>
                 </Flex>
-                {!isDbtBlock && (
+                {(!isDbtBlock && pipeline?.type !== PipelineTypeEnum.INTEGRATION) && (
                   <Tooltip
                     appearBefore
                     block

--- a/mage_ai/frontend/components/BlockSettings/index.tsx
+++ b/mage_ai/frontend/components/BlockSettings/index.tsx
@@ -391,8 +391,6 @@ function BlockSettings({
                         {
                           ...ignoreKeys(blockWithUpdatedContent, [
                             'all_upstream_blocks_executed',
-                            'callback_blocks',
-                            'conditional_blocks',
                             'downstream_blocks',
                             'executor_config',
                             'executor_type',

--- a/mage_ai/frontend/components/BlockSettings/index.tsx
+++ b/mage_ai/frontend/components/BlockSettings/index.tsx
@@ -92,7 +92,7 @@ type BlockSettingsProps = {
   showUpdateBlockModal?: (
     block: BlockType,
     name: string,
-    preventDuplicateBlockName?: boolean,
+    isReplacingBlock?: boolean,
   ) => void;
 } & OpenDataIntegrationModalType;
 
@@ -231,7 +231,7 @@ function BlockSettings({
   , [blockDetails]);
   const blockPipelinesCount = blockPipelines?.length || 1;
 
-  const [updateBlock, { isLoading: isLoadingUpdateBlock }] = useMutation(
+  const [updateBlock, { isLoading: isLoadingUpdateBlock }]: any = useMutation(
     api.blocks.pipelines.useUpdate(pipelineUUID, encodeURIComponent(blockUUID)),
     {
       onSuccess: (response: any) => onSuccess(
@@ -387,10 +387,12 @@ function BlockSettings({
                       {...SHARED_BUTTON_PROPS}
                       afterIcon={<DiamondDetached size={ICON_SIZE_SMALL} />}
                       iconOnly={false}
-                      onClick={() => addNewBlockAtIndex(
+                      onClick={() => showUpdateBlockModal(
                         {
                           ...ignoreKeys(blockWithUpdatedContent, [
                             'all_upstream_blocks_executed',
+                            'callback_blocks',
+                            'conditional_blocks',
                             'downstream_blocks',
                             'executor_config',
                             'executor_type',
@@ -401,11 +403,9 @@ function BlockSettings({
                             'tags',
                             'timeout',
                           ]),
-                          block_uuid_to_remove: blockUUID,
+                          detach: true,
                         },
-                        currentBlockIndex,
-                        setSelectedBlock,
-                        undefined,
+                        `${blockName}_copy`,
                         true,
                       )}
                       padding={null}
@@ -932,7 +932,6 @@ function BlockSettings({
           <Button
             disabled={!blockAttributesTouched}
             loading={isLoadingUpdateBlock}
-            // @ts-ignore
             onClick={() => updateBlock({
               block: {
                 configuration: blockAttributes?.configuration,

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -1980,7 +1980,22 @@ df = get_variable('${pipelineUUID}', '${blockUUID}', 'output_0')`;
                       size={UNIT * 1.5}
                       square
                     />
-
+                    <FlexContainer alignItems="center">
+                      {isDBT && BlockLanguageEnum.YAML !== blockLanguage && (
+                        <Tooltip
+                          block
+                          label={getModelName(block, {
+                            fullPath: true,
+                          })}
+                          size={null}
+                          widthFitContent
+                        >
+                          <Text monospace muted>
+                            {getModelName(block)}
+                          </Text>
+                        </Tooltip>
+                      )}
+                    </FlexContainer>
                     <Spacing mr={1} />
 
                     <FlyoutMenuWrapper

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -1980,22 +1980,7 @@ df = get_variable('${pipelineUUID}', '${blockUUID}', 'output_0')`;
                       size={UNIT * 1.5}
                       square
                     />
-                    <FlexContainer alignItems="center">
-                      {isDBT && BlockLanguageEnum.YAML !== blockLanguage && (
-                        <Tooltip
-                          block
-                          label={getModelName(block, {
-                            fullPath: true,
-                          })}
-                          size={null}
-                          widthFitContent
-                        >
-                          <Text monospace muted>
-                            {getModelName(block)}
-                          </Text>
-                        </Tooltip>
-                      )}
-                    </FlexContainer>
+
                     <Spacing mr={1} />
 
                     <FlyoutMenuWrapper

--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -205,7 +205,6 @@ export type DependencyGraphProps = {
   showUpdateBlockModal?: (
     block: BlockType,
     name: string,
-    preventDuplicateBlockName?: boolean,
   ) => void;
   treeRef?: { current?: CanvasRef };
   zoomable?: boolean;
@@ -1448,7 +1447,6 @@ function DependencyGraph({
           showUpdateBlockModal(
             block,
             block?.name,
-            true,
           );
         },
         uuid: 'Rename block',

--- a/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
@@ -308,7 +308,8 @@ function ConfigureBlock({
               }
               {isReplacingBlock &&
                 'This will create a copy of the selected block and replace the existing'
-                + ' one so that it is no longer shared with any other pipelines.'
+                + ' one so it is no longer shared with any other pipelines. Note that you'
+                + ' may need to re-add any downstream connections.'
               }
             </Text>
           </Flex>
@@ -373,7 +374,7 @@ function ConfigureBlock({
 
               if (
                 (
-                  (!isCustomBlock || isUpdatingBlock)
+                  (!isCustomBlock || isUpdatingBlock || isReplacingBlock)
                   && !selected
                   && (
                     (!isDataIntegration || BlockLanguageEnum.R === v)
@@ -432,6 +433,7 @@ function ConfigureBlock({
           {isCustomBlock && (
             <Select
               alignRight
+              disabled={isReplacingBlock}
               noBackground
               noBorder
               // @ts-ignore

--- a/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
@@ -50,6 +50,7 @@ import { useError } from '@context/Error';
 type ConfigureBlockProps = {
   block: BlockType | BlockRequestPayloadType;
   defaultName: string;
+  isReplacingBlock?: boolean;
   isUpdatingBlock?: boolean;
   onClose: () => void;
   onSave: (opts: {
@@ -64,6 +65,7 @@ type ConfigureBlockProps = {
 function ConfigureBlock({
   block,
   defaultName,
+  isReplacingBlock,
   isUpdatingBlock,
   onClose,
   onSave,
@@ -300,8 +302,14 @@ function ConfigureBlock({
 
           <Flex flex="6">
             <Text bold warning>
-              Renaming this block will affect {sharedPipelinesCount} pipelines.
-              The renamed block may need to be re-added to the shared pipeline(s).
+              {isUpdatingBlock &&
+                `Renaming this block will affect ${sharedPipelinesCount} pipelines.`
+                + ' The renamed block may need to be re-added to the shared pipeline(s).'
+              }
+              {isReplacingBlock &&
+                'This will create a copy of the selected block and replace the existing'
+                + ' one so that it is no longer shared with any other pipelines.'
+              }
             </Text>
           </Flex>
         </RowStyle>
@@ -523,7 +531,13 @@ function ConfigureBlock({
             tabIndex={0}
             uuid="ConfigureBlock/SaveAndAddBlock"
           >
-            Save and {isUpdatingBlock ? 'update' : 'add'} block
+            Save and&nbsp;
+            {isUpdatingBlock
+              ? 'update'
+              : (isReplacingBlock
+                ? 'replace'
+                : 'add')
+            } block
           </KeyboardShortcutButton>
 
           <Spacing ml={1}>

--- a/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
@@ -59,7 +59,6 @@ type ConfigureBlockProps = {
     name: string;
   }) => void;
   pipeline: PipelineType;
-  preventDuplicateBlockName?: boolean;
 };
 
 function ConfigureBlock({
@@ -70,7 +69,6 @@ function ConfigureBlock({
   onClose,
   onSave,
   pipeline,
-  preventDuplicateBlockName,
 }: ConfigureBlockProps) {
   const [showError] = useError(null, {}, [], {
     uuid: 'ConfigureBlock',
@@ -308,8 +306,7 @@ function ConfigureBlock({
               }
               {isReplacingBlock &&
                 'This will create a copy of the selected block and replace the existing'
-                + ' one so it is no longer shared with any other pipelines. Note that you'
-                + ' may need to re-add any downstream connections.'
+                + ' one so it is no longer shared with any other pipelines.'
               }
             </Text>
           </Flex>
@@ -323,6 +320,7 @@ function ConfigureBlock({
 
         <TextInput
           alignRight
+          fullWidth
           noBackground
           noBorder
           // @ts-ignore

--- a/mage_ai/frontend/components/PipelineDetail/Extensions/constants.ts
+++ b/mage_ai/frontend/components/PipelineDetail/Extensions/constants.ts
@@ -67,7 +67,6 @@ export type ExtensionProps = {
   showUpdateBlockModal?: (
     block: BlockType,
     name: string,
-    preventDuplicateBlockName?: boolean,
   ) => Promise<any>;
   textareaFocused: boolean;
 };

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -77,6 +77,7 @@ export type SidekickProps = {
     idx: number,
     onCreateCallback?: (block: BlockType) => void,
     name?: string,
+    isReplacingBlock?: boolean,
   ) => Promise<any>;
   afterWidth: number;
   blockInteractionsMapping: {
@@ -518,6 +519,7 @@ function Sidekick({
 
   const blockSettingsMemo = useMemo(() => pipeline && selectedBlock && (
     <BlockSettings
+      addNewBlockAtIndex={addNewBlockAtIndex}
       block={selectedBlock}
       contentByBlockUUID={contentByBlockUUID}
       fetchFileTree={fetchFileTree}
@@ -529,6 +531,7 @@ function Sidekick({
       showUpdateBlockModal={showUpdateBlockModal}
     />
   ), [
+    addNewBlockAtIndex,
     contentByBlockUUID,
     fetchFileTree,
     fetchPipeline,

--- a/mage_ai/frontend/interfaces/BlockType.ts
+++ b/mage_ai/frontend/interfaces/BlockType.ts
@@ -210,6 +210,7 @@ export interface BlockRequestPayloadType {
     title?: string;
     uuid: string;
   };
+  block_uuid_to_remove?: string;
   color?: BlockColorEnum;
   config?: BlockRequestConfigType;
   configuration?: ConfigurationType;

--- a/mage_ai/frontend/interfaces/BlockType.ts
+++ b/mage_ai/frontend/interfaces/BlockType.ts
@@ -210,7 +210,6 @@ export interface BlockRequestPayloadType {
     title?: string;
     uuid: string;
   };
-  block_uuid_to_remove?: string;
   color?: BlockColorEnum;
   config?: BlockRequestConfigType;
   configuration?: ConfigurationType;
@@ -220,6 +219,7 @@ export interface BlockRequestPayloadType {
   defaults?: {
     language?: BlockLanguageEnum;
   };
+  detach?: boolean;
   downstream_blocks?: string[];
   extension_uuid?: string;
   language?: BlockLanguageEnum;
@@ -265,6 +265,7 @@ export default interface BlockType {
   defaults?: {
     language?: BlockLanguageEnum;
   };
+  detach?: boolean;
   description?: string;
   documentation?: string;
   downstream_blocks?: string[];

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1787,6 +1787,7 @@ function PipelineDetailPage({
   }: {
     block: BlockRequestPayloadType;
     idx?: number;
+    isReplacingBlock?: boolean;
     isUpdatingBlock?: boolean;
     name: string;
     onCreateCallback?: (block: BlockType) => void;

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1779,6 +1779,7 @@ function PipelineDetailPage({
   const [showAddBlockModal, hideAddBlockModal] = useModal(({
     block,
     idx,
+    isReplacingBlock = false,
     isUpdatingBlock = false,
     name = randomNameGenerator(),
     onCreateCallback,
@@ -1795,6 +1796,7 @@ function PipelineDetailPage({
       <ConfigureBlock
         block={block}
         defaultName={name}
+        isReplacingBlock={isReplacingBlock}
         isUpdatingBlock={isUpdatingBlock}
         onClose={hideAddBlockModal}
         onSave={(opts: {
@@ -2516,9 +2518,16 @@ function PipelineDetailPage({
   const sideKick = useMemo(() => (
     <Sidekick
       activeView={activeSidekickView}
-      addNewBlockAtIndex={(block, idx, onCreateCallback, name) => new Promise(() => showAddBlockModal({
+      addNewBlockAtIndex={(
+        block: BlockType,
+        idx: number,
+        onCreateCallback: any,
+        name: string,
+        isReplacingBlock = false,
+      ) => new Promise(() => showAddBlockModal({
         block,
         idx,
+        isReplacingBlock,
         name,
         onCreateCallback,
       }))}

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1783,7 +1783,6 @@ function PipelineDetailPage({
     isUpdatingBlock = false,
     name = randomNameGenerator(),
     onCreateCallback,
-    preventDuplicateBlockName,
   }: {
     block: BlockRequestPayloadType;
     idx?: number;
@@ -1791,7 +1790,6 @@ function PipelineDetailPage({
     isUpdatingBlock?: boolean;
     name: string;
     onCreateCallback?: (block: BlockType) => void;
-    preventDuplicateBlockName?: boolean;
   }) => (
     <ErrorProvider>
       <ConfigureBlock
@@ -1805,10 +1803,12 @@ function PipelineDetailPage({
           language?: BlockLanguageEnum;
           name?: string;
         } = {}) => {
-          if (isUpdatingBlock) {
+          if (isUpdatingBlock || isReplacingBlock) {
+            const detachBlock = block.detach || false;
             savePipelineContent({
               block: {
                 color: opts?.color || null,
+                detach: detachBlock,
                 name: opts?.name,
                 uuid: block.uuid,
               },
@@ -1833,7 +1833,6 @@ function PipelineDetailPage({
         }
         }
         pipeline={pipeline}
-        preventDuplicateBlockName={preventDuplicateBlockName}
       />
     </ErrorProvider>
   ), {
@@ -2607,12 +2606,12 @@ function PipelineDetailPage({
       showUpdateBlockModal={(
         block,
         name = randomNameGenerator(),
-        preventDuplicateBlockName,
+        isReplacingBlock = false,
       ) => new Promise(() => showAddBlockModal({
         block,
-        isUpdatingBlock: true,
+        isReplacingBlock,
+        isUpdatingBlock: !isReplacingBlock,
         name,
-        preventDuplicateBlockName,
       }))}
       sideBySideEnabled={sideBySideEnabled}
       statistics={statistics}


### PR DESCRIPTION
# Description
- Add block "Detach" feature, which lets user duplicate a block and remove any associations with other pipelines (would require to choose a new, unique block name). Feature is visible for blocks with shared pipelines.
- Supported for python, sql, R, and data integration YAML blocks (not supported for dbt blocks).

# How Has This Been Tested?
With add-on blocks (conditional and callback) and upstrea/downstream dependencies:
![detach block with PUT](https://github.com/mage-ai/mage-ai/assets/78053898/76a6c266-b354-4777-bcf1-1da00028dd56)

Dep graph before detaching `custom_sql_block2_c2`:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/c15501ea-7b68-4697-a040-ef369a8509c1)
Dep graph after detaching `custom_sql_block2_c2` (replaced with `custom_sql_block2_c2_copy`):
![image](https://github.com/mage-ai/mage-ai/assets/78053898/4cf18f56-33ef-4b59-a67a-a2e9b2f9a2c0)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
