### PR TITLE
[jk] Update backfill statuses

### DIFF
--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -56,6 +56,7 @@ import {
   getFormattedVariable,
   getFormattedVariables,
 } from '@components/Sidekick/utils';
+import { getRunStatusTextProps } from '@components/shared/Table/constants';
 import { getTimeInUTCString } from '@components/Triggers/utils';
 import { goToWithQuery } from '@utils/routing';
 import { isEmptyObject } from '@utils/hash';
@@ -271,12 +272,8 @@ function BackfillDetail({
           </Text>
         </FlexContainer>,
         <Text
-          danger={BackfillStatusEnum.CANCELLED === status || BackfillStatusEnum.FAILED == status}
-          default={BackfillStatusEnum.INITIAL === status}
+          {...getRunStatusTextProps(status)}
           key="backfill_status"
-          monospace
-          muted={!status}
-          success={BackfillStatusEnum.RUNNING === status || BackfillStatusEnum.COMPLETED === status}
         >
           {status || 'inactive'}
         </Text>,

--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -3,7 +3,6 @@ import NextLink from 'next/link';
 import BackfillType, {
   BACKFILL_TYPE_DATETIME,
   BACKFILL_TYPE_CODE,
-  BackfillStatusEnum,
 } from '@interfaces/BackfillType';
 import Button from '@oracle/elements/Button';
 import Link from '@oracle/elements/Link';

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -119,6 +119,18 @@ class PipelineSchedule(BaseModel):
         query = query.filter(PipelineRun.pipeline_schedule_id.in_(ids))
         return query.all()
 
+    @classmethod
+    def fetch_latest_pipeline_runs_without_retries(self, ids: List[int]) -> List:
+        query = PipelineRun.query
+        query.cache = True
+        query = (
+            query.
+            filter(PipelineRun.pipeline_schedule_id.in_(ids)).
+            group_by(PipelineRun.execution_date).
+            order_by(func.max(PipelineRun.started_at))
+        )
+        return query.all()
+
     def get_settings(self) -> 'SettingsConfig':
         settings = self.settings if self.settings else dict()
         return SettingsConfig.load(config=settings)

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -268,13 +268,18 @@ class PipelineScheduler:
                     status=PipelineRun.PipelineRunStatus.FAILED)
 
                 # Backfill status updated to "failed" if at least 1 of its pipeline runs failed
-                if backfill is not None and any(
-                    [PipelineRun.PipelineRunStatus.FAILED == pr.status
-                        for pr in backfill.pipeline_runs]
-                ):
-                    backfill.update(
-                        status=Backfill.Status.FAILED,
-                    )
+                if backfill is not None:
+                    latest_pipeline_runs = \
+                        PipelineSchedule.fetch_latest_pipeline_runs_without_retries(
+                            [backfill.pipeline_schedule_id]
+                        )
+                    if any(
+                        [PipelineRun.PipelineRunStatus.FAILED == pr.status
+                            for pr in latest_pipeline_runs]
+                    ):
+                        backfill.update(
+                            status=Backfill.Status.FAILED,
+                        )
 
                 asyncio.run(UsageStatisticLogger().pipeline_run_ended(self.pipeline_run))
 

--- a/mage_ai/tests/orchestration/db/models/test_schedules.py
+++ b/mage_ai/tests/orchestration/db/models/test_schedules.py
@@ -21,6 +21,7 @@ from mage_ai.orchestration.pipeline_scheduler import configure_pipeline_run_payl
 from mage_ai.shared.hash import merge_dict
 from mage_ai.tests.base_test import DBTestCase
 from mage_ai.tests.factory import (
+    create_pipeline,
     create_pipeline_run,
     create_pipeline_run_with_schedule,
     create_pipeline_with_blocks,
@@ -34,6 +35,62 @@ class PipelineScheduleTests(DBTestCase):
         self.pipeline = create_pipeline_with_blocks(
             'test pipeline',
             self.repo_path,
+        )
+
+    def test_fetch_latest_pipeline_runs_without_retries(self):
+        pipeline_schedule = PipelineSchedule.create(
+            name='test pipeline',
+            pipeline_uuid='test_pipeline',
+        )
+        for i in range(1, 5):
+            create_pipeline_run_with_schedule(
+                'test_pipeline',
+                execution_date=datetime(2023, 10, 1),
+                pipeline_schedule_id=pipeline_schedule.id,
+                started_at=datetime(2023, 10, 1, i, 0, 0),
+            )
+            create_pipeline_run_with_schedule(
+                'test_pipeline',
+                execution_date=datetime(2023, 10, 15),
+                pipeline_schedule_id=pipeline_schedule.id,
+                started_at=datetime(2023, 10, 15, 0, i * 10, 0),
+            )
+            create_pipeline_run_with_schedule(
+                'test_pipeline',
+                execution_date=datetime(2023, 11, 1),
+                pipeline_schedule_id=pipeline_schedule.id,
+                started_at=datetime(2023, 11, 1, 12, 30, i),
+            )
+        latest_pipeline_runs = pipeline_schedule.fetch_latest_pipeline_runs_without_retries(
+            [pipeline_schedule.id],
+        )
+        self.assertEqual(len(latest_pipeline_runs), 3)
+        latest_pipeline_runs.sort(
+            key=lambda r: r.execution_date,
+        )
+        self.assertEqual(
+            latest_pipeline_runs[0].execution_date,
+            datetime(2023, 10, 1),
+        )
+        self.assertEqual(
+            latest_pipeline_runs[0].started_at,
+            datetime(2023, 10, 1, 4, 0, 0)
+        )
+        self.assertEqual(
+            latest_pipeline_runs[1].execution_date,
+            datetime(2023, 10, 15),
+        )
+        self.assertEqual(
+            latest_pipeline_runs[1].started_at,
+            datetime(2023, 10, 15, 0, 40, 0)
+        )
+        self.assertEqual(
+            latest_pipeline_runs[2].execution_date,
+            datetime(2023, 11, 1),
+        )
+        self.assertEqual(
+            latest_pipeline_runs[2].started_at,
+            datetime(2023, 11, 1, 12, 30, 4)
         )
 
     def test_pipeline_runs_count(self):

--- a/mage_ai/tests/orchestration/db/models/test_schedules.py
+++ b/mage_ai/tests/orchestration/db/models/test_schedules.py
@@ -21,7 +21,6 @@ from mage_ai.orchestration.pipeline_scheduler import configure_pipeline_run_payl
 from mage_ai.shared.hash import merge_dict
 from mage_ai.tests.base_test import DBTestCase
 from mage_ai.tests.factory import (
-    create_pipeline,
     create_pipeline_run,
     create_pipeline_run_with_schedule,
     create_pipeline_with_blocks,


### PR DESCRIPTION
# Description
- The backfill status was not updating to `running` when the backfill's pipeline runs were running, or `failed` after at least 1 of the backfill's pipeline runs failed, or `completed` when the backfill initially failed but successfully completed upon retrying. This PR updates the backfill statuses accordingly.

# How Has This Been Tested?
## BEFORE
Failed backfill does not update status (you have to cancel the backfill to retry again):
![BEFORE - backfill stuck on initial](https://github.com/mage-ai/mage-ai/assets/78053898/0741c26e-2f72-41bf-a86d-6b0cef1a186c)
Successful backfill retry does not update status:
![BEFORE - successful backfill retry does not update status](https://github.com/mage-ai/mage-ai/assets/78053898/e8541b54-6c90-4d97-a88c-f9487415e250)

## AFTER
Successful backfill:
![successful backfill](https://github.com/mage-ai/mage-ai/assets/78053898/59b5cb8e-10f4-4a37-924e-70853db81820)
Failed backfill:
![failed backfill](https://github.com/mage-ai/mage-ai/assets/78053898/a2e5785c-dd7b-448d-8d13-9344b1d467db)
Successful backfill retry:
![successful backfill retry](https://github.com/mage-ai/mage-ai/assets/78053898/db142c30-ba7e-4549-86a0-160db8eb9714)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
