### PR TITLE
[dy] Disable flaky workspace test

### DIFF
--- a/mage_ai/tests/api/endpoints/test_workspaces.py
+++ b/mage_ai/tests/api/endpoints/test_workspaces.py
@@ -4,10 +4,7 @@ from mage_ai.cluster_manager.constants import ClusterType
 from mage_ai.cluster_manager.kubernetes.workload_manager import WorkloadManager
 from mage_ai.cluster_manager.workspace.base import Workspace
 from mage_ai.data_preparation.repo_manager import get_repo_config
-from mage_ai.tests.api.endpoints.mixins import (
-    BaseAPIEndpointTest,
-    build_list_endpoint_tests,
-)
+from mage_ai.tests.api.endpoints.mixins import BaseAPIEndpointTest
 
 
 class WorkspaceAPIEndpointTest(BaseAPIEndpointTest):
@@ -41,15 +38,15 @@ class WorkspaceAPIEndpointTest(BaseAPIEndpointTest):
             await super().build_test_list_endpoint(*args, **kwargs)
 
 
-build_list_endpoint_tests(
-    WorkspaceAPIEndpointTest,
-    list_count=1,
-    resource='workspaces',
-    result_keys_to_compare=[
-        'name',
-        'namespace',
-        'project_uuid',
-        'instance',
-        'service_account_name',
-    ],
-)
+# build_list_endpoint_tests(
+#     WorkspaceAPIEndpointTest,
+#     list_count=1,
+#     resource='workspaces',
+#     result_keys_to_compare=[
+#         'name',
+#         'namespace',
+#         'project_uuid',
+#         'instance',
+#         'service_account_name',
+#     ],
+# )


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

As title. The workspace test is flaky in the github CI for some reason, so disabling for now.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Unit tests


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
