### PR TITLE
[Documentation] Add correct types of blocks in core-abstractions.mdx

### DIFF
--- a/docs/design/core-abstractions.mdx
+++ b/docs/design/core-abstractions.mdx
@@ -36,7 +36,7 @@ Pipelines can be filtered, tagged, and grouped by various properties. See our [d
 A block is a file with code that can be executed independently or within a
 pipeline. Together, blocks form a Directed Acyclic Graph (DAG), which we call pipelines. A block won't start running in a pipeline until all its upstream dependencies are met.
 
-There are 5 types of blocks.
+There are 8 types of blocks.
 
 1. Data loader
 
@@ -48,7 +48,11 @@ There are 5 types of blocks.
 
 5. Sensor
 
-6. Chart
+6. dbt
+
+7. Extensions
+
+8. Callbacks
 
 For more information, please see the [documentation on blocks](/design/blocks)
 


### PR DESCRIPTION
Used the following doc for reference: https://docs.mage.ai/design/blocks

# Description
The documentation had incorrect number of block types and their names. Correcting the same via this change.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [ ] Test A
- [ ] Test B


# Checklist
- [Check] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [Check] I have performed a self-review of my own code
- [ N/A ] I have added unit tests that prove my fix is effective or that my feature works
- [ N/A ] I have commented my code, particularly in hard-to-understand areas
- [ N/A ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
