### PR TITLE
[xy] Support override assignPublicIp and enableExecuteCommand in EcsConfig

### DIFF
--- a/mage_ai/services/aws/ecs/config.py
+++ b/mage_ai/services/aws/ecs/config.py
@@ -17,11 +17,13 @@ class EcsConfig(BaseConfig):
     cluster: str
     security_groups: List[str]
     subnets: List[str]
-    tags: List = field(default_factory=list)
-    network_configuration: Dict = None
+    assign_public_ip: bool = True
     cpu: int = 512
-    memory: int = 1024
+    enable_execute_command: bool = False
     launch_type: str = 'FARGATE'
+    memory: int = 1024
+    network_configuration: Dict = None
+    tags: List = field(default_factory=list)
     wait_timeout: int = 600
 
     @classmethod
@@ -71,20 +73,21 @@ class EcsConfig(BaseConfig):
             network_configuration = {
                 'awsvpcConfiguration': {
                     'subnets': self.subnets,
-                    'assignPublicIp': 'ENABLED',
+                    'assignPublicIp': 'ENABLED' if self.assign_public_ip else 'DISABLED',
                     'securityGroups': self.security_groups,
                 }
             }
 
         task_config = dict(
-            taskDefinition=self.task_definition,
-            launchType=self.launch_type,
             cluster=self.cluster,
-            platformVersion='LATEST',
             count=1,
+            enableExecuteCommand=self.enable_execute_command,
+            launchType=self.launch_type,
             networkConfiguration=network_configuration,
-            tags=self.tags,
+            platformVersion='LATEST',
             propagateTags='TASK_DEFINITION',
+            tags=self.tags,
+            taskDefinition=self.task_definition,
         )
         if command is not None:
             task_config['overrides'] = {

--- a/mage_ai/tests/services/aws/ecs/test_config.py
+++ b/mage_ai/tests/services/aws/ecs/test_config.py
@@ -1,0 +1,144 @@
+from unittest.mock import MagicMock, patch
+
+from mage_ai.services.aws.ecs.config import EcsConfig
+from mage_ai.tests.base_test import TestCase
+
+
+class TestEcsConfig(TestCase):
+
+    @patch('os.getenv', return_value='mock_metadata_uri')
+    @patch('requests.get')
+    @patch('boto3.client')
+    @patch('boto3.resource')
+    def test_load_extra_config(self, mock_resource, mock_client, mock_requests, mock_os_getenv):
+        # Mock responses for requests.get
+        mock_response_task = MagicMock()
+        mock_response_task.json.return_value = {'Cluster': 'mock_cluster', 'Family': 'mock_family'}
+        mock_response_container = MagicMock()
+        mock_response_container.json.return_value = {'Name': 'mock_container_name'}
+
+        # Configure the side effects for the requests.get mocks
+        mock_requests.side_effect = [mock_response_container, mock_response_task]
+
+        # Mock response for boto3.client.describe_tasks
+        mock_task_config = {
+            'tasks': [{
+                'attachments': [{'type': 'ElasticNetworkInterface', 'details': [
+                    {'name': 'subnetId', 'value': 'mock_subnet'},
+                    {'name': 'networkInterfaceId', 'value': 'mock_network_interface'}
+                ]}]
+            }]
+        }
+        mock_client.return_value.describe_tasks.return_value = mock_task_config
+
+        # Mock response for boto3.resource.NetworkInterface
+        mock_network_interface = MagicMock()
+        mock_network_interface.groups = [{'GroupId': 'mock_security_group'}]
+        mock_resource.return_value.NetworkInterface.return_value = mock_network_interface
+
+        # Create an instance of EcsConfig and call the method to test
+        ecs_config = EcsConfig.load_extra_config()
+
+        # Assertions
+        self.assertEqual(ecs_config, {
+            'cluster': 'mock_cluster',
+            'subnets': ['mock_subnet'],
+            'security_groups': ['mock_security_group'],
+            'task_definition': 'mock_family',
+            'container_name': 'mock_container_name'
+        })
+
+    def test_get_task_config(self):
+        # assign_public_ip: True, enable_execute_command: True
+        ecs_config1 = EcsConfig(
+            task_definition='mock_task_def',
+            container_name='mock_container',
+            cluster='mock_cluster',
+            security_groups=['mock_sg'],
+            subnets=['mock_subnet'],
+            assign_public_ip=True,
+            cpu=512,
+            enable_execute_command=True,
+            launch_type='FARGATE',
+            memory=1024,
+            network_configuration=None,
+            tags=['tag1', 'tag2'],
+            wait_timeout=600
+        )
+        task_config1 = ecs_config1.get_task_config(command='mock_command')
+        self.assertEqual(task_config1, {
+            'cluster': 'mock_cluster',
+            'count': 1,
+            'enableExecuteCommand': True,
+            'launchType': 'FARGATE',
+            'networkConfiguration': {
+                'awsvpcConfiguration': {
+                    'subnets': ['mock_subnet'],
+                    'assignPublicIp': 'ENABLED',
+                    'securityGroups': ['mock_sg'],
+                }
+            },
+            'platformVersion': 'LATEST',
+            'propagateTags': 'TASK_DEFINITION',
+            'tags': ['tag1', 'tag2'],
+            'taskDefinition': 'mock_task_def',
+            'overrides': {
+                'containerOverrides': [
+                    {
+                        'name': 'mock_container',
+                        'command': ['mock_command'],
+                        'cpu': 512,
+                        'memory': 1024,
+                    },
+                ],
+                'cpu': '512',
+                'memory': '1024',
+            },
+        })
+
+        # assign_public_ip: False, enable_execute_command: False
+        ecs_config2 = EcsConfig(
+            task_definition='mock_task_def',
+            container_name='mock_container',
+            cluster='mock_cluster',
+            security_groups=['mock_sg'],
+            subnets=['mock_subnet'],
+            assign_public_ip=False,
+            cpu=512,
+            enable_execute_command=False,
+            launch_type='FARGATE',
+            memory=1024,
+            network_configuration=None,
+            tags=['tag1', 'tag2'],
+            wait_timeout=600
+        )
+        task_config2 = ecs_config2.get_task_config(command='mock_command')
+        self.assertEqual(task_config2, {
+            'cluster': 'mock_cluster',
+            'count': 1,
+            'enableExecuteCommand': False,
+            'launchType': 'FARGATE',
+            'networkConfiguration': {
+                'awsvpcConfiguration': {
+                    'subnets': ['mock_subnet'],
+                    'assignPublicIp': 'DISABLED',
+                    'securityGroups': ['mock_sg'],
+                }
+            },
+            'platformVersion': 'LATEST',
+            'propagateTags': 'TASK_DEFINITION',
+            'tags': ['tag1', 'tag2'],
+            'taskDefinition': 'mock_task_def',
+            'overrides': {
+                'containerOverrides': [
+                    {
+                        'name': 'mock_container',
+                        'command': ['mock_command'],
+                        'cpu': 512,
+                        'memory': 1024,
+                    },
+                ],
+                'cpu': '512',
+                'memory': '1024',
+            },
+        })


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Close: https://github.com/mage-ai/mage-ai/issues/3939

Support override assignPublicIp and enableExecuteCommand in EcsConfig

Example config
```yaml
ecs_config:
  assign_public_ip: false
  enable_execute_command: true
```

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested run ecs task with the `assign_public_ip: false` and `enable_execute_command: true` on test ecs cluster


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  - [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
