### PR TITLE
[xy] Support 'text/csv' response type in API source

### DIFF
--- a/mage_integrations/mage_integrations/sources/api/__init__.py
+++ b/mage_integrations/mage_integrations/sources/api/__init__.py
@@ -190,7 +190,7 @@ class Api(Source):
 
         checked_type = self._check_response_type(response)
 
-        if checked_type == 'text/plain':
+        if checked_type == 'text/plain' or checked_type == 'text/csv':
             df = polars.read_csv(StringIO(response.content.decode()), separator=separator,
                                  has_header=header).to_pandas()
             yield df.to_dict()

--- a/mage_integrations/mage_integrations/sources/api/__init__.py
+++ b/mage_integrations/mage_integrations/sources/api/__init__.py
@@ -193,11 +193,11 @@ class Api(Source):
         if checked_type == 'text/plain' or checked_type == 'text/csv':
             df = polars.read_csv(StringIO(response.content.decode()), separator=separator,
                                  has_header=header).to_pandas()
-            yield df.to_dict()
+            yield df.to_dict(orient='records')
 
         elif checked_type == 'google_sheets':
             df = self._deal_with_google_sheets(response, separator, header)
-            yield df.to_dict()
+            yield df.to_dict(orient='records')
 
         elif checked_type == 'application/json':
             result = response.json()
@@ -246,9 +246,9 @@ class Api(Source):
         else:
             try:
                 df = polars.read_excel(BytesIO(response.content),
-                                       read_csv_options={"separator": separator,
-                                       "has_header": header}).to_pandas()
-                yield df.to_dict()
+                                       read_csv_options={'separator': separator,
+                                       'has_header': header}).to_pandas()
+                yield df.to_dict(orient='records')
             except Exception:
                 raise Exception(f'Problems reading file {checked_type}. Check if extension is XLSX')
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Support 'text/csv' response type in API source.

This PR also fixes converting dataframe to the list of records in API integration source.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with the below config in an API source
<img width="919" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/6118dded-13e1-4e16-b374-539695ea5207">
The sync succeeded.
<img width="854" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/8a0106e0-c144-42ee-b8ae-238f65b2954e">

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
