### PR TITLE
[jk] Break while loop when not raising error on failure for pipeline triggered by code

### DIFF
--- a/mage_ai/orchestration/triggers/utils.py
+++ b/mage_ai/orchestration/triggers/utils.py
@@ -27,6 +27,8 @@ def check_pipeline_run_status(
         if PipelineRun.PipelineRunStatus.FAILED.value == status:
             if error_on_failure:
                 raise Exception(message)
+            else:
+                break
 
         if verbose:
             print(message)


### PR DESCRIPTION
# Description
- There was an infinite loop when triggering a pipeline via code if the pipeline run failed and the `check_status` setting was enabled and the `error_on_failure` setting was disabled. This PR causes the loop to end.


# How Has This Been Tested?
Before (infinite loop, had to cancel pipeline run to stop it):
<img width="1405" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/e98ad98f-31ea-4827-8425-7d394492cfa0">

After (pipeline run completed after triggered pipeline run failed):
<img width="1378" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/c25f2a5b-b8a9-465e-b6b7-26eea6fdbf9f">

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
