### PR TITLE
[dy] Fix load sample data for integration pipelines

### DIFF
--- a/mage_ai/data_preparation/models/block/utils.py
+++ b/mage_ai/data_preparation/models/block/utils.py
@@ -16,6 +16,7 @@ from mage_ai.data_preparation.models.block.dynamic import (
 from mage_ai.data_preparation.models.constants import (
     DATAFRAME_ANALYSIS_MAX_COLUMNS,
     BlockType,
+    PipelineType,
 )
 from mage_ai.server.kernel_output_parser import DataType
 from mage_ai.shared.array import find, unique_by
@@ -513,22 +514,28 @@ def output_variables(
             partition=execution_partition,
         )
 
+    if should_reduce_output(block):
+        all_variables = all_variable_uuids(
+            block,
+            partition=execution_partition,
+        )
+    else:
+        all_variables = block.get_variables_by_block(
+            block_uuid=block_uuid,
+            partition=execution_partition,
+        )
+    output_variables = [v for v in all_variables
+                        if is_output_variable(v, include_df=include_df)]
+
     if block and di_settings:
         streams = get_selected_streams(di_settings.get('catalog'))
-        output_variables = [s.get('tap_stream_id') for s in streams]
-    else:
-        if should_reduce_output(block):
-            all_variables = all_variable_uuids(
-                block,
-                partition=execution_partition,
-            )
+        tap_stream_ids = [s.get('tap_stream_id') for s in streams]
+        # For integration pipelines, we want to include variables with the "output" prefix
+        # to view sample data for the selected streams.
+        if pipeline.type == PipelineType.INTEGRATION:
+            output_variables.extend(tap_stream_ids)
         else:
-            all_variables = block.get_variables_by_block(
-                block_uuid=block_uuid,
-                partition=execution_partition,
-            )
-        output_variables = [v for v in all_variables
-                            if is_output_variable(v, include_df=include_df)]
+            output_variables = tap_stream_ids
 
     output_variables.sort()
 

--- a/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
+++ b/mage_ai/data_preparation/models/pipelines/integration_pipeline.py
@@ -272,7 +272,6 @@ class IntegrationPipeline(Pipeline):
                             sample_data_json = data.get('sample_data')
                             sample_data = pd.DataFrame.from_dict(json.loads(sample_data_json))
                             stream_id = data.get('stream_id')
-
                             variables = {
                                 f'output_sample_data_{stream_id}': sample_data,
                             }

--- a/mage_ai/tests/data_preparation/models/test_block.py
+++ b/mage_ai/tests/data_preparation/models/test_block.py
@@ -13,6 +13,7 @@ from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.data_preparation.repo_manager import get_repo_config
 from mage_ai.data_preparation.variable_manager import VariableManager
 from mage_ai.tests.base_test import DBTestCase
+from mage_ai.tests.factory import create_integration_pipeline_with_blocks
 
 
 class BlockTest(DBTestCase):
@@ -707,3 +708,28 @@ def test_output(output, *args) -> None:
             block3.upstream_block_uuids[1],
             'test_data_loader_1',
         )
+
+    def test_output_variables_for_integration_pipeline_blocks(self):
+        pipeline = create_integration_pipeline_with_blocks(
+            'test integration pipeline',
+            repo_path=self.repo_path,
+        )
+        block = pipeline.get_block('test_integration_source')
+
+        df = pd.DataFrame(
+            [
+                [1, 'abc@xyz.com', '32132'],
+                [2, 'abc2@xyz.com', '12345'],
+                [3, 'test', '1234'],
+                [4, 'abc@test.net', 'abcde'],
+                [5, 'abc12345@', '54321'],
+                [6, 'abcdef@123.com', '56789'],
+            ],
+            columns=['id', 'email', 'zip_code'],
+        )
+
+        block.store_variables({
+            'output_sample_data_stream1': df
+        })
+        output_variables = block.output_variables()
+        self.assertTrue('output_sample_data_stream1' in output_variables)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Loading sample data from integration pipelines was not working when the data integration block in batch pipelines feature was enabled. This PR updates the load sample data logic for integration pipelines  so that the sample data can be properly fetched.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally by loading sample data from an integration pipeline source


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
