### PR TITLE
[ac] Add keyboard shortcuts for inserting new scratchpad cell

### DIFF
--- a/mage_ai/frontend/components/CodeEditor/index.tsx
+++ b/mage_ai/frontend/components/CodeEditor/index.tsx
@@ -179,6 +179,10 @@ function CodeEditor({
       setTextareaFocused?.(true);
     });
 
+    editor.onDidBlurEditorWidget(() => {
+      setTextareaFocused?.(false);
+    });
+
     editor.onDidContentSizeChange(({
       contentHeight,
       contentHeightChanged,

--- a/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
@@ -1,6 +1,6 @@
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation } from 'react-query';
 
 import BlockCubeGradient from '@oracle/icons/custom/BlockCubeGradient';
@@ -90,6 +90,30 @@ function ConfigureBlock({
     name: defaultName,
     type: block?.type,
   });
+
+  const handleOnSave = useCallback(() => {
+    onSave({
+      ...blockAttributes,
+      name: blockAttributes?.name || defaultName,
+    });
+  }, [blockAttributes, defaultName, onSave]);
+
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      event.stopPropagation();
+      if (event.key === 'Escape') {
+        onClose();
+      } else if (event.key === 'Enter') {
+        handleOnSave();
+      }
+    };
+
+    document?.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document?.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleOnSave, onClose]);
 
   useEffect(() => {
     refTextInput?.current?.focus();
@@ -523,10 +547,7 @@ function ConfigureBlock({
             bold
             centerText
             disabled={isLoadingCreateLLM}
-            onClick={() => onSave({
-              ...blockAttributes,
-              name: blockAttributes?.name || defaultName,
-            })}
+            onClick={handleOnSave}
             primary
             tabIndex={0}
             uuid="ConfigureBlock/SaveAndAddBlock"

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -516,26 +516,18 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
       ) {
         event.preventDefault();
         savePipelineContent();
-      } else if (onlyKeysPresent([KEY_CODE_A], keyMapping)) {
-        if (!event.repeat && !isInputElement(event)) {
+      } else if (onlyKeysPresent([KEY_CODE_A], keyMapping) || onlyKeysPresent([KEY_CODE_B], keyMapping)) {
+        if (selectedBlock && !event.repeat && !isInputElement(event)) {
           const selectedBlockIndex =
             blocks.findIndex(({ uuid }: BlockType) => selectedBlock.uuid === uuid);
             if (selectedBlockIndex !== -1) {
-              // Add new scratchpad block above the current selected block
+              // Add new scratchpad block above (A) or below (B) the current selected block
+              const newBlockIndex = (onlyKeysPresent([KEY_CODE_A], keyMapping)) 
+                ? selectedBlockIndex 
+                : selectedBlockIndex + 1;
               addNewBlock({
                 type: BlockTypeEnum.SCRATCHPAD,
-              }, selectedBlockIndex);
-            }
-        }
-      } else if (onlyKeysPresent([KEY_CODE_B], keyMapping)) {
-        if (!event.repeat && !isInputElement(event)) {
-          const selectedBlockIndex =
-            blocks.findIndex(({ uuid }: BlockType) => selectedBlock.uuid === uuid);
-            if (selectedBlockIndex !== -1) {
-              // Add new scratchpad block below the current selected block
-              addNewBlock({
-                type: BlockTypeEnum.SCRATCHPAD,
-              }, selectedBlockIndex + 1);
+              }, newBlockIndex);
             }
         }
       } else if (textareaFocused) {

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -516,6 +516,28 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
       ) {
         event.preventDefault();
         savePipelineContent();
+      } else if (onlyKeysPresent([KEY_CODE_A], keyMapping)) {
+        if (!event.repeat && !isInputElement(event)) {
+          const selectedBlockIndex =
+            blocks.findIndex(({ uuid }: BlockType) => selectedBlock.uuid === uuid);
+            if (selectedBlockIndex !== -1) {
+              // Add new scratchpad block above the current selected block
+              addNewBlock({
+                type: BlockTypeEnum.SCRATCHPAD,
+              }, selectedBlockIndex);
+            }
+        }
+      } else if (onlyKeysPresent([KEY_CODE_B], keyMapping)) {
+        if (!event.repeat && !isInputElement(event)) {
+          const selectedBlockIndex =
+            blocks.findIndex(({ uuid }: BlockType) => selectedBlock.uuid === uuid);
+            if (selectedBlockIndex !== -1) {
+              // Add new scratchpad block below the current selected block
+              addNewBlock({
+                type: BlockTypeEnum.SCRATCHPAD,
+              }, selectedBlockIndex + 1);
+            }
+        }
       } else if (textareaFocused) {
         if (keyMapping[KEY_CODE_ESCAPE]) {
           setTextareaFocused(false);
@@ -541,21 +563,7 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
           const selectedBlockIndex =
             blocks.findIndex(({ uuid }: BlockType) => selectedBlock.uuid === uuid);
 
-          if (onlyKeysPresent([KEY_CODE_A], keyMapping) && !event.repeat && selectedBlockIndex !== -1) {
-            if (!isInputElement(event)) {
-              // Add new scratchpad block above the current selected block
-              addNewBlock({
-                type: BlockTypeEnum.SCRATCHPAD,
-              }, selectedBlockIndex);
-            }
-          } else if (onlyKeysPresent([KEY_CODE_B], keyMapping) && !event.repeat && selectedBlockIndex !== -1) {
-            if (!isInputElement(event)) {
-              // Add new scratchpad block below the current selected block
-              addNewBlock({
-                type: BlockTypeEnum.SCRATCHPAD,
-              }, selectedBlockIndex + 1);
-            }
-          } else if (keyMapping[KEY_CODE_ESCAPE]) {
+          if (keyMapping[KEY_CODE_ESCAPE]) {
             setSelectedBlock(null);
           } else if (keyHistory[0] === KEY_CODE_I
             && keyHistory[1] === KEY_CODE_I

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -61,8 +61,10 @@ import {
 } from './constants';
 import {
   KEY_CODES_SYSTEM,
+  KEY_CODE_A,
   KEY_CODE_ARROW_DOWN,
   KEY_CODE_ARROW_UP,
+  KEY_CODE_B,
   KEY_CODE_CONTROL,
   KEY_CODE_D,
   KEY_CODE_ENTER,
@@ -82,6 +84,7 @@ import { addScratchpadNote, addSqlBlockNote } from '@components/PipelineDetail/A
 import { addUnderscores, randomNameGenerator, removeExtensionFromFilename } from '@utils/string';
 import { buildBlockRefKey } from './utils';
 import { getUpstreamBlockUuids } from '@components/CodeBlock/utils';
+import { isInputElement } from '@context/shared/utils';
 import { onlyKeysPresent } from '@utils/hooks/keyboardShortcuts/utils';
 import { onSuccess } from '@api/utils/response';
 import { pushAtIndex, removeAtIndex } from '@utils/array';
@@ -332,9 +335,8 @@ function PipelineDetail({
   }), {}), [runningBlocks]);
 
   const [cursorHeight1, setCursorHeight1] = useState<number>(null);
-  const column1ScrollMemo = useMemo(() => {
-    return (
-      <ColumnScroller
+  const column1ScrollMemo = useMemo(() => (
+    <ColumnScroller
         blocks={blocksFiltered}
         columnIndex={0}
         columns={2}
@@ -347,8 +349,7 @@ function PipelineDetail({
         scrollTogether={scrollTogether}
         setCursorHeight={setCursorHeight1}
       />
-    );
-  }, [
+    ), [
     blockRefs,
     blocksFiltered,
     cursorHeight1,
@@ -358,9 +359,8 @@ function PipelineDetail({
   ]);
 
   const [cursorHeight2, setCursorHeight2] = useState<number>(null);
-  const column2ScrollMemo = useMemo(() => {
-    return (
-      <ColumnScroller
+  const column2ScrollMemo = useMemo(() => (
+    <ColumnScroller
         blocks={blocksFiltered}
         columnIndex={1}
         columns={2}
@@ -374,8 +374,7 @@ function PipelineDetail({
         scrollTogether={scrollTogether}
         setCursorHeight={setCursorHeight2}
       />
-    );
-  }, [
+    ), [
     blockOutputRefs,
     blocksFiltered,
     cursorHeight2,
@@ -385,13 +384,12 @@ function PipelineDetail({
   ]);
 
   const [cursorHeight3, setCursorHeight3] = useState<number>(null);
-  const column3ScrollMemo = useMemo(() => {
-    return (
-      <ColumnScroller
+  const column3ScrollMemo = useMemo(() => (
+    <ColumnScroller
         blocks={blocksFiltered}
-        disabled={!scrollTogether}
         columnIndex={2}
         columns={1}
+        disabled={!scrollTogether}
         eventNameRefsMapping={{
           [CUSTOM_EVENT_BLOCK_OUTPUT_CHANGED]: blockOutputRefs,
           [CUSTOM_EVENT_CODE_BLOCK_CHANGED]: blockRefs,
@@ -402,8 +400,7 @@ function PipelineDetail({
         scrollTogether={scrollTogether}
         setCursorHeight={setCursorHeight3}
       />
-    );
-  }, [
+    ), [
     blockOutputRefs,
     blockRefs,
     blocksFiltered,
@@ -433,6 +430,60 @@ function PipelineDetail({
     useMemo(() => dataBlockTemplates?.block_templates || [], [
       dataBlockTemplates,
     ]);
+
+  const addNewBlock = useCallback((newBlock: BlockRequestPayloadType, newBlockIndex?: number) => {
+      const block = blocks[blocks.length - 1];
+
+      let content = null;
+      let configuration = newBlock.configuration || {};
+      const upstreamBlocks = block ? getUpstreamBlockUuids(block, newBlock) : [];
+
+      if (block) {
+        if ([BlockTypeEnum.DATA_LOADER, BlockTypeEnum.TRANSFORMER].includes(block.type)
+          && BlockTypeEnum.SCRATCHPAD === newBlock.type
+        ) {
+          content = `from mage_ai.data_preparation.variable_manager import get_variable
+
+
+df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
+`;
+        }
+
+        if (BlockLanguageEnum.SQL === block.language) {
+          configuration = {
+            ...selectKeys(block.configuration, [
+              CONFIG_KEY_DATA_PROVIDER,
+              CONFIG_KEY_DATA_PROVIDER_DATABASE,
+              CONFIG_KEY_DATA_PROVIDER_PROFILE,
+              CONFIG_KEY_DATA_PROVIDER_SCHEMA,
+              CONFIG_KEY_EXPORT_WRITE_POLICY,
+            ]),
+            ...configuration,
+          };
+        }
+      }
+
+      if (BlockLanguageEnum.SQL === newBlock.language) {
+        content = addSqlBlockNote(content);
+      }
+      content = addScratchpadNote(newBlock, content);
+
+      const blockIndex = (newBlockIndex !== null) ? newBlockIndex : numberOfBlocks;
+      addNewBlockAtIndex({
+        ...newBlock,
+        configuration,
+        content,
+        upstream_blocks: upstreamBlocks,
+      }, blockIndex, setSelectedBlock);
+      setTextareaFocused(true);
+  }, [
+    addNewBlockAtIndex,
+    blocks,
+    numberOfBlocks,
+    pipeline,
+    setSelectedBlock,
+    setTextareaFocused,
+  ]);
 
   const uuidKeyboard = 'PipelineDetail/index';
   const {
@@ -490,7 +541,21 @@ function PipelineDetail({
           const selectedBlockIndex =
             blocks.findIndex(({ uuid }: BlockType) => selectedBlock.uuid === uuid);
 
-          if (keyMapping[KEY_CODE_ESCAPE]) {
+          if (onlyKeysPresent([KEY_CODE_A], keyMapping) && !event.repeat && selectedBlockIndex !== -1) {
+            if (!isInputElement(event)) {
+              // Add new scratchpad block above the current selected block
+              addNewBlock({
+                type: BlockTypeEnum.SCRATCHPAD,
+              }, selectedBlockIndex);
+            }
+          } else if (onlyKeysPresent([KEY_CODE_B], keyMapping) && !event.repeat && selectedBlockIndex !== -1) {
+            if (!isInputElement(event)) {
+              // Add new scratchpad block below the current selected block
+              addNewBlock({
+                type: BlockTypeEnum.SCRATCHPAD,
+              }, selectedBlockIndex + 1);
+            }
+          } else if (keyMapping[KEY_CODE_ESCAPE]) {
             setSelectedBlock(null);
           } else if (keyHistory[0] === KEY_CODE_I
             && keyHistory[1] === KEY_CODE_I
@@ -664,51 +729,7 @@ function PipelineDetail({
   const addNewBlocksMemo = useMemo(() => pipeline && (
     <>
       <AddNewBlocks
-        addNewBlock={(newBlock: BlockRequestPayloadType) => {
-          const block = blocks[blocks.length - 1];
-
-          let content = null;
-          let configuration = newBlock.configuration || {};
-          const upstreamBlocks = block ? getUpstreamBlockUuids(block, newBlock) : [];
-
-          if (block) {
-            if ([BlockTypeEnum.DATA_LOADER, BlockTypeEnum.TRANSFORMER].includes(block.type)
-              && BlockTypeEnum.SCRATCHPAD === newBlock.type
-            ) {
-              content = `from mage_ai.data_preparation.variable_manager import get_variable
-
-
-  df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
-  `;
-            }
-
-            if (BlockLanguageEnum.SQL === block.language) {
-              configuration = {
-                ...selectKeys(block.configuration, [
-                  CONFIG_KEY_DATA_PROVIDER,
-                  CONFIG_KEY_DATA_PROVIDER_DATABASE,
-                  CONFIG_KEY_DATA_PROVIDER_PROFILE,
-                  CONFIG_KEY_DATA_PROVIDER_SCHEMA,
-                  CONFIG_KEY_EXPORT_WRITE_POLICY,
-                ]),
-                ...configuration,
-              };
-            }
-          }
-
-          if (BlockLanguageEnum.SQL === newBlock.language) {
-            content = addSqlBlockNote(content);
-          }
-          content = addScratchpadNote(newBlock, content);
-
-          addNewBlockAtIndex({
-            ...newBlock,
-            configuration,
-            content,
-            upstream_blocks: upstreamBlocks,
-          }, numberOfBlocks, setSelectedBlock);
-          setTextareaFocused(true);
-        }}
+        addNewBlock={addNewBlock}
         blockTemplates={blockTemplates}
         focusedAddNewBlockSearch={focusedAddNewBlockSearch}
         hideCustom={isIntegration || isStreaming}
@@ -750,24 +771,19 @@ function PipelineDetail({
       )}
     </>
   ), [
-    addNewBlockAtIndex,
+    addNewBlock,
     blockTemplates,
-    blocks,
     focusedAddNewBlockSearch,
     isIntegration,
     isStreaming,
-    numberOfBlocks,
     onClickAddSingleDBTModel,
     pipeline,
     project,
     searchTextInputRef,
     setFocusedAddNewBlockSearch,
-    setSelectedBlock,
-    setTextareaFocused,
     showBrowseTemplates,
     showConfigureProjectModal,
     showGlobalDataProducts,
-    sideBySideEnabled,
     useV2AddNewBlock,
   ]);
 

--- a/mage_ai/frontend/context/shared/utils.ts
+++ b/mage_ai/frontend/context/shared/utils.ts
@@ -26,27 +26,36 @@ export const isFunctionalComponent = (Component: Function) => {
   return !prototype || !prototype.isReactComponent;
 };
 
-/** Remove keyboard focus from the currently focused element  */
-export const removeKeyboardFocus = () => {
-  (document.activeElement as HTMLElement).blur();
-};
 
-/** Determine whether the event target is an interactive element */
-export const isInteractiveElement = (event): boolean => {
+/* * * * * * * * * * *
+ * Element utilities *
+ * * * * * * * * * * */
+
+enum EventElementType {
+  INPUT = 'input',
+  INTERACTIVE = 'interactive',
+}
+
+const isEventElementType = (event, elementType): boolean => {
   if (event.target instanceof Element) {
     const tagName = (event.target as Element).tagName.toLowerCase();
-    return ['a', 'button', 'input', 'select', 'textarea'].includes(tagName);
+    if (elementType === EventElementType.INPUT) {
+      return ['input', 'textarea'].includes(tagName);
+    } else if (elementType === EventElementType.INTERACTIVE) {
+      return ['a', 'button', 'input', 'select', 'textarea'].includes(tagName);
+    }
   }
 
   return false;
 };
 
 /** Determine whether the event target is an input element */
-export const isInputElement = (event): boolean => {
-  if (event.target instanceof Element) {
-    const tagName = (event.target as Element).tagName.toLowerCase();
-    return ['input', 'textarea'].includes(tagName);
-  }
+export const isInputElement = (event): boolean => isEventElementType(event, EventElementType.INPUT);
 
-  return false;
+/** Determine whether the event target is an interactive element */
+export const isInteractiveElement = (event): boolean => isEventElementType(event, EventElementType.INTERACTIVE);
+
+/** Remove keyboard focus from the currently focused element  */
+export const removeKeyboardFocus = () => {
+  (document.activeElement as HTMLElement).blur();
 };

--- a/mage_ai/frontend/context/shared/utils.ts
+++ b/mage_ai/frontend/context/shared/utils.ts
@@ -35,7 +35,17 @@ export const removeKeyboardFocus = () => {
 export const isInteractiveElement = (event): boolean => {
   if (event.target instanceof Element) {
     const tagName = (event.target as Element).tagName.toLowerCase();
-    return ['a', 'button', 'input', 'select'].includes(tagName);
+    return ['a', 'button', 'input', 'select', 'textarea'].includes(tagName);
+  }
+
+  return false;
+};
+
+/** Determine whether the event target is an input element */
+export const isInputElement = (event): boolean => {
+  if (event.target instanceof Element) {
+    const tagName = (event.target as Element).tagName.toLowerCase();
+    return ['input', 'textarea'].includes(tagName);
   }
 
   return false;


### PR DESCRIPTION
# Description

This PR adds the same keyboard shortcuts as Jupyter notebooks for inserting new scratchpad cells:

* If a block is selected and the user presses `a`, a new scratchpad cell is inserted above the selected block.
* If a block is selected and the user presses `b`, a new scratchpad cell is inserted below the selected block.
* If no block is selected or the user is typing in an input / text area, the `a` and `b` keyboard shortcuts do nothing.

# How Has This Been Tested?

- [x] Test that `a` inserts a new scratchpad cell **above** the selected block when a block is selected and an input / text area isn't focused
- [x] Test that `b` inserts a new scratchpad cell **below** the selected block when a block is selected and an input / text area isn't focused
- [x] Test that the `a` and `b` keyboard shortcuts do nothing when no block is selected
- [x] Test that the `a` and `b` keyboard shortcuts do nothing when an input / text area is focused

cc: @johnson-mage 