### PR TITLE
[ac] Add `ctrl/cmd + click` keyboard shortcut for selecting pipeline run rows

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -182,7 +182,11 @@ function RetryButton({
         default={RunStatus.INITIAL === status}
         disabled={disabled || isViewerRole}
         loading={!pipelineRun}
-        onClick={() => setShowConfirmationId(pipelineRunId)}
+        onClick={(e) => {
+          // Stop table row from being highlighted as well
+          e.stopPropagation();
+          setShowConfirmationId(pipelineRunId);
+        }}
         padding="6px"
         primary={RunStatus.RUNNING === status && !isCancelingPipeline && !isViewerRole}
         warning={RunStatus.CANCELLED === status && !isViewerRole}
@@ -298,7 +302,6 @@ function PipelineRunsTable({
   const router = useRouter();
   const isViewerRole = isViewer();
   const displayLocalTimezone = shouldDisplayLocalTimezone();
-  const canRegisterKeyDown = useRef<boolean>(true);
   const deleteButtonRefs = useRef({});
   const [cancelingRunId, setCancelingRunId] = useState<number>(null);
   const [showConfirmationId, setShowConfirmationId] = useState<number>(null);
@@ -650,9 +653,13 @@ function PipelineRunsTable({
                     iconOnly
                     key="row_logs"
                     noBackground
-                    onClick={() => router.push(
-                      `/pipelines/${pipelineUUID}/logs?pipeline_run_id[]=${id}`,
-                    )}
+                    onClick={(e) => {
+                      // Stop table row from being highlighted as well
+                      e.stopPropagation();
+                      router.push(
+                        `/pipelines/${pipelineUUID}/logs?pipeline_run_id[]=${id}`,
+                      );
+                    }}
                   >
                     <Logs default size={ICON_SIZE_SMALL} />
                   </Button>,
@@ -779,9 +786,13 @@ function PipelineRunsTable({
                     iconOnly
                     key="row_logs"
                     noBackground
-                    onClick={() => router.push(
-                      `/pipelines/${pipelineUUID}/logs?pipeline_run_id[]=${id}`,
-                    )}
+                    onClick={(e) => {
+                      // Stop table row from being highlighted as well
+                      e.stopPropagation();
+                      router.push(
+                        `/pipelines/${pipelineUUID}/logs?pipeline_run_id[]=${id}`,
+                      );
+                    }}
                   >
                     <Logs default size={ICON_SIZE_SMALL} />
                   </Button>,
@@ -837,7 +848,9 @@ function PipelineRunsTable({
                   <Checkbox
                     checked={selected}
                     key={`selected-pipeline-run-${id}`}
-                    onClick={() => {
+                    onClick={(e) => {
+                      // Stop table row from being highlighted as well
+                      e.stopPropagation();
                       setSelectedRuns(prev => ({
                         ...prev,
                         [id]: selected ? null : pipelineRun,

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -497,6 +497,21 @@ function PipelineRunsTable({
     });
   }
 
+  const handleOnClickRow = useCallback((rowIndex: number, event: any) => {
+    if (onClickRow && setSelectedRuns && event && event.metaKey) {
+      const pipelineRun = pipelineRuns[rowIndex];
+      setSelectedRuns(prevRuns => {
+        const selected = !!prevRuns?.[pipelineRun.id];
+        return {
+          ...prevRuns,
+          [pipelineRun.id]: selected ? null : pipelineRun,
+        };
+      });
+    } else if (onClickRow) {
+      onClickRow(rowIndex);
+    }
+  }, [onClickRow, pipelineRuns, setSelectedRuns]);
+
   return (
     <TableContainerStyle
       minHeight={UNIT * 30}
@@ -517,7 +532,7 @@ function PipelineRunsTable({
               ? false
               : pipelineRuns[rowIndex].id === selectedRun?.id
             }
-            onClickRow={disableRowSelect ? null : onClickRow}
+            onClickRow={disableRowSelect ? null : handleOnClickRow}
             rowVerticalPadding={6}
             rows={pipelineRuns?.map((pipelineRun, index) => {
               const {

--- a/mage_ai/frontend/components/shared/Table/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/index.tsx
@@ -1,6 +1,5 @@
 import NextLink from 'next/link';
 import React, {
-  createRef,
   useCallback,
   useEffect,
   useMemo,
@@ -36,8 +35,9 @@ import {
   TableWrapperStyle,
 } from './index.style';
 import { goToWithQuery } from '@utils/routing';
-import { pushAtIndex, sortByKey } from '@utils/array';
+import { isInteractiveElement } from '@context/shared/utils';
 import { set } from '@storage/localStorage';
+import { sortByKey } from '@utils/array';
 
 export type ColumnType = {
   center?: boolean;
@@ -428,11 +428,13 @@ function Table({
           noHover={!(linkProps || onClickRow || renderExpandedRowWithObject)}
           // @ts-ignore
           onClick={(e) => {
-            if (onClickRow) {
-              handleRowClick(rowIndex, e);
+            if (!isInteractiveElement(e)) {
+              if (onClickRow) {
+                handleRowClick(rowIndex, e);
+              }
+  
+              onClickRowInternal(rowIndex, e);
             }
-
-            onClickRowInternal(rowIndex, e);
           }}
           onContextMenu={hasRightClickMenu
             ? (e) => {

--- a/mage_ai/frontend/components/shared/Table/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/index.tsx
@@ -88,7 +88,7 @@ type TableProps = {
   menu?: any;
   noBorder?: boolean;
   noHeader?: boolean;
-  onClickRow?: (index: number) => void;
+  onClickRow?: (index: number, event?: any) => void;
   onDoubleClickRow?: (index: number) => void;
   onRightClickRow?: (index: number, event?: any) => void;
   renderExpandedRowWithObject?: (index: number, object: any) => any;
@@ -413,7 +413,7 @@ function Table({
     } else {
       const handleRowClick = (rowIndex: number, event: React.MouseEvent) => {
         if (event?.detail === 1) {
-          onClickRow(rowIndex);
+          onClickRow(rowIndex, event);
         } else if (onDoubleClickRow && event?.detail === 2) {
           onDoubleClickRow(rowIndex);
         }
@@ -432,7 +432,7 @@ function Table({
               if (onClickRow) {
                 handleRowClick(rowIndex, e);
               }
-  
+
               onClickRowInternal(rowIndex, e);
             }
           }}

--- a/mage_ai/frontend/context/shared/utils.ts
+++ b/mage_ai/frontend/context/shared/utils.ts
@@ -30,3 +30,13 @@ export const isFunctionalComponent = (Component: Function) => {
 export const removeKeyboardFocus = () => {
   (document.activeElement as HTMLElement).blur();
 };
+
+/** Determine whether the event target is an interactive element */
+export const isInteractiveElement = (event): boolean => {
+  if (event.target instanceof Element) {
+    const tagName = (event.target as Element).tagName.toLowerCase();
+    return ['a', 'button', 'input', 'select'].includes(tagName);
+  }
+
+  return false;
+};


### PR DESCRIPTION
# Description

In the Pipeline Runs table, you can click on a row to **highlight** it and open the sidekick with run details. You can also click on a row's checkbox (on the far left) to **select/deselect** it for performing actions on one or more rows. Previously, clicking on a row's checkbox both selected/deselected and highlighted the row.

This PR makes a few updates to how we highlight/select rows:
* When you click on a row's checkbox, we no longer highlight the row and only select/deselect it. We've also made a broader change to prevent a table row from being highlighted if the user clicked on an interactive element (e.g. `a`, `button`, `input`) in the row.
* We also add a new keyboard shortcut for selecting rows. If you hold the meta key (`Cmd` on Mac or `Ctrl` on Windows) and click on an unselected row, that row will be selected without being highlighted. If the clicked row is already selected, that row will be unselected. ([Airtable task](https://airtable.com/applEuqJsK4zF5yJK/tbl5bIlFkk2KhCpL4/viwCmaGgcnwD9IqOM/rectr4unRQGOn8xjz?blocks=hide))
* The new keyboard shortcut only works when rows are selectable in the Pipeline Runs table. If rows are not selectable (e.g. on the Backfills page), the keyboard shortcut does not take effect. For example, if you hold the meta key + click a row in the Pipeline Runs table on the Backfills page, the row will be highlighted.

# How Has This Been Tested?

- [x] Tested that clicking on a row's checkbox selects/deselects it without highlighting it
- [x] Tested that clicking on a row highlights it (but does not select/unselect it)
- [x] Tested that clicking on an unselected row while holding the meta key down selects it without highlighting it
- [x] Tested that clicking on a selected row while holding the meta key down deselects it without highlighting it
- [x] Tested that clicking on an interactive element in the row doesn't highlight the row

https://github.com/mage-ai/mage-ai/assets/8130751/436fca61-796c-4959-ae5b-cfc3385b483c

cc: @johnson-mage 