### PR TITLE
[td] Add hook operation for running when block is updated in a pipeline

### DIFF
--- a/mage_ai/api/operations/base.py
+++ b/mage_ai/api/operations/base.py
@@ -276,12 +276,16 @@ class BaseOperation():
         if not project.is_feature_enabled(FeatureUUID.GLOBAL_HOOKS):
             return None
 
+        operation_types = [operation_type]
+        if HookOperation.UPDATE == operation_type:
+            operation_types.append(HookOperation.UPDATE_ANYWHERE)
+
         try:
             global_hooks = GlobalHooks.load_from_file()
             hooks = global_hooks.get_and_run_hooks(
                 conditions=[condition] if condition else None,
                 operation_resource=operation_resource,
-                operation_type=operation_type,
+                operation_types=operation_types,
                 resource_type=EntityName(self.__classified_class()),
                 stage=stage,
                 **kwargs,

--- a/mage_ai/api/resources/GlobalHookResource.py
+++ b/mage_ai/api/resources/GlobalHookResource.py
@@ -3,6 +3,9 @@ from typing import Dict
 from mage_ai.api.errors import ApiError
 from mage_ai.api.resources.GenericResource import GenericResource
 from mage_ai.authentication.permissions.constants import EntityName
+from mage_ai.data_preparation.models.global_hooks.constants import (
+    DISABLED_RESOURCE_TYPES,
+)
 from mage_ai.data_preparation.models.global_hooks.models import (
     GlobalHooks,
     Hook,
@@ -53,6 +56,13 @@ class GlobalHookResource(GenericResource):
             error = ApiError.RESOURCE_INVALID.copy()
             error.update(
                 message=f'Hook is missing the following required attributes: {", ".join(missing)}.',
+            )
+            raise ApiError(error)
+
+        if hook.resource_type and hook.resource_type in DISABLED_RESOURCE_TYPES:
+            error = ApiError.RESOURCE_INVALID.copy()
+            error.update(
+                message=f'Hooks cannot be created for resource type {hook.resource_type.value}.',
             )
             raise ApiError(error)
 

--- a/mage_ai/data_preparation/models/global_hooks/constants.py
+++ b/mage_ai/data_preparation/models/global_hooks/constants.py
@@ -1,0 +1,21 @@
+from mage_ai.authentication.permissions.constants import EntityName
+
+DISABLED_RESOURCE_TYPES = [
+  EntityName.File,
+  EntityName.FileContent,
+  EntityName.Folder,
+  EntityName.GlobalHook,
+  EntityName.Oauth,
+  EntityName.OauthAccessToken,
+  EntityName.OauthApplication,
+  EntityName.Permission,
+  EntityName.Role,
+  EntityName.RolePermission,
+  EntityName.Secret,
+  EntityName.Session,
+  EntityName.User,
+  EntityName.UserRole,
+  EntityName.Workspace,
+]
+
+RESOURCE_TYPES = [en for en in EntityName if en not in DISABLED_RESOURCE_TYPES]

--- a/mage_ai/data_preparation/models/global_hooks/models.py
+++ b/mage_ai/data_preparation/models/global_hooks/models.py
@@ -11,6 +11,7 @@ from mage_ai.api.resources.BaseResource import BaseResource
 from mage_ai.authentication.permissions.constants import EntityName
 from mage_ai.data_preparation.models.block import Block
 from mage_ai.data_preparation.models.block.utils import fetch_input_variables
+from mage_ai.data_preparation.models.global_hooks.constants import RESOURCE_TYPES
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.orchestration.db.models.schedules import PipelineRun
 from mage_ai.orchestration.triggers.api import trigger_pipeline
@@ -516,7 +517,7 @@ class GlobalHookResource(GlobalHookResourceBase):
 def __build_global_hook_resources_fields() -> List[Tuple]:
     arr = []
 
-    for entity_name in EntityName:
+    for entity_name in RESOURCE_TYPES:
         arr.append((
             entity_name.value,
             GlobalHookResource,
@@ -538,7 +539,7 @@ class GlobalHookResources(GlobalHookResourcesBase):
     disable_attribute_snake_case = True
 
     def __post_init__(self):
-        for entity_name in EntityName:
+        for entity_name in RESOURCE_TYPES:
             self.serialize_attribute_class(
                 entity_name.value,
                 GlobalHookResource,
@@ -548,7 +549,7 @@ class GlobalHookResources(GlobalHookResourcesBase):
     def update_attributes(self, **kwargs):
         super().update_attributes(**kwargs)
 
-        for entity_name in EntityName:
+        for entity_name in RESOURCE_TYPES:
             resource = getattr(self, entity_name.value)
             if resource:
                 resource.update_attributes(resource_type=entity_name)
@@ -672,7 +673,7 @@ class GlobalHooks(BaseDataClass):
     ) -> List[Hook]:
         arr = []
         if self.resources:
-            for entity_name in EntityName:
+            for entity_name in RESOURCE_TYPES:
                 resource = getattr(self.resources, entity_name.value)
                 if not resource:
                     continue

--- a/mage_ai/data_preparation/models/global_hooks/models.py
+++ b/mage_ai/data_preparation/models/global_hooks/models.py
@@ -16,7 +16,7 @@ from mage_ai.orchestration.db.models.schedules import PipelineRun
 from mage_ai.orchestration.triggers.api import trigger_pipeline
 from mage_ai.orchestration.triggers.constants import TRIGGER_NAME_FOR_GLOBAL_HOOK
 from mage_ai.settings.repo import get_repo_path
-from mage_ai.shared.array import find, find_index
+from mage_ai.shared.array import find, find_index, flatten
 from mage_ai.shared.hash import (
     dig,
     extract,
@@ -37,7 +37,7 @@ class HookOperation(str, Enum):
     EXECUTE = 'execute'
     LIST = OperationType.LIST.value
     UPDATE = OperationType.UPDATE.value
-    UPDATE_SPECIAL = 'update_special'
+    UPDATE_ANYWHERE = 'update_anywhere'
 
 
 class HookCondition(str, Enum):
@@ -367,13 +367,13 @@ class Hook(BaseDataClass):
 
     def should_run(
         self,
-        operation_type: HookOperation,
+        operation_types: List[HookOperation],
         resource_type: EntityName,
         stage: HookStage,
         conditions: List[HookCondition] = None,
         operation_resource: Union[BaseResource, Block, Dict, List[BaseResource], Pipeline] = None,
     ) -> bool:
-        if self.operation_type != operation_type:
+        if self.operation_type not in operation_types:
             return False
 
         if self.resource_type != resource_type:
@@ -555,12 +555,16 @@ class GlobalHookResources(GlobalHookResourcesBase):
                 setattr(self, entity_name.value, resource)
 
 
-def run_hook(args_array: List):
-    hook_dict, kwargs = args_array
-    hook = Hook.load(**hook_dict)
-    hook.run(**kwargs)
+def run_hooks(args_arrays: List[List]) -> List[Dict]:
+    arr = []
 
-    return hook.to_dict(include_run_data=True)
+    for args_array in args_arrays:
+        hook_dict, kwargs = args_array
+        hook = Hook.load(**hook_dict)
+        hook.run(**kwargs)
+        arr.append(hook.to_dict(include_run_data=True))
+
+    return arr
 
 
 @dataclass
@@ -705,7 +709,7 @@ class GlobalHooks(BaseDataClass):
 
     def get_hooks(
         self,
-        operation_type: HookOperation,
+        operation_types: List[HookOperation],
         resource_type: EntityName,
         stage: HookStage,
         conditions: List[HookCondition] = None,
@@ -715,14 +719,14 @@ class GlobalHooks(BaseDataClass):
             hook: Hook,
             conditions=conditions,
             operation_resource=operation_resource,
-            operation_type=operation_type,
+            operation_types=operation_types,
             resource_type=resource_type,
             stage=stage,
         ) -> bool:
             return hook.should_run(
                 conditions=conditions,
                 operation_resource=operation_resource,
-                operation_type=operation_type,
+                operation_types=operation_types,
                 resource_type=resource_type,
                 stage=stage,
             )
@@ -733,16 +737,30 @@ class GlobalHooks(BaseDataClass):
         ))
 
     def run_hooks(self, hooks: List[Hook], **kwargs) -> List[Hook]:
-        hook_dicts = run_parallel_multiple_args(run_hook, [(hook.to_dict(
-            include_all=True,
-            include_output=True,
-        ), kwargs) for hook in hooks])
+        hooks_by_pipeline = {}
+        for hook in hooks:
+            if not hook.pipeline_settings or not hook.pipeline_settings.get('uuid'):
+                continue
 
-        return [Hook.load(**m) for m in hook_dicts]
+            pipeline_uuid = hook.pipeline_settings.get('uuid')
+            if pipeline_uuid not in hooks_by_pipeline:
+                hooks_by_pipeline[pipeline_uuid] = []
+
+            hooks_by_pipeline[pipeline_uuid].append((
+                hook.to_dict(
+                    include_all=True,
+                    include_output=True,
+                ),
+                kwargs,
+            ))
+
+        hook_dicts_arr = run_parallel_multiple_args(run_hooks, list(hooks_by_pipeline.values()))
+
+        return [Hook.load(**m) for m in flatten(hook_dicts_arr)]
 
     def get_and_run_hooks(
         self,
-        operation_type: HookOperation,
+        operation_types: List[HookOperation],
         resource_type: EntityName,
         stage: HookStage,
         conditions: List[HookCondition] = None,
@@ -750,7 +768,7 @@ class GlobalHooks(BaseDataClass):
         **kwargs,
     ) -> List[Hook]:
         hooks = self.get_hooks(
-            operation_type=operation_type,
+            operation_types=operation_types,
             resource_type=resource_type,
             stage=stage,
             conditions=conditions,

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -11,6 +11,7 @@ import pytz
 import yaml
 from jinja2 import Template
 
+from mage_ai.authentication.permissions.constants import EntityName
 from mage_ai.data_preparation.models.block import Block, run_blocks, run_blocks_sync
 from mage_ai.data_preparation.models.block.data_integration.utils import (
     convert_outputs_to_data,
@@ -32,6 +33,8 @@ from mage_ai.data_preparation.models.constants import (
 from mage_ai.data_preparation.models.errors import SerializationError
 from mage_ai.data_preparation.models.file import File
 from mage_ai.data_preparation.models.pipelines.models import PipelineSettings
+from mage_ai.data_preparation.models.project import Project
+from mage_ai.data_preparation.models.project.constants import FeatureUUID
 from mage_ai.data_preparation.models.utils import is_yaml_serializable
 from mage_ai.data_preparation.models.variable import Variable
 from mage_ai.data_preparation.repo_manager import (
@@ -909,6 +912,16 @@ class Pipeline:
                             self.extensions.get(extension_uuid, {}).get('blocks_by_uuid', {}),
                         ))
 
+            global_hooks = None
+            if len(arr) >= 1:
+                project = Project(self.repo_config)
+                if project.is_feature_enabled(FeatureUUID.GLOBAL_HOOKS):
+                    from mage_ai.data_preparation.models.global_hooks.models import (
+                        GlobalHooks,
+                    )
+
+                    global_hooks = GlobalHooks.load_from_file()
+
             for tup in arr:
                 key, blocks_arr, mapping = tup
                 widget = key == 'widgets'
@@ -922,6 +935,31 @@ class Pipeline:
                     block = mapping.get(block_data['uuid'])
                     if block is None:
                         continue
+
+                    if global_hooks:
+                        from mage_ai.data_preparation.models.global_hooks.models import (
+                            HookOperation,
+                            HookStage,
+                        )
+
+                        hooks = global_hooks.get_and_run_hooks(
+                            operation_resource=block,
+                            operation_types=[HookOperation.UPDATE_ANYWHERE],
+                            resource_type=EntityName.Block,
+                            stage=HookStage.BEFORE,
+                            payload=block_data,
+                        )
+                        if hooks:
+                            for hook in (hooks or []):
+                                output = hook.output
+                                if not output:
+                                    continue
+
+                                if output.get('payload'):
+                                    value = output.get('payload') or {}
+                                    if isinstance(value, dict):
+                                        block_data = merge_dict(block_data, value)
+
                     if 'content' in block_data:
                         from mage_ai.cache.block_action_object import (
                             BlockActionObjectCache,

--- a/mage_ai/tests/api/operations/test_operations_with_hooks.py
+++ b/mage_ai/tests/api/operations/test_operations_with_hooks.py
@@ -236,6 +236,22 @@ class BaseOperationWithHooksTest(BaseApiTestCase):
             test_predicate_before=True,
         )
 
+    async def test_update_anywhere(self):
+        await run_test_for_operation(
+            self,
+            HookOperation.UPDATE_ANYWHERE,
+            lambda: self.build_update_operation(self.pipeline.uuid, {}),
+        )
+
+    async def test_update_anywhere_with_predicates(self):
+        await run_test_for_operation(
+            self,
+            HookOperation.UPDATE_ANYWHERE,
+            lambda: self.build_update_operation(self.pipeline.uuid, {}),
+            test_predicate_after=True,
+            test_predicate_before=True,
+        )
+
     async def test_delete(self):
         pipeline = create_pipeline_with_blocks(
             self.faker.unique.name(),


### PR DESCRIPTION
# Description
- Add a special operation `UPDATE_ANYWHERE` so that when a block is updated via the Pipeline endpoint, the hook with that operation also runs.
- If operation is `UPDATE_ANYWHERE`, the hook will run in 2 place:
    - When updating a block from the block API endpoint
    - When updating a block from the pipeline API endpoint
 
# How Has This Been Tested?
- [x] Adding unit tests in a follow-up PR


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
