### PR TITLE
[jk] Fix project dashboard overview count formatting

### DIFF
--- a/mage_ai/frontend/components/PipelineRun/MetricsSummary/index.style.ts
+++ b/mage_ai/frontend/components/PipelineRun/MetricsSummary/index.style.ts
@@ -15,3 +15,19 @@ export const MetricsSummaryContainerStyle = styled.div`
   `}
 
 `;
+
+export const MetricContainerStyle = styled.div<{
+  includeLeftBorder?: boolean;
+}>`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: space-between;
+
+  ${props => props.includeLeftBorder && `
+    @media (min-width: 1200px) {
+      padding-left: 24px;
+      border-left: ${BORDER_WIDTH}px ${BORDER_STYLE} ${(props.theme || dark).interactive.defaultBorder};
+    }
+  `}
+`;

--- a/mage_ai/frontend/components/PipelineRun/MetricsSummary/index.tsx
+++ b/mage_ai/frontend/components/PipelineRun/MetricsSummary/index.tsx
@@ -7,6 +7,7 @@ import Text from '@oracle/elements/Text';
 import Tile from '@oracle/components/Tile';
 import Tooltip from '@oracle/components/Tooltip';
 import dark from '@oracle/styles/themes/dark';
+import { Col, Row } from '@components/shared/Grid';
 import { GroupedPipelineRunCountType } from '@interfaces/MonitorStatsType';
 import { MetricsSummaryContainerStyle } from './index.style';
 import {
@@ -16,8 +17,10 @@ import {
 } from '@interfaces/PipelineType';
 import { RunStatus as RunStatusEnum } from '@interfaces/BlockRunType';
 import { SHARED_UTC_TOOLTIP_PROPS } from '@components/PipelineRun/shared/constants';
+import { VerticalDividerStyle } from '@oracle/elements/Divider/index.style';
 import { capitalize } from '@utils/string';
 import { formatNumber } from '@utils/number';
+import { formatNumberLabel } from '@components/charts/utils/label';
 import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
 import { sortTuplesArrayByFirstItem } from '@utils/array';
 
@@ -75,7 +78,7 @@ function MetricsSummary({
 
       <Spacing mb={2} />
 
-      <FlexContainer alignItems="center" justifyContent="space-between">
+      <Row>
         {pipelineRunCounts.map((
           [pipelineType, countsObj],
           idx: number,
@@ -99,28 +102,33 @@ function MetricsSummary({
 
             {sortTuplesArrayByFirstItem(Object.entries(countsObj))
               .map(([runStatus, count], idx: number) => (
-                <Flex
-                  flexDirection="column"
-                  key={`${runStatus}_${idx}`}
-                >
-                  <Text>
-                    {capitalize(runStatus)}
-                  </Text>
-                  <Text
-                    bold
-                    danger={runStatus === RunStatusEnum.FAILED && count > 0}
-                    xlarge
+                <Spacing key={`${runStatus}_${idx}`} px={1}>
+                  <Flex
+                    flexDirection="column"
                   >
-                    {formatNumber(count)}
-                  </Text>
-                </Flex>
+                    <Text>
+                      {capitalize(runStatus)}
+                    </Text>
+                    <Text
+                      bold
+                      danger={runStatus === RunStatusEnum.FAILED && count > 0}
+                      title={formatNumber(count)}
+                      xlarge
+                    >
+                      {formatNumberLabel(
+                        count,
+                        { maxFractionDigits: 1, minAmount: 1000 },
+                      )}
+                    </Text>
+                  </Flex>
+                </Spacing>
               ),
             )}
 
             <Spacing pr={idx !== pipelineRunCounts.length - 1 ? 2 : 0} />
           </Flex>
         ))}
-      </FlexContainer>
+      </Row>
     </MetricsSummaryContainerStyle>
   );
 }

--- a/mage_ai/frontend/components/PipelineRun/MetricsSummary/index.tsx
+++ b/mage_ai/frontend/components/PipelineRun/MetricsSummary/index.tsx
@@ -6,18 +6,19 @@ import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
 import Tile from '@oracle/components/Tile';
 import Tooltip from '@oracle/components/Tooltip';
-import dark from '@oracle/styles/themes/dark';
-import { Col, Row } from '@components/shared/Grid';
 import { GroupedPipelineRunCountType } from '@interfaces/MonitorStatsType';
-import { MetricsSummaryContainerStyle } from './index.style';
+import {
+  MetricContainerStyle,
+  MetricsSummaryContainerStyle,
+} from './index.style';
 import {
   PIPELINE_TYPE_ICON_MAPPING,
   PIPELINE_TYPE_LABEL_MAPPING,
   PipelineTypeEnum,
 } from '@interfaces/PipelineType';
+import { Row } from '@components/shared/Grid';
 import { RunStatus as RunStatusEnum } from '@interfaces/BlockRunType';
 import { SHARED_UTC_TOOLTIP_PROPS } from '@components/PipelineRun/shared/constants';
-import { VerticalDividerStyle } from '@oracle/elements/Divider/index.style';
 import { capitalize } from '@utils/string';
 import { formatNumber } from '@utils/number';
 import { formatNumberLabel } from '@components/charts/utils/label';
@@ -78,27 +79,19 @@ function MetricsSummary({
 
       <Spacing mb={2} />
 
-      <Row>
+      <Row style={{ gap: '16px' }}>
         {pipelineRunCounts.map((
           [pipelineType, countsObj],
           idx: number,
         ) => (
-          <Flex
-            alignItems="center"
-            flex="1"
-            justifyContent="space-between"
+          <MetricContainerStyle
+            includeLeftBorder={idx !== 0}
             key={`${pipelineType}_metric`}
-            style={idx !== 0
-              ? { borderLeft: `1px solid ${dark.interactive.defaultBorder}` }
-              : null
-            }
           >
-            <Spacing pl={idx !== 0 ? 3 : 0}>
-              <Tile
-                Icon={PIPELINE_TYPE_ICON_MAPPING[pipelineType]}
-                label={PIPELINE_TYPE_LABEL_MAPPING[pipelineType]}
-              />
-            </Spacing>
+            <Tile
+              Icon={PIPELINE_TYPE_ICON_MAPPING[pipelineType]}
+              label={PIPELINE_TYPE_LABEL_MAPPING[pipelineType]}
+            />
 
             {sortTuplesArrayByFirstItem(Object.entries(countsObj))
               .map(([runStatus, count], idx: number) => (
@@ -126,7 +119,7 @@ function MetricsSummary({
             )}
 
             <Spacing pr={idx !== pipelineRunCounts.length - 1 ? 2 : 0} />
-          </Flex>
+          </MetricContainerStyle>
         ))}
       </Row>
     </MetricsSummaryContainerStyle>

--- a/mage_ai/frontend/components/charts/BarStack.tsx
+++ b/mage_ai/frontend/components/charts/BarStack.tsx
@@ -16,6 +16,7 @@ import dark from '@oracle/styles/themes/dark';
 import { BORDER_RADIUS_LARGE } from '@oracle/styles/units/borders';
 import { FONT_FAMILY_REGULAR } from '@oracle/styles/fonts/primary';
 import { UNIT } from '@oracle/styles/units/spacing';
+import { formatNumber } from '@utils/number';
 import { formatNumberLabel } from './utils/label';
 
 type TooltipData = {
@@ -105,6 +106,14 @@ function BarStackChart({
     range: [yMax, 0],
     round: true,
   });
+
+  let yTooltipValue = null;
+  if (tooltipOpen && tooltipData) {
+    yTooltipValue = tooltipData.bar.data[tooltipData.key];
+    if (Number.isSafeInteger(yTooltipValue)) {
+      yTooltipValue = formatNumber(yTooltipValue);
+    }
+  }
 
   const colorScale = scaleOrdinal<string, string>({
     domain: keys,
@@ -234,7 +243,7 @@ function BarStackChart({
           <Text bold color={colorScale(tooltipData.key)}>
             {tooltipData.key}
           </Text>
-          <Text>{tooltipData.bar.data[tooltipData.key]}</Text>
+          <Text>{yTooltipValue}</Text>
           <Text>
             {getXValue(tooltipData.bar.data)}
           </Text>

--- a/mage_ai/frontend/components/charts/utils/label.ts
+++ b/mage_ai/frontend/components/charts/utils/label.ts
@@ -3,16 +3,26 @@ import { isNumeric, roundNumber } from '@utils/string';
 export const SCATTER_PLOT_X_LABEL_MAX_LENGTH = 20;
 export const SCATTER_PLOT_Y_LABEL_MAX_LENGTH = 10;
 
-const numberFormat = Intl.NumberFormat('en-US', {
-  notation: 'compact',
-  maximumFractionDigits: 2,
-});
+export function formatNumberLabel(
+  label: any,
+  opts?: {
+    maxFractionDigits?: number,
+    minAmount?: number,
+  },
+) {
+  const { maxFractionDigits, minAmount } = opts || {};
+  const numberFormat = Intl.NumberFormat('en-US', {
+    maximumFractionDigits: maxFractionDigits || 2,
+    notation: 'compact',
+  });
 
-export function formatNumberLabel(label) {
   if (typeof label !== 'number') {
     return label;
-  } 
-  return label >= 10000 ? numberFormat.format(label) : label.toString();
+  }
+
+  return label >= (minAmount || 10000)
+    ? numberFormat.format(label)
+    : label.toString();
 }
 
 export function truncateLabel(label, length) {

--- a/mage_ai/frontend/components/shared/Grid/Col.tsx
+++ b/mage_ai/frontend/components/shared/Grid/Col.tsx
@@ -11,6 +11,8 @@ type ColProps = {
   hiddenMdUp?: boolean;
   hiddenSmDown?: boolean;
   hiddenSmUp?: boolean;
+  hiddenXlDown?: boolean;
+  hiddenXlUp?: boolean;
   hiddenXsDown?: boolean;
   hiddenXsUp?: boolean;
   lg?: number;

--- a/mage_ai/frontend/components/shared/Grid/Row.tsx
+++ b/mage_ai/frontend/components/shared/Grid/Row.tsx
@@ -20,6 +20,7 @@ function Row({
   ...props
 }: RowProps) {
   const style: {
+    gap?: string;
     height?: string | number;
     marginLeft?: number;
     marginRight?: number;

--- a/mage_ai/frontend/pages/overview/index.tsx
+++ b/mage_ai/frontend/pages/overview/index.tsx
@@ -76,6 +76,7 @@ import {
   randomSimpleHashGenerator,
   randomNameGenerator,
 } from '@utils/string';
+import { formatNumber } from '@utils/number';
 import { getAllPipelineRunDataGrouped } from '@components/PipelineRun/shared/utils';
 import { getNewPipelineButtonMenuItems } from '@components/Dashboard/utils';
 import { goToWithQuery } from '@utils/routing';
@@ -639,7 +640,10 @@ def d(df):
               <Spacing ml={2}>
                 <FlexContainer alignItems="center">
                   <Text bold large>
-                    {isValidatingMonitorStats ? '--' : totalPipelineRunCount} total pipeline runs
+                    {isValidatingMonitorStats
+                      ? '--'
+                      : formatNumber(totalPipelineRunCount)
+                    } total pipeline runs
                   </Text>
                   {utcTooltipEl}
                 </FlexContainer>


### PR DESCRIPTION
# Description
- The formatting was off for very large pipeline run counts in the project overview dashboard, so this PR fixes it.

# How Has This Been Tested?
![pipeline run count formatting](https://github.com/mage-ai/mage-ai/assets/78053898/de4cb66e-cba1-4d2d-8552-f3af3f8cf5bf)

Responsive pipeline run metrics component:
![pipeline run metrics](https://github.com/mage-ai/mage-ai/assets/78053898/433f89a5-511f-474f-904c-dc7d02e7aee1)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
