### PR TITLE
[jk] Limit output when running GDP blocks in Pipeline Editor

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -789,7 +789,7 @@ function CodeBlock({
         Object.entries(interaction?.variables || {}).forEach(([
           variableUUID,
           {
-            types
+            types,
           },
         ]) => {
           if (variablesToUse && variableUUID in variablesToUse) {

--- a/mage_ai/server/websocket_server.py
+++ b/mage_ai/server/websocket_server.py
@@ -324,6 +324,11 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
         replicated_block = msg_id_value.get('replicated_block')
         pipeline_uuid = msg_id_value.get('pipeline_uuid')
 
+        if block_type == BlockType.GLOBAL_DATA_PRODUCT and \
+            type(message['data']) is list and \
+                message['data'][0].startswith('INFO:'):
+            return
+
         error = message.get('error')
         if error:
             message['data'] = cls.format_error(

--- a/mage_ai/server/websocket_server.py
+++ b/mage_ai/server/websocket_server.py
@@ -324,6 +324,7 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
         replicated_block = msg_id_value.get('replicated_block')
         pipeline_uuid = msg_id_value.get('pipeline_uuid')
 
+        # Hide excessive printing of INFO messages in GDP block output in UI
         if block_type == BlockType.GLOBAL_DATA_PRODUCT and \
             type(message['data']) is list and \
                 message['data'][0].startswith('INFO:'):


### PR DESCRIPTION
# Description
- There would be excessive output printed when running GDP blocks in the Pipeline Editor, so this PR hides the `INFO` messages in the block output for GDP blocks to clean up the output and mitigate browser memory issues.

# How Has This Been Tested?
Sample block output without hiding `INFO` messages:
![verbose gdp block output](https://github.com/mage-ai/mage-ai/assets/78053898/fa75e7c4-8d97-4c1d-acd9-4b6b2bef9c71)

Cleaned up sample block output for same block:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/5de6433c-4b3b-4dc7-bd37-67e49b15f4e3)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
