### PR TITLE
[xy] Send notification on block run intialization failure.

### DIFF
--- a/docs/integrations/observability/alerting-email.mdx
+++ b/docs/integrations/observability/alerting-email.mdx
@@ -89,7 +89,7 @@ you can specify `title` and either `summary` or `details`.
 * If you specify the `details`, the `details` will be used as your email body
 
 To interpolate variables in the messaget template, you can use `{variable_name}` syntax.
-Hare are the supported variables: `execution_time`, `pipeline_run_url`, `pipeline_schedule_id`,
+Hare are the supported variables: `error`, `execution_time`, `pipeline_run_url`, `pipeline_schedule_id`,
 `pipeline_schedule_name`, `pipeline_uuid`.
 
 For `pipeline_run_url`, the default host is `http://localhost:6789`. You can specify `MAGE_PUBLIC_HOST` to be

--- a/docs/integrations/observability/alerting-slack.mdx
+++ b/docs/integrations/observability/alerting-slack.mdx
@@ -100,7 +100,7 @@ you can specify either `summary` or `details`.
 * If you specify the `details`, the `details` will be used as your slack message directly
 
 To interpolate variables in the messaget template, you can use `{variable_name}` syntax.
-Hare are the supported variables: `execution_time`, `pipeline_run_url`, `pipeline_schedule_id`,
+Hare are the supported variables: `error`, `execution_time`, `pipeline_run_url`, `pipeline_schedule_id`,
 `pipeline_schedule_name`, `pipeline_uuid`.
 
 For `pipeline_run_url`, the default host is `http://localhost:6789`. You can specify `MAGE_PUBLIC_HOST` to be

--- a/mage_ai/orchestration/notification/sender.py
+++ b/mage_ai/orchestration/notification/sender.py
@@ -166,10 +166,11 @@ class NotificationSender:
             `default_message`.
 
         Args:
-            default_message (TYPE): default message dict, containing "title",
+            default_message (Dict): default message dict, containing "title",
                 "summary", "details" keys.
             pipeline: the pipeline object, used to interpolate variables in the message.
             pipeline_run: the pipeline run object, used to interpolate variables in the message.
+            error (str): the error message that can be interpolated in the message.
             message_template (MessageTemplate, optional): custom message template that's provided
                 by user.
             summary (str, optional): summary that's used to override the custom message template.

--- a/mage_ai/orchestration/notification/sender.py
+++ b/mage_ai/orchestration/notification/sender.py
@@ -25,7 +25,8 @@ DEFAULT_MESSAGES = dict(
         title='Failed to run Mage pipeline {pipeline_uuid}',
         summary=(
             'Failed to run Pipeline `{pipeline_uuid}` with Trigger {pipeline_schedule_id} '
-            '`{pipeline_schedule_name}` at execution time `{execution_time}`.'
+            '`{pipeline_schedule_name}` at execution time `{execution_time}`. '
+            'Error: {error}'
         ),
     ),
     passed_sla=dict(
@@ -98,6 +99,7 @@ class NotificationSender:
         self,
         pipeline,
         pipeline_run,
+        error: str = None,
         summary: str = None,
     ) -> None:
         if AlertOn.PIPELINE_RUN_FAILURE in self.config.alert_on:
@@ -110,6 +112,7 @@ class NotificationSender:
                 default_message,
                 pipeline,
                 pipeline_run,
+                error=error,
                 message_template=message_template,
                 summary=summary,
             )
@@ -128,10 +131,17 @@ class NotificationSender:
                 message_template=message_template,
             )
 
-    def __interpolate_vars(self, text: str, pipeline, pipeline_run):
+    def __interpolate_vars(
+        self,
+        text: str,
+        pipeline,
+        pipeline_run,
+        error: str = None,
+    ):
         if text is None or pipeline is None or pipeline_run is None:
             return text
         return text.format(
+            error=error,
             execution_time=pipeline_run.execution_date,
             pipeline_run_url=self.__pipeline_run_url(pipeline, pipeline_run),
             pipeline_schedule_id=pipeline_run.pipeline_schedule.id,
@@ -144,6 +154,7 @@ class NotificationSender:
         default_message: Dict,
         pipeline,
         pipeline_run,
+        error: str = None,
         message_template: MessageTemplate = None,
         summary: str = None,
     ):
@@ -182,9 +193,24 @@ class NotificationSender:
                 details = message_template.details
 
         self.send(
-            title=self.__interpolate_vars(title or default_title, pipeline, pipeline_run),
-            summary=self.__interpolate_vars(summary or default_summary, pipeline, pipeline_run),
-            details=self.__interpolate_vars(details or default_details, pipeline, pipeline_run),
+            title=self.__interpolate_vars(
+                title or default_title,
+                pipeline,
+                pipeline_run,
+                error=error,
+            ),
+            summary=self.__interpolate_vars(
+                summary or default_summary,
+                pipeline,
+                pipeline_run,
+                error=error,
+            ),
+            details=self.__interpolate_vars(
+                details or default_details,
+                pipeline,
+                pipeline_run,
+                error=error,
+            ),
         )
 
     def __with_pipeline_run_url(self, text, pipeline, pipeline_run):

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -155,6 +155,10 @@ class PipelineScheduler:
                 )),
             )
             self.pipeline_run.update(status=PipelineRun.PipelineRunStatus.FAILED)
+            self.notification_sender.send_pipeline_run_failure_message(
+                pipeline=self.pipeline,
+                pipeline_run=self.pipeline_run,
+            )
             return False
 
         self.pipeline_run.update(

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -148,7 +148,7 @@ class PipelineScheduler:
                 else:
                     self.pipeline_run.create_block_runs()
         except Exception as e:
-            error_msg = 'Fail to initialize block runs'
+            error_msg = 'Fail to initialize block runs.'
             self.logger.exception(
                 error_msg,
                 **merge_dict(tags, dict(
@@ -203,7 +203,7 @@ class PipelineScheduler:
                     )
                     failed_block_runs = self.pipeline_run.failed_block_runs
                     error_msg = 'Failed blocks: '\
-                                f'{", ".join([b.block_uuid for b in failed_block_runs])}'
+                                f'{", ".join([b.block_uuid for b in failed_block_runs])}.'
                     self.notification_sender.send_pipeline_run_failure_message(
                         error=error_msg,
                         pipeline=self.pipeline,
@@ -255,9 +255,9 @@ class PipelineScheduler:
                 failed_block_runs = self.pipeline_run.failed_block_runs
                 if len(failed_block_runs) > 0:
                     error_msg = 'Failed blocks: '\
-                                f'{", ".join([b.block_uuid for b in failed_block_runs])}'
+                                f'{", ".join([b.block_uuid for b in failed_block_runs])}.'
                 else:
-                    error_msg = 'Pipelien run timed out'
+                    error_msg = 'Pipelien run timed out.'
                 self.notification_sender.send_pipeline_run_failure_message(
                     pipeline=self.pipeline,
                     pipeline_run=self.pipeline_run,
@@ -1391,7 +1391,7 @@ def schedule_all():
             ),
             PipelineRun.status == PipelineRun.PipelineRunStatus.COMPLETED,
         )
-        query = query.add_column(row_number_column)
+        query = query.add_columns(row_number_column)
         query = query.from_self().filter(row_number_column == 1)
         for tup in query.all():
             pr, _ = tup

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -202,7 +202,8 @@ class PipelineScheduler:
                         completed_at=datetime.now(tz=pytz.UTC),
                     )
                     failed_block_runs = self.pipeline_run.failed_block_runs
-                    error_msg = f'Failed blocks: {[b.uuid for b in failed_block_runs]}'
+                    error_msg = 'Failed blocks: '\
+                                f'{", ".join([b.block_uuid for b in failed_block_runs])}'
                     self.notification_sender.send_pipeline_run_failure_message(
                         error=error_msg,
                         pipeline=self.pipeline,
@@ -253,7 +254,8 @@ class PipelineScheduler:
 
                 failed_block_runs = self.pipeline_run.failed_block_runs
                 if len(failed_block_runs) > 0:
-                    error_msg = f'Failed blocks: {[b.uuid for b in failed_block_runs]}'
+                    error_msg = 'Failed blocks: '\
+                                f'{", ".join([b.block_uuid for b in failed_block_runs])}'
                 else:
                     error_msg = 'Pipelien run timed out'
                 self.notification_sender.send_pipeline_run_failure_message(

--- a/mage_ai/tests/orchestration/notification/test_sender.py
+++ b/mage_ai/tests/orchestration/notification/test_sender.py
@@ -58,7 +58,7 @@ class NotificationSenderTests(DBTestCase):
             'Failed to run Pipeline `test_pipeline` '
             f'with Trigger {pipeline_run.pipeline_schedule.id} '
             f'`{pipeline_run.pipeline_schedule.name}` '
-            f'at execution time `{pipeline_run.execution_date}`.\n'
+            f'at execution time `{pipeline_run.execution_date}`. Error: None\n'
             f'Open http://localhost:6789/pipelines/test_pipeline/runs/'
             f'{pipeline_run.id} to check pipeline run results and logs.'
         )
@@ -110,7 +110,7 @@ class NotificationSenderTests(DBTestCase):
             'Failed to run Pipeline `test_pipeline` '
             f'with Trigger {pipeline_run.pipeline_schedule.id} '
             f'`{pipeline_run.pipeline_schedule.name}` '
-            f'at execution time `{pipeline_run.execution_date}`.'
+            f'at execution time `{pipeline_run.execution_date}`. Error: None'
         )
         mock_send_teams_message.assert_called_once_with(
             notification_config.teams_config,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Close: https://github.com/mage-ai/mage-ai/issues/3802

When a pipeline fail due to Fail to initialize block runs, send the failure message to notification channels.

This PR also add the support to include the error message in notifications.

The error message includes the failed block uuids if there're any.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally by manually raising exception in the PipelineScheduler start method. The slack notification is sent.

Custom template
<img width="528" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/db9fea77-19d1-4ea7-9dcc-bfbdadb7efd0">

Default template
<img width="540" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/74520de3-5a7c-4d5e-851b-ddcc56c3756e">

Error message with failed block runs:
<img width="407" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/712f9fa6-055c-4067-b125-f1524a610c1d">


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
