### PR TITLE
[ac] Make sure file browser context menu is always fully visible in the viewport when open

### DIFF
--- a/mage_ai/frontend/components/FileBrowser/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/index.tsx
@@ -515,7 +515,7 @@ function FileBrowser({
       }
     }
 
-    let yFinal = y;
+    let yFinal = y + (UNIT / 2);
     const menuHeight = MENU_ITEM_HEIGHT * items.length;
     if (y + menuHeight >= window.innerHeight) {
       yFinal = y - menuHeight;

--- a/mage_ai/frontend/components/FileBrowser/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/index.tsx
@@ -11,7 +11,7 @@ import { useMutation } from 'react-query';
 
 import BlockType, { BlockRequestPayloadType, BlockTypeEnum } from '@interfaces/BlockType';
 import FileType from '@interfaces/FileType';
-import FlyoutMenu from '@oracle/components/FlyoutMenu';
+import FlyoutMenu, { DEFAULT_MENU_ITEM_HEIGHT } from '@oracle/components/FlyoutMenu';
 import Folder, { FolderSharedProps } from './Folder';
 import NewFile from './NewFile';
 import NewFolder from './NewFolder';
@@ -28,6 +28,7 @@ import {
 import { HEADER_Z_INDEX } from '@components/constants';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { buildAddBlockRequestPayload } from '../FileEditor/utils';
+import { createPortal } from 'react-dom';
 import { getBlockFromFile, getFullPathWithoutRootFolder } from './utils';
 import { find } from '@utils/array';
 import { onSuccess } from '@api/utils/response';
@@ -521,22 +522,25 @@ function FileBrowser({
     }
 
     return (
-      <div
-        style={{
-          left: xFinal,
-          position: 'fixed',
-          top: yFinal,
-          zIndex: HEADER_Z_INDEX + 100,
-        }}
-      >
-        <FlyoutMenu
-          items={items}
-          open
-          parentRef={undefined}
-          uuid="FileBrowser/ContextMenu"
-          width={MENU_WIDTH}
-        />
-      </div>
+      createPortal(
+        <div
+          style={{
+            left: xFinal,
+            position: 'fixed',
+            top: yFinal,
+            zIndex: HEADER_Z_INDEX + 100,
+          }}
+        >
+          <FlyoutMenu
+            items={items}
+            open
+            parentRef={undefined}
+            uuid="FileBrowser/ContextMenu"
+            width={MENU_WIDTH}
+          />
+        </div>, 
+        document.body,
+      )
     );
   }, [
     coordinates,

--- a/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/FlyoutMenu/index.tsx
@@ -21,8 +21,11 @@ import {
   KEY_CODE_ARROW_UP,
   KEY_CODE_ENTER,
 } from '@utils/hooks/keyboardShortcuts/constants';
+import { UNIT } from '@oracle/styles/units/spacing';
 import { pauseEvent } from '@utils/events';
 import { useKeyboardContext } from '@context/Keyboard';
+
+export const DEFAULT_MENU_ITEM_HEIGHT = UNIT * 4.5;
 
 export type FlyoutMenuItemType = {
   beforeIcon?: JSX.Element;
@@ -176,7 +179,7 @@ function FlyoutMenu({
       ? customSubmenuHeights?.[uuid]
       : null;
     const customHeightOffset = hasCustomHeight
-      ? customSubmenuHeights?.[uuid] - 36
+      ? customSubmenuHeights?.[uuid] - DEFAULT_MENU_ITEM_HEIGHT
       : 0;
 
     return (


### PR DESCRIPTION
# Description

Previously, the file browser context menu would be partially hidden in scenarios where the file browser area was too small to fit the full menu. This was because overflow was hidden in the file browser aside:

https://github.com/mage-ai/mage-ai/assets/8130751/91073d14-39f7-4688-ad97-5e4ca81990c5

This PR fixes this bug and makes sure that the file browser context menu is always fully visible within the viewport ([Airtable Task Pt. 1](https://airtable.com/applEuqJsK4zF5yJK/tbl5bIlFkk2KhCpL4/viwCmaGgcnwD9IqOM/recrnz90jwBp3lxJJ?blocks=hide)). The fix makes use of [React Portals](https://react.dev/reference/react-dom/createPortal) to render the context menu into a DOM node that exists outside the DOM hierarchy of the parent component, which has `overflow: hidden`.

Note: This is a one-off fix that works because the menu uses fixed positioning; the longer term solution would be a much bigger refactor to `FlyoutMenu` (potentially using React Portals while supporting absolute positioning).

# How Has This Been Tested?

- [x] Tested that the file browser context menu is fully visible when aside has a narrow width
- [x] Tested that the file browser context menu is fully visible when clicking a file near the bottom of the viewport
- [x] Tested that the above behavior works for the file, block file, and folder context menus

https://github.com/mage-ai/mage-ai/assets/8130751/7f934ad8-2b3e-4b30-951d-d94ec3cfbcb7

cc: @johnson-mage 