### PR TITLE
[xy] Re-enqueue the job if queue is empty.

### DIFF
--- a/mage_ai/orchestration/queue/process_queue.py
+++ b/mage_ai/orchestration/queue/process_queue.py
@@ -116,7 +116,15 @@ class ProcessQueue(Queue):
             if job_client_id != self.client_id and self.redis_client.get(job_client_id):
                 return True
         job = self.job_dict.get(job_id)
-        return job is not None and (job == JobStatus.QUEUED or isinstance(job, int))
+        return (
+            job is not None and
+            (
+                # In queue
+                (job == JobStatus.QUEUED and not self.queue.empty()) or
+                # Running
+                isinstance(job, int)
+            )
+        )
 
     def kill_job(self, job_id: str):
         """

--- a/mage_ai/tests/orchestration/queue/test_process_queue.py
+++ b/mage_ai/tests/orchestration/queue/test_process_queue.py
@@ -1,6 +1,12 @@
+from unittest.mock import patch
+
 from mage_ai.orchestration.queue.config import QueueConfig
 from mage_ai.orchestration.queue.process_queue import JobStatus, ProcessQueue
 from mage_ai.tests.base_test import TestCase
+
+
+def run_block():
+    print('test run block')
 
 
 class ProcessQueueTests(TestCase):
@@ -17,17 +23,24 @@ class ProcessQueueTests(TestCase):
         self.queue.job_dict['block_run_3'] = JobStatus.COMPLETED
         self.queue.job_dict['block_run_4'] = JobStatus.CANCELLED
         self.queue.clean_up_jobs()
-        self.assertEqual(self.queue.job_dict['block_run_1'], JobStatus.QUEUED)
+        # queue is empty, thus 'block_run_1' is not in queue
+        self.assertFalse('block_run_1' in self.queue.job_dict)
         self.assertEqual(self.queue.job_dict['block_run_2'], 100)
         self.assertFalse('block_run_3' in self.queue.job_dict)
         self.assertFalse('block_run_4' in self.queue.job_dict)
 
-    def test_has_job(self):
+    @patch('mage_ai.orchestration.queue.process_queue.poll_job_and_execute')
+    def test_has_job(self, mock_poll_job_and_execute):
         self.queue.job_dict['block_run_1'] = JobStatus.QUEUED
         self.queue.job_dict['block_run_2'] = 100
         self.queue.job_dict['block_run_3'] = JobStatus.COMPLETED
         self.queue.job_dict['block_run_4'] = JobStatus.CANCELLED
+        # Queue is empty, thus return False
+        self.assertFalse(self.queue.has_job('block_run_1'))
+        # After enqueueing the job, the has_job method returns True
+        self.queue.enqueue('block_run_1', run_block)
         self.assertTrue(self.queue.has_job('block_run_1'))
+
         self.assertTrue(self.queue.has_job('block_run_2'))
         self.assertFalse(self.queue.has_job('block_run_3'))
         self.assertFalse(self.queue.has_job('block_run_4'))


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Enhance the `has_job` check in ProcessQueue method. It's reported by user that some block runs are stuck in queued status. I suspect it's some random issue of enqueueing or dequeueing the job.
Thus when checking the job existence, we also check whether the queue is empty to make sure the job is in queue or not. 

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested via unit test
- [x] Run pipelines normally locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
