### PR TITLE
[ac] Fix Monaco editor theme

### DIFF
--- a/mage_ai/frontend/components/CodeEditor/index.tsx
+++ b/mage_ai/frontend/components/CodeEditor/index.tsx
@@ -105,7 +105,7 @@ function CodeEditor({
   showLineNumbers = true,
   tabSize = 4,
   textareaFocused,
-  theme: themeProp,
+  theme = DEFAULT_THEME,
   value,
   width = '100%',
 }: CodeEditorProps) {
@@ -116,12 +116,28 @@ function CodeEditor({
   const [completionDisposable, setCompletionDisposable] = useState([]);
   const [monacoInstance, setMonacoInstance] = useState(null);
   const [mounted, setMounted] = useState<boolean>(false);
-  const [theme, setTheme] = useState(themeProp || DEFAULT_THEME);
+  const [loadedTheme, setLoadedTheme] = useState<string>(null);
+
+  const updateTheme = useCallback((monaco) => {
+    setLoadedTheme((prevTheme) => {
+      if (prevTheme !== theme) {
+        defineTheme(theme).then((loaded) => {
+          if (loaded) {
+            monaco.editor.setTheme(theme);
+            return theme;
+          }
+        });
+      }
+
+      return prevTheme;
+    });
+  }, [theme]);
 
   const handleEditorWillMount = useCallback((monaco) => {
     monaco.languages.typescript.javascriptDefaults.setEagerModelSync(true);
     setMonacoInstance(monaco);
-  }, []);
+    updateTheme(monaco);
+  }, [updateTheme]);
 
   const handleEditorDidMount = useCallback((editor, monaco) => {
     editorRef.current = editor;
@@ -223,12 +239,6 @@ function CodeEditor({
     textareaFocused,
     value,
   ]);
-
-  useEffect(() => {
-    defineTheme(DEFAULT_THEME).then(() => {
-      setTheme(DEFAULT_THEME);
-    });
-  }, []);
 
   useEffect(() => {
     let autoSaveInterval;
@@ -366,7 +376,7 @@ function CodeEditor({
           wordBasedSuggestions: false,
           wordWrap: block?.type === BlockTypeEnum.MARKDOWN ? 'on' : 'off',
         }}
-        theme={theme}
+        theme={loadedTheme || 'vs-dark'}
         value={value}
         width={width}
       />

--- a/mage_ai/frontend/components/CodeEditor/utils.ts
+++ b/mage_ai/frontend/components/CodeEditor/utils.ts
@@ -56,7 +56,7 @@ const monacoThemes = {
   zenburnesque: 'Zenburnesque',
 };
 
-export const defineTheme = theme => new Promise((res) => {
+export const defineTheme = theme => new Promise<boolean>((loaded) => {
   Promise.all([
     loader.init(),
     import(`monaco-themes/themes/${monacoThemes[theme]}.json`),
@@ -70,12 +70,14 @@ export const defineTheme = theme => new Promise((res) => {
         "editorCursor.foreground": "#A7A7A7",
         "editorWhitespace.foreground": "#FFFFFF40"
       }
-    `
+    `;
     themeData.colors['editor.background'] = '#000000';
     themeData.colors['editor.foreground'] = '#FFFFFF';
     monaco.editor.defineTheme(theme, themeData);
     // @ts-ignore
-    res();
+    loaded(true);
+  }).catch(() => {
+    loaded(false);
   });
 });
 


### PR DESCRIPTION
# Description

A user was running into an issue where the Code Editor was displaying the light theme on the initial load but not in subsequent refreshes:

<img src="https://github.com/mage-ai/mage-ai/assets/8130751/2cc090f6-899e-4939-a5f2-8d02600421ef" width="400" />

This seems to be caused by either the Monaco theme failing to load OR the component mounting before the theme loaded. This PR attempts to fix this issue by moving the theme definition call into the `handleEditorWillMount` function, which is called before the editor is mounted. In the off chance that the Monaco custom theme doesn't load properly, we fallback to Monaco's default dark theme (`vs-dark`).

# How Has This Been Tested?

- [x] Tested loading the code editor on multiple touchpoints
    <img width="513" alt="image" src="https://github.com/mage-ai/mage-ai/assets/8130751/6866558f-32dc-4aa6-9dcc-0bd92e4c668a">

cc: @johnson-mage 