### PR TITLE
[dy] Add clone action to version control

### DIFF
--- a/mage_ai/frontend/components/VersionControl/Remote/index.tsx
+++ b/mage_ai/frontend/components/VersionControl/Remote/index.tsx
@@ -19,7 +19,13 @@ import Table from '@components/shared/Table';
 import Text from '@oracle/elements/Text';
 import TextInput from '@oracle/elements/Inputs/TextInput';
 import api from '@api';
-import { ACTION_FETCH, ACTION_PULL, ACTION_RESET, ACTION_RESET_HARD } from '../constants';
+import {
+  ACTION_CLONE,
+  ACTION_FETCH,
+  ACTION_PULL,
+  ACTION_RESET,
+  ACTION_RESET_HARD,
+} from '../constants';
 import {
   Add,
   Branch,
@@ -653,6 +659,9 @@ function Remote({
                   <option value={ACTION_RESET}>
                     {capitalizeRemoveUnderscoreLower(ACTION_RESET_HARD)}
                   </option>
+                  <option value={ACTION_CLONE}>
+                    {capitalizeRemoveUnderscoreLower(ACTION_CLONE)}
+                  </option>
                 </Select>
 
                 <Spacing mr={1} />
@@ -672,7 +681,7 @@ function Remote({
                   ))}
                 </Select>
                 
-                {actionName !== ACTION_FETCH && (
+                {![ACTION_FETCH, ACTION_CLONE].includes(actionName) && (
                   <Spacing ml={1}>
                     <Select
                       beforeIcon={<Branch />}
@@ -700,16 +709,26 @@ function Remote({
                   loading={isLoadingAction}
                   onClick={() => {
                     setActionProgress(null);
-                    // @ts-ignore
-                    actionGitBranch({
-                      git_custom_branch: {
-                        action_type: actionName,
-                        [actionName]: {
-                          branch: actionBranchName,
-                          remote: actionRemoteName,
+                    if (actionName !== ACTION_CLONE || (
+                      typeof window !== 'undefined'
+                      && typeof location !== 'undefined'
+                      && window.confirm(
+                        `Are you sure you want to clone remote ${actionRemoteName}? This will ` +
+                        'overwrite all your local changes and may reset any settings you may ' + 
+                        'have configured for your local Git repo. This action cannot be undone.',
+                      )
+                    )) {
+                      // @ts-ignore
+                      actionGitBranch({
+                        git_custom_branch: {
+                          action_type: actionName,
+                          [actionName]: {
+                            branch: actionBranchName,
+                            remote: actionRemoteName,
+                          },
                         },
-                      },
-                    });
+                      });
+                    }
                   }}
                   primary
                 >

--- a/mage_ai/frontend/components/VersionControl/constants.ts
+++ b/mage_ai/frontend/components/VersionControl/constants.ts
@@ -1,5 +1,6 @@
 import { TabType } from '@oracle/components/Tabs/ButtonTabs';
 
+export const ACTION_CLONE = 'clone';
 export const ACTION_DELETE = 'delete';
 export const ACTION_FETCH = 'fetch';
 export const ACTION_MERGE = 'merge';


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Add clone action to the "Remote" page in the version control app. I was trying to set up a mage project with git, and I realized there was no clone option at the moment. It may be necessary for users to clone their remote repository into Mage, so I'm adding the option to do that here.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally by performing clone function from version control app
![Screenshot 2023-10-31 at 11 43 31 AM](https://github.com/mage-ai/mage-ai/assets/14357209/8cc4972b-7e91-4b32-ba9d-79582e76381f)


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
