### PR TITLE
[Feat] Add colour code for pipeline backfills

### DIFF
--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -91,13 +91,13 @@ function BackfillsTable({
         const arr = [
           <Text
             danger={BackfillStatusEnum.FAILED === status}
-            default={BackfillStatusEnum.CANCELLED === status}
-            info={BackfillStatusEnum.INITIAL === status}
+            default={status === null}
+            info={BackfillStatusEnum.RUNNING === status || BackfillStatusEnum.INITIAL === status}
             key="status"
             monospace
             success={BackfillStatusEnum.COMPLETED === status}
-            warning={BackfillStatusEnum.RUNNING === status}
-            >
+            warning={BackfillStatusEnum.CANCELLED === status}
+          >
             {status || 'inactive'}
           </Text>,
           <NextLink

--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -3,6 +3,7 @@ import NextLink from 'next/link';
 import BackfillType, {
   BACKFILL_TYPE_DATETIME,
   BACKFILL_TYPE_CODE,
+  BackfillStatusEnum,
 } from '@interfaces/BackfillType';
 import Button from '@oracle/elements/Button';
 import Link from '@oracle/elements/Link';
@@ -88,7 +89,17 @@ function BackfillsTable({
         total_run_count: totalRunCount,
       }, idx) => {
         const arr = [
-          <Text default key="status" monospace>{status || 'inactive'}</Text>,
+          <Text
+            danger={BackfillStatusEnum.FAILED === status}
+            default={BackfillStatusEnum.CANCELLED === status}
+            info={BackfillStatusEnum.INITIAL === status}
+            key="status"
+            monospace
+            success={BackfillStatusEnum.COMPLETED === status}
+            warning={BackfillStatusEnum.RUNNING === status}
+            >
+            {status || 'inactive'}
+          </Text>,
           <NextLink
             as={`/pipelines/${pipelineUUID}/backfills/${id}`}
             href={'/pipelines/[pipeline]/backfills/[...slug]'}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This PR adds colour code for pipeline backfills.

# Test
![image](https://github.com/mage-ai/mage-ai/assets/132081506/03599cf1-8b67-4cfe-bc09-e16bfca8d3ab)

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  - [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc: @johnson-mage 
<!-- Optionally mention someone to let them know about this pull request -->
