### PR TITLE
[ac] Fix save block functionality after pipeline execution

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/PipelineExecution/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/PipelineExecution/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import Ansi from 'ansi-to-react';
 
 import Button from '@oracle/elements/Button';
@@ -47,6 +47,17 @@ function PipelineExecution({
     numberOfMessages > 100 ? pipelineMessages.slice(-100) : pipelineMessages
   ), [numberOfMessages, pipelineMessages]);
 
+  // When the pipeline starts executing, the execution button gets disabled.
+  // Disabled buttons are not focusable, so manually remove the focus here.
+  const handleExecutePipeline = useCallback(() => {
+    (document.activeElement as HTMLElement).blur();
+    executePipeline();
+  }, [executePipeline]);
+  const handleCancelPipeline = useCallback(() => {
+    (document.activeElement as HTMLElement).blur();
+    cancelPipeline();
+  }, [cancelPipeline]);
+
   const togglePipelineExecution = useCallback(() => {
     const val = !pipelineExecutionHidden;
     setPipelineExecutionHidden(val);
@@ -66,7 +77,7 @@ function PipelineExecution({
               compact={isPipelineExecuting}
               disabled={isPipelineExecuting}
               loading={isPipelineExecuting}
-              onClick={executePipeline}
+              onClick={handleExecutePipeline}
               success
             >
               <Text
@@ -83,7 +94,7 @@ function PipelineExecution({
               <>
                 <Button
                   beforeIcon={<Close inverted size={UNIT * 2}/>}
-                  onClick={cancelPipeline}
+                  onClick={handleCancelPipeline}
                   success
                 >
                   <Text

--- a/mage_ai/frontend/components/PipelineDetail/PipelineExecution/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/PipelineExecution/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import Ansi from 'ansi-to-react';
 
 import Button from '@oracle/elements/Button';
@@ -22,6 +22,7 @@ import {
 } from '@storage/localStorage';
 import { OutputContainerStyle, OutputHeaderStyle } from './index.style';
 import { UNIT } from '@oracle/styles/units/spacing';
+import { removeKeyboardFocus } from '@context/shared/utils';
 
 export type PipelineExecutionProps = {
   cancelPipeline: () => void;
@@ -50,11 +51,11 @@ function PipelineExecution({
   // When the pipeline starts executing, the execution button gets disabled.
   // Disabled buttons are not focusable, so manually remove the focus here.
   const handleExecutePipeline = useCallback(() => {
-    (document.activeElement as HTMLElement).blur();
+    removeKeyboardFocus();
     executePipeline();
   }, [executePipeline]);
   const handleCancelPipeline = useCallback(() => {
-    (document.activeElement as HTMLElement).blur();
+    removeKeyboardFocus();
     cancelPipeline();
   }, [cancelPipeline]);
 

--- a/mage_ai/frontend/components/Sidekick/GlobalVariables/Secrets.tsx
+++ b/mage_ai/frontend/components/Sidekick/GlobalVariables/Secrets.tsx
@@ -20,6 +20,7 @@ import { DARK_CONTENT_BACKGROUND } from '@oracle/styles/colors/content';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { VariableType } from '@interfaces/PipelineVariableType';
 import { onSuccess } from '@api/utils/response';
+import { removeKeyboardFocus } from '@context/shared/utils';
 
 
 type SecretsProps = {
@@ -100,14 +101,16 @@ function Secrets({
         secret: {
           name: newSecretName,
           value: newSecretValue,
-        }
+        },
       }).then(() => {
         fetchSecrets();
         setNewSecretName(null);
         setNewSecretValue(null);
       });
+      removeKeyboardFocus();
       setShowNewSecret(false);
     } else if (e.key === 'Escape') {
+      removeKeyboardFocus();
       setShowNewSecret(false);
     }
   }, [
@@ -116,6 +119,11 @@ function Secrets({
     newSecretName,
     newSecretValue,
   ]);
+
+  const handleDelete = useCallback((secretName) => {
+    removeKeyboardFocus();
+    deleteSecret(secretName);
+  }, [deleteSecret]);
 
   const SAMPLE_SECRET_VALUE = `
     "{{ mage_secret_var('<secret_name>') }}"
@@ -235,7 +243,7 @@ function Secrets({
           {secrets?.map((secret: SecretType) => (
             <VariableRow
               copyText={secret.name}
-              deleteVariable={() => deleteSecret(secret.name)}
+              deleteVariable={() => handleDelete(secret.name)}
               fetchVariables={fetchSecrets}
               hideEdit
               key={secret.name}
@@ -259,9 +267,9 @@ function Secrets({
       <Spacing mb={PADDING_UNITS}>
         <CodeBlock
           language="yaml"
+          maxWidth={tableWidth}
           small
           source={SAMPLE_SECRET_VALUE}
-          maxWidth={tableWidth}
         />
       </Spacing>
       <Spacing mb={PADDING_UNITS}>
@@ -272,9 +280,9 @@ function Secrets({
       <Spacing mb={PADDING_UNITS}>
         <CodeBlock
           language="python"
+          maxWidth={tableWidth}
           small
           source={SECRET_IN_CODE}
-          maxWidth={tableWidth}
         />
       </Spacing>
     </Spacing>

--- a/mage_ai/frontend/components/Sidekick/GlobalVariables/VariableRow.tsx
+++ b/mage_ai/frontend/components/Sidekick/GlobalVariables/VariableRow.tsx
@@ -97,8 +97,10 @@ function VariableRow({
           },
         });
       }
+      (document.activeElement as HTMLElement).blur();
       onEnterCallback?.();
     } else if (e.key === 'Escape') {
+      (document.activeElement as HTMLElement).blur();
       setEdit(false);
       onEscapeCallback?.();
     }
@@ -110,6 +112,11 @@ function VariableRow({
     variableName,
     variableValue,
   ]);
+
+  const handleDelete = useCallback(() => {
+    (document.activeElement as HTMLElement).blur();
+    deleteVariable();
+  }, [deleteVariable]);
 
   useEffect(() => {
     if (edit) {
@@ -129,7 +136,7 @@ function VariableRow({
       onMouseLeave={() => setShowActions(false)}
     >
       <Row>
-        <Col md={1} hiddenSmDown>
+        <Col hiddenSmDown md={1}>
           <CellStyle noPadding>
             <KeyboardShortcutButton
               backgroundColor={DARK_CONTENT_BACKGROUND}
@@ -236,7 +243,7 @@ function VariableRow({
                     borderless
                     inline
                     muted
-                    onClick={deleteVariable}
+                    onClick={handleDelete}
                     small
                     uuid={`Sidekick/GlobalVariables/delete_${uuid}`}
                     withIcon

--- a/mage_ai/frontend/components/Sidekick/GlobalVariables/VariableRow.tsx
+++ b/mage_ai/frontend/components/Sidekick/GlobalVariables/VariableRow.tsx
@@ -14,6 +14,7 @@ import { LIME_DARK } from '@oracle/styles/colors/main';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { VariableType } from '@interfaces/PipelineVariableType';
 import { onSuccess } from '@api/utils/response';
+import { removeKeyboardFocus } from '@context/shared/utils';
 import { useMutation } from 'react-query';
 import api from '@api';
 
@@ -97,10 +98,10 @@ function VariableRow({
           },
         });
       }
-      (document.activeElement as HTMLElement).blur();
+      removeKeyboardFocus();
       onEnterCallback?.();
     } else if (e.key === 'Escape') {
-      (document.activeElement as HTMLElement).blur();
+      removeKeyboardFocus();
       setEdit(false);
       onEscapeCallback?.();
     }
@@ -114,7 +115,7 @@ function VariableRow({
   ]);
 
   const handleDelete = useCallback(() => {
-    (document.activeElement as HTMLElement).blur();
+    removeKeyboardFocus();
     deleteVariable();
   }, [deleteVariable]);
 

--- a/mage_ai/frontend/components/Sidekick/GlobalVariables/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/GlobalVariables/index.tsx
@@ -26,8 +26,9 @@ import { DARK_CONTENT_BACKGROUND } from '@oracle/styles/colors/content';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { ScheduleTypeEnum, SCHEDULE_TYPE_TO_LABEL } from '@interfaces/PipelineScheduleType';
 import { addTriggerVariables, getFormattedVariables } from '../utils';
-import { onSuccess } from '@api/utils/response';
 import { capitalizeRemoveUnderscoreLower } from '@utils/string';
+import { onSuccess } from '@api/utils/response';
+import { removeKeyboardFocus } from '@context/shared/utils';
 
 const SAMPLE_SOURCE = `
     from mage_ai.data_preparation.variable_manager import (
@@ -154,10 +155,10 @@ function GlobalVariables({
         setNewVariableName(null);
         setNewVariableValue(null);
       });
-      (document.activeElement as HTMLElement).blur();
+      removeKeyboardFocus();
       setShowNewVariable(false);
     } else if (e.key === 'Escape') {
-      (document.activeElement as HTMLElement).blur();
+      removeKeyboardFocus();
       setShowNewVariable(false);
     }
   }, [

--- a/mage_ai/frontend/components/Sidekick/GlobalVariables/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/GlobalVariables/index.tsx
@@ -148,14 +148,16 @@ function GlobalVariables({
         variable: {
           name: newVariableName,
           value: updatedValue,
-        }
+        },
       }).then(() => {
         fetchVariables();
         setNewVariableName(null);
         setNewVariableValue(null);
       });
+      (document.activeElement as HTMLElement).blur();
       setShowNewVariable(false);
     } else if (e.key === 'Escape') {
+      (document.activeElement as HTMLElement).blur();
       setShowNewVariable(false);
     }
   }, [
@@ -207,8 +209,8 @@ function GlobalVariables({
           <Col md={4}>
             <CellStyle>
               <TextInput
-                compact
                 borderless
+                compact
                 fullWidth
                 monospace
                 onChange={(e) => {
@@ -226,8 +228,8 @@ function GlobalVariables({
           <Col md={7}>
             <CellStyle>
               <TextInput
-                compact
                 borderless
+                compact
                 fullWidth
                 monospace
                 onChange={(e) => {

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { CanvasRef } from 'reaflow';
 
 import ApiReloader from '@components/ApiReloader';
@@ -582,6 +582,7 @@ function Sidekick({
           }
         }}
         overflowHidden={activeView === ViewKeyEnum.TREE}
+        tabIndex={0} // Make this div a focusable element
       >
         {activeView === ViewKeyEnum.TREE &&
           <ApiReloader uuid={`PipelineDetail/${pipeline?.uuid}`}>
@@ -744,11 +745,11 @@ function Sidekick({
 
         {ViewKeyEnum.INTERACTIONS === activeView && isInteractionsEnabled && (
           <PipelineInteractions
+            blockInteractionsMapping={blockInteractionsMapping}
             containerWidth={afterWidth}
             createInteraction={(interaction: InteractionType) => createInteraction({
               interaction,
             })}
-            blockInteractionsMapping={blockInteractionsMapping}
             interactions={interactions}
             interactionsMapping={interactionsMapping}
             isLoadingCreateInteraction={isLoadingCreateInteraction}

--- a/mage_ai/frontend/context/shared/utils.ts
+++ b/mage_ai/frontend/context/shared/utils.ts
@@ -2,7 +2,7 @@
  * Utility function to generate unique number per component instance
  */
 export const generateKey = (() => {
-  let count = 0;
+  const count = 0;
 
   return () => `${count}`;
 
@@ -24,4 +24,9 @@ export const isFunctionalComponent = (Component: Function) => {
   const prototype = Component.prototype;
 
   return !prototype || !prototype.isReactComponent;
+};
+
+/** Remove keyboard focus from the currently focused element  */
+export const removeKeyboardFocus = () => {
+  (document.activeElement as HTMLElement).blur();
 };


### PR DESCRIPTION
# Description

There was a bug on the Pipeline Runs page where after clicking the "Execute Pipeline" or "Cancel Pipeline" button, you could no longer save a code block via the `cmd + s` shortcut ([Airtable task](https://airtable.com/applEuqJsK4zF5yJK/tbl5bIlFkk2KhCpL4/viwCmaGgcnwD9IqOM/recdr4j0pXLg8tAFc?blocks=hide)). It would instead bring up the default system file save dialog:

https://github.com/mage-ai/mage-ai/assets/8130751/5aafe36b-4825-4734-9033-094aa5a2f526

The issue was that in `SidekickContainerStyle`, we disabled keyboard shortcuts in `onFocus` but the `onBlur` event was never triggered when the sidekick focus was lost. This is a result of a `div` not being a focusable element by default. This PR fixes this issue!

# How Has This Been Tested?
- [x] Test you can use the `cmd + s` shortcut to save a code block after clicking the `Execute pipeline` button
- [x] Test you can use the `cmd + s` shortcut to save a code block after clicking the `Cancel pipeline` button
- [x] Test you can use the `cmd + s` shortcut after interacting with the dependency graph
- [x] Test you can use the `cmd + s` shortcut after clicking the other buttons/toggles in the sidekick

**Pipeline Execution**

https://github.com/mage-ai/mage-ai/assets/8130751/1a756451-0666-40d6-b374-6e491275a867

**Global Variables**

https://github.com/mage-ai/mage-ai/assets/8130751/171ae052-cc48-4357-9e12-62877dde8a8f

**Secrets**

https://github.com/mage-ai/mage-ai/assets/8130751/036aa838-a2c5-4436-9771-ae49f921134b

cc: @johnson-mage 
