### PR TITLE
[td] Add unit test to test user list response for admins

### DIFF
--- a/mage_ai/tests/api/operations/test_base.py
+++ b/mage_ai/tests/api/operations/test_base.py
@@ -142,6 +142,7 @@ class BaseApiTestCase(AsyncDBTestCase):
         self,
         create_payloads: List[Dict] = None,
         model_fields_to_check: List[str] = None,
+        skip_creation: bool = False,
         **kwargs,
     ) -> Dict:
         if create_payloads is None:
@@ -149,11 +150,12 @@ class BaseApiTestCase(AsyncDBTestCase):
         if model_fields_to_check is None:
             model_fields_to_check = []
         models = []
-        for payload in create_payloads:
-            response = await self.build_create_operation(payload, **kwargs).execute()
-            if 'error' in response:
-                raise Exception(response['error'])
-            models.append(response[self.model_class_name])
+        if not skip_creation:
+            for payload in create_payloads:
+                response = await self.build_create_operation(payload, **kwargs).execute()
+                if 'error' in response:
+                    raise Exception(response['error'])
+                models.append(response[self.model_class_name])
 
         operation = self.build_list_operation(**kwargs)
         response = await operation.execute()

--- a/mage_ai/tests/api/operations/test_base.py
+++ b/mage_ai/tests/api/operations/test_base.py
@@ -144,16 +144,16 @@ class BaseApiTestCase(AsyncDBTestCase):
         model_fields_to_check: List[str] = None,
         **kwargs,
     ) -> Dict:
-        if create_payloads is None:
-            create_payloads = [{}]
         if model_fields_to_check is None:
             model_fields_to_check = []
         models = []
-        for payload in create_payloads:
-            response = await self.build_create_operation(payload, **kwargs).execute()
-            if 'error' in response:
-                raise Exception(response['error'])
-            models.append(response[self.model_class_name])
+
+        if create_payloads:
+            for payload in create_payloads:
+                response = await self.build_create_operation(payload, **kwargs).execute()
+                if 'error' in response:
+                    raise Exception(response['error'])
+                models.append(response[self.model_class_name])
 
         operation = self.build_list_operation(**kwargs)
         response = await operation.execute()

--- a/mage_ai/tests/api/operations/test_base.py
+++ b/mage_ai/tests/api/operations/test_base.py
@@ -144,16 +144,16 @@ class BaseApiTestCase(AsyncDBTestCase):
         model_fields_to_check: List[str] = None,
         **kwargs,
     ) -> Dict:
+        if create_payloads is None:
+            create_payloads = [{}]
         if model_fields_to_check is None:
             model_fields_to_check = []
         models = []
-
-        if create_payloads:
-            for payload in create_payloads:
-                response = await self.build_create_operation(payload, **kwargs).execute()
-                if 'error' in response:
-                    raise Exception(response['error'])
-                models.append(response[self.model_class_name])
+        for payload in create_payloads:
+            response = await self.build_create_operation(payload, **kwargs).execute()
+            if 'error' in response:
+                raise Exception(response['error'])
+            models.append(response[self.model_class_name])
 
         operation = self.build_list_operation(**kwargs)
         response = await operation.execute()

--- a/mage_ai/tests/api/operations/test_users.py
+++ b/mage_ai/tests/api/operations/test_users.py
@@ -16,9 +16,6 @@ class UserOperationTests(BaseApiTestCase):
         super().setUpClass()
         Role.create_default_roles()
 
-    def tearDown(self):
-        User.query.delete()
-
     async def test_execute_create(self):
         email = self.faker.email()
         response = await self.base_test_execute_create(dict(
@@ -131,6 +128,8 @@ class UserOperationTests(BaseApiTestCase):
             UserPresenter.default_attributes,
             user=admin,
         )
+
+        admin.delete()
 
     async def test_execute_list_unauthorized(self):
         async def _func():

--- a/mage_ai/tests/api/operations/test_users.py
+++ b/mage_ai/tests/api/operations/test_users.py
@@ -99,6 +99,7 @@ class UserOperationTests(BaseApiTestCase):
         await self.base_test_execute_list(
             None,
             UserPresenter.default_attributes,
+            skip_creation=True,
             user=admin,
         )
 

--- a/mage_ai/tests/api/operations/test_users.py
+++ b/mage_ai/tests/api/operations/test_users.py
@@ -16,6 +16,9 @@ class UserOperationTests(BaseApiTestCase):
         super().setUpClass()
         Role.create_default_roles()
 
+    def tearDown(self):
+        User.query.delete()
+
     async def test_execute_create(self):
         email = self.faker.email()
         response = await self.base_test_execute_create(dict(

--- a/mage_ai/tests/api/operations/test_users.py
+++ b/mage_ai/tests/api/operations/test_users.py
@@ -73,33 +73,6 @@ class UserOperationTests(BaseApiTestCase):
         email1 = self.faker.email()
         email2 = self.faker.email()
 
-        await self.base_test_execute_list(
-            [
-                dict(
-                    email=email1,
-                    password='water_lightning',
-                    password_confirmation='water_lightning',
-                    roles_new=[Role.get_role('Editor').id],
-                ),
-                dict(
-                    email=email2,
-                    password='water_lightning',
-                    password_confirmation='water_lightning',
-                    roles_new=[Role.get_role('Editor').id],
-                ),
-            ],
-            [
-                'id',
-            ],
-            user=owner,
-        )
-
-    async def test_execute_list_admin(self):
-        owner = create_user(_owner=True)
-
-        email1 = self.faker.email()
-        email2 = self.faker.email()
-
         response = await self.base_test_execute_list(
             [
                 dict(
@@ -128,8 +101,6 @@ class UserOperationTests(BaseApiTestCase):
             UserPresenter.default_attributes,
             user=admin,
         )
-
-        admin.delete()
 
     async def test_execute_list_unauthorized(self):
         async def _func():


### PR DESCRIPTION
# Description
Add additional unit test to validate that admin users can access the user attributes when fetching list of users.

# How Has This Been Tested?
- [x] New unit test

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
