### PR TITLE
[jk] Update backfill variables

### DIFF
--- a/mage_ai/api/resources/BackfillResource.py
+++ b/mage_ai/api/resources/BackfillResource.py
@@ -16,6 +16,7 @@ ALLOWED_PAYLOAD_KEYS = [
     'interval_units',
     'name',
     'start_datetime',
+    'variables',
 ]
 
 

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -22,7 +22,10 @@ import PipelineRunType, {
   RunStatus,
 } from '@interfaces/PipelineRunType';
 import PipelineType from '@interfaces/PipelineType';
-import PipelineVariableType, { GLOBAL_VARIABLES_UUID } from '@interfaces/PipelineVariableType';
+import PipelineVariableType, {
+  GLOBAL_VARIABLES_UUID,
+  VariableType,
+} from '@interfaces/PipelineVariableType';
 import Select from '@oracle/elements/Inputs/Select';
 import Spacing from '@oracle/elements/Spacing';
 import Spinner from '@oracle/components/Spinner';
@@ -404,17 +407,23 @@ function BackfillDetail({
 
   const modelVariables = useMemo(() => modelVariablesInit || {}, [modelVariablesInit]);
   const variablesTable = useMemo(() => {
-    let arr = [];
+    const arr = getFormattedVariables(variables, block => block.uuid === GLOBAL_VARIABLES_UUID) || [];
 
     if (!isEmptyObject(modelVariables)) {
       Object.entries(modelVariables).forEach(([k, v]) => {
-        arr.push({
-          uuid: k,
-          value: getFormattedVariable(v),
-        });
+        const currentVarIdx = arr.findIndex((pipelineVar: VariableType) => pipelineVar?.uuid === k);
+        if (currentVarIdx !== -1) {
+          arr.splice(currentVarIdx, 1, {
+            uuid: k,
+            value: getFormattedVariable(v),
+          });
+        } else {
+          arr.push({
+            uuid: k,
+            value: getFormattedVariable(v),
+          });
+        }
       });
-    } else {
-      arr = getFormattedVariables(variables, block => block.uuid === GLOBAL_VARIABLES_UUID);
     }
 
     if (typeof arr === 'undefined' || !arr?.length) {

--- a/mage_ai/frontend/components/Sidekick/utils.ts
+++ b/mage_ai/frontend/components/Sidekick/utils.ts
@@ -1,3 +1,4 @@
+import PipelineVariableType, { GLOBAL_VARIABLES_UUID } from '@interfaces/PipelineVariableType';
 import { ScheduleTypeEnum } from '@interfaces/PipelineScheduleType';
 
 export function getFormattedVariable(variable) {
@@ -15,6 +16,16 @@ export function getFormattedVariables(variables, filterBlock) {
         value: getFormattedVariable(variableValue),
       };
     });
+}
+
+export function getFormattedGlobalVariables(variables: PipelineVariableType[]) {
+  return getFormattedVariables(
+    variables,
+    block => block.uuid === GLOBAL_VARIABLES_UUID,
+  )?.reduce((acc, { uuid, value }) => ({
+    ...acc,
+    [uuid]: value,
+  }), {});
 }
 
 export function addTriggerVariables(variablesArr, scheduleType) {

--- a/mage_ai/frontend/components/Triggers/OverwriteVariables/index.tsx
+++ b/mage_ai/frontend/components/Triggers/OverwriteVariables/index.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from 'react';
+
+import FlexContainer from '@oracle/components/FlexContainer';
+import Spacing from '@oracle/elements/Spacing';
+import Table from '@components/shared/Table';
+import Text from '@oracle/elements/Text';
+import TextArea from '@oracle/elements/Inputs/TextArea';
+import TextInput from '@oracle/elements/Inputs/TextInput';
+import ToggleSwitch from '@oracle/elements/Inputs/ToggleSwitch';
+import { ToggleStyle } from '../RunPipelinePopup/index.style';
+import { isJsonString } from '@utils/string';
+
+type OverwriteVariablesProps = {
+  borderless?: boolean;
+  compact?: boolean;
+  enableVariablesOverwrite: boolean;
+  runtimeVariables: { [keyof: string]: string };
+  setEnableVariablesOverwrite: (enableVariablesOverwrite: boolean) => void;
+  setRuntimeVariables: (runtimeVariables: any) => void;
+};
+
+function OverwriteVariables({
+  borderless,
+  compact,
+  enableVariablesOverwrite,
+  runtimeVariables,
+  setEnableVariablesOverwrite,
+  setRuntimeVariables,
+}: OverwriteVariablesProps) {
+  const [textAreaElementMapping, setTextAreaElementMapping] = useState({});
+
+  useEffect(() => {
+    const textAreaElementMappingInit = Object.entries(runtimeVariables)
+      .reduce((acc, keyValPair) => {
+        const [uuid, val] = keyValPair;
+        const isUsingTextAreaEl = isJsonString(val)
+          && typeof JSON.parse(val) === 'object'
+          && !Array.isArray(JSON.parse(val))
+          && JSON.parse(val) !== null;
+
+        return {
+          ...acc,
+          [uuid]: isUsingTextAreaEl,
+        };
+      }, {});
+
+    setTextAreaElementMapping(textAreaElementMappingInit);
+
+  /*
+   * The runtimeVariables prop is intentionally excluded from the dependency array
+   * because adding it would convert the input element back to a normal TextInput
+   * component once the user edits the variable value. 
+   */
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const buildValueRowEl = (uuid: string, value: string) => {
+    const sharedValueElProps = {
+      borderless: true,
+      key: `variable_uuid_input_${uuid}`,
+      monospace: true,
+      onChange: (e) => {
+        e.preventDefault();
+        setRuntimeVariables(vars => ({
+          ...vars,
+          [uuid]: e.target.value,
+        }));
+      },
+      paddingHorizontal: 0,
+      placeholder: 'Variable value',
+      value,
+    };
+
+    if (textAreaElementMapping[uuid]) {
+      return (
+        <TextArea
+          {...sharedValueElProps}
+          rows={1}
+          value={value}
+        />
+      );
+    }
+
+    return (
+      <TextInput {...sharedValueElProps} />
+    );
+  };
+
+  return (
+    <>
+      <ToggleStyle borderless={borderless}>
+        <FlexContainer alignItems="center">
+          <Spacing mr={2}>
+            <ToggleSwitch
+              checked={enableVariablesOverwrite}
+              compact={compact}
+              onCheck={setEnableVariablesOverwrite}
+            />
+          </Spacing>
+          <Text
+            bold={!compact}
+            large={!compact}
+          >
+            Overwrite runtime variables
+          </Text>
+        </FlexContainer>
+      </ToggleStyle>
+
+      {enableVariablesOverwrite && runtimeVariables
+        && Object.entries(runtimeVariables).length > 0 && (
+        <Spacing mt={2}>
+          <Table
+            columnFlex={[null, 1]}
+            columns={[
+              {
+                uuid: 'Variable',
+              },
+              {
+                uuid: 'Value',
+              },
+            ]}
+            rows={Object.entries(runtimeVariables).map(([uuid, value]) => [
+              <Text
+                default
+                key={`variable_${uuid}`}
+                monospace
+              >
+                {uuid}
+              </Text>,
+              buildValueRowEl(uuid, value),
+            ])}
+          />
+        </Spacing>
+      )}
+    </>
+  );
+}
+
+export default OverwriteVariables;

--- a/mage_ai/frontend/components/Triggers/RunPipelinePopup/index.style.ts
+++ b/mage_ai/frontend/components/Triggers/RunPipelinePopup/index.style.ts
@@ -4,11 +4,13 @@ import dark from '@oracle/styles/themes/dark';
 import { BORDER_RADIUS } from '@oracle/styles/units/borders';
 import { UNIT } from '@oracle/styles/units/spacing';
 
-export const ToggleStyle = styled.div`
+export const ToggleStyle = styled.div<{
+  borderless?: boolean;
+}>`
   padding: ${UNIT * 1.5}px ${UNIT * 2}px;
   border-radius: ${BORDER_RADIUS}px;
 
-  ${props => `
+  ${props => !props.borderless && `
     border: 1px solid ${(props.theme || dark).borders.light};
     background-color: ${(props.theme || dark).background.popup};
   `}

--- a/mage_ai/frontend/interfaces/PipelineType.ts
+++ b/mage_ai/frontend/interfaces/PipelineType.ts
@@ -124,5 +124,6 @@ export default interface PipelineType {
   type?: PipelineTypeEnum;
   updated_at?: string;
   uuid: string;
+  variables?: { [keyof: string]: string };
   widgets?: BlockType[];
 }

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -41,7 +41,7 @@ import { VerticalDividerStyle } from '@oracle/elements/Divider/index.style';
 import { capitalize, randomNameGenerator } from '@utils/string';
 import { dateFormatLong } from '@utils/date';
 import { filterQuery, queryFromUrl, queryString } from '@utils/url';
-import { getFormattedVariables } from '@components/Sidekick/utils';
+import { getFormattedGlobalVariables, getFormattedVariables } from '@components/Sidekick/utils';
 import { getPipelineScheduleApiFilterQuery } from '@components/Triggers/utils';
 import { indexBy, sortByKey } from '@utils/array';
 import { isEmptyObject } from '@utils/hash';
@@ -157,15 +157,9 @@ function PipelineSchedules({
   const [createOnceSchedule, { isLoading: isLoadingCreateOnceSchedule }]: any =
     useCreateScheduleMutation(fetchPipelineSchedules);
 
-  const variablesOrig = useMemo(() => (
-    getFormattedVariables(
-      globalVariables,
-      block => block.uuid === GLOBAL_VARIABLES_UUID,
-    )?.reduce((acc, { uuid, value }) => ({
-      ...acc,
-      [uuid]: value,
-    }), {})
-  ), [globalVariables]);
+  const variablesOrig = useMemo(() => getFormattedGlobalVariables(globalVariables), [
+    globalVariables,
+  ]);
 
   const randomTriggerName = randomNameGenerator();
   const pipelineOnceSchedulePayload = useMemo(() => ({
@@ -450,7 +444,7 @@ function PipelineSchedules({
 
   if (isCreatingTrigger) {
     return (
-       <TriggerEdit
+      <TriggerEdit
         creatingWithLimitation
         errors={errors}
         onCancel={() => setIsCreatingTrigger(false)}

--- a/mage_ai/frontend/utils/hash.ts
+++ b/mage_ai/frontend/utils/hash.ts
@@ -59,6 +59,14 @@ export function isEqual(a, b) {
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
+export function mapObject(obj, func) {
+  return Object.fromEntries(
+    Object.entries(obj).map(
+      ([k, v], i) => [k, func(v, k, i)],
+    ),
+  );
+}
+
 export function pickKey(obj) {
   const keys = Object.keys(obj);
   return keys.filter(k => obj[k]);


### PR DESCRIPTION
# Description
- Allow backfill variables to be updated via API requests. Resolves Github issue https://github.com/mage-ai/mage-ai/issues/3928.
- Add ability to overwrite runtime variables for pipeline runs created by backfills from the UI. The `Overwrite runtime variables` toggle must be enabled or the default pipeline variables will be used.

# How Has This Been Tested?
- Tested updating backfill variables through PUT requests using Insomnia.
- Updated backfill variables in the UI and confirmed the existing variables were overwritten when running the pipeline with the backfills.

Update backfill variables in UI:
![update backfill vars](https://github.com/mage-ai/mage-ai/assets/78053898/c8d45e6a-7cfc-4d0d-8b56-6431a45628f1)

Remove overwritten backfill variables in UI (e.g. if user had updated a backfill's variables but decides they no longer want to overwrite the pipeline's variables):
![revert backfill vars](https://github.com/mage-ai/mage-ai/assets/78053898/371f93eb-31fc-4b22-bf99-682ee216ab9b)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  - [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
