### PR TITLE
[xy] Fix libodbc conflicts in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,17 +16,13 @@ RUN \
     msodbcsql18\
     unixodbc-dev \
     # R
-    r-base
-
-# Resolve the conflicts between libodbc1 (from msodbcsql18) library and libodbc2 library (from freetds-bin)
-RUN apt-get -y remove libodbc1
-
-RUN apt-get -y install --no-install-recommends \
+    r-base && \
+  # Resolve the conflicts between libodbc1 (from msodbcsql18) library and libodbc2 library (from freetds-bin)
+  apt-get -y remove libodbc1 && \
+  apt-get -y install --no-install-recommends \
     # pymssql dependencies
     freetds-dev \
-    freetds-bin
-
-RUN \
+    freetds-bin && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,18 @@ RUN \
     # odbc dependencies
     msodbcsql18\
     unixodbc-dev \
+    # R
+    r-base
+
+# Resolve the conflicts between libodbc1 (from msodbcsql18) library and libodbc2 library (from freetds-bin)
+RUN apt-get -y remove libodbc1
+
+RUN apt-get -y install --no-install-recommends \
     # pymssql dependencies
     freetds-dev \
-    freetds-bin \
-    # R
-    r-base && \
+    freetds-bin
+
+RUN \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix libodbc conflicts in Dockerfile.

Resolve the conflicts between libodbc1 (from msodbcsql18) library and libodbc2 library (from freetds-bin)

Error: https://github.com/mage-ai/mage-ai/actions/runs/6635841565/job/18027399703
<img width="484" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/e878bb59-47d1-4259-bc21-50e77b25b2ed">



# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested building docker image with amd64 architecture locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
