### PR TITLE
[ac] Make current time button transparent by default

### DIFF
--- a/mage_ai/frontend/components/ServerTimeDropdown/ServerTimeButton.tsx
+++ b/mage_ai/frontend/components/ServerTimeDropdown/ServerTimeButton.tsx
@@ -1,16 +1,18 @@
 import { memo, useEffect, useRef } from 'react';
 
-import Button, { ButtonProps } from '@oracle/elements/Button';
 import Text from '@oracle/elements/Text';
-import dark from '@oracle/styles/themes/dark';
+import { ButtonProps } from '@oracle/elements/Button';
+import { ButtonStyle } from './index.style';
 
 type ServerTimeButtonProps = {
+  active: boolean;
   mountedCallback: any;
   time: string;
   timeZone: string;
 } & ButtonProps;
 
 function ServerTimeButton({
+  active,
   mountedCallback,
   time,
   timeZone,
@@ -25,9 +27,9 @@ function ServerTimeButton({
   }, [mountedCallback]);
 
   return (
-    <Button 
+    <ButtonStyle 
       {...props}
-      backgroundColor={dark.background.dashboard}
+      active={active}
       borderLess
       compact
       ref={buttonRef}
@@ -35,7 +37,7 @@ function ServerTimeButton({
       <Text inline monospace>
         {`${time} ${timeZone}`}
       </Text>
-    </Button>
+    </ButtonStyle>
   );
 }
 

--- a/mage_ai/frontend/components/ServerTimeDropdown/ServerTimeButton.tsx
+++ b/mage_ai/frontend/components/ServerTimeDropdown/ServerTimeButton.tsx
@@ -32,7 +32,9 @@ function ServerTimeButton({
       active={active}
       borderLess
       compact
+      highlightOnHoverAlt
       ref={buttonRef}
+      transparent
     >
       <Text inline monospace>
         {`${time} ${timeZone}`}

--- a/mage_ai/frontend/components/ServerTimeDropdown/index.style.tsx
+++ b/mage_ai/frontend/components/ServerTimeDropdown/index.style.tsx
@@ -1,11 +1,24 @@
 import styled from 'styled-components';
 
+import Button from '@oracle/elements/Button';
 import dark from '@oracle/styles/themes/dark';
 import { BORDER_RADIUS } from '@oracle/styles/units/borders';
 import { UNIT } from '@oracle/styles/units/spacing';
 
 const SHARED_CELL_PADDING = '12px 20px';
 const SHARED_GAP = '1px';
+
+export const ButtonStyle = styled(Button)<{ active?: boolean }>`
+  background-color: transparent;
+
+  ${props => (props.active) && `
+    background-color: ${(props.theme.background || dark.background).dashboard};
+  `};
+
+  &:hover {
+    background-color: ${props => (props.theme.background || dark.background).dashboard};
+  }
+`;
 
 export const DropdownContainerStyle = styled.div<{
   top?: number;

--- a/mage_ai/frontend/components/ServerTimeDropdown/index.style.tsx
+++ b/mage_ai/frontend/components/ServerTimeDropdown/index.style.tsx
@@ -9,15 +9,9 @@ const SHARED_CELL_PADDING = '12px 20px';
 const SHARED_GAP = '1px';
 
 export const ButtonStyle = styled(Button)<{ active?: boolean }>`
-  background-color: transparent;
-
   ${props => (props.active) && `
     background-color: ${(props.theme.background || dark.background).dashboard};
   `};
-
-  &:hover {
-    background-color: ${props => (props.theme.background || dark.background).dashboard};
-  }
 `;
 
 export const DropdownContainerStyle = styled.div<{

--- a/mage_ai/frontend/components/ServerTimeDropdown/index.tsx
+++ b/mage_ai/frontend/components/ServerTimeDropdown/index.tsx
@@ -101,6 +101,7 @@ function ServerTimeDropdown() {
     <ClickOutside onClickOutside={() => setShowDropdown(false)} open>
       <div style={{ position: 'relative' }}>
         <ServerTimeButton 
+          active={showDropdown}
           disabled={isSmallBreakpoint}
           mountedCallback={setDropdownPosition}
           onClick={handleButtonClick}

--- a/mage_ai/frontend/oracle/elements/Button/index.tsx
+++ b/mage_ai/frontend/oracle/elements/Button/index.tsx
@@ -46,6 +46,7 @@ export type ButtonProps = {
   disabled?: boolean;
   fullWidth?: boolean;
   highlightOnHover?: boolean;
+  highlightOnHoverAlt?: boolean;
   iconOnly?: boolean;
   id?: string;
   large?: boolean;
@@ -229,6 +230,12 @@ const SHARED_STYLES = css<{
   ${props => props.highlightOnHover && `
     &:hover {
       background-color: ${(props.theme.interactive || dark.interactive).hoverBorder};
+    }
+  `}
+
+  ${props => props.highlightOnHoverAlt && `
+    &:hover {
+      background-color: ${(props.theme.background || dark.background).dashboard};
     }
   `}
 


### PR DESCRIPTION
# Description
Previously, we would show the current time button in the top right of the app header with a dark background by default (#3785):

<img width="371" alt="image" src="https://github.com/mage-ai/mage-ai/assets/8130751/e0391fc8-d1fc-42f6-a397-ff2adca0572a">

This PR makes a slight style adjustment such that the button has a transparent background by default. When you hover over the button OR if the dropdown menu is open, the button displays a dark background. This was a design request by Kai!

# How Has This Been Tested?

- [x] Check that current time button has a transparent background by default (when the dropdown is closed)
- [x] Check that the current time button has a dark background on hover
- [x] Check that the current time button has a dark background when the dropdown is open

    https://github.com/mage-ai/mage-ai/assets/8130751/2bee93b3-da72-49e4-9152-8625264af4b4

cc:
@johnson-mage 