### PR TITLE
[xy] Serialize np.ndarray before exporting to postgres.

### DIFF
--- a/mage_ai/io/mssql.py
+++ b/mage_ai/io/mssql.py
@@ -101,7 +101,7 @@ class MSSQL(BaseSQL):
         **kwargs,
     ) -> None:
         def serialize_obj(val):
-            if type(val) is dict:
+            if type(val) is dict or type(val) is np.ndarray:
                 return simplejson.dumps(
                     val,
                     default=encode_complex,

--- a/mage_ai/io/mysql.py
+++ b/mage_ai/io/mysql.py
@@ -87,7 +87,7 @@ class MySQL(BaseSQL):
         **kwargs,
     ) -> None:
         def serialize_obj(val):
-            if type(val) is dict:
+            if type(val) is dict or type(val) is np.ndarray:
                 return simplejson.dumps(
                     val,
                     default=encode_complex,

--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -189,7 +189,7 @@ class Postgres(BaseSQL):
                     # All values are empty list
                     return column_type
                 value = values_not_empty_list[0]
-                if type(value) is list:
+                if isinstance(value, list):
                     if len(value) >= 1:
                         item = value[0]
                         if type(item) is dict:
@@ -284,7 +284,7 @@ class Postgres(BaseSQL):
             return val
 
         def serialize_obj(val):
-            if type(val) is dict:
+            if type(val) is dict or type(val) is np.ndarray:
                 return simplejson.dumps(
                     val,
                     default=encode_complex,

--- a/mage_ai/io/trino.py
+++ b/mage_ai/io/trino.py
@@ -225,7 +225,7 @@ class Trino(BaseSQL):
         sql = f'INSERT INTO {full_table_name} VALUES ({values_placeholder})'
 
         def serialize_obj(val):
-            if type(val) is dict or type(val) is list:
+            if type(val) is dict or type(val) is list or type(val) is np.ndarray:
                 return simplejson.dumps(
                     val,
                     default=encode_complex,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix exception of exporting dataframe to Postgres when one column's type is numpy.ndarray
```
psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type json
DETAIL:  Token "'" is invalid.
CONTEXT:  JSON data, line 1: ['...
COPY exam_diag, line 1, column malformations: "['aaaaaa' 'bbbbbbb']"
```

Serialize np.ndarray before exporting to postgres, mysql, mssql and trino


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested exporting to Postgres with numpy.ndarray column
- [x] MySQL
- [x] MSSQL
- [x] Trino

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
