### PR TITLE
[jk] Revert pipeline type when error occurs switching type

### DIFF
--- a/mage_ai/api/resources/PipelineResource.py
+++ b/mage_ai/api/resources/PipelineResource.py
@@ -415,7 +415,7 @@ class PipelineResource(BaseResource):
             if pipeline_type_updated is not None:
                 await self.model.update(dict(type=pipeline_type))
 
-            raise Exception(e)
+            raise e
 
         @safe_db_query
         def update_schedule_status(status, pipeline_uuid):

--- a/mage_ai/api/resources/PipelineResource.py
+++ b/mage_ai/api/resources/PipelineResource.py
@@ -412,7 +412,7 @@ class PipelineResource(BaseResource):
             switch_active_kernel(PIPELINE_TO_KERNEL_NAME[self.model.type])
         except Exception as e:
             pipeline_type_updated = payload.get('type')
-            if pipeline_type_updated is not None:
+            if pipeline_type_updated is not None and pipeline_type_updated != pipeline_type:
                 await self.model.update(dict(type=pipeline_type))
 
             raise e


### PR DESCRIPTION
# Description
- When users switch the `python` kernel to `pyspark` and an error occurs, the pipeline `type` should not update from `python` to `pyspark`, but should revert back to `python`. This PR reverts the pipeline type when trying to update the kernel and an error occurs.

# How Has This Been Tested?
Before (pipeline type is updated):
![BEFORE - revert pipeline type](https://github.com/mage-ai/mage-ai/assets/78053898/cc11cfe7-c55e-438b-a256-781b28426c10)

After (pipeline type is reverted back to its original type):
![AFTER - revert pipeline type](https://github.com/mage-ai/mage-ai/assets/78053898/4b4a9ede-30a1-4a3a-9ddc-91c913bc56c1)

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
