### PR TITLE
[xy] Pass envFrom to job pod.

### DIFF
--- a/mage_ai/services/k8s/job_manager.py
+++ b/mage_ai/services/k8s/job_manager.py
@@ -173,6 +173,9 @@ class JobManager():
         mage_server_container_spec = self.get_mage_server_container()
         container_spec.env = container_spec.env + \
             [item for item in mage_server_container_spec.env if item not in container_spec.env]
+        container_spec.env_from = (container_spec.env_from or []) + \
+            [item for item in (mage_server_container_spec.env_from or [])
+             if item not in (container_spec.env_from or [])]
         container_spec.volume_mounts = container_spec.volume_mounts + \
             [item for item in mage_server_container_spec.volume_mounts
                 if item not in container_spec.volume_mounts]


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Pass env_from to k8s job pod.

Close: https://github.com/mage-ai/mage-ai/issues/3975

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested in local k8s cluster. The env_from value is passed to job pod.
<img width="319" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/89c5d5b3-1353-44d4-840e-22397da0013f">
<img width="326" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/17a59829-867e-4317-9023-f20bc4fe98a1">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
