### PR TITLE
[dy] Add pipeline run limit for a pipeline

### DIFF
--- a/mage_ai/orchestration/concurrency.py
+++ b/mage_ai/orchestration/concurrency.py
@@ -3,7 +3,14 @@ from dataclasses import dataclass
 from mage_ai.shared.config import BaseConfig
 
 
+class OnLimitReached:
+    WAIT = 'wait'
+    SKIP = 'skip'
+
+
 @dataclass
 class ConcurrencyConfig(BaseConfig):
-    pipeline_run_limit: int = None
     block_run_limit: int = None
+    pipeline_run_limit: int = None
+    pipeline_run_limit_all_triggers: int = None
+    on_pipeline_run_limit_reached: OnLimitReached = OnLimitReached.WAIT

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -1539,7 +1539,7 @@ def schedule_all():
             pipeline_quota = None
 
         quota_filtered_runs = pipeline_runs_to_start
-        if pipeline_quota is not None:
+        if pipeline_quota is not None and pipeline_quota >= 0:
             pipeline_runs_to_start.sort(key=lambda x: x.execution_date)
             quota_filtered_runs = pipeline_runs_to_start[:pipeline_quota]
             pipeline_runs_excluded_by_limit.extend(
@@ -1547,8 +1547,6 @@ def schedule_all():
             )
 
         for r in quota_filtered_runs:
-            if r.block_runs_count == 0 and r.pipeline_uuid is not None:
-                r.create_block_runs()
             PipelineScheduler(r).start()
 
         # If on_pipeline_run_limit_reached is set as SKIP, cancel the pipeline runs that

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -1539,7 +1539,8 @@ def schedule_all():
             pipeline_quota = None
 
         quota_filtered_runs = pipeline_runs_to_start
-        if pipeline_quota is not None and pipeline_quota >= 0:
+        if pipeline_quota is not None:
+            pipeline_quota = pipeline_quota if pipeline_quota > 0 else 0
             pipeline_runs_to_start.sort(key=lambda x: x.execution_date)
             quota_filtered_runs = pipeline_runs_to_start[:pipeline_quota]
             pipeline_runs_excluded_by_limit.extend(

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import traceback
 from datetime import datetime, timedelta
+from itertools import groupby
 from typing import Any, Dict, List, Set, Tuple
 
 import pytz
@@ -30,7 +31,7 @@ from mage_ai.data_preparation.models.triggers import (
 )
 from mage_ai.data_preparation.repo_manager import get_repo_config
 from mage_ai.data_preparation.sync.git_sync import get_sync_config
-from mage_ai.orchestration.concurrency import ConcurrencyConfig
+from mage_ai.orchestration.concurrency import ConcurrencyConfig, OnLimitReached
 from mage_ai.orchestration.db import db_connection, safe_db_query
 from mage_ai.orchestration.db.models.schedules import (
     Backfill,
@@ -1397,106 +1398,143 @@ def schedule_all():
             pr, _ = tup
             previous_pipeline_run_by_pipeline_schedule_id[pr.pipeline_schedule_id] = pr
 
-    pipeline_by_uuid = dict()
-    concurrency_config_by_uuid = dict()
-
     git_sync_result = None
     sync_config = get_sync_config()
-    for pipeline_schedule in active_pipeline_schedules:
-        lock_key = f'pipeline_schedule_{pipeline_schedule.id}'
-        if not lock.try_acquire_lock(lock_key):
-            continue
 
-        previous_runtimes = []
-        if pipeline_schedule.id in active_pipeline_schedule_ids_with_landing_time_enabled:
-            previous_pipeline_run = previous_pipeline_run_by_pipeline_schedule_id.get(
-                pipeline_schedule.id,
-            )
-            if previous_pipeline_run:
-                previous_runtimes = pipeline_schedule.runtime_history(
-                    pipeline_run=previous_pipeline_run,
+    active_pipeline_uuids = list(set([s.pipeline_uuid for s in active_pipeline_schedules]))
+    pipeline_runs_by_pipeline = PipelineRun.active_runs_for_pipelines_grouped(active_pipeline_uuids)
+
+    pipeline_schedules_by_pipeline = {
+        key: list(runs)
+        for key, runs in groupby(active_pipeline_schedules, key=lambda x: x.pipeline_uuid)
+    }
+
+    for pipeline_uuid, active_pipeline_schedules in pipeline_schedules_by_pipeline.items():
+        pipeline = Pipeline.get(pipeline_uuid)
+        concurrency_config = ConcurrencyConfig.load(config=pipeline.concurrency_config)
+
+        pipeline_runs_to_start = []
+        pipeline_runs_excluded_by_limit = []
+        for pipeline_schedule in active_pipeline_schedules:
+            lock_key = f'pipeline_schedule_{pipeline_schedule.id}'
+            if not lock.try_acquire_lock(lock_key):
+                continue
+
+            previous_runtimes = []
+            if pipeline_schedule.id in active_pipeline_schedule_ids_with_landing_time_enabled:
+                previous_pipeline_run = previous_pipeline_run_by_pipeline_schedule_id.get(
+                    pipeline_schedule.id,
+                )
+                if previous_pipeline_run:
+                    previous_runtimes = pipeline_schedule.runtime_history(
+                        pipeline_run=previous_pipeline_run,
+                    )
+
+            # Decide whether to schedule any pipeline runs
+            should_schedule = pipeline_schedule.should_schedule(previous_runtimes=previous_runtimes)
+            initial_pipeline_runs = [
+                r for r in pipeline_schedule.pipeline_runs
+                if r.status == PipelineRun.PipelineRunStatus.INITIAL
+            ]
+
+            if not should_schedule and not initial_pipeline_runs:
+                lock.release_lock(lock_key)
+                continue
+
+            running_pipeline_runs = [
+                r for r in pipeline_schedule.pipeline_runs
+                if r.status == PipelineRun.PipelineRunStatus.RUNNING
+            ]
+
+            if should_schedule and \
+                    pipeline_schedule.id not in backfills_by_pipeline_schedule_id:
+                # Perform git sync if "sync_on_pipeline_run" is enabled and no other git sync
+                # has been run for this scheduler loop.
+                if not git_sync_result and sync_config and sync_config.sync_on_pipeline_run:
+                    git_sync_result = run_git_sync(lock=lock, sync_config=sync_config)
+
+                payload = dict(
+                    execution_date=pipeline_schedule.current_execution_date(),
+                    pipeline_schedule_id=pipeline_schedule.id,
+                    pipeline_uuid=pipeline_uuid,
+                    variables=pipeline_schedule.variables,
                 )
 
-        # Decide whether to schedule any pipeline runs
-        should_schedule = pipeline_schedule.should_schedule(previous_runtimes=previous_runtimes)
-        initial_pipeline_runs = [
-            r for r in pipeline_schedule.pipeline_runs
-            if r.status == PipelineRun.PipelineRunStatus.INITIAL
-        ]
+                if len(previous_runtimes) >= 1:
+                    payload['metrics'] = dict(previous_runtimes=previous_runtimes)
 
-        if not should_schedule and not initial_pipeline_runs:
-            lock.release_lock(lock_key)
-            continue
+                if PipelineType.INTEGRATION == pipeline.type:
+                    payload['create_block_runs'] = False
 
-        pipeline_uuid = pipeline_schedule.pipeline_uuid
-        if pipeline_uuid not in pipeline_by_uuid:
-            pipeline = pipeline_by_uuid.setdefault(pipeline_uuid, Pipeline.get(pipeline_uuid))
-        else:
-            pipeline = pipeline_by_uuid[pipeline_uuid]
-
-        if pipeline_uuid not in concurrency_config_by_uuid:
-            concurrency_config = concurrency_config_by_uuid.setdefault(
-                pipeline_uuid,
-                ConcurrencyConfig.load(config=pipeline.concurrency_config),
-            )
-        else:
-            concurrency_config = concurrency_config_by_uuid[pipeline_uuid]
-
-        running_pipeline_runs = [
-            r for r in pipeline_schedule.pipeline_runs
-            if r.status == PipelineRun.PipelineRunStatus.RUNNING
-        ]
-
-        if should_schedule and \
-                pipeline_schedule.id not in backfills_by_pipeline_schedule_id:
-            # Perform git sync if "sync_on_pipeline_run" is enabled and no other git sync has been
-            # run for this scheduler loop.
-            if not git_sync_result and sync_config and sync_config.sync_on_pipeline_run:
-                git_sync_result = run_git_sync(lock=lock, sync_config=sync_config)
-
-            payload = dict(
-                execution_date=pipeline_schedule.current_execution_date(),
-                pipeline_schedule_id=pipeline_schedule.id,
-                pipeline_uuid=pipeline_uuid,
-                variables=pipeline_schedule.variables,
-            )
-
-            if len(previous_runtimes) >= 1:
-                payload['metrics'] = dict(previous_runtimes=previous_runtimes)
-
-            if PipelineType.INTEGRATION == pipeline.type:
-                payload['create_block_runs'] = False
-
-            if pipeline_schedule.get_settings().skip_if_previous_running and \
-                    (initial_pipeline_runs or running_pipeline_runs):
-                # Cancel the current pipeline run if previous pipeline runs haven't completed
-                payload['create_block_runs'] = False
-                pipeline_run = PipelineRun.create(**payload)
-                pipeline_run.update(status=PipelineRun.PipelineRunStatus.CANCELLED)
-            else:
-                pipeline_run = PipelineRun.create(**payload)
-                # Log Git sync status for new pipeline runs if a git sync result exists
-                if git_sync_result:
-                    pipeline_scheduler = PipelineScheduler(pipeline_run)
-                    log_git_sync(
-                        git_sync_result,
-                        pipeline_scheduler.logger,
-                        pipeline_scheduler.build_tags(),
+                if (
+                    pipeline_schedule.get_settings().skip_if_previous_running
+                    and (initial_pipeline_runs or running_pipeline_runs)
+                ):
+                    # Cancel the current pipeline run if previous pipeline runs haven't completed
+                    from mage_ai.orchestration.triggers.utils import (
+                        create_and_cancel_pipeline_run,
                     )
-                initial_pipeline_runs.append(pipeline_run)
 
-        # Enforce pipeline concurrency limit
-        pipeline_run_quota = len(initial_pipeline_runs)
-        if concurrency_config.pipeline_run_limit:
-            pipeline_run_quota = concurrency_config.pipeline_run_limit - \
-                len(running_pipeline_runs)
+                    pipeline_run = create_and_cancel_pipeline_run(
+                        pipeline,
+                        pipeline_schedule,
+                        payload,
+                        message='Pipeline run limit reached... skipping this run',
+                    )
+                else:
+                    pipeline_run = PipelineRun.create(**payload, create_block_runs=False)
+                    # Log Git sync status for new pipeline runs if a git sync result exists
+                    if git_sync_result:
+                        pipeline_scheduler = PipelineScheduler(pipeline_run)
+                        log_git_sync(
+                            git_sync_result,
+                            pipeline_scheduler.logger,
+                            pipeline_scheduler.build_tags(),
+                        )
+                    initial_pipeline_runs.append(pipeline_run)
 
-        if pipeline_run_quota > 0:
-            initial_pipeline_runs.sort(key=lambda x: x.execution_date)
-            for r in initial_pipeline_runs[:pipeline_run_quota]:
-                PipelineScheduler(r).start(should_schedule=False)
+            # Enforce pipeline concurrency limit
+            pipeline_run_quota = None
+            if concurrency_config.pipeline_run_limit is not None:
+                pipeline_run_quota = concurrency_config.pipeline_run_limit - \
+                    len(running_pipeline_runs)
 
-        lock.release_lock(lock_key)
+            if pipeline_run_quota is None:
+                pipeline_run_quota = len(initial_pipeline_runs)
+
+            if pipeline_run_quota > 0:
+                initial_pipeline_runs.sort(key=lambda x: x.execution_date)
+                pipeline_runs_to_start.extend(initial_pipeline_runs[:pipeline_run_quota])
+                pipeline_runs_excluded_by_limit.extend(initial_pipeline_runs[pipeline_run_quota:])
+
+            lock.release_lock(lock_key)
+
+        pipeline_run_limit = concurrency_config.pipeline_run_limit_all_triggers
+        if pipeline_run_limit is not None:
+            pipeline_quota = pipeline_run_limit - len(
+                pipeline_runs_by_pipeline.get(pipeline_uuid, [])
+            )
+        else:
+            pipeline_quota = None
+
+        if pipeline_quota is not None:
+            pipeline_runs_to_start.sort(key=lambda x: x.execution_date)
+            pipeline_runs_to_start = pipeline_runs_to_start[:pipeline_quota]
+            pipeline_runs_excluded_by_limit.extend(pipeline_runs_to_start[pipeline_quota:])
+
+        for r in pipeline_runs_to_start:
+            if r.block_runs_count == 0 and r.pipeline_uuid is not None:
+                r.create_block_runs()
+            PipelineScheduler(r).start()
+
+        if concurrency_config.on_pipeline_run_limit_reached == OnLimitReached.SKIP:
+            for r in pipeline_runs_excluded_by_limit:
+                pipeline_scheduler = PipelineScheduler(r)
+                pipeline_scheduler.logger.warning(
+                    'Pipeline run limit reached... skipping this run',
+                    **pipeline_scheduler.build_tags(),
+                )
+                r.update(status=PipelineRun.PipelineRunStatus.CANCELLED)
 
     # Schedule active pipeline runs
     active_pipeline_runs = PipelineRun.active_runs_for_pipelines(
@@ -1537,23 +1575,59 @@ def schedule_with_event(event: Dict = None):
         if sync_config and sync_config.sync_on_pipeline_run:
             git_sync_result = run_git_sync(lock=lock, sync_config=sync_config)
 
-        for p in matched_pipeline_schedules:
-            payload = dict(
-                execution_date=datetime.now(tz=pytz.UTC),
-                pipeline_schedule_id=p.id,
-                pipeline_uuid=p.pipeline_uuid,
-                variables=merge_dict(p.variables or dict(), dict(event=event)),
-            )
-            pipeline_run = PipelineRun.create(**payload)
-            pipeline_scheduler = PipelineScheduler(pipeline_run)
+        matched_pipeline_uuids = list(set([s.pipeline_uuid for s in matched_pipeline_schedules]))
+        pipeline_runs_by_pipeline = PipelineRun.active_runs_for_pipelines_grouped(
+            matched_pipeline_uuids
+        )
 
-            log_git_sync(
-                git_sync_result,
-                pipeline_scheduler.logger,
-                pipeline_scheduler.build_tags(),
-            )
+        pipeline_schedules_by_pipeline = {
+            key: list(runs)
+            for key, runs in groupby(matched_pipeline_schedules, key=lambda x: x.pipeline_uuid)
+        }
 
-            pipeline_scheduler.start(should_schedule=True)
+        for pipeline_uuid, matched_pipeline_schedules in pipeline_schedules_by_pipeline.items():
+            pipeline = Pipeline.get(pipeline_uuid)
+            concurrency_config = ConcurrencyConfig.load(config=pipeline.concurrency_config)
+            pipeline_run_limit = concurrency_config.pipeline_run_limit_all_triggers
+            if pipeline_run_limit is not None:
+                remaining_quota = pipeline_run_limit - len(
+                    pipeline_runs_by_pipeline.get(pipeline_uuid, [])
+                )
+            else:
+                remaining_quota = None
+
+            for p in matched_pipeline_schedules:
+                payload = dict(
+                    execution_date=datetime.now(tz=pytz.UTC),
+                    pipeline_schedule_id=p.id,
+                    pipeline_uuid=pipeline_uuid,
+                    variables=merge_dict(p.variables or dict(), dict(event=event)),
+                )
+
+                if remaining_quota is not None and remaining_quota <= 0:
+                    from mage_ai.orchestration.triggers.utils import (
+                        create_and_cancel_pipeline_run,
+                    )
+                    pipeline_run = create_and_cancel_pipeline_run(
+                        pipeline,
+                        p,
+                        payload,
+                        message='Pipeline run limit reached... skipping this run',
+                    )
+                else:
+                    pipeline_run = PipelineRun.create(**payload)
+                    pipeline_scheduler = PipelineScheduler(pipeline_run)
+
+                    log_git_sync(
+                        git_sync_result,
+                        pipeline_scheduler.logger,
+                        pipeline_scheduler.build_tags(),
+                    )
+
+                    pipeline_scheduler.start(should_schedule=True)
+
+                    if remaining_quota is not None:
+                        remaining_quota -= 1
 
 
 def sync_schedules(pipeline_uuids: List[str]):

--- a/mage_ai/orchestration/triggers/utils.py
+++ b/mage_ai/orchestration/triggers/utils.py
@@ -93,11 +93,12 @@ def create_and_start_pipeline_run(
         payload,
     )
 
+    pipeline_run = PipelineRun.create(**configured_payload)
+
     # Do not start the pipeline run immediately due to concurrency control
     if should_schedule:
         from mage_ai.orchestration.pipeline_scheduler import PipelineScheduler
 
-        pipeline_run = PipelineRun.create(**configured_payload)
         pipeline_scheduler = PipelineScheduler(pipeline_run)
 
         # if is_integration:

--- a/mage_ai/orchestration/triggers/utils.py
+++ b/mage_ai/orchestration/triggers/utils.py
@@ -54,6 +54,29 @@ def check_pipeline_run_status(
     return pipeline_run
 
 
+def create_and_cancel_pipeline_run(
+    pipeline: Pipeline,
+    pipeline_schedule: PipelineSchedule,
+    payload: Dict,
+    message: str = None,
+) -> PipelineRun:
+    from mage_ai.orchestration.pipeline_scheduler import PipelineScheduler
+
+    payload_copy = payload.copy()
+    configured_payload, _ = configure_pipeline_run_payload(
+        pipeline_schedule,
+        pipeline.type,
+        payload_copy,
+    )
+    configured_payload['create_block_runs'] = False
+    pipeline_run = PipelineRun.create(**configured_payload)
+    if message:
+        pipeline_scheduler = PipelineScheduler(pipeline_run)
+        pipeline_scheduler.logger.warning(message, **pipeline_scheduler.build_tags())
+    pipeline_run.update(status=PipelineRun.PipelineRunStatus.CANCELLED)
+    return pipeline_run
+
+
 @safe_db_query
 def create_and_start_pipeline_run(
     pipeline: Pipeline,
@@ -70,12 +93,11 @@ def create_and_start_pipeline_run(
         payload,
     )
 
-    pipeline_run = PipelineRun.create(**configured_payload)
-
     # Do not start the pipeline run immediately due to concurrency control
     if should_schedule:
         from mage_ai.orchestration.pipeline_scheduler import PipelineScheduler
 
+        pipeline_run = PipelineRun.create(**configured_payload)
         pipeline_scheduler = PipelineScheduler(pipeline_run)
 
         # if is_integration:

--- a/mage_ai/server/api/triggers.py
+++ b/mage_ai/server/api/triggers.py
@@ -3,9 +3,13 @@ import json
 from mage_ai.api.errors import ApiError
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.data_preparation.models.triggers import ScheduleType
+from mage_ai.orchestration.concurrency import ConcurrencyConfig
 from mage_ai.orchestration.db import safe_db_query
 from mage_ai.orchestration.db.models.schedules import PipelineRun, PipelineSchedule
-from mage_ai.orchestration.triggers.utils import create_and_start_pipeline_run
+from mage_ai.orchestration.triggers.utils import (
+    create_and_cancel_pipeline_run,
+    create_and_start_pipeline_run,
+)
 from mage_ai.server.api.base import BaseHandler
 from mage_ai.server.api.errors import UnauthenticatedRequestException
 from mage_ai.shared.requests import get_bearer_auth_token_from_headers
@@ -44,10 +48,27 @@ class ApiTriggerPipelineHandler(BaseHandler):
                 payload['event_variables'][k] = v
 
         pipeline = Pipeline.get(pipeline_schedule.pipeline_uuid)
-        pipeline_run = create_and_start_pipeline_run(
-            pipeline,
-            pipeline_schedule,
-            payload,
-        )
+
+        pipeline_runs = PipelineRun.active_runs_for_pipelines([pipeline.uuid])
+        concurrency_config = ConcurrencyConfig.load(config=pipeline.concurrency_config)
+        pipeline_run_limit_all_triggers = concurrency_config.pipeline_run_limit_all_triggers
+        if pipeline_run_limit_all_triggers is not None:
+            remaining_quota = pipeline_run_limit_all_triggers - len(pipeline_runs)
+        else:
+            remaining_quota = None
+
+        if remaining_quota is not None and remaining_quota <= 0:
+            pipeline_run = create_and_cancel_pipeline_run(
+                pipeline,
+                pipeline_schedule,
+                payload,
+                message='Pipeline run limit reached... skipping this run',
+            )
+        else:
+            pipeline_run = create_and_start_pipeline_run(
+                pipeline,
+                pipeline_schedule,
+                payload,
+            )
 
         self.write(dict(pipeline_run=pipeline_run.to_dict()))

--- a/mage_ai/server/api/triggers.py
+++ b/mage_ai/server/api/triggers.py
@@ -3,13 +3,9 @@ import json
 from mage_ai.api.errors import ApiError
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.data_preparation.models.triggers import ScheduleType
-from mage_ai.orchestration.concurrency import ConcurrencyConfig
 from mage_ai.orchestration.db import safe_db_query
 from mage_ai.orchestration.db.models.schedules import PipelineRun, PipelineSchedule
-from mage_ai.orchestration.triggers.utils import (
-    create_and_cancel_pipeline_run,
-    create_and_start_pipeline_run,
-)
+from mage_ai.orchestration.triggers.utils import create_and_start_pipeline_run
 from mage_ai.server.api.base import BaseHandler
 from mage_ai.server.api.errors import UnauthenticatedRequestException
 from mage_ai.shared.requests import get_bearer_auth_token_from_headers
@@ -48,27 +44,11 @@ class ApiTriggerPipelineHandler(BaseHandler):
                 payload['event_variables'][k] = v
 
         pipeline = Pipeline.get(pipeline_schedule.pipeline_uuid)
-
-        pipeline_runs = PipelineRun.active_runs_for_pipelines([pipeline.uuid])
-        concurrency_config = ConcurrencyConfig.load(config=pipeline.concurrency_config)
-        pipeline_run_limit_all_triggers = concurrency_config.pipeline_run_limit_all_triggers
-        if pipeline_run_limit_all_triggers is not None:
-            remaining_quota = pipeline_run_limit_all_triggers - len(pipeline_runs)
-        else:
-            remaining_quota = None
-
-        if remaining_quota is not None and remaining_quota <= 0:
-            pipeline_run = create_and_cancel_pipeline_run(
-                pipeline,
-                pipeline_schedule,
-                payload,
-                message='Pipeline run limit reached... skipping this run',
-            )
-        else:
-            pipeline_run = create_and_start_pipeline_run(
-                pipeline,
-                pipeline_schedule,
-                payload,
-            )
+        pipeline_run = create_and_start_pipeline_run(
+            pipeline,
+            pipeline_schedule,
+            payload,
+            should_schedule=False,
+        )
 
         self.write(dict(pipeline_run=pipeline_run.to_dict()))

--- a/mage_ai/tests/orchestration/test_pipeline_scheduler.py
+++ b/mage_ai/tests/orchestration/test_pipeline_scheduler.py
@@ -62,21 +62,28 @@ class PipelineSchedulerTests(DBTestCase):
         with patch.object(scheduler2, 'schedule') as mock_schedule2:
             scheduler2.start(should_schedule=True)
             mock_schedule2.assert_called_once()
-            self.assertEqual(pipeline_run2.status, PipelineRun.PipelineRunStatus.RUNNING)
+            self.assertEqual(
+                pipeline_run2.status, PipelineRun.PipelineRunStatus.RUNNING
+            )
 
     def test_start_with_exception(self):
         # Not create block runs at the beginning
-        pipeline_run = PipelineRun.create(pipeline_uuid='test_pipeline', create_block_runs=False)
+        pipeline_run = PipelineRun.create(
+            pipeline_uuid='test_pipeline', create_block_runs=False
+        )
         scheduler = PipelineScheduler(pipeline_run=pipeline_run)
         with patch.object(scheduler, 'schedule') as mock_schedule:
-            with patch.object(pipeline_run, 'create_block_runs') as mock_create_block_runs:
+            with patch.object(
+                pipeline_run, 'create_block_runs'
+            ) as mock_create_block_runs:
                 with patch.object(
-                    scheduler.notification_sender,
-                    'send_pipeline_run_failure_message'
+                    scheduler.notification_sender, 'send_pipeline_run_failure_message'
                 ) as mock_send_message:
                     mock_create_block_runs.side_effect = Exception()
                     scheduler.start()
-                    self.assertEqual(pipeline_run.status, PipelineRun.PipelineRunStatus.FAILED)
+                    self.assertEqual(
+                        pipeline_run.status, PipelineRun.PipelineRunStatus.FAILED
+                    )
                     mock_send_message.assert_called_once_with(
                         error='Fail to initialize block runs.',
                         pipeline=scheduler.pipeline,
@@ -118,11 +125,12 @@ class PipelineSchedulerTests(DBTestCase):
             b.update(status=BlockRun.BlockRunStatus.COMPLETED)
         scheduler = PipelineScheduler(pipeline_run=pipeline_run)
         with patch.object(
-            scheduler.notification_sender,
-            'send_pipeline_run_success_message'
+            scheduler.notification_sender, 'send_pipeline_run_success_message'
         ) as mock_send_message:
             scheduler.schedule()
-            self.assertEqual(pipeline_run.status, PipelineRun.PipelineRunStatus.COMPLETED)
+            self.assertEqual(
+                pipeline_run.status, PipelineRun.PipelineRunStatus.COMPLETED
+            )
             mock_send_message.assert_called_once_with(
                 pipeline=scheduler.pipeline,
                 pipeline_run=pipeline_run,
@@ -131,7 +139,9 @@ class PipelineSchedulerTests(DBTestCase):
     @freeze_time('2023-10-11 12:13:14')
     def test_schedule_all_for_pipeline_schedules_with_landing_time(self):
         def new_schedule(self):
-            print(f'Mock PipelineScheduler().schedule() for pipeline run {self.pipeline_run.id}.')
+            print(
+                f'Mock PipelineScheduler().schedule() for pipeline run {self.pipeline_run.id}.'
+            )
 
         shared_attrs = dict(
             name='trigger',
@@ -142,38 +152,51 @@ class PipelineSchedulerTests(DBTestCase):
             status=ScheduleStatus.ACTIVE,
         )
 
-        pipeline_schedule = PipelineSchedule.create(**merge_dict(shared_attrs, dict(
-            start_time=datetime(2023, 10, 10, 13, 13, 20),
-        )))
+        pipeline_schedule = PipelineSchedule.create(
+            **merge_dict(
+                shared_attrs,
+                dict(
+                    start_time=datetime(2023, 10, 10, 13, 13, 20),
+                ),
+            )
+        )
 
         # No previous pipeline runs
-        self.assertEqual(len((
-            PipelineRun.
-            query.
-            filter(
-                PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
-                PipelineRun.status == PipelineRun.PipelineRunStatus.RUNNING,
-            ).
-            all()
-        )), 0)
+        self.assertEqual(
+            len(
+                (
+                    PipelineRun.query.filter(
+                        PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
+                        PipelineRun.status == PipelineRun.PipelineRunStatus.RUNNING,
+                    ).all()
+                )
+            ),
+            0,
+        )
 
         with patch.object(PipelineScheduler, 'schedule', new_schedule):
             schedule_all()
 
-        self.assertEqual(len((
-            PipelineRun.
-            query.
-            filter(
-                PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
-                PipelineRun.status == PipelineRun.PipelineRunStatus.RUNNING,
-            ).
-            all()
-        )), 1)
+        self.assertEqual(
+            len(
+                (
+                    PipelineRun.query.filter(
+                        PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
+                        PipelineRun.status == PipelineRun.PipelineRunStatus.RUNNING,
+                    ).all()
+                )
+            ),
+            1,
+        )
 
     @freeze_time('2023-10-11 12:13:14')
-    def test_schedule_all_for_pipeline_schedules_with_landing_time_with_previous_runs(self):
+    def test_schedule_all_for_pipeline_schedules_with_landing_time_with_previous_runs(
+        self,
+    ):
         def new_schedule(self):
-            print(f'Mock PipelineScheduler().schedule() for pipeline run {self.pipeline_run.id}.')
+            print(
+                f'Mock PipelineScheduler().schedule() for pipeline run {self.pipeline_run.id}.'
+            )
 
         shared_attrs = dict(
             name='trigger',
@@ -184,20 +207,27 @@ class PipelineSchedulerTests(DBTestCase):
             status=ScheduleStatus.ACTIVE,
         )
 
-        pipeline_schedule = PipelineSchedule.create(**merge_dict(shared_attrs, dict(
-            start_time=datetime(2023, 10, 10, 13, 13, 20),
-        )))
+        pipeline_schedule = PipelineSchedule.create(
+            **merge_dict(
+                shared_attrs,
+                dict(
+                    start_time=datetime(2023, 10, 10, 13, 13, 20),
+                ),
+            )
+        )
 
         # No previous pipeline runs
-        self.assertEqual(len((
-            PipelineRun.
-            query.
-            filter(
-                PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
-                PipelineRun.status == PipelineRun.PipelineRunStatus.RUNNING,
-            ).
-            all()
-        )), 0)
+        self.assertEqual(
+            len(
+                (
+                    PipelineRun.query.filter(
+                        PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
+                        PipelineRun.status == PipelineRun.PipelineRunStatus.RUNNING,
+                    ).all()
+                )
+            ),
+            0,
+        )
 
         # With previous pipeline runs
         PipelineRun.create(
@@ -230,15 +260,17 @@ class PipelineSchedulerTests(DBTestCase):
         with patch.object(PipelineScheduler, 'schedule', new_schedule):
             schedule_all()
 
-        self.assertEqual(len((
-            PipelineRun.
-            query.
-            filter(
-                PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
-                PipelineRun.status == PipelineRun.PipelineRunStatus.RUNNING,
-            ).
-            all()
-        )), 1)
+        self.assertEqual(
+            len(
+                (
+                    PipelineRun.query.filter(
+                        PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
+                        PipelineRun.status == PipelineRun.PipelineRunStatus.RUNNING,
+                    ).all()
+                )
+            ),
+            1,
+        )
 
     def test_schedule_all_blocks_completed_with_failures(self):
         pipeline_run = create_pipeline_run_with_schedule(
@@ -256,8 +288,7 @@ class PipelineSchedulerTests(DBTestCase):
             ct += 1
         scheduler = PipelineScheduler(pipeline_run=pipeline_run)
         with patch.object(
-            scheduler.notification_sender,
-            'send_pipeline_run_failure_message'
+            scheduler.notification_sender, 'send_pipeline_run_failure_message'
         ) as mock_send_message:
             scheduler.schedule()
             self.assertEqual(pipeline_run.status, PipelineRun.PipelineRunStatus.FAILED)
@@ -280,8 +311,7 @@ class PipelineSchedulerTests(DBTestCase):
             ct += 1
         scheduler = PipelineScheduler(pipeline_run=pipeline_run)
         with patch.object(
-            scheduler.notification_sender,
-            'send_pipeline_run_failure_message'
+            scheduler.notification_sender, 'send_pipeline_run_failure_message'
         ) as mock_send_message:
             scheduler.schedule()
             self.assertEqual(pipeline_run.status, PipelineRun.PipelineRunStatus.FAILED)
@@ -300,7 +330,9 @@ class PipelineSchedulerTests(DBTestCase):
         )
         pipeline.type = PipelineType.STREAMING
         pipeline.save()
-        pipeline_run = create_pipeline_run_with_schedule(pipeline_uuid='test_pipeline_2')
+        pipeline_run = create_pipeline_run_with_schedule(
+            pipeline_uuid='test_pipeline_2'
+        )
         pipeline_run.update(status=PipelineRun.PipelineRunStatus.RUNNING)
         scheduler = PipelineScheduler(pipeline_run=pipeline_run)
         mock_has_pipeline_run_job = MagicMock()
@@ -343,7 +375,9 @@ class PipelineSchedulerTests(DBTestCase):
         with patch.object(scheduler, 'schedule') as mock_schedule:
             scheduler.on_block_complete('block1')
             mock_schedule.assert_called_once()
-            block_run = BlockRun.get(pipeline_run_id=pipeline_run.id, block_uuid='block1')
+            block_run = BlockRun.get(
+                pipeline_run_id=pipeline_run.id, block_uuid='block1'
+            )
             self.assertEqual(block_run.status, BlockRun.BlockRunStatus.COMPLETED)
 
     def test_on_block_failure(self):
@@ -387,12 +421,8 @@ class PipelineSchedulerTests(DBTestCase):
                     mock_block_variables.return_value = ['values', 'metadata']
                     # only mock the metadata
                     mock_variable.return_value = [
-                        {
-                            'block_uuid': 'for_user_1'
-                        },
-                        {
-                            'block_uuid': 'for_user_2'
-                        }
+                        {'block_uuid': 'for_user_1'},
+                        {'block_uuid': 'for_user_2'},
                     ]
                     scheduler.on_block_complete_without_schedule('block1')
                     mock_schedule.assert_not_called()
@@ -437,12 +467,8 @@ class PipelineSchedulerTests(DBTestCase):
                     mock_block_variables.return_value = ['values', 'metadata']
                     # only mock the metadata
                     mock_variable.return_value = [
-                        {
-                            'block_uuid': 'for_user_1'
-                        },
-                        {
-                            'block_uuid': 'for_user_2'
-                        }
+                        {'block_uuid': 'for_user_1'},
+                        {'block_uuid': 'for_user_2'},
                     ]
                     scheduler.on_block_complete_without_schedule('block1')
                     mock_schedule.assert_not_called()
@@ -474,12 +500,8 @@ class PipelineSchedulerTests(DBTestCase):
                     mock_block_variables.return_value = ['values', 'metadata']
                     # only mock the metadata
                     mock_variable.return_value = [
-                        {
-                            'block_uuid': 'for_user_1'
-                        },
-                        {
-                            'block_uuid': 'for_user_2'
-                        }
+                        {'block_uuid': 'for_user_1'},
+                        {'block_uuid': 'for_user_2'},
                     ]
                     scheduler.on_block_complete_without_schedule('block1')
                     mock_schedule.assert_not_called()
@@ -530,8 +552,7 @@ class PipelineSchedulerTests(DBTestCase):
         )
         pipeline_run3.update(status=PipelineRun.PipelineRunStatus.RUNNING)
         with patch.object(
-            NotificationSender,
-            'send_pipeline_run_sla_passed_message'
+            NotificationSender, 'send_pipeline_run_sla_passed_message'
         ) as mock_send_message:
             check_sla()
             mock_send_message.assert_called_once()
@@ -563,12 +584,15 @@ class PipelineSchedulerTests(DBTestCase):
         )
         preferences = get_preferences(repo_path=self.repo_path)
         preferences.update_preferences(
-            dict(sync_config=dict(
-                remote_repo_link='test_git_repo',
-                repo_path=self.repo_path,
-                branch='main',
-                sync_on_pipeline_run=True,
-            )))
+            dict(
+                sync_config=dict(
+                    remote_repo_link='test_git_repo',
+                    repo_path=self.repo_path,
+                    branch='main',
+                    sync_on_pipeline_run=True,
+                )
+            )
+        )
         with patch.object(PipelineScheduler, 'schedule') as _:
             schedule_all()
             git_sync_instance.sync_data.assert_called_once()
@@ -608,19 +632,27 @@ class PipelineSchedulerTests(DBTestCase):
             pipeline_run_limit_all_triggers=2,
         )
         with open(pipeline.config_path, 'w') as f:
-            yaml.dump(merge_dict(
-                pipeline.to_dict(),
-                dict(concurrency_config=test_concurrency_config)
-            ), f)
+            yaml.dump(
+                merge_dict(
+                    pipeline.to_dict(), dict(concurrency_config=test_concurrency_config)
+                ),
+                f,
+            )
 
         with patch.object(PipelineScheduler, 'schedule') as _:
             schedule_all()
         self.assertEqual(1, len(ps1.pipeline_runs))
-        self.assertEqual(PipelineRun.PipelineRunStatus.INITIAL, ps1.pipeline_runs[0].status)
+        self.assertEqual(
+            PipelineRun.PipelineRunStatus.INITIAL, ps1.pipeline_runs[0].status
+        )
         self.assertEqual(1, len(ps2.pipeline_runs))
-        self.assertEqual(PipelineRun.PipelineRunStatus.RUNNING, ps2.pipeline_runs[0].status)
+        self.assertEqual(
+            PipelineRun.PipelineRunStatus.RUNNING, ps2.pipeline_runs[0].status
+        )
         self.assertEqual(1, len(ps3.pipeline_runs))
-        self.assertEqual(PipelineRun.PipelineRunStatus.RUNNING, ps3.pipeline_runs[0].status)
+        self.assertEqual(
+            PipelineRun.PipelineRunStatus.RUNNING, ps3.pipeline_runs[0].status
+        )
 
     @freeze_time('2023-05-03 01:20:33')
     def test_schedule_all_pipeline_run_limit_set(self):
@@ -664,18 +696,24 @@ class PipelineSchedulerTests(DBTestCase):
             pipeline_run_limit_all_triggers=2,
         )
         with open(pipeline.config_path, 'w') as f:
-            yaml.dump(merge_dict(
-                pipeline.to_dict(),
-                dict(concurrency_config=test_concurrency_config)
-            ), f)
+            yaml.dump(
+                merge_dict(
+                    pipeline.to_dict(), dict(concurrency_config=test_concurrency_config)
+                ),
+                f,
+            )
 
         with patch.object(PipelineScheduler, 'schedule') as _:
             schedule_all()
         self.assertEqual(2, len(ps1.pipeline_runs))
         self.assertEqual(1, len(ps2.pipeline_runs))
-        self.assertEqual(PipelineRun.PipelineRunStatus.RUNNING, ps2.pipeline_runs[0].status)
+        self.assertEqual(
+            PipelineRun.PipelineRunStatus.RUNNING, ps2.pipeline_runs[0].status
+        )
         self.assertEqual(1, len(ps3.pipeline_runs))
-        self.assertEqual(PipelineRun.PipelineRunStatus.INITIAL, ps3.pipeline_runs[0].status)
+        self.assertEqual(
+            PipelineRun.PipelineRunStatus.INITIAL, ps3.pipeline_runs[0].status
+        )
 
     @freeze_time('2023-05-03 01:20:33')
     def test_schedule_all_pipeline_run_limit_skip_runs(self):
@@ -703,7 +741,7 @@ class PipelineSchedulerTests(DBTestCase):
             schedule_type=ScheduleType.TIME,
             status=ScheduleStatus.ACTIVE,
             start_time=datetime(2023, 4, 5, 1, 20, 33),
-            schedule_interval='@weekly',
+            schedule_interval='@daily',
         )
         ps3 = PipelineSchedule.create(
             name='test_limit_skip_pipeline_trigger_3',
@@ -720,18 +758,102 @@ class PipelineSchedulerTests(DBTestCase):
             on_pipeline_run_limit_reached='skip',
         )
         with open(pipeline.config_path, 'w') as f:
-            yaml.dump(merge_dict(
-                pipeline.to_dict(),
-                dict(concurrency_config=test_concurrency_config)
-            ), f)
+            yaml.dump(
+                merge_dict(
+                    pipeline.to_dict(), dict(concurrency_config=test_concurrency_config)
+                ),
+                f,
+            )
 
         with patch.object(PipelineScheduler, 'schedule') as _:
             schedule_all()
         self.assertEqual(2, len(ps1.pipeline_runs))
         self.assertEqual(1, len(ps2.pipeline_runs))
-        self.assertEqual(PipelineRun.PipelineRunStatus.RUNNING, ps2.pipeline_runs[0].status)
+        self.assertEqual(
+            PipelineRun.PipelineRunStatus.RUNNING, ps2.pipeline_runs[0].status
+        )
         self.assertEqual(1, len(ps3.pipeline_runs))
-        self.assertEqual(PipelineRun.PipelineRunStatus.CANCELLED, ps3.pipeline_runs[0].status)
+        self.assertEqual(
+            PipelineRun.PipelineRunStatus.CANCELLED, ps3.pipeline_runs[0].status
+        )
+
+    @freeze_time('2023-05-03 01:20:33')
+    def test_schedule_all_pipeline_run_limit_set_negative_quota(self):
+        pipeline = create_pipeline_with_blocks(
+            'test pipeline_run_limit_negative_quota',
+            self.repo_path,
+        )
+        ps1 = PipelineSchedule.create(
+            name='test_negative_quota_pipeline_trigger_1',
+            pipeline_uuid=pipeline.uuid,
+            schedule_type=ScheduleType.TIME,
+            status=ScheduleStatus.ACTIVE,
+            start_time=datetime(2023, 2, 28, 1, 20, 33),
+            schedule_interval='@daily',
+        )
+        PipelineRun.create(
+            execution_date=datetime(2023, 3, 1, 0, 0, 0),
+            pipeline_schedule_id=ps1.id,
+            pipeline_uuid=pipeline.uuid,
+            status=PipelineRun.PipelineRunStatus.RUNNING,
+        )
+        PipelineRun.create(
+            execution_date=datetime(2023, 3, 2, 0, 0, 0),
+            pipeline_schedule_id=ps1.id,
+            pipeline_uuid=pipeline.uuid,
+            status=PipelineRun.PipelineRunStatus.RUNNING,
+        )
+        ps2 = PipelineSchedule.create(
+            name='test_negative_quota_pipeline_trigger_2',
+            pipeline_uuid=pipeline.uuid,
+            schedule_type=ScheduleType.TIME,
+            status=ScheduleStatus.ACTIVE,
+            start_time=datetime(2023, 4, 5, 1, 20, 33),
+            schedule_interval='@weekly',
+        )
+        ps3 = PipelineSchedule.create(
+            name='test_negative_quota_pipeline_trigger_3',
+            pipeline_uuid=pipeline.uuid,
+            schedule_type=ScheduleType.TIME,
+            status=ScheduleStatus.ACTIVE,
+            start_time=datetime(2023, 4, 6, 1, 20, 33),
+            schedule_interval='@hourly',
+        )
+
+        test_concurrency_config = dict(
+            pipeline_run_limit_all_triggers=1,
+        )
+        with open(pipeline.config_path, 'w') as f:
+            yaml.dump(
+                merge_dict(
+                    pipeline.to_dict(), dict(concurrency_config=test_concurrency_config)
+                ),
+                f,
+            )
+
+        self.assertEqual(2, len(ps1.pipeline_runs))
+
+        with patch.object(PipelineScheduler, 'schedule') as _:
+            schedule_all()
+        self.assertEqual(
+            2,
+            len(
+                list(
+                    filter(
+                        lambda r: r.status == PipelineRun.PipelineRunStatus.RUNNING,
+                        ps1.pipeline_runs,
+                    )
+                )
+            ),
+        )
+        self.assertEqual(1, len(ps2.pipeline_runs))
+        self.assertEqual(
+            PipelineRun.PipelineRunStatus.INITIAL, ps2.pipeline_runs[0].status
+        )
+        self.assertEqual(1, len(ps3.pipeline_runs))
+        self.assertEqual(
+            PipelineRun.PipelineRunStatus.INITIAL, ps3.pipeline_runs[0].status
+        )
 
     @freeze_time('2023-05-03 01:20:33')
     def test_schedule_all_pipeline_run_limit_include_all(self):
@@ -776,18 +898,24 @@ class PipelineSchedulerTests(DBTestCase):
             on_pipeline_run_limit_reached='skip',
         )
         with open(pipeline.config_path, 'w') as f:
-            yaml.dump(merge_dict(
-                pipeline.to_dict(),
-                dict(concurrency_config=test_concurrency_config)
-            ), f)
+            yaml.dump(
+                merge_dict(
+                    pipeline.to_dict(), dict(concurrency_config=test_concurrency_config)
+                ),
+                f,
+            )
 
         with patch.object(PipelineScheduler, 'schedule') as _:
             schedule_all()
         self.assertEqual(2, len(ps1.pipeline_runs))
         self.assertEqual(1, len(ps2.pipeline_runs))
-        self.assertEqual(PipelineRun.PipelineRunStatus.RUNNING, ps2.pipeline_runs[0].status)
+        self.assertEqual(
+            PipelineRun.PipelineRunStatus.RUNNING, ps2.pipeline_runs[0].status
+        )
         self.assertEqual(1, len(ps3.pipeline_runs))
-        self.assertEqual(PipelineRun.PipelineRunStatus.RUNNING, ps3.pipeline_runs[0].status)
+        self.assertEqual(
+            PipelineRun.PipelineRunStatus.RUNNING, ps3.pipeline_runs[0].status
+        )
 
     @freeze_time('2023-05-01 01:20:33')
     @patch('mage_ai.orchestration.pipeline_scheduler.job_manager')
@@ -875,7 +1003,9 @@ class PipelineSchedulerTests(DBTestCase):
             pipeline_uuid=pipeline_uuid,
             pipeline_schedule_id=pipeline_schedule.id,
         )
-        block_run2 = find(lambda br: br.block_uuid == 'block1', pipeline_run2.block_runs)
+        block_run2 = find(
+            lambda br: br.block_uuid == 'block1', pipeline_run2.block_runs
+        )
         block_run2.update(
             status=BlockRun.BlockRunStatus.RUNNING,
             started_at=now_time - timedelta(seconds=599),

--- a/mage_ai/tests/orchestration/test_pipeline_scheduler.py
+++ b/mage_ai/tests/orchestration/test_pipeline_scheduler.py
@@ -163,14 +163,10 @@ class PipelineSchedulerTests(DBTestCase):
 
         # No previous pipeline runs
         self.assertEqual(
-            len(
-                (
-                    PipelineRun.query.filter(
-                        PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
-                        PipelineRun.status == PipelineRun.PipelineRunStatus.RUNNING,
-                    ).all()
-                )
-            ),
+            PipelineRun.query.filter(
+                PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
+                PipelineRun.status == PipelineRun.PipelineRunStatus.RUNNING,
+            ).count(),
             0,
         )
 
@@ -178,14 +174,10 @@ class PipelineSchedulerTests(DBTestCase):
             schedule_all()
 
         self.assertEqual(
-            len(
-                (
-                    PipelineRun.query.filter(
-                        PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
-                        PipelineRun.status == PipelineRun.PipelineRunStatus.RUNNING,
-                    ).all()
-                )
-            ),
+            PipelineRun.query.filter(
+                PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
+                PipelineRun.status == PipelineRun.PipelineRunStatus.RUNNING,
+            ).count(),
             1,
         )
 
@@ -218,14 +210,10 @@ class PipelineSchedulerTests(DBTestCase):
 
         # No previous pipeline runs
         self.assertEqual(
-            len(
-                (
-                    PipelineRun.query.filter(
-                        PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
-                        PipelineRun.status == PipelineRun.PipelineRunStatus.RUNNING,
-                    ).all()
-                )
-            ),
+            PipelineRun.query.filter(
+                PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
+                PipelineRun.status == PipelineRun.PipelineRunStatus.RUNNING,
+            ).count(),
             0,
         )
 
@@ -261,14 +249,10 @@ class PipelineSchedulerTests(DBTestCase):
             schedule_all()
 
         self.assertEqual(
-            len(
-                (
-                    PipelineRun.query.filter(
-                        PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
-                        PipelineRun.status == PipelineRun.PipelineRunStatus.RUNNING,
-                    ).all()
-                )
-            ),
+            PipelineRun.query.filter(
+                PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
+                PipelineRun.status == PipelineRun.PipelineRunStatus.RUNNING,
+            ).count(),
             1,
         )
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Add new config options to `ConcurrencyConfig`:
* `pipeline_run_limit_all_triggers`: set the maximum number of pipeline runs for a single pipeline
* `on_pipeline_run_limit_reached`: set behavior for pipeline runs when the pipeline run limit is reached. if set to "skip", the scheduler will cancel the current run when the limit is reached.

I had to update the scheduling logic in `schedule_all` to handle the new configuration option to loop through schedules grouped by pipeline.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally
- [x] Unit tests


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
