### PR TITLE
[ac] Fix disabled keyboard shortcuts due to Pipeline Runs table keyboard nav

### DIFF
--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -163,6 +163,7 @@ function BackfillDetail({
           pipelineRuns={pipelineRuns}
           selectedRun={selectedRun}
           setErrors={setErrors}
+          setSelectedRun={setSelectedRun}
         />
         <Spacing p={2}>
           <Paginate

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -346,58 +346,50 @@ function PipelineRunsTable({
 
   const {
     registerOnKeyDown,
-    registerOnKeyUp,
     unregisterOnKeyDown,
-    unregisterOnKeyUp,
   } = useKeyboardContext();
 
   useEffect(() => () => {
     unregisterOnKeyDown(uuidKeyboard);
   }, [unregisterOnKeyDown, uuidKeyboard]);
 
-  useEffect(() => () => {
-    unregisterOnKeyUp(uuidKeyboard);
-  }, [unregisterOnKeyUp, uuidKeyboard]);
-
   registerOnKeyDown(
     uuidKeyboard,
     (event, keyMapping) => {
-      // This disables the default scrolling response to the arrow keys
-      event.preventDefault();
+      const upPressed = keyMapping[KEY_CODE_ARROW_UP];
+      const downPressed = keyMapping[KEY_CODE_ARROW_DOWN];
 
-      if (!setSelectedRun || disableKeyboardNav || !canRegisterKeyDown.current) return;
+      if (setSelectedRun && !disableKeyboardNav && (upPressed || downPressed)) {
+        setSelectedRun((prevSelectedRun) => {
+          const prevRowIndex = getRunRowIndex(prevSelectedRun);
+          if (prevRowIndex !== null) {
+            // This disables the default auto-scrolling response to the up/down arrow keys
+            if (event.repeat) {
+              event.preventDefault();
+              return prevSelectedRun;
+            }
 
-      canRegisterKeyDown.current = false;
-      
-      setSelectedRun((prevSelectedRun) => {
-        const prevRowIndex = getRunRowIndex(prevSelectedRun);
-        if (prevRowIndex !== null) {
-          if (keyMapping[KEY_CODE_ARROW_UP]) {
-            let newRowIndex = prevRowIndex - 1;
-            if (newRowIndex < 0) {
-              newRowIndex = pipelineRuns.length - 1;
+            if (upPressed) {
+              let newRowIndex = prevRowIndex - 1;
+              if (newRowIndex < 0) {
+                newRowIndex = pipelineRuns.length - 1;
+              }
+              return pipelineRuns[newRowIndex];
+            } else if (downPressed) {
+              let newRowIndex = prevRowIndex + 1;
+              if (newRowIndex >= pipelineRuns.length) {
+                newRowIndex = 0;
+              }
+              return pipelineRuns[newRowIndex];
             }
-            return pipelineRuns[newRowIndex];
-          } else if (keyMapping[KEY_CODE_ARROW_DOWN]) {
-            let newRowIndex = prevRowIndex + 1;
-            if (newRowIndex >= pipelineRuns.length) {
-              newRowIndex = 0;
-            }
-            return pipelineRuns[newRowIndex];
           }
-        }
-
-        return prevSelectedRun;
-      });
+  
+          return prevSelectedRun;
+        });
+      }
     }, 
     [pipelineRuns, setSelectedRun],
   );
-
-  registerOnKeyUp(
-    uuidKeyboard,
-    () => {
-      canRegisterKeyDown.current = true;
-    }, []);
 
   useEffect(() => {
     const rowIndex = getRunRowIndex(selectedRun);

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -1,6 +1,6 @@
 import NextLink from 'next/link';
 import { MutateFunction, useMutation } from 'react-query';
-import { createRef, useCallback, useMemo, useRef, useState } from 'react';
+import { createRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 
 import Button from '@oracle/elements/Button';
@@ -37,8 +37,10 @@ import {
   DELETE_CONFIRM_TOP_OFFSET_DIFF,
   DELETE_CONFIRM_TOP_OFFSET_DIFF_FIRST,
   TIMEZONE_TOOLTIP_PROPS,
+  getTableRowUuid,
 } from '@components/shared/Table/constants';
 import { ICON_SIZE_SMALL } from '@oracle/styles/units/icons';
+import { KEY_CODE_ARROW_DOWN, KEY_CODE_ARROW_UP } from '@utils/hooks/keyboardShortcuts/constants';
 import { PopupContainerStyle } from './Table.style';
 import { ScheduleTypeEnum } from '@interfaces/PipelineScheduleType';
 import { TableContainerStyle } from '@components/shared/Table/index.style';
@@ -51,6 +53,7 @@ import { onSuccess } from '@api/utils/response';
 import { pauseEvent } from '@utils/events';
 import { queryFromUrl } from '@utils/url';
 import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
+import { useKeyboardContext } from '@context/Keyboard';
 
 const SHARED_DATE_FONT_PROPS = {
   monospace: true,
@@ -259,6 +262,7 @@ type PipelineRunsTableProps = {
   allowBulkSelect?: boolean;
   allowDelete?: boolean;
   deletePipelineRun?: MutateFunction<any>;
+  disableKeyboardNav?: boolean;
   disableRowSelect?: boolean;
   emptyMessage?: string;
   fetchPipelineRuns?: () => void;
@@ -268,6 +272,7 @@ type PipelineRunsTableProps = {
   pipelineRuns: PipelineRunType[];
   selectedRun?: PipelineRunType;
   selectedRuns?: { [keyof: string]: PipelineRunType };
+  setSelectedRun?: (selectedRun: any) => void;
   setSelectedRuns?: (selectedRuns: any) => void;
   setErrors?: (errors: ErrorsType) => void;
 };
@@ -276,6 +281,7 @@ function PipelineRunsTable({
   allowBulkSelect,
   allowDelete,
   deletePipelineRun,
+  disableKeyboardNav,
   disableRowSelect,
   emptyMessage = 'No runs available',
   fetchPipelineRuns,
@@ -285,12 +291,14 @@ function PipelineRunsTable({
   pipelineRuns,
   selectedRun,
   selectedRuns,
+  setSelectedRun,
   setSelectedRuns,
   setErrors,
 }: PipelineRunsTableProps) {
   const router = useRouter();
   const isViewerRole = isViewer();
   const displayLocalTimezone = shouldDisplayLocalTimezone();
+  const canRegisterKeyDown = useRef<boolean>(true);
   const deleteButtonRefs = useRef({});
   const [cancelingRunId, setCancelingRunId] = useState<number>(null);
   const [showConfirmationId, setShowConfirmationId] = useState<number>(null);
@@ -325,6 +333,82 @@ function PipelineRunsTable({
       ),
     },
   );
+
+  const uuidKeyboard = 'PipelineDetail/Runs/Table';
+  const uuidTable = 'pipeline-runs';
+
+  const getRunRowIndex = useCallback((run: PipelineRunType) => {
+    if (!run) return null;
+    
+    const rowIndex = pipelineRuns.findIndex(pipelineRun => pipelineRun.id === run.id);
+    return rowIndex >= 0 ? rowIndex : null;
+  }, [pipelineRuns]);
+
+  const {
+    registerOnKeyDown,
+    registerOnKeyUp,
+    unregisterOnKeyDown,
+    unregisterOnKeyUp,
+  } = useKeyboardContext();
+
+  useEffect(() => () => {
+    unregisterOnKeyDown(uuidKeyboard);
+  }, [unregisterOnKeyDown, uuidKeyboard]);
+
+  useEffect(() => () => {
+    unregisterOnKeyUp(uuidKeyboard);
+  }, [unregisterOnKeyUp, uuidKeyboard]);
+
+  registerOnKeyDown(
+    uuidKeyboard,
+    (event, keyMapping) => {
+      // This disables the default scrolling response to the arrow keys
+      event.preventDefault();
+
+      if (!setSelectedRun || disableKeyboardNav || !canRegisterKeyDown.current) return;
+
+      canRegisterKeyDown.current = false;
+      
+      setSelectedRun((prevSelectedRun) => {
+        const prevRowIndex = getRunRowIndex(prevSelectedRun);
+        if (prevRowIndex !== null) {
+          if (keyMapping[KEY_CODE_ARROW_UP]) {
+            let newRowIndex = prevRowIndex - 1;
+            if (newRowIndex < 0) {
+              newRowIndex = pipelineRuns.length - 1;
+            }
+            return pipelineRuns[newRowIndex];
+          } else if (keyMapping[KEY_CODE_ARROW_DOWN]) {
+            let newRowIndex = prevRowIndex + 1;
+            if (newRowIndex >= pipelineRuns.length) {
+              newRowIndex = 0;
+            }
+            return pipelineRuns[newRowIndex];
+          }
+        }
+
+        return prevSelectedRun;
+      });
+    }, 
+    [pipelineRuns, setSelectedRun],
+  );
+
+  registerOnKeyUp(
+    uuidKeyboard,
+    () => {
+      canRegisterKeyDown.current = true;
+    }, []);
+
+  useEffect(() => {
+    const rowIndex = getRunRowIndex(selectedRun);
+    if (rowIndex !== null) {
+      const tableRowUuid = getTableRowUuid({ rowIndex, uuid: uuidTable });
+      const newSelectedRow = document.getElementById(tableRowUuid);
+      if (newSelectedRow) {
+        newSelectedRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    }
+  }, [getRunRowIndex, selectedRun]);
 
   const timezoneTooltipProps = displayLocalTimezone ? TIMEZONE_TOOLTIP_PROPS : {};
   const columnFlex = [null, 1];
@@ -781,7 +865,7 @@ function PipelineRunsTable({
 
               return arr;
             })}
-            uuid="pipeline-runs"
+            uuid={uuidTable}
           />
       }
     </TableContainerStyle>

--- a/mage_ai/frontend/components/Triggers/Detail/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Detail/index.tsx
@@ -167,6 +167,7 @@ function TriggerDetail({
           pipelineRuns={pipelineRuns}
           selectedRun={selectedRun}
           setErrors={setErrors}
+          setSelectedRun={setSelectedRun}
         />
         <Spacing p={2}>
           <Paginate

--- a/mage_ai/frontend/components/shared/Table/constants.ts
+++ b/mage_ai/frontend/components/shared/Table/constants.ts
@@ -21,3 +21,6 @@ export const TIMEZONE_TOOLTIP_PROPS = {
   fitTooltipContentWidth: true,
   tooltipMessage: `Timezone: ${LOCAL_TIMEZONE}`,
 };
+
+export const getTableRowUuid = 
+  ({ uuid, rowIndex }: { uuid: string, rowIndex: number }) => `${uuid}-row-${rowIndex}`;

--- a/mage_ai/frontend/components/shared/Table/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/index.tsx
@@ -23,6 +23,7 @@ import {
   MENU_WIDTH,
   SortDirectionEnum,
   SortQueryEnum,
+  getTableRowUuid,
 } from './constants';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { SortAscending, SortDescending } from '@oracle/icons';
@@ -418,10 +419,12 @@ function Table({
         }
       };
 
+      const uuidRow = getTableRowUuid({ rowIndex, uuid });
       rowEl = (
         <TableRowStyle
           highlightOnHover={highlightRowOnHover}
-          key={`${uuid}-row-${rowIndex}`}
+          id={uuidRow}
+          key={uuidRow}
           noHover={!(linkProps || onClickRow || renderExpandedRowWithObject)}
           // @ts-ignore
           onClick={(e) => {
@@ -716,7 +719,7 @@ function Table({
                     {els}
                   </>
                 </TableStyle>
-              </div>
+              </div>,
             );
           } else {
             acc.push(
@@ -753,7 +756,7 @@ function Table({
       }, []);
     } else if (!!renderExpandedRowWithObject && selectedRowIndexInternal !== null) {
       const rowsBefore = rowEls?.slice(0, selectedRowIndexInternal + 1);
-      const rowsAfter = rowEls?.slice(selectedRowIndexInternal + 1, rowEls?.length)
+      const rowsAfter = rowEls?.slice(selectedRowIndexInternal + 1, rowEls?.length);
 
       return (
         <>

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -415,6 +415,7 @@ function PipelineRuns({
         allowBulkSelect={pipeline?.type !== PipelineTypeEnum.STREAMING}
         allowDelete
         deletePipelineRun={deletePipelineRun}
+        disableKeyboardNav={showActionsMenu}
         emptyMessage={variableSearchText
           ? 'No runs on this page match your search.'
           : undefined
@@ -429,6 +430,7 @@ function PipelineRuns({
         selectedRun={selectedRun}
         selectedRuns={selectedRuns}
         setErrors={setErrors}
+        setSelectedRun={setSelectedRun}
         setSelectedRuns={setSelectedRuns}
       />
       {paginationEl}
@@ -441,6 +443,7 @@ function PipelineRuns({
     pipelineRuns,
     selectedRun,
     selectedRuns,
+    showActionsMenu,
     variableSearchText,
   ]);
 


### PR DESCRIPTION
# Description

PR #3815 introduced a bug where other keyboard shortcuts (e.g. `cmd+R` to refresh the page or `opt+cmd+I` to open the browser console) and text input abilities (e.g. `Search pipeline run variables` on the Pipeline Runs page) were disabled. This was the result of the `event.preventDefault(...)` in the `registerOnKeyDown(...)` function, which disables key press actions as well. 

The original intent of using `event.preventDefault(...)` was to prevent the default auto-scrolling behavior in response to the pressing the up/down arrow keys:

https://github.com/mage-ai/mage-ai/assets/8130751/5acbd501-ade0-4f18-a0de-6b8daed2d6f1

This PR fixes this bug! The table nav behavior is now as follows:

* When no row is selected, pressing the up/down arrow keys will trigger the default auto-scrolling behavior.
* When a row is selected, pressing the up/down arrow keys will navigate to the previous/next rows (and the default auto-scrolling behavior is disabled).
* All other keyboard shortcuts and text input abilities are NOT disabled.

# How Has This Been Tested?

- [x] Test that when a row is selected, you can use the up/down arrow keys to navigate to previous/next rows
- [x] Test that when a row is selected, the default auto-scrolling behavior is disabled
- [x] Test that the text input ability is not disabled
- [x] Test that other keyboard shortcuts (e.g. `cmd+R`, `opt+cmd+I`) work
- [x] Test that action menu keyboard shortcuts work
- [x] Test that when no row is selected, the default auto-scrolling behavior is enabled

- [x] Test the above steps on the Pipeline Runs page, Backfills page, and Triggers page

https://github.com/mage-ai/mage-ai/assets/8130751/d1eb89e0-277c-40bc-b5ce-af78a12c78d3

cc: @johnson-mage 
