### PR TITLE
[dy] Update authorize_query check

### DIFF
--- a/mage_ai/api/policies/BasePolicy.py
+++ b/mage_ai/api/policies/BasePolicy.py
@@ -503,15 +503,12 @@ class BasePolicy(UserPermissionMixIn, ResultSetMixIn):
             await self.authorize_attribute(read_or_write, attrb, **kwargs)
 
     async def authorize_query(self, query, **kwargs):
-        if not REQUIRE_USER_AUTHENTICATION:
+        if not REQUIRE_USER_AUTHENTICATION and not DISABLE_NOTEBOOK_EDIT_ACCESS:
             return True
 
         query_filtered = ignore_keys(query or {}, [URL_PARAMETER_API_KEY])
 
         if not query_filtered:
-            return True
-
-        if self.is_owner():
             return True
 
         api_operation_action = self.options.get(

--- a/mage_ai/api/policies/BasePolicy.py
+++ b/mage_ai/api/policies/BasePolicy.py
@@ -503,7 +503,11 @@ class BasePolicy(UserPermissionMixIn, ResultSetMixIn):
             await self.authorize_attribute(read_or_write, attrb, **kwargs)
 
     async def authorize_query(self, query, **kwargs):
-        if not REQUIRE_USER_AUTHENTICATION and not DISABLE_NOTEBOOK_EDIT_ACCESS:
+        # If DISABLE_NOTEBOOK_EDIT_ACCESS is enabled, we will need to perform
+        # the policy check for queries.
+        if not DISABLE_NOTEBOOK_EDIT_ACCESS and (
+            not REQUIRE_USER_AUTHENTICATION or self.is_owner()
+        ):
             return True
 
         query_filtered = ignore_keys(query or {}, [URL_PARAMETER_API_KEY])


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Before, if a user was a owner, the `authorize_query` check would automatically return true. We need to perform the policy checks if `DISABLE_NOTEBOOK_EDIT_ACCESS` is enabled, so I changed the condition to check for that environment variable.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with user authentication enabled
- [x] Tested locally with user authentication disabled
- [x] Unit tests


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
