### PR TITLE
[dy] Update how global data products are run

### DIFF
--- a/mage_ai/data_preparation/models/block/global_data_product/__init__.py
+++ b/mage_ai/data_preparation/models/block/global_data_product/__init__.py
@@ -2,7 +2,7 @@ from typing import Dict, List
 
 from mage_ai.data_preparation.models.block import Block
 from mage_ai.data_preparation.models.global_data_product import GlobalDataProduct
-from mage_ai.orchestration.triggers import global_data_product as trigger
+from mage_ai.orchestration.triggers.global_data_product import trigger_and_check_status
 
 
 class GlobalDataProductBlock(Block):
@@ -27,7 +27,7 @@ class GlobalDataProductBlock(Block):
         global_vars: Dict = None,
         **kwargs,
     ) -> List:
-        trigger.trigger_and_check_status(
+        trigger_and_check_status(
             self.get_global_data_product(),
             global_vars.get('variables') if global_vars else None,
         )

--- a/mage_ai/data_preparation/models/block/global_data_product/__init__.py
+++ b/mage_ai/data_preparation/models/block/global_data_product/__init__.py
@@ -2,7 +2,7 @@ from typing import Dict, List
 
 from mage_ai.data_preparation.models.block import Block
 from mage_ai.data_preparation.models.global_data_product import GlobalDataProduct
-from mage_ai.orchestration.triggers.global_data_product import trigger_and_check_status
+from mage_ai.orchestration.triggers import global_data_product as trigger
 
 
 class GlobalDataProductBlock(Block):
@@ -27,7 +27,7 @@ class GlobalDataProductBlock(Block):
         global_vars: Dict = None,
         **kwargs,
     ) -> List:
-        trigger_and_check_status(
+        trigger.trigger_and_check_status(
             self.get_global_data_product(),
             global_vars.get('variables') if global_vars else None,
         )

--- a/mage_ai/tests/orchestration/triggers/test_global_data_product.py
+++ b/mage_ai/tests/orchestration/triggers/test_global_data_product.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 from freezegun import freeze_time
 
@@ -8,6 +9,7 @@ from mage_ai.data_preparation.models.constants import BlockType
 from mage_ai.data_preparation.models.global_data_product import GlobalDataProduct
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.orchestration.db.models.schedules import PipelineRun, PipelineSchedule
+from mage_ai.orchestration.pipeline_scheduler import PipelineScheduler, schedule_all
 from mage_ai.orchestration.triggers.global_data_product import (
     fetch_or_create_pipeline_schedule,
     trigger_and_check_status,
@@ -294,6 +296,35 @@ class TriggerGlobalDataProductTest(DBTestCase):
                 PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
             ).count(),
             count + 1,
+        )
+
+    def test_trigger_and_check_status_with_schedule_all(self):
+        self.global_data_product.outdated_after = dict(seconds=2)
+        self.global_data_product.outdated_starting_at = {}
+
+        trigger_and_check_status(
+            self.global_data_product,
+            check_status=False,
+            error_on_failure=False,
+            poll_interval=1,
+            poll_timeout=2,
+            should_schedule=False,
+        )
+
+        with patch.object(PipelineScheduler, 'schedule') as _:
+            schedule_all()
+
+        pipeline_schedule = fetch_or_create_pipeline_schedule(self.global_data_product)
+        pipeline_runs = PipelineRun.query.filter(
+            PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
+        ).all()
+
+        pipeline_runs.sort(key=lambda pr: pr.execution_date)
+        pipeline_run = pipeline_runs[-1]
+
+        self.assertEqual(
+            pipeline_run.status,
+            PipelineRun.PipelineRunStatus.RUNNING,
         )
 
     def test_fetch_or_create_pipeline_schedule(self):

--- a/mage_ai/tests/orchestration/triggers/test_global_data_product.py
+++ b/mage_ai/tests/orchestration/triggers/test_global_data_product.py
@@ -299,6 +299,12 @@ class TriggerGlobalDataProductTest(DBTestCase):
         )
 
     def test_trigger_and_check_status_with_schedule_all(self):
+        pipeline_schedule = fetch_or_create_pipeline_schedule(self.global_data_product)
+
+        count = PipelineRun.query.filter(
+            PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
+        ).count()
+
         self.global_data_product.outdated_after = dict(seconds=2)
         self.global_data_product.outdated_starting_at = {}
 
@@ -314,7 +320,6 @@ class TriggerGlobalDataProductTest(DBTestCase):
         with patch.object(PipelineScheduler, 'schedule') as _:
             schedule_all()
 
-        pipeline_schedule = fetch_or_create_pipeline_schedule(self.global_data_product)
         pipeline_runs = PipelineRun.query.filter(
             PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
         ).all()
@@ -325,6 +330,12 @@ class TriggerGlobalDataProductTest(DBTestCase):
         self.assertEqual(
             pipeline_run.status,
             PipelineRun.PipelineRunStatus.RUNNING,
+        )
+        self.assertEqual(
+            PipelineRun.query.filter(
+                PipelineRun.pipeline_schedule_id == pipeline_schedule.id,
+            ).count(),
+            count + 1,
         )
 
     def test_fetch_or_create_pipeline_schedule(self):


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Instead of running global data products by directly running it on the webserver process, we create the pipeline schedule, pipeline run, and just turn the pipeline schedule active. This way, the scheduler will pick up the pipeline run and scheduler it in the scheduler process, so the unnecessary logs won't show up in the block output.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally
- [x] Added a unit test to ensure that the global data produce pipeline run gets scheduled by the `schedule_all` method.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc: @tommydangerous 
<!-- Optionally mention someone to let them know about this pull request -->
