### PR TITLE
[Fix] Backfill's date-picker date value mismatch

### DIFF
--- a/mage_ai/frontend/components/Triggers/utils.ts
+++ b/mage_ai/frontend/components/Triggers/utils.ts
@@ -3,9 +3,9 @@ import moment from 'moment';
 import BlockRunType from '@interfaces/BlockRunType';
 import PipelineScheduleType from '@interfaces/PipelineScheduleType';
 import {
-  DATE_FORMAT_DISPLAY,
   DATE_FORMAT_LONG_NO_SEC,
   DATE_FORMAT_LONG_NO_SEC_WITH_OFFSET,
+  DATE_FORMAT_LONG_T_SEP,
   dateFormatLong,
 } from '@utils/date';
 import { DEFAULT_PORT } from '@api/utils/url';
@@ -122,7 +122,7 @@ export function getTimeInUTCString(dateTime: string) {
   }
   const formattedDate = dateTime.split('+')[0];
   const momentObj = moment(getTimeInUTC(formattedDate));
-  const datetimeString = momentObj.format(DATE_FORMAT_DISPLAY);
+  const datetimeString = momentObj.format(DATE_FORMAT_LONG_T_SEP);
 
   return datetimeString;
 }

--- a/mage_ai/frontend/components/Triggers/utils.ts
+++ b/mage_ai/frontend/components/Triggers/utils.ts
@@ -2,7 +2,12 @@ import moment from 'moment';
 
 import BlockRunType from '@interfaces/BlockRunType';
 import PipelineScheduleType from '@interfaces/PipelineScheduleType';
-import { DATE_FORMAT_LONG_NO_SEC, DATE_FORMAT_LONG_NO_SEC_WITH_OFFSET, dateFormatLong } from '@utils/date';
+import {
+  DATE_FORMAT_DISPLAY,
+  DATE_FORMAT_LONG_NO_SEC,
+  DATE_FORMAT_LONG_NO_SEC_WITH_OFFSET,
+  dateFormatLong,
+} from '@utils/date';
 import { DEFAULT_PORT } from '@api/utils/url';
 import {
   PipelineScheduleFilterQueryEnum,
@@ -108,15 +113,7 @@ export function getTimeInUTC(dateTime: string): Date {
   }
   const date = new Date(moment(dateTime).valueOf());
 
-  const utcTs = Date.UTC(
-    date.getFullYear(),
-    date.getMonth(),
-    date.getDate(),
-    date.getHours(),
-    date.getMinutes(),
-    date.getSeconds(),
-  );
-  return new Date(utcTs);
+  return date;
 }
 
 export function getTimeInUTCString(dateTime: string) {
@@ -124,10 +121,10 @@ export function getTimeInUTCString(dateTime: string) {
     return dateTime;
   }
   const formattedDate = dateTime.split('+')[0];
+  const momentObj = moment(getTimeInUTC(formattedDate));
+  const datetimeString = momentObj.format(DATE_FORMAT_DISPLAY);
 
-  return getTimeInUTC(formattedDate)
-    .toISOString()
-    .split('.')[0];
+  return datetimeString;
 }
 
 export enum TimeUnitEnum {
@@ -214,7 +211,7 @@ export function getTriggerApiEndpoint(
       url = `${window.origin}/api/pipeline_schedules/${pipelineSchedule?.id}/api_trigger`;
     } else {
       url = `${window.origin}/api/pipeline_schedules/${pipelineSchedule?.id}/pipeline_runs`;
-      
+
       if (pipelineSchedule?.token) {
         url = `${url}/${pipelineSchedule.token}`;
       }

--- a/mage_ai/frontend/components/Triggers/utils.ts
+++ b/mage_ai/frontend/components/Triggers/utils.ts
@@ -2,7 +2,7 @@ import moment from 'moment';
 
 import BlockRunType from '@interfaces/BlockRunType';
 import PipelineScheduleType from '@interfaces/PipelineScheduleType';
-import { DATE_FORMAT_LONG_NO_SEC_WITH_OFFSET, dateFormatLong } from '@utils/date';
+import { DATE_FORMAT_LONG_NO_SEC, DATE_FORMAT_LONG_NO_SEC_WITH_OFFSET, dateFormatLong } from '@utils/date';
 import { DEFAULT_PORT } from '@api/utils/url';
 import {
   PipelineScheduleFilterQueryEnum,
@@ -177,16 +177,18 @@ export function getDatetimeFromDateAndTime(
     includeSeconds?: boolean,
   },
 ): string {
-  let datetimeString = `${date.toISOString().split('T')[0]} ${time?.hour}:${time?.minute}`;
+  let datetimeString;
+
+  const momentObj = moment(date);
+  momentObj.set('hour', +time?.hour || 0);
+  momentObj.set('minute', +time?.minute || 0);
+  momentObj.set('second', 0);
+  datetimeString = momentObj.format(DATE_FORMAT_LONG_NO_SEC);
 
   if (opts?.includeSeconds) {
     datetimeString = datetimeString.concat(':00');
   }
   if (opts?.localTimezone) {
-    const momentObj = moment(date);
-    momentObj.set('hour', +time?.hour || 0);
-    momentObj.set('minute', +time?.minute || 0);
-    momentObj.set('second', 0);
     datetimeString = momentObj.format(DATE_FORMAT_LONG_NO_SEC_WITH_OFFSET);
     if (opts?.convertToUtc) {
       datetimeString = dateFormatLong(

--- a/mage_ai/frontend/utils/date.ts
+++ b/mage_ai/frontend/utils/date.ts
@@ -28,7 +28,7 @@ export const TIME_PERIOD_INTERVAL_MAPPING = {
   [TimePeriodEnum.MONTH]: 29,
 };
 
-export const DATE_FORMAT_DISPLAY = 'YYYY-MM-DDTHH:mm:ss';
+export const DATE_FORMAT_LONG_T_SEP = 'YYYY-MM-DDTHH:mm:ss';
 export const DATE_FORMAT_LONG = 'YYYY-MM-DD HH:mm:ss';
 export const DATE_FORMAT_LONG_MS = 'YYYY-MM-DD HH:mm:ss.SSS';
 export const DATE_FORMAT_LONG_NO_SEC = 'YYYY-MM-DD HH:mm';

--- a/mage_ai/frontend/utils/date.ts
+++ b/mage_ai/frontend/utils/date.ts
@@ -28,6 +28,7 @@ export const TIME_PERIOD_INTERVAL_MAPPING = {
   [TimePeriodEnum.MONTH]: 29,
 };
 
+export const DATE_FORMAT_DISPLAY = 'YYYY-MM-DDTHH:mm:ss';
 export const DATE_FORMAT_LONG = 'YYYY-MM-DD HH:mm:ss';
 export const DATE_FORMAT_LONG_MS = 'YYYY-MM-DD HH:mm:ss.SSS';
 export const DATE_FORMAT_LONG_NO_SEC = 'YYYY-MM-DD HH:mm';


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
The problem existed due to the use of `.toISOSString()` when formatting the selected date, which will add time zone offset. Fixed using (the already exists) `moment`.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
- Before
![Animation](https://github.com/mage-ai/mage-ai/assets/132081506/a98b6b32-f62e-4353-ab49-6d61604c57f7)

- After
![a](https://github.com/mage-ai/mage-ai/assets/132081506/8cfa8a55-0fea-4879-9235-f2ee4bb884ce)


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  - [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc: @johnson-mage 
<!-- Optionally mention someone to let them know about this pull request -->
