### PR TITLE
[xy] Use read_namespaced_job instead of read_namespaced_job_status.

### DIFF
--- a/mage_ai/services/k8s/job_manager.py
+++ b/mage_ai/services/k8s/job_manager.py
@@ -67,7 +67,7 @@ class JobManager():
         api_response = None
         job_completed = False
         while not job_completed:
-            api_response = self.batch_api_client.read_namespaced_job_status(
+            api_response = self.batch_api_client.read_namespaced_job(
                 name=self.job_name,
                 namespace=self.namespace
             )


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Use `read_namespaced_job` instead of `read_namespaced_job_status` when getting k8s job status.

I check the response of `read_namespaced_job` and `read_namespaced_job_status` methods. The responses are the same. `read_namespaced_job` doesn't require the extra permissions of `jobs/status` resource.

Close: https://github.com/mage-ai/mage-ai/issues/3810

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested in a local kubernetes cluster and use k8s as the executor_type. Update service account role to not have  [`jobs/status`](https://github.com/mage-ai/helm-charts/blob/master/charts/mageai/templates/serviceaccount.yaml#L24) permissions. The k8s job manager runs normally.

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
