### PR TITLE
[jk] Consistent run status colors across tables

### DIFF
--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -91,8 +91,8 @@ function BackfillsTable({
         const arr = [
           <Text
             danger={BackfillStatusEnum.FAILED === status}
-            default={status === null}
-            info={BackfillStatusEnum.RUNNING === status || BackfillStatusEnum.INITIAL === status}
+            default={!status}
+            info={BackfillStatusEnum.RUNNING === status}
             key="status"
             monospace
             success={BackfillStatusEnum.COMPLETED === status}

--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -11,7 +11,10 @@ import Table, { ColumnType } from '@components/shared/Table';
 import Text from '@oracle/elements/Text';
 import { Edit } from '@oracle/icons';
 import { RunStatus } from '@interfaces/PipelineRunType';
-import { TIMEZONE_TOOLTIP_PROPS } from '@components/shared/Table/constants';
+import {
+  TIMEZONE_TOOLTIP_PROPS,
+  getRunStatusTextProps,
+} from '@components/shared/Table/constants';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { datetimeInLocalTimezone, utcStringToElapsedTime } from '@utils/date';
 import { getTimeInUTCString } from '@components/Triggers/utils';
@@ -90,13 +93,8 @@ function BackfillsTable({
       }, idx) => {
         const arr = [
           <Text
-            danger={BackfillStatusEnum.FAILED === status}
-            default={!status}
-            info={BackfillStatusEnum.RUNNING === status}
+            {...getRunStatusTextProps(status)}
             key="status"
-            monospace
-            success={BackfillStatusEnum.COMPLETED === status}
-            warning={BackfillStatusEnum.CANCELLED === status}
           >
             {status || 'inactive'}
           </Text>,

--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
@@ -195,12 +195,12 @@ function BlockRunsTable({
         const rows = [
           <Text
             danger={RunStatus.FAILED === status}
-            default={RunStatus.CANCELLED === status}
-            info={RunStatus.INITIAL === status}
+            default={!status}
+            info={RunStatus.RUNNING === status}
             key={`${id}_status`}
             monospace
             success={RunStatus.COMPLETED === status}
-            warning={RunStatus.RUNNING === status}
+            warning={RunStatus.CANCELLED === status}
           >
             {status}
           </Text>,

--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
@@ -24,6 +24,7 @@ import {
   SortDirectionEnum,
   SortQueryEnum,
   TIMEZONE_TOOLTIP_PROPS,
+  getRunStatusTextProps,
 } from '@components/shared/Table/constants';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { dateFormatLong, datetimeInLocalTimezone, utcStringToElapsedTime } from '@utils/date';
@@ -194,13 +195,8 @@ function BlockRunsTable({
 
         const rows = [
           <Text
-            danger={RunStatus.FAILED === status}
-            default={!status}
-            info={RunStatus.RUNNING === status}
+            {...getRunStatusTextProps(status)}
             key={`${id}_status`}
-            monospace
-            success={RunStatus.COMPLETED === status}
-            warning={RunStatus.CANCELLED === status}
           >
             {status}
           </Text>,

--- a/mage_ai/frontend/components/Triggers/Table.tsx
+++ b/mage_ai/frontend/components/Triggers/Table.tsx
@@ -33,6 +33,7 @@ import {
   DELETE_CONFIRM_TOP_OFFSET_DIFF,
   DELETE_CONFIRM_TOP_OFFSET_DIFF_FIRST,
   TIMEZONE_TOOLTIP_PROPS,
+  getRunStatusTextProps,
 } from '@components/shared/Table/constants';
 import { ICON_SIZE_SMALL } from '@oracle/styles/units/icons';
 import { RunStatus } from '@interfaces/BlockRunType';
@@ -385,13 +386,8 @@ function TriggersTable({
                   }
                 </Text>,
                 <Text
-                  danger={RunStatus.FAILED === lastPipelineRunStatus}
-                  default={!lastPipelineRunStatus}
-                  info={RunStatus.RUNNING === lastPipelineRunStatus}
+                  {...getRunStatusTextProps(lastPipelineRunStatus)}
                   key={`latest_run_status_${idx}`}
-                  monospace
-                  success={RunStatus.COMPLETED === lastPipelineRunStatus}
-                  warning={RunStatus.CANCELLED === lastPipelineRunStatus}
                 >
                   {lastPipelineRunStatus || 'N/A'}
                 </Text>,

--- a/mage_ai/frontend/components/Triggers/Table.tsx
+++ b/mage_ai/frontend/components/Triggers/Table.tsx
@@ -387,6 +387,7 @@ function TriggersTable({
                 <Text
                   danger={RunStatus.FAILED === lastPipelineRunStatus}
                   default={!lastPipelineRunStatus}
+                  info={RunStatus.RUNNING === lastPipelineRunStatus}
                   key={`latest_run_status_${idx}`}
                   monospace
                   success={RunStatus.COMPLETED === lastPipelineRunStatus}

--- a/mage_ai/frontend/components/shared/Table/constants.ts
+++ b/mage_ai/frontend/components/shared/Table/constants.ts
@@ -1,4 +1,5 @@
 import { LOCAL_TIMEZONE } from '@utils/date';
+import { RunStatus as RunStatusEnum } from '@interfaces/BlockRunType';
 import { UNIT } from '@oracle/styles/units/spacing';
 
 export const MENU_WIDTH: number = UNIT * 20;
@@ -24,3 +25,24 @@ export const TIMEZONE_TOOLTIP_PROPS = {
 
 export const getTableRowUuid = 
   ({ uuid, rowIndex }: { uuid: string, rowIndex: number }) => `${uuid}-row-${rowIndex}`;
+
+/*
+ * Run statuses that appear in tables (e.g. Block Runs, Triggers,
+ * and Backfills) have the following text colors:
+ * cancelled - yellow
+ * completed - green
+ * failed - red
+ * inactive or N/A - grey
+ * initial - white
+ * running - blue
+ */
+export const getRunStatusTextProps = (
+  status: RunStatusEnum,
+) => ({
+  danger: RunStatusEnum.FAILED === status,
+  default: !status,
+  info: RunStatusEnum.RUNNING === status,
+  monospace: true,
+  success: RunStatusEnum.COMPLETED === status,
+  warning: RunStatusEnum.CANCELLED === status,
+});


### PR DESCRIPTION
# Description
- The run status colors were not uniform across tables, so this PR makes them consistent. "Run status" is a catch-all term which includes backfill statuses, block run statuses, and pipeline run statuses. These status colors match the bar colors in the pipeline run chart in the project "Overview" page.

The status colors used are the following:
1. cancelled - yellow
2. completed - green
3. failed - red
4. inactive or N/A - grey
5. initial - white
6. running - blue

# How Has This Been Tested?
Triggers page:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/253e29a1-2c17-4213-867f-18cce110f05e)
![image](https://github.com/mage-ai/mage-ai/assets/78053898/00289f17-2b53-4db1-8f4b-860681becb3d)

Backfills page:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/5323192a-011d-45d1-8e70-eb86acf72ed4)

Block runs page:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/4979993d-d1aa-45dc-9f5e-2f6f9474b5db)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  - [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
