### PR TITLE
[td] Don’t show SSH tunnel option unless kernel is PySpark

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/KernelStatus.tsx
@@ -337,6 +337,7 @@ function KernelStatus({
     if (!sparkEnabled
       || !validComputePipelineType
       || computeServiceUUIDs.AWS_EMR !== computeService?.uuid
+      || PipelineTypeEnum.PYSPARK !== pipeline?.type
     ) {
       return null;
     }
@@ -448,6 +449,7 @@ function KernelStatus({
     connections,
     connectionsLoading,
     fetchAll,
+    pipeline,
     setClusterSelectionVisible,
     setComputeConnectionVisible,
     validComputePipelineType,


### PR DESCRIPTION
# Description
If the current kernel is not PySpark, don’t show the status in the notebook header for SSH tunneling.

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
