### PR TITLE
[dy] Add exception failure message in callbacks

### DIFF
--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -563,7 +563,7 @@ class BlockExecutor:
                         logging_tags=tags,
                         pipeline_run=pipeline_run,
                         callback_kwargs=dict(
-                            error=error,
+                            __error=error,
                         )
                     )
                     raise error

--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -562,6 +562,9 @@ class BlockExecutor:
                         global_vars=global_vars,
                         logging_tags=tags,
                         pipeline_run=pipeline_run,
+                        callback_kwargs=dict(
+                            error=error,
+                        )
                     )
                     raise error
 
@@ -1043,6 +1046,7 @@ class BlockExecutor:
         global_vars: Dict,
         logging_tags: Dict,
         pipeline_run: PipelineRun,
+        callback_kwargs: Dict = None,
         dynamic_block_index: Union[int, None] = None,
         dynamic_upstream_block_uuids: Union[List[str], None] = None,
     ):
@@ -1068,6 +1072,7 @@ class BlockExecutor:
             try:
                 callback_block.execute_callback(
                     callback,
+                    callback_kwargs=callback_kwargs,
                     dynamic_block_index=dynamic_block_index,
                     dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
                     execution_partition=self.execution_partition,

--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -557,14 +557,12 @@ class BlockExecutor:
                         )
                     self._execute_callback(
                         'on_failure',
+                        callback_kwargs=dict(__error=error),
                         dynamic_block_index=dynamic_block_index,
                         dynamic_upstream_block_uuids=dynamic_upstream_block_uuids,
                         global_vars=global_vars,
                         logging_tags=tags,
                         pipeline_run=pipeline_run,
-                        callback_kwargs=dict(
-                            __error=error,
-                        )
                     )
                     raise error
 

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -934,7 +934,7 @@ class Block(DataIntegrationMixin, SparkBlock):
                     parent_block=self,
                     from_notebook=from_notebook,
                     callback_kwargs=dict(
-                        error=error,
+                        __error=error,
                     )
                 )
             raise

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -928,14 +928,12 @@ class Block(DataIntegrationMixin, SparkBlock):
             for callback_block in callback_arr:
                 callback_block.execute_callback(
                     'on_failure',
+                    callback_kwargs=dict(__error=error),
+                    from_notebook=from_notebook,
                     global_vars=global_vars,
                     logger=logger,
                     logging_tags=logging_tags,
                     parent_block=self,
-                    from_notebook=from_notebook,
-                    callback_kwargs=dict(
-                        __error=error,
-                    )
                 )
             raise
 

--- a/mage_ai/data_preparation/templates/callbacks/base.jinja
+++ b/mage_ai/data_preparation/templates/callbacks/base.jinja
@@ -12,5 +12,9 @@ def success_callback(parent_block_data, **kwargs):
 
 @callback('failure')
 def failure_callback(parent_block_data, **kwargs):
+    """
+    The error that caused the block to fail is passed in as keyword
+    argument __error.
+    """
     pass
 {% endblock %}

--- a/mage_ai/shared/hash.py
+++ b/mage_ai/shared/hash.py
@@ -106,7 +106,7 @@ def index_by(func, arr):
     return obj
 
 
-def merge_dict(a, b):
+def merge_dict(a: Dict, b: Dict) -> Dict:
     if a:
         c = a.copy()
     else:

--- a/mage_ai/tests/data_preparation/executors/test_block_executor.py
+++ b/mage_ai/tests/data_preparation/executors/test_block_executor.py
@@ -217,6 +217,7 @@ class BlockExecutorTest(TestCase):
         )
 
         expected_kwargs = dict(
+            callback_kwargs=None,
             dynamic_block_index=None,
             dynamic_upstream_block_uuids=None,
             execution_partition=self.execution_partition,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Add error information to failure callback as a keyword argument. I also changed the fallback logic for the callbacks because it was catching all `TypeError` exceptions even if it was occurring inside the callback block.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with failure callback blocks


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  - [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
