### PR TITLE
[xy] Support Redshift Serverless 

### DIFF
--- a/docs/integrations/databases/Redshift.mdx
+++ b/docs/integrations/databases/Redshift.mdx
@@ -22,6 +22,9 @@ default:
   REDSHIFT_TEMP_CRED_PASSWORD: ...
 ```
 
+When connecting to **Redshift Serverless**, you can use `workgroup-name.account-number.aws-region.redshift-serverless.amazonaws.com`
+as the `REDSHIFT_HOST` value.
+
 <br />
 
 ## Using SQL block


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
* Update Redshift doc to clarify how to specify host for Redshift Serverless
* Fix Redshift Servereless destination in data integration pipeline

Close: https://github.com/mage-ai/mage-ai/issues/2754

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested Redshift Serverless in a Python and SQL block
- [x] Tested Redshift Serverless in data integration pipeline

Example config:
```yaml
database: dev
host: workgroup.account.region.redshift-serverless.amazonaws.com
password: password
port: 5439
region: us-west-2
schema: public
user: username
```

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
