### PR TITLE
[xy] Initialize db_connection session before interpolating repo config.

### DIFF
--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -235,9 +235,10 @@ def run(
             runtime_variables = parse_runtime_variables(runtime_vars)
 
         sys.path.append(os.path.dirname(project_path))
-        pipeline = Pipeline.get(pipeline_uuid, repo_path=project_path)
-
+        # Initialize db_connection session before getting the pipeline in case
+        # "mage_secret_var" syntax is used in the project's metadata.yaml
         db_connection.start_session()
+        pipeline = Pipeline.get(pipeline_uuid, repo_path=project_path)
 
         if pipeline_run_id is None:
             default_variables = get_global_variables(pipeline_uuid)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
When project's metadata.yaml file uses the `mage_secret_var` syntax, the job using k8s executor fails to execute due to exception:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/repo_manager.py", line 70, in __init__
    config_file = Template(f.read()).render(
  File "/usr/local/lib/python3.10/site-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.10/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "<template>", line 46, in top-level template code
  File "/usr/local/lib/python3.10/site-packages/mage_ai/orchestration/db/__init__.py", line 118, in func_with_rollback
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/shared/secrets.py", line 169, in get_secret_value
    secret = Secret.query.filter(
  File "/usr/local/lib/python3.10/site-packages/mage_ai/orchestration/db/models/base.py", line 17, in __get__
    return self.fget(owner_cls)
  File "/usr/local/lib/python3.10/site-packages/mage_ai/orchestration/db/models/base.py", line 29, in query
    return db_connection.session.query(cls)
AttributeError: 'NoneType' object has no attribute 'query'
No schema in PostgreSQL connection URL: use the default "public" schema
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/repo_manager.py", line 70, in __init__
    config_file = Template(f.read()).render(
  File "/usr/local/lib/python3.10/site-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.10/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "<template>", line 46, in top-level template code
  File "/usr/local/lib/python3.10/site-packages/mage_ai/orchestration/db/__init__.py", line 118, in func_with_rollback
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/shared/secrets.py", line 169, in get_secret_value
    secret = Secret.query.filter(
  File "/usr/local/lib/python3.10/site-packages/mage_ai/orchestration/db/models/base.py", line 17, in __get__
    return self.fget(owner_cls)
  File "/usr/local/lib/python3.10/site-packages/mage_ai/orchestration/db/models/base.py", line 29, in query
    return db_connection.session.query(cls)
AttributeError: 'NoneType' object has no attribute 'query'
```
Fix this issue by initializing db_connection session before interpolating repo config.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested in a local k8s cluster with k8s executor and use `mage_secret_var` syntax in project's metadata.yaml.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
