### PR TITLE
[td] Fix tree for data integration pipeline

### DIFF
--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -1324,8 +1324,6 @@ function DependencyGraph({
       infos = blocksWithDownstreamBlockSet?.[toBlock?.uuid];
     }
 
-    console.log(edge, infos);
-
     let removeBlocks = () => {
       updateBlockByDragAndDrop({
         block: toBlock,
@@ -1905,15 +1903,18 @@ function DependencyGraph({
               <Edge
                 {...edge}
                 className={edgeClassNames.join(' ')}
-                onClick={(event, edge) => {
-                  // @ts-ignore
-                  setActiveEdge(prev => prev?.edge?.id === edge?.id ? null : {
-                    block,
-                    edge,
-                    event,
-                  });
-                  setContextMenuData(null);
-                }}
+                onClick={contextMenuEnabled
+                  ? (event, edge) => {
+                    // @ts-ignore
+                    setActiveEdge(prev => prev?.edge?.id === edge?.id ? null : {
+                      block,
+                      edge,
+                      event,
+                    });
+                    setContextMenuData(null);
+                  }
+                  : null
+                }
                 style={{
                   stroke: anotherBlockSelected && !selected
                     ? colorData?.accentLight

--- a/mage_ai/frontend/components/DependencyGraph/utils.ts
+++ b/mage_ai/frontend/components/DependencyGraph/utils.ts
@@ -307,7 +307,14 @@ export function buildNodesEdgesPorts({
       if (!(key in mappingUpstreamBlockSet)) {
         mappingUpstreamBlockSet[key] = {
           downstreamBlocks: [],
-          upstreamBlocks: arr?.map(uuid => blocksMapping?.[uuid]),
+          upstreamBlocks: arr?.reduce((acc, uuid) => {
+            const block2 = blocksMapping?.[uuid];
+            if (block2) {
+              return acc.concat(block2);
+            }
+
+            return acc;
+          }, []),
         };
       }
       mappingUpstreamBlockSet[key].downstreamBlocks.push(block);


### PR DESCRIPTION
# Description
Data integration pipelines weren’t being handled when viewing their block runs in the tree.

The block run UUID wasn’t being mapped to the original block UUIDs and the upstream and downstream blocks weren’t being re-assigned to handle suffix UUIDs containing colons and indexes.

![CleanShot 2023-11-14 at 19 48 33@2x](https://github.com/mage-ai/mage-ai/assets/1066980/d8ae2f02-c086-4705-89d7-d07b12c62777)