### PR TITLE
[Fix] Reposition file browser context menu

### DIFF
--- a/mage_ai/frontend/components/FileBrowser/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/index.tsx
@@ -394,7 +394,6 @@ function FileBrowser({
     const {
       x: xContainer,
       width,
-      height,
     } = ref?.current?.getBoundingClientRect() || {};
     const {
       x = 0,
@@ -517,8 +516,8 @@ function FileBrowser({
 
     let yFinal = y;
     const menuHeight = MENU_ITEM_HEIGHT * items.length;
-    if (y + menuHeight >= height) {
-      yFinal = height - menuHeight;
+    if (y + menuHeight >= window.innerHeight) {
+      yFinal = y - menuHeight;
     }
 
     return (

--- a/mage_ai/frontend/components/FileBrowser/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/index.tsx
@@ -400,7 +400,7 @@ function FileBrowser({
       x = 0,
       y = 0,
     } = coordinates || {};
-    let xFinal = x;
+    let xFinal = x + UNIT;
     if (x + MENU_WIDTH >= xContainer + width) {
       xFinal = (xContainer + width) - (MENU_WIDTH + UNIT);
     }

--- a/mage_ai/frontend/components/FileBrowser/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/index.tsx
@@ -34,6 +34,7 @@ import { onSuccess } from '@api/utils/response';
 import { useModal } from '@context/Modal';
 
 const MENU_WIDTH: number = UNIT * 20;
+const MENU_ITEM_HEIGHT = 36;
 
 type FileBrowserProps = {
   addNewBlock?: (b: BlockRequestPayloadType, cb: any) => void;
@@ -393,6 +394,7 @@ function FileBrowser({
     const {
       x: xContainer,
       width,
+      height,
     } = ref?.current?.getBoundingClientRect() || {};
     const {
       x = 0,
@@ -513,12 +515,18 @@ function FileBrowser({
       }
     }
 
+    let yFinal = y;
+    const menuHeight = MENU_ITEM_HEIGHT * items.length;
+    if (y + menuHeight >= height) {
+      yFinal = height - menuHeight;
+    }
+
     return (
       <div
         style={{
           left: xFinal,
           position: 'fixed',
-          top: y + (UNIT / 2),
+          top: yFinal,
           zIndex: HEADER_Z_INDEX + 100,
         }}
       >


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Moved the menu up whenever it overflows off the screen. Also moved it a bit to the right, for good measure.
Resolves #3800.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- Before
![image](https://github.com/mage-ai/mage-ai/assets/132081506/89565a7e-4103-4c98-ae4f-5f33b265264a)

- After
![image](https://github.com/mage-ai/mage-ai/assets/132081506/7e3b101e-5a85-45f4-a85c-99635918d7a3)

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc: @johnson-mage 
<!-- Optionally mention someone to let them know about this pull request -->
