### PR TITLE
[dy] Fix saving tokens when creating triggers with code

### DIFF
--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -242,8 +242,11 @@ class PipelineSchedule(BaseModel):
                     existing_trigger.status != kwargs.get('status'),
                     existing_trigger.variables != kwargs.get('variables'),
                 ]):
+                    if existing_trigger.token is None:
+                        kwargs['token'] = uuid.uuid4().hex
                     existing_trigger.update(**kwargs)
             else:
+                kwargs['token'] = uuid.uuid4().hex
                 triggers_to_create.append(kwargs)
 
         db_connection.session.bulk_save_objects(

--- a/mage_ai/tests/orchestration/db/models/test_schedules.py
+++ b/mage_ai/tests/orchestration/db/models/test_schedules.py
@@ -9,6 +9,7 @@ from mage_ai.data_preparation.models.triggers import (
     ScheduleInterval,
     ScheduleStatus,
     ScheduleType,
+    Trigger,
 )
 from mage_ai.data_preparation.repo_manager import get_repo_config
 from mage_ai.orchestration.db.models.schedules import (
@@ -674,6 +675,70 @@ class PipelineScheduleTests(DBTestCase):
             status=PipelineRun.PipelineRunStatus.RUNNING,
         )
         self.assertFalse(pipeline_schedule.should_schedule())
+
+    def test_create_or_update_batch(self):
+        create_pipeline_with_blocks(
+            'test create or update batch',
+            self.repo_path,
+        )
+
+        PipelineSchedule.create(**dict(
+            name='test create batch trigger 3',
+            pipeline_uuid='test_create_or_update_batch',
+            schedule_type=ScheduleType.TIME,
+            schedule_interval=ScheduleInterval.DAILY,
+        ))
+
+        trigger_configs = [
+            Trigger.load(
+                config=dict(
+                    name='test create batch trigger 1',
+                    pipeline_uuid='test_create_or_update_batch',
+                    schedule_type=ScheduleType.TIME,
+                    start_time=datetime.now(),
+                    schedule_interval=ScheduleInterval.HOURLY,
+                    status=ScheduleStatus.ACTIVE,
+                )
+            ),
+            Trigger.load(
+                config=dict(
+                    name='test create batch trigger 2',
+                    pipeline_uuid='test_create_or_update_batch',
+                    schedule_type=ScheduleType.API,
+                    start_time=datetime.now(),
+                    schedule_interval=None,
+                    status=ScheduleStatus.ACTIVE,
+                )
+            ),
+            Trigger.load(
+                config=dict(
+                    name='test create batch trigger 3',
+                    pipeline_uuid='test_create_or_update_batch',
+                    schedule_type=ScheduleType.TIME,
+                    start_time=datetime.now(),
+                    schedule_interval=ScheduleInterval.WEEKLY,
+                    status=ScheduleStatus.ACTIVE,
+                )
+            )
+        ]
+
+        PipelineSchedule.create_or_update_batch(trigger_configs)
+
+        ps1 = PipelineSchedule.query.filter(
+            PipelineSchedule.name == 'test create batch trigger 1'
+        ).one_or_none()
+        self.assertIsNotNone(ps1)
+        self.assertEqual(ps1.schedule_type, ScheduleType.TIME)
+        self.assertEqual(ps1.pipeline_uuid, 'test_create_or_update_batch')
+        self.assertEqual(ps1.schedule_interval, ScheduleInterval.HOURLY)
+        self.assertIsNotNone(ps1.token)
+
+        ps3 = PipelineSchedule.query.filter(
+            PipelineSchedule.name == 'test create batch trigger 3'
+        ).one_or_none()
+        self.assertEqual(ps3.schedule_type, ScheduleType.TIME)
+        self.assertEqual(ps3.pipeline_uuid, 'test_create_or_update_batch')
+        self.assertEqual(ps3.schedule_interval, ScheduleInterval.WEEKLY)
 
 
 class PipelineRunTests(DBTestCase):


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

When a trigger is created in code and synced with the database, the `token` field was getting left out when new triggers were created. This PR fixes that issue.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with code triggers
- [x] Unit tests


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  - [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc: 
<!-- Optionally mention someone to let them know about this pull request -->
