### PR TITLE
[td] Interpolate variables and upstream block output in dbt commands

### DIFF
--- a/mage_ai/data_preparation/models/block/dbt/block_yaml.py
+++ b/mage_ai/data_preparation/models/block/dbt/block_yaml.py
@@ -1,5 +1,7 @@
 import os
+import re
 import shlex
+from functools import reduce
 from logging import Logger
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -12,6 +14,7 @@ from mage_ai.data_preparation.models.block.dbt.dbt_cli import DBTCli
 from mage_ai.data_preparation.models.block.dbt.profiles import Profiles
 from mage_ai.data_preparation.models.block.dbt.project import Project
 from mage_ai.data_preparation.shared.utils import get_template_vars
+from mage_ai.data_preparation.templates.utils import get_variable_for_template
 from mage_ai.orchestration.constants import PIPELINE_RUN_MAGE_VARIABLES_KEY
 from mage_ai.shared.hash import merge_dict
 
@@ -89,6 +92,76 @@ class DBTBlockYAML(DBTBlock):
             }
         }
 
+    def _hydrate_block_outputs(
+        self,
+        content: str,
+        outputs_from_input_vars: Dict,
+        variables: Dict = None,
+    ) -> str:
+        def _block_output(
+            block_uuid: str = None,
+            parse: str = None,
+            outputs_from_input_vars=outputs_from_input_vars,
+            upstream_block_uuids=self.upstream_block_uuids,
+            variables=variables,
+        ) -> Any:
+            data = outputs_from_input_vars
+
+            if parse:
+                if block_uuid:
+                    data = outputs_from_input_vars.get(block_uuid)
+                elif upstream_block_uuids:
+                    def _build_positional_arguments(acc: List, upstream_block_uuid: str) -> List:
+                        acc.append(outputs_from_input_vars.get(upstream_block_uuid))
+                        return acc
+
+                    data = reduce(
+                        _build_positional_arguments,
+                        upstream_block_uuids,
+                        [],
+                    )
+
+                try:
+                    return parse(data, variables)
+                except Exception as err:
+                    print(f'[WARNING] block_output: {err}')
+
+            return data
+
+        variable_pattern = r'{}[ ]*block_output[^{}]*[ ]*{}'.format(r'\{\{', r'\}\}', r'\}\}')
+
+        match = 1
+        while match is not None:
+            match = None
+
+            match = re.search(
+                variable_pattern,
+                content,
+                re.IGNORECASE,
+            )
+
+            if not match:
+                continue
+
+            si, ei = match.span()
+            substring = content[si:ei]
+
+            match2 = re.match(
+                r'{}([^{}{}]+){}'.format(r'\{\{', r'\{\{', r'\}\}', r'\}\}'),
+                substring,
+            )
+            if match2:
+                groups = match2.groups()
+                if groups:
+                    function_string = groups[0].strip()
+                    results = dict(block_output=_block_output)
+                    exec(f'value_hydrated = {function_string}', results)
+
+                    value_hydrated = results['value_hydrated']
+                    content = f'{content[0:si]}{value_hydrated}{content[ei:]}'
+
+        return content
+
     def _execute_block(
         self,
         outputs_from_input_vars,
@@ -108,15 +181,27 @@ class DBTBlockYAML(DBTBlock):
         # Which dbt task should be executed
         task = self._dbt_configuration.get('command', 'run')
 
+        # Get variables
+        variables = merge_dict(global_vars, runtime_arguments or {})
+
+        content = self.content or ''
+
+        content = self._hydrate_block_outputs(content, outputs_from_input_vars, variables)
+        content = Template(content).render(
+            variables=lambda x, p=None, v=variables: get_variable_for_template(
+                x,
+                parse=p,
+                variables=v,
+            ),
+            **get_template_vars(),
+        )
+
         # Get args from block content and split them by word, just like a shell does
         # This handles quoting correctly, e.g. when supplying a json string
-        args = shlex.split(self.content)
+        args = shlex.split(content)
 
         # Set project-dir argument for invoking dbt
         args += ["--project-dir", self.project_path]
-
-        # Get varaibles
-        variables = merge_dict(global_vars, runtime_arguments or {})
 
         # Set flags and prefix/suffix from runtime_configuration
         # e.g. setting --full-refresh
@@ -135,15 +220,20 @@ class DBTBlockYAML(DBTBlock):
             vars_index = args.index('--vars') + 1
         except Exception:
             pass
+
         if vars_index:
-            vars = Template(args[vars_index]).render(
-                variables=lambda x: variables.get(x) if variables else None,
+            variables2 = Template(args[vars_index]).render(
+                variables=lambda x, p=None, v=variables: get_variable_for_template(
+                    x,
+                    parse=p,
+                    variables=v,
+                ),
                 **get_template_vars(),
             )
             args[vars_index] = self._variables_json(merge_dict(
                 variables,
                 # manual vars second, as these update the automatically interpolated vars
-                simplejson.loads(vars),
+                simplejson.loads(variables2),
             ))
         else:
             args += ['--vars', self._variables_json(variables)]

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -2280,217 +2280,25 @@ df = get_variable('${pipelineUUID}', '${blockUUID}', 'output_0')`;
                 {!hideExtraConfiguration && BlockTypeEnum.DBT === blockType
                   && !codeCollapsed
                   && (
-                  <CodeHelperStyle normalPadding>
-                    <FlexContainer
-                      alignItems="center"
-                      justifyContent="space-between"
-                    >
-                      <Flex alignItems="center">
-                        {BlockLanguageEnum.YAML === blockLanguage && (
-                          <Select
-                            compact
-                            monospace
-                            onBlur={() => setTimeout(() => {
-                              setAnyInputFocused(false);
-                            }, 300)}
-                            onChange={(e) => {
-                              updateDataProviderConfig({
-                                [CONFIG_KEY_DBT_PROFILE_TARGET]: '',
-                                [CONFIG_KEY_DBT_PROJECT_NAME]: e.target.value,
-                              });
-                              e.preventDefault();
-                            }}
-                            onClick={pauseEvent}
-                            onFocus={() => {
-                              setAnyInputFocused(true);
-                            }}
-                            placeholder="Project"
-                            small
-                            value={dataProviderConfig[CONFIG_KEY_DBT_PROJECT_NAME] || ''}
-                          >
-                            {Object.keys(dbtProjects || {}).map((projectName: string) => (
-                              <option key={projectName} value={projectName}>
-                                {projectName}
-                              </option>
-                            ))}
-                          </Select>
-                        )}
-
-                        {BlockLanguageEnum.YAML !== blockLanguage && (
-                          <Text monospace small>
-                            {dbtProjectName}
-                          </Text>
-                        )}
-
-                        <Spacing mr={2} />
-
-                        <Text monospace muted small>
-                          Target
-                        </Text>
-
-                        <span>&nbsp;</span>
-
-                        {!manuallyEnterTarget && (
-                          <Select
-                            compact
-                            disabled={!dbtProjectName}
-                            monospace
-                            onBlur={() => setTimeout(() => {
-                              setAnyInputFocused(false);
-                            }, 300)}
-                            onChange={(e) => {
-                              updateDataProviderConfig({
-                                [CONFIG_KEY_DBT_PROFILE_TARGET]: e.target.value,
-                              });
-                              e.preventDefault();
-                            }}
-                            onClick={pauseEvent}
-                            onFocus={() => {
-                              setAnyInputFocused(true);
-                            }}
-                            placeholder={dbtProfileTargetSelectPlaceholder}
-                            small
-                            value={dbtProfileTarget || ''}
-                          >
-                            {dbtProfileTargets?.map((target: string) => (
-                              <option key={target} value={target}>
-                                {target}
-                              </option>
-                            ))}
-                          </Select>
-                        )}
-
-                        {manuallyEnterTarget && (
-                          <TextInput
-                            compact
-                            monospace
-                            onBlur={() => setTimeout(() => {
-                              setAnyInputFocused(false);
-                            }, 300)}
-                            onChange={(e) => {
-                              updateDataProviderConfig({
-                                [CONFIG_KEY_DBT_PROFILE_TARGET]: e.target.value,
-                              });
-                              e.preventDefault();
-                            }}
-                            onClick={pauseEvent}
-                            onFocus={() => {
-                              setAnyInputFocused(true);
-                            }}
-                            placeholder={dbtProjectName
-                              ? (dbtProfileData?.target || 'Enter target')
-                              : 'Select project first'
-                            }
-                            small
-                            value={dbtProfileTarget || ''}
-                            width={UNIT * 21}
-                          />
-                        )}
-
-                        <Spacing mr={1} />
-
-                        <FlexContainer alignItems="center">
-                          <Tooltip
-                            block
-                            description={
-                              <Text default inline>
-                                Manually type the name of the target you want to use in the profile.
-                                <br />
-                                Interpolate environment variables and
-                                global variables using the following syntax:
-                                <br />
-                                <Text default inline monospace>
-                                  {'{{ env_var(\'NAME\') }}'}
-                                </Text> or <Text default inline monospace>
-                                  {'{{ variables(\'NAME\') }}'}
-                                </Text>
-                              </Text>
-                            }
-                            size={null}
-                            widthFitContent
-                          >
-                            <FlexContainer alignItems="center">
-                              <Checkbox
-                                checked={manuallyEnterTarget}
-                                label={
-                                  <Text muted small>
-                                    Manually enter target
-                                  </Text>
-                                }
-                                onClick={(e) => {
-                                  pauseEvent(e);
-                                  setManuallyEnterTarget(!manuallyEnterTarget);
-                                  if (manuallyEnterTarget) {
-                                    updateDataProviderConfig({
-                                      [CONFIG_KEY_DBT_PROFILE_TARGET]: null,
-                                    });
-                                  }
-                                }}
-                              />
-                              <span>&nbsp;</span>
-                              <Info muted />
-                            </FlexContainer>
-                          </Tooltip>
-                        </FlexContainer>
-                      </Flex>
-
-                      {BlockLanguageEnum.YAML !== blockLanguage && !dbtMetadata?.block?.snapshot && (
-                        <FlexContainer alignItems="center">
-                          <Tooltip
-                            appearBefore
-                            block
-                            description={
-                              <Text default inline>
-                                Limit the number of results that are returned
-                                <br />
-                                when running this block in the notebook.
-                                <br />
-                                This limit won’t affect the number of results
-                                <br />
-                                returned when running the pipeline end-to-end.
-                              </Text>
-                            }
-                            size={null}
-                            widthFitContent
-                          >
-                            <FlexContainer alignItems="center">
-                              <Info muted />
-                              <span>&nbsp;</span>
-                              <Text monospace muted small>
-                                Sample limit
-                              </Text>
-                              <span>&nbsp;</span>
-                            </FlexContainer>
-                          </Tooltip>
-                          {limitInputEl}
-                          <Spacing mr={1} />
-                        </FlexContainer>
-                      )}
-                    </FlexContainer>
-
-                    {BlockLanguageEnum.YAML === blockLanguage && (
-                      <Spacing mt={1}>
-                        <FlexContainer alignItems="center">
-                          <Flex alignItems="center" flex={1}>
-                            <Text default monospace small>
-                              dbt
-                            </Text>
-
-                            <Spacing mr={1} />
-
-                            <TextInput
+                  <>
+                    <Spacing mt={1} />
+                    <CodeHelperStyle normalPadding>
+                      <FlexContainer
+                        alignItems="center"
+                        justifyContent="space-between"
+                      >
+                        <Flex alignItems="center">
+                          {BlockLanguageEnum.YAML === blockLanguage && (
+                            <Select
                               compact
                               monospace
                               onBlur={() => setTimeout(() => {
                                 setAnyInputFocused(false);
                               }, 300)}
                               onChange={(e) => {
-                                // @ts-ignore
                                 updateDataProviderConfig({
-                                  [CONFIG_KEY_DBT]: {
-                                    ...dataProviderConfig?.[CONFIG_KEY_DBT],
-                                    [CONFIG_KEY_DBT_COMMAND]: e.target.value,
-                                  },
+                                  [CONFIG_KEY_DBT_PROFILE_TARGET]: '',
+                                  [CONFIG_KEY_DBT_PROJECT_NAME]: e.target.value,
                                 });
                                 e.preventDefault();
                               }}
@@ -2498,45 +2306,240 @@ df = get_variable('${pipelineUUID}', '${blockUUID}', 'output_0')`;
                               onFocus={() => {
                                 setAnyInputFocused(true);
                               }}
-                              placeholder="command"
+                              placeholder="Project"
                               small
-                              value={dataProviderConfig?.[CONFIG_KEY_DBT]?.[CONFIG_KEY_DBT_COMMAND] || ''}
-                              width={UNIT * 10}
-                            />
-
-                            <Spacing mr={1} />
-
-                            <Text
-                              monospace
-                              small
+                              value={dataProviderConfig[CONFIG_KEY_DBT_PROJECT_NAME] || ''}
                             >
-                              [type your --select and --exclude syntax below]
+                              {Object.keys(dbtProjects || {}).map((projectName: string) => (
+                                <option key={projectName} value={projectName}>
+                                  {projectName}
+                                </option>
+                              ))}
+                            </Select>
+                          )}
+
+                          {BlockLanguageEnum.YAML !== blockLanguage && (
+                            <Text monospace small>
+                              {dbtProjectName}
                             </Text>
+                          )}
 
-                            <Spacing mr={1} />
+                          <Spacing mr={2} />
 
-                            <Text monospace muted small>
-                              (paths start from {dataProviderConfig?.[CONFIG_KEY_DBT_PROJECT_NAME] || 'project'} folder)
-                            </Text>
-                          </Flex>
-
-                          <Spacing mr={1} />
-
-                          <Text muted small>
-                            <Link
-                              href="https://docs.getdbt.com/reference/node-selection/syntax#examples"
-                              openNewWindow
-                              small
-                            >
-                              Examples
-                            </Link>
+                          <Text monospace muted small>
+                            Target
                           </Text>
 
+                          <span>&nbsp;</span>
+
+                          {!manuallyEnterTarget && (
+                            <Select
+                              compact
+                              disabled={!dbtProjectName}
+                              monospace
+                              onBlur={() => setTimeout(() => {
+                                setAnyInputFocused(false);
+                              }, 300)}
+                              onChange={(e) => {
+                                updateDataProviderConfig({
+                                  [CONFIG_KEY_DBT_PROFILE_TARGET]: e.target.value,
+                                });
+                                e.preventDefault();
+                              }}
+                              onClick={pauseEvent}
+                              onFocus={() => {
+                                setAnyInputFocused(true);
+                              }}
+                              placeholder={dbtProfileTargetSelectPlaceholder}
+                              small
+                              value={dbtProfileTarget || ''}
+                            >
+                              {dbtProfileTargets?.map((target: string) => (
+                                <option key={target} value={target}>
+                                  {target}
+                                </option>
+                              ))}
+                            </Select>
+                          )}
+
+                          {manuallyEnterTarget && (
+                            <TextInput
+                              compact
+                              monospace
+                              onBlur={() => setTimeout(() => {
+                                setAnyInputFocused(false);
+                              }, 300)}
+                              onChange={(e) => {
+                                updateDataProviderConfig({
+                                  [CONFIG_KEY_DBT_PROFILE_TARGET]: e.target.value,
+                                });
+                                e.preventDefault();
+                              }}
+                              onClick={pauseEvent}
+                              onFocus={() => {
+                                setAnyInputFocused(true);
+                              }}
+                              placeholder={dbtProjectName
+                                ? (dbtProfileData?.target || 'Enter target')
+                                : 'Select project first'
+                              }
+                              small
+                              value={dbtProfileTarget || ''}
+                              width={UNIT * 21}
+                            />
+                          )}
+
                           <Spacing mr={1} />
-                        </FlexContainer>
-                      </Spacing>
-                    )}
-                  </CodeHelperStyle>
+
+                          <FlexContainer alignItems="center">
+                            <Tooltip
+                              block
+                              description={
+                                <Text default inline>
+                                  Manually type the name of the target you want to use in the profile.
+                                  <br />
+                                  Interpolate environment variables and
+                                  global variables using the following syntax:
+                                  <br />
+                                  <Text default inline monospace>
+                                    {'{{ env_var(\'NAME\') }}'}
+                                  </Text> or <Text default inline monospace>
+                                    {'{{ variables(\'NAME\') }}'}
+                                  </Text>
+                                </Text>
+                              }
+                              size={null}
+                              widthFitContent
+                            >
+                              <FlexContainer alignItems="center">
+                                <Checkbox
+                                  checked={manuallyEnterTarget}
+                                  label={
+                                    <Text muted small>
+                                      Manually enter target
+                                    </Text>
+                                  }
+                                  onClick={(e) => {
+                                    pauseEvent(e);
+                                    setManuallyEnterTarget(!manuallyEnterTarget);
+                                    if (manuallyEnterTarget) {
+                                      updateDataProviderConfig({
+                                        [CONFIG_KEY_DBT_PROFILE_TARGET]: null,
+                                      });
+                                    }
+                                  }}
+                                />
+                                <span>&nbsp;</span>
+                                <Info muted />
+                              </FlexContainer>
+                            </Tooltip>
+                          </FlexContainer>
+                        </Flex>
+
+                        {BlockLanguageEnum.YAML !== blockLanguage && !dbtMetadata?.block?.snapshot && (
+                          <FlexContainer alignItems="center">
+                            <Tooltip
+                              appearBefore
+                              block
+                              description={
+                                <Text default inline>
+                                  Limit the number of results that are returned
+                                  <br />
+                                  when running this block in the notebook.
+                                  <br />
+                                  This limit won’t affect the number of results
+                                  <br />
+                                  returned when running the pipeline end-to-end.
+                                </Text>
+                              }
+                              size={null}
+                              widthFitContent
+                            >
+                              <FlexContainer alignItems="center">
+                                <Info muted />
+                                <span>&nbsp;</span>
+                                <Text monospace muted small>
+                                  Sample limit
+                                </Text>
+                                <span>&nbsp;</span>
+                              </FlexContainer>
+                            </Tooltip>
+                            {limitInputEl}
+                            <Spacing mr={1} />
+                          </FlexContainer>
+                        )}
+                      </FlexContainer>
+
+                      {BlockLanguageEnum.YAML === blockLanguage && (
+                        <Spacing mt={1}>
+                          <FlexContainer alignItems="center">
+                            <Flex alignItems="center" flex={1}>
+                              <Text default monospace small>
+                                dbt
+                              </Text>
+
+                              <Spacing mr={1} />
+
+                              <TextInput
+                                compact
+                                monospace
+                                onBlur={() => setTimeout(() => {
+                                  setAnyInputFocused(false);
+                                }, 300)}
+                                onChange={(e) => {
+                                  // @ts-ignore
+                                  updateDataProviderConfig({
+                                    [CONFIG_KEY_DBT]: {
+                                      ...dataProviderConfig?.[CONFIG_KEY_DBT],
+                                      [CONFIG_KEY_DBT_COMMAND]: e.target.value,
+                                    },
+                                  });
+                                  e.preventDefault();
+                                }}
+                                onClick={pauseEvent}
+                                onFocus={() => {
+                                  setAnyInputFocused(true);
+                                }}
+                                placeholder="command"
+                                small
+                                value={dataProviderConfig?.[CONFIG_KEY_DBT]?.[CONFIG_KEY_DBT_COMMAND] || ''}
+                                width={UNIT * 10}
+                              />
+
+                              <Spacing mr={1} />
+
+                              <Text
+                                monospace
+                                small
+                              >
+                                [type your --select and --exclude syntax below]
+                              </Text>
+
+                              <Spacing mr={1} />
+
+                              <Text monospace muted small>
+                                (paths start from {dataProviderConfig?.[CONFIG_KEY_DBT_PROJECT_NAME] || 'project'} folder)
+                              </Text>
+                            </Flex>
+
+                            <Spacing mr={1} />
+
+                            <Text muted small>
+                              <Link
+                                href="https://docs.getdbt.com/reference/node-selection/syntax#examples"
+                                openNewWindow
+                                small
+                              >
+                                Examples
+                              </Link>
+                            </Text>
+
+                            <Spacing mr={1} />
+                          </FlexContainer>
+                        </Spacing>
+                      )}
+                    </CodeHelperStyle>
+                  </>
                 )}
 
                 {!hideExtraConfiguration && isSQLBlock

--- a/mage_ai/tests/data_preparation/models/block/dbt/test_block_yaml.py
+++ b/mage_ai/tests/data_preparation/models/block/dbt/test_block_yaml.py
@@ -2,9 +2,26 @@ import asyncio
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from mage_ai.data_preparation.models.block import Block
 from mage_ai.data_preparation.models.block.dbt.block import DBTBlock
 from mage_ai.data_preparation.models.constants import BlockLanguage, BlockType
 from mage_ai.tests.base_test import TestCase
+
+
+def build_block(pipeline, content: str) -> DBTBlock:
+    return DBTBlock(
+        name='test_dbt_block_yaml',
+        uuid='test_dbt_block_yaml',
+        block_type=BlockType.DBT,
+        language=BlockLanguage.YAML,
+        pipeline=pipeline,
+        configuration={
+            'dbt_project_name': 'test_project_name',
+            'dbt_profile_target': 'dev',
+            'dbt': {'command': 'build'}
+        },
+        content=content,
+    )
 
 
 class DBTBlockYAMLTest(TestCase):
@@ -12,22 +29,13 @@ class DBTBlockYAMLTest(TestCase):
     def setUpClass(self):
         super().setUpClass()
 
-        pipeline = MagicMock()
-        pipeline.uuid = 'test'
-        pipeline.repo_path = 'test_repo_path'
+        self.pipeline = MagicMock()
+        self.pipeline.uuid = 'test'
+        self.pipeline.repo_path = 'test_repo_path'
 
-        self.dbt_block = DBTBlock(
-            name='test_dbt_block_yaml',
-            uuid='test_dbt_block_yaml',
-            block_type=BlockType.DBT,
-            language=BlockLanguage.YAML,
-            pipeline=pipeline,
-            configuration={
-                'dbt_project_name': 'test_project_name',
-                'dbt_profile_target': 'dev',
-                'dbt': {'command': 'build'}
-            },
-            content='--select model+ --exclude model --vars \'{"foo":"bar"}\''
+        self.dbt_block = build_block(
+            self.pipeline,
+            '--select model+ --exclude model --vars \'{"foo":"bar"}\'',
         )
 
     @classmethod
@@ -115,4 +123,107 @@ class DBTBlockYAMLTest(TestCase):
             '--full-refresh',
             '--target', 'dev',
             '--profiles-dir', 'test_profiles_dir'
+        ], None)
+
+    @patch('mage_ai.data_preparation.models.block.dbt.block_yaml.DBTCli')
+    @patch('mage_ai.data_preparation.models.block.dbt.block_yaml.Profiles')
+    def test_execute_block_with_interpolation(self, Profiles, DBTCli: MagicMock):
+        DBTCli.return_value.invoke.return_value = (None, True)
+        Profiles.return_value.__enter__.return_value.profiles_dir = 'test_profiles_dir'
+
+        dbt_block = build_block(
+            self.pipeline,
+            ' '.join([
+                '--select',
+                'models/example/"{} {} {}".sql'.format(
+                    '{' + '{',
+                    "variables('model1')",
+                    '}' + '}',
+                ),
+                'models/example/"{} {} {}".sql'.format(
+                    '{' + '{',
+                    "block_output(parse=lambda arr, _variables: arr[0][0]['model2'])",
+                    '}' + '}',
+                ),
+                '\n',
+                '--vars',
+                (
+                    '\'{}"test1": "{} {} {}", '
+                    '"test2": "{} {} {}", '
+                    '"test3": "{} {} {}", '
+                    '"test4": "{} {} {}"{}\'',
+                )[0].format(
+                    '{',
+                    '{' + '{',
+                    'env_var("ENV")',
+                    '}' + '}',
+                    '{' + '{',
+                    "variables('model1')",
+                    '}' + '}',
+                    '{' + '{',
+                    'block_output(parse=lambda arr, _variables: arr[1])',
+                    '}' + '}',
+                    '{' + '{',
+                    'block_output("pastel_portal", parse=lambda arr, _variables: arr[2])',
+                    '}' + '}',
+                    '}',
+                ),
+            ])
+        )
+
+        outputs_from_input_vars = dict(
+            df_1=[dict(model2='my_second_dbt_model')],
+            df_2=[1, 2, 3],
+            fanciful_moon=[dict(model2='my_second_dbt_model')],
+            pastel_portal=[1, 2, 3],
+        )
+
+        dbt_block.upstream_blocks = [
+            Block(
+                'fanciful_moon',
+                'fanciful_moon',
+                BlockType.DATA_LOADER,
+            ),
+            Block(
+                'pastel_portal',
+                'pastel_portal',
+                BlockType.DATA_LOADER,
+            ),
+        ]
+
+        dbt_block._execute_block(
+            outputs_from_input_vars,
+            runtime_arguments={
+                '__mage_variables': {
+                    'blocks': {
+                        'test_dbt_block_yaml': {
+                            'configuration': {
+                                'flags': ['--full-refresh']
+                            }
+                        }
+                    }
+                }
+            },
+            global_vars=dict(
+                foo='bar',
+                model1='my_first_dbt_model',
+            ),
+        )
+
+        DBTCli.assert_called_once_with([
+            'build',
+            '--select',
+            'models/example/my_first_dbt_model.sql',
+            'models/example/my_second_dbt_model.sql',
+            '--vars',
+            '{"foo": "bar", "model1": "my_first_dbt_model", '
+            '"test1": "dev", "test2": "my_first_dbt_model", '
+            '"test3": "[1, 2, 3]", "test4": "3"}',
+            '--project-dir',
+            str(Path('test_repo_path/dbt/test_project_name')),
+            '--full-refresh',
+            '--target',
+            'dev',
+            '--profiles-dir',
+            'test_profiles_dir',
         ], None)

--- a/mage_ai/tests/data_preparation/models/block/dbt/test_block_yaml.py
+++ b/mage_ai/tests/data_preparation/models/block/dbt/test_block_yaml.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+import secrets
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -131,6 +133,10 @@ class DBTBlockYAMLTest(TestCase):
         DBTCli.return_value.invoke.return_value = (None, True)
         Profiles.return_value.__enter__.return_value.profiles_dir = 'test_profiles_dir'
 
+        key = secrets.token_urlsafe()
+        value = secrets.token_urlsafe()
+        os.environ[key] = value
+
         dbt_block = build_block(
             self.pipeline,
             ' '.join([
@@ -155,7 +161,7 @@ class DBTBlockYAMLTest(TestCase):
                 )[0].format(
                     '{',
                     '{' + '{',
-                    'env_var("ENV")',
+                    f'env_var("{key}")',
                     '}' + '}',
                     '{' + '{',
                     "variables('model1')",
@@ -217,7 +223,7 @@ class DBTBlockYAMLTest(TestCase):
             'models/example/my_second_dbt_model.sql',
             '--vars',
             '{"foo": "bar", "model1": "my_first_dbt_model", '
-            '"test1": "dev", "test2": "my_first_dbt_model", '
+            f'"test1": "{value}", "test2": "my_first_dbt_model", '
             '"test3": "[1, 2, 3]", "test4": "3"}',
             '--project-dir',
             str(Path('test_repo_path/dbt/test_project_name')),


### PR DESCRIPTION
# Description

A dbt block with a generic command with 2 upstream blocks and the following content:

```
--select models/example/"{{ variables('model1') }}".sql models/example/"{{ block_output(parse=lambda arr, _variables: arr[0][0]['model2']) }}".sql
--vars '{"test1": "{{ env_var("ENV") }}", "test2": "{{ variables('model1') }}", "test3": "{{ block_output(parse=lambda arr, _variables: arr[1]) }}", "test4": "{{ block_output('pastel_portal', parse=lambda arr, _variables: arr[2]) }}"}'
```

Produces this command:

```
dbt run \

  --select models/example/my_first_dbt_model.sql models/example/my_second_dbt_model.sql \

  --vars {"foo": 1, "model1": "my_first_dbt_model", "env": "dev", "execution_date": "2023-11-09T11:34:47.251412", "interval_start_datetime": "2023-11-09T11:34:47.251412", "event": {}, "configuration": {"dbt": {"command": "run"}, "dbt_profile_target": "dev", "dbt_project_name": "demo7", "export_write_policy": "append", "use_raw_sql": false}, "context": {}, "pipeline_uuid": "marvelous_dawn", "block_uuid": "intriguing_sumo", "test1": "dev", "test2": "my_first_dbt_model", "test3": "[1, 2, 3]", "test4": "3"} \

  --project-dir /home/src/default_repo/dbt/demo7 \

  --target dev \

  --profiles-dir /home/src/default_repo/dbt/demo7/.mage_temp_profiles_407af05d-7916-4b07-b6e1-d7bf859b4c1e
```