### PR TITLE
[dy] Fix roles getting overwritten when updating profile

### DIFF
--- a/mage_ai/api/policies/RolePolicy.py
+++ b/mage_ai/api/policies/RolePolicy.py
@@ -53,8 +53,8 @@ RolePolicy.allow_read(RolePresenter.default_attributes + [
 ], condition=lambda policy: policy.has_at_least_admin_role())
 
 
-# allow all logged in users to view roles on update and delete because they
-# can update their own profile
+# allow all logged in users to view roles on update because they can update
+# their own profile, and roles will be passed back in the response.
 RolePolicy.allow_read(RolePresenter.default_attributes + [
     'user_id',
     'users',

--- a/mage_ai/api/policies/RolePolicy.py
+++ b/mage_ai/api/policies/RolePolicy.py
@@ -50,8 +50,19 @@ RolePolicy.allow_read(RolePresenter.default_attributes + [
 ], on_action=[
     constants.CREATE,
     constants.DELETE,
-    constants.UPDATE,
 ], condition=lambda policy: policy.has_at_least_admin_role())
+
+
+# allow all logged in users to view roles on update and delete because they
+# can update their own profile
+RolePolicy.allow_read(RolePresenter.default_attributes + [
+    'user_id',
+    'users',
+], scopes=[
+    OauthScope.CLIENT_PRIVATE,
+], on_action=[
+    constants.UPDATE,
+], condition=lambda policy: policy.has_at_least_viewer_role())
 
 
 RolePolicy.allow_write([


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

When updating any user profile information from the user profile page, the roles were getting deleted when `role_ids` was not being passed into the payload. This PR updates the logic in the `UserResource` to not delete all the roles when `role_ids` is not passed in.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Verified that roles were not being deleted when a user profile is updated
- [x] Roles can still be added to users properly


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
