### PR TITLE
[xy] Fix pipeline LIST API performance.

### DIFF
--- a/mage_ai/data_preparation/models/block/integration/__init__.py
+++ b/mage_ai/data_preparation/models/block/integration/__init__.py
@@ -439,10 +439,10 @@ class DestinationBlock(IntegrationBlock):
 
         return merge_dict(
             super().to_dict(
-                include_content,
-                include_outputs,
-                sample_count,
-                check_if_file_exists,
+                include_content=include_content,
+                include_outputs=include_outputs,
+                sample_count=sample_count,
+                check_if_file_exists=check_if_file_exists,
             ),
             data,
         )


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix pipeline LIST API performance.

Pipeline LIST API was slow on the Pipeline list page.
```
GET /api/pipelines?include_schedules=1
```
The slow performance is due to the bug in the data integration block `to_dict` method. When the data integration block calls `super().to_dict`, it didn't specify the keyword argument name in the method, which causes the `include_outputs` to be set to `True` and the block fetches the unnecessary output data.

This PR fixes this issue.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with pipeline list URL with 108 standard batch pipeline + 131 data integration pipeline + 37 streaming pipeline. The original time of the API call was 22s. After the fix, the time of the API call is 4s.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  - [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
