### PR TITLE
[sm] Added data loader templates for Druid and Pinot in the doc

### DIFF
--- a/docs/development/blocks/data_loaders/templates.mdx
+++ b/docs/development/blocks/data_loaders/templates.mdx
@@ -530,6 +530,79 @@ def test_output(output, *args) -> None:
     assert output is not None, 'The output is undefined'
 ```
 
+## Druid
+
+```python
+from mage_ai.settings.repo import get_repo_path
+from mage_ai.io.config import ConfigFileLoader
+from mage_ai.io.druid import Druid
+from os import path
+if 'data_loader' not in globals():
+    from mage_ai.data_preparation.decorators import data_loader
+if 'test' not in globals():
+    from mage_ai.data_preparation.decorators import test
+
+
+@data_loader
+def load_data_from_druid(*args, **kwargs):
+    """
+    Template for loading data from a Druid warehouse.
+    Specify your configuration settings in 'io_config.yaml'.
+
+    Docs: https://docs.mage.ai/design/data-loading#druid
+    """
+    query = 'your Druid query'  # Specify your SQL query here
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
+    config_profile = 'default'
+
+    with Druid.with_config(ConfigFileLoader(config_path, config_profile)) as loader:
+        return loader.load(query)
+
+
+@test
+def test_output(output, *args) -> None:
+    """
+    Template code for testing the output of the block.
+    """
+    assert output is not None, 'The output is undefined'
+```
+
+## Pinot
+
+```python
+from mage_ai.data_preparation.repo_manager import get_repo_path
+from mage_ai.io.config import ConfigFileLoader
+from mage_ai.io.pinot import Pinot
+from os import path
+if 'data_loader' not in globals():
+    from mage_ai.data_preparation.decorators import data_loader
+if 'test' not in globals():
+    from mage_ai.data_preparation.decorators import test
+
+
+@data_loader
+def load_data_from_pinot(*args, **kwargs):
+    """
+    Template for loading data from a Pinot warehouse.
+    Specify your configuration settings in 'io_config.yaml'.
+    Docs: https://docs.mage.ai/design/data-loading#pinot
+    """
+    query = 'your Pinot query'  # Specify your SQL query here
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
+    config_profile = 'default'
+
+    with Pinot.with_config(ConfigFileLoader(config_path, config_profile)) as loader:
+        return loader.load(query)
+
+
+@test
+def test_output(output, *args) -> None:
+    """
+    Template code for testing the output of the block.
+    """
+    assert output is not None, 'The output is undefined'
+```
+
 ## Orchestration
 
 ### Trigger pipeline


### PR DESCRIPTION
# Description
![Screenshot 2023-11-20 at 3 23 51 PM](https://github.com/mage-ai/mage-ai/assets/6594483/91d657d1-2c9c-4d49-bb6f-ad5d7c4c17fc)

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [ Yes ] Tested by opening the docs locally [Screenshot attached]


# Checklist
- [ Yes ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ Yes ] I have performed a self-review of my own code
- [ N/A ] I have added unit tests that prove my fix is effective or that my feature works
- [ N/A ] I have commented my code, particularly in hard-to-understand areas
- [ N/A ] I have made corresponding changes to the documentation
- [ N/A ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
