### PR TITLE
[xy] Clean column name when using batch load in Snowflake destination.

### DIFF
--- a/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
@@ -431,7 +431,9 @@ WHERE TABLE_SCHEMA = '{schema_name}' AND TABLE_NAME = '{table_name}'
                 self.logger.info(f'Skip executing empty query_strings: {query_strings}')
 
             df = pd.DataFrame([d['record'] for d in record_data])
-            df.columns = df.columns.str.lower()
+            # Clean column names in the dataframe
+            col_mapping = {col: self.clean_column_name(col) for col in df.columns}
+            df = df.rename(columns=col_mapping)
             self.logger.info(f'Batch upload to Snowflake: {df.shape[0]} rows.')
             self.logger.info(f'Columns: {df.columns}')
             database = self.config.get(self.DATABASE_CONFIG_KEY)

--- a/mage_integrations/mage_integrations/tests/sources/api/test_api.py
+++ b/mage_integrations/mage_integrations/tests/sources/api/test_api.py
@@ -231,7 +231,7 @@ class ApiTest(unittest.TestCase):
             source.test_connection()
 
             catalog = source.discover()
-            self.assertTrue(catalog.to_dict() == csv_catalog_example())
+            self.assertEqual(catalog.to_dict(), csv_catalog_example())
             mock_build_connection.assert_called()
 
     def test_api_tsv(self):
@@ -249,7 +249,7 @@ class ApiTest(unittest.TestCase):
             source.test_connection()
 
             catalog = source.discover()
-            self.assertTrue(catalog.to_dict() == csv_catalog_example())
+            self.assertEqual(catalog.to_dict(), csv_catalog_example())
             mock_build_connection.assert_called()
 
     def test_api_xlsx(self):
@@ -267,7 +267,7 @@ class ApiTest(unittest.TestCase):
             source.test_connection()
 
             catalog = source.discover()
-            self.assertTrue(catalog.to_dict() == csv_catalog_example())
+            self.assertEqual(catalog.to_dict(), csv_catalog_example())
             mock_build_connection.assert_called()
 
     def test_api_json(self):
@@ -286,4 +286,4 @@ class ApiTest(unittest.TestCase):
             mock_build_connection.assert_called_once()
 
             catalog = source.discover()
-            self.assertTrue(catalog.to_dict() == json_catalog_example())
+            self.assertEqual(catalog.to_dict(), json_catalog_example())


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Close: https://github.com/mage-ai/mage-ai/issues/3954

Clean the column correctly instead of just using the lower case when using batch load to export to Snowflake.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested syncing Google Sheets to Snowflake.
<img width="300" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/cac94787-03f0-4819-8341-9ac1752a9a85">

config
```yaml
...
disable_double_quotes: true
use_batch_load: true
```
The sync succeeded with the fix.
<img width="1391" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/490da9b4-61b4-49bf-a55b-957ebe911b42">


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  - [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
