### PR TITLE
Add kafka api_version to the data loader and data exporter templates

### DIFF
--- a/docs/streaming/destinations/kafka.mdx
+++ b/docs/streaming/destinations/kafka.mdx
@@ -99,3 +99,5 @@ topic: topic_name
 ```
 
 - The default time timestamp is the current time of execution.
+
+- In case you are using newer versions of Kafka brokers, you should consider using corresponding Kafka api_version.

--- a/docs/streaming/sources/kafka.mdx
+++ b/docs/streaming/sources/kafka.mdx
@@ -92,3 +92,7 @@ serde_config:
   schema_registry_username: username
   schema_registry_password: password
 ```
+
+## API version
+
+In case you are using newer versions of Kafka brokers, you should consider using corresponding Kafka api_version.

--- a/mage_ai/data_preparation/templates/data_exporters/streaming/kafka.yaml
+++ b/mage_ai/data_preparation/templates/data_exporters/streaming/kafka.yaml
@@ -1,6 +1,7 @@
 connector_type: kafka
 bootstrap_server: "localhost:9092"
 topic: topic_name
+api_version: 0.10.2
 
 # Uncomment the config below to use SSL config
 # security_protocol: "SSL"

--- a/mage_ai/data_preparation/templates/data_loaders/streaming/kafka.yaml
+++ b/mage_ai/data_preparation/templates/data_loaders/streaming/kafka.yaml
@@ -3,6 +3,7 @@ bootstrap_server: "localhost:9092"
 topic: topic_name
 consumer_group: unique_consumer_group
 include_metadata: false
+api_version: 0.10.2
 
 # Uncomment the config below to use SSL config
 # security_protocol: "SSL"

--- a/mage_ai/tests/data_preparation/test_templates.py
+++ b/mage_ai/tests/data_preparation/test_templates.py
@@ -240,6 +240,7 @@ bootstrap_server: "localhost:9092"
 topic: topic_name
 consumer_group: unique_consumer_group
 include_metadata: false
+api_version: 0.10.2
 
 # Uncomment the config below to use SSL config
 # security_protocol: "SSL"


### PR DESCRIPTION
# Description
Added kafka api_version to the data loader and data exporter templates, updated the docs to incorporate this accordingly.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [ Yes ] Made changes to data preparation test accordingly
- [ N/A ] Test B


# Checklist
- [ Yes ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ Yes ] I have performed a self-review of my own code
- [ N/A ] I have added unit tests that prove my fix is effective or that my feature works
- [ N/A ] I have commented my code, particularly in hard-to-understand areas
- [ Yes ] I have made corresponding changes to the documentation
- [ N/A ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
