### PR TITLE
[ac] Improve app header styling

### DIFF
--- a/mage_ai/frontend/components/ServerTimeDropdown/ServerTimeButton.tsx
+++ b/mage_ai/frontend/components/ServerTimeDropdown/ServerTimeButton.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useRef } from 'react';
 
 import Text from '@oracle/elements/Text';
+import { BORDER_RADIUS_SMALL } from '@oracle/styles/units/borders';
 import { ButtonProps } from '@oracle/elements/Button';
 import { ButtonStyle } from './index.style';
 
@@ -31,12 +32,13 @@ function ServerTimeButton({
       {...props}
       active={active}
       borderLess
+      borderRadius={BORDER_RADIUS_SMALL}
       compact
       highlightOnHoverAlt
       ref={buttonRef}
       transparent
     >
-      <Text inline monospace>
+      <Text inline monospace small>
         {`${time} ${timeZone}`}
       </Text>
     </ButtonStyle>

--- a/mage_ai/frontend/components/shared/Header/index.tsx
+++ b/mage_ai/frontend/components/shared/Header/index.tsx
@@ -246,40 +246,16 @@ function Header({
           </Flex>
 
           <Flex alignItems="center">
-            <ServerTimeDropdown />
-            {latestVersion && version && latestVersion !== version && (
-              <Spacing ml={2}>
-                <Button
-                  borderLess
-                  linkProps={{
-                    href: 'https://docs.mage.ai/about/releases',
-                  }}
-                  noHoverUnderline
-                  primary
-                  target="_blank"
-                >
-                  <Text>
-                    🚀 Download new version <Text
-                      bold
-                      inline
-                      monospace
-                    >
-                      {latestVersion}
-                    </Text>
-                  </Text>
-                </Button>
-              </Spacing>
-            )}
-
             {gitIntegrationEnabled && branch && (
-              <Spacing ml={2}>
+              <Spacing ml={1}>
                 <KeyboardShortcutButton
-                  blackBorder
-                  block
                   compact
+                  highlightOnHoverAlt
+                  noBackground
                   noHoverUnderline
                   onClick={showModal}
                   sameColorAsText
+                  title={branch}
                   uuid="Header/GitActions"
                 >
                   <FlexContainer alignItems="center">
@@ -293,29 +269,54 @@ function Header({
               </Spacing>
             )}
 
+            <Spacing ml={1}>
+              <ServerTimeDropdown />
+            </Spacing>
+
             {version && typeof(version) !== 'undefined' && (
               <Spacing ml={2}>
                 <Link
-                  default
                   href="https://www.mage.ai/changelog"
                   monospace
                   openNewWindow
+                  sameColorAsText
+                  small
                 >
                   {`v${version}`}
                 </Link>
               </Spacing>
             )}
 
-            <Spacing ml={2}>
+            {latestVersion && version && latestVersion !== version && (
+              <Spacing ml={1}>
+                <Button
+                  borderLess
+                  compact
+                  linkProps={{
+                    href: 'https://docs.mage.ai/about/releases',
+                  }}
+                  noHoverUnderline
+                  pill
+                  primary
+                  target="_blank"
+                  title={`Update to version ${latestVersion}`}
+                >
+                  <Text bold>Update</Text>
+                </Button>
+              </Spacing>
+            )}
+
+            <Spacing ml={3}>
               <KeyboardShortcutButton
                 beforeElement={<Slack />}
-                blackBorder
                 compact
+                highlightOnHoverAlt
                 inline
                 linkProps={{
                   as: 'https://www.mage.ai/chat',
                   href: 'https://www.mage.ai/chat',
                 }}
+                noBackground
                 noHoverUnderline
                 openNewTab
                 sameColorAsText

--- a/mage_ai/frontend/components/shared/Header/index.tsx
+++ b/mage_ai/frontend/components/shared/Header/index.tsx
@@ -24,7 +24,7 @@ import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
 import Tooltip from '@oracle/components/Tooltip';
 import api from '@api';
-import { BLUE_TRANSPARENT } from '@oracle/styles/colors/main';
+import { BLUE_TRANSPARENT, YELLOW } from '@oracle/styles/colors/main';
 import { Branch, Slack } from '@oracle/icons';
 import {
   HeaderStyle,
@@ -290,6 +290,7 @@ function Header({
             {latestVersion && version && latestVersion !== version && (
               <Spacing ml={1}>
                 <Button
+                  backgroundColor={YELLOW}
                   borderLess
                   compact
                   linkProps={{
@@ -297,11 +298,11 @@ function Header({
                   }}
                   noHoverUnderline
                   pill
-                  primary
+                  sameColorAsText
                   target="_blank"
                   title={`Update to version ${latestVersion}`}
                 >
-                  <Text bold>Update</Text>
+                  <Text black bold>Update</Text>
                 </Button>
               </Spacing>
             )}

--- a/mage_ai/frontend/oracle/elements/Button/KeyboardShortcutButton.tsx
+++ b/mage_ai/frontend/oracle/elements/Button/KeyboardShortcutButton.tsx
@@ -20,6 +20,7 @@ import {
   OUTLINE_OFFSET,
   OUTLINE_WIDTH,
 } from '@oracle/styles/units/borders';
+import { ButtonHighlightProps, SHARED_HIGHLIGHT_STYLES } from '.';
 import {
   FONT_FAMILY_BOLD,
   FONT_FAMILY_REGULAR,
@@ -104,10 +105,11 @@ export type KeyboardShortcutButtonProps = {
   withIcon?: boolean;
   wrapText?: boolean;
   useModelTheme?: boolean;
-} & KeyboardShortcutSharedProps & LinkProps;
+} & ButtonHighlightProps & KeyboardShortcutSharedProps & LinkProps;
 
 const SHARED_STYLES = css<KeyboardShortcutButtonProps>`
   ${transition()}
+  ${SHARED_HIGHLIGHT_STYLES}
 
   align-items: center;
   border: none;

--- a/mage_ai/frontend/oracle/elements/Button/index.tsx
+++ b/mage_ai/frontend/oracle/elements/Button/index.tsx
@@ -28,6 +28,11 @@ export function selectOutlineColor(props) {
   return (props.theme.background || dark.background).panel;
 }
 
+export type ButtonHighlightProps = {
+  highlightOnHover?: boolean;
+  highlightOnHoverAlt?: boolean;
+};
+
 export type ButtonProps = {
   afterIcon?: any;
   backgroundColor?: string;
@@ -45,8 +50,6 @@ export type ButtonProps = {
   default?: boolean;
   disabled?: boolean;
   fullWidth?: boolean;
-  highlightOnHover?: boolean;
-  highlightOnHoverAlt?: boolean;
   iconOnly?: boolean;
   id?: string;
   large?: boolean;
@@ -89,12 +92,27 @@ export type ButtonProps = {
   transparent?: boolean;
   warning?: boolean;
   width?: number;
-};
+} & ButtonHighlightProps;
+
+export const SHARED_HIGHLIGHT_STYLES = css<ButtonHighlightProps>`
+  ${props => props.highlightOnHover && `
+    &:hover {
+      background-color: ${(props.theme.interactive || dark.interactive).hoverBorder} !important;
+    }
+  `}
+
+  ${props => props.highlightOnHoverAlt && `
+    &:hover {
+      background-color: ${(props.theme.background || dark.background).dashboard} !important;
+    }
+  `}
+`;
 
 const SHARED_STYLES = css<{
   hasOnClick?: boolean;
 } & ButtonProps>`
   ${transition()}
+  ${SHARED_HIGHLIGHT_STYLES}
 
   border: none;
   display: block;
@@ -225,18 +243,6 @@ const SHARED_STYLES = css<{
 
   ${props => props.transparent && `
     background-color: transparent;
-  `}
-
-  ${props => props.highlightOnHover && `
-    &:hover {
-      background-color: ${(props.theme.interactive || dark.interactive).hoverBorder};
-    }
-  `}
-
-  ${props => props.highlightOnHoverAlt && `
-    &:hover {
-      background-color: ${(props.theme.background || dark.background).dashboard};
-    }
   `}
 
   ${props => props.outline && !props.disabled && !props.notClickable && `


### PR DESCRIPTION
# Description
Kai and I were chatting about how the shared app header had inconsistent styling (e.g. button sizing, item placements):

![original_header](https://github.com/mage-ai/mage-ai/assets/8130751/ba5bd307-6e6b-48b8-a57f-f7ab4037dc20)

So we came up with a couple minor styling improvements!

* Re-ordered the items on the right side of the app header: Github actions button, current time display, version display, version update button, Live Chat button
* Standardized the Github actions button, current time display, and version display to be 12px Fira codemonospace 
* Standardized the version update button and Live Chat button to be 14px Roboto
* Made the button styling more minimalistic + cleaner and shortened the version update button text
* Hovering over the Github actions button shows the full branch name
* Hovering over the version update button shows a more descriptive action: "Update version to `<version>`"

# How Has This Been Tested?

https://github.com/mage-ai/mage-ai/assets/8130751/5a6cae48-1866-44cb-b315-415f83cfa2ad

<img width="1792" alt="image" src="https://github.com/mage-ai/mage-ai/assets/8130751/1c9d0bb4-1a0f-45df-9a7c-43bbc46389f0">

cc: @johnson-mage 