### PR TITLE
[jk] Clarification when applying bookmark to all streams

### DIFF
--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
@@ -1020,32 +1020,34 @@ function SchemaTable({
                 }
               </>
             }
-
-            <Spacing my={2}>
-              <Text bold large>
-                Valid replication keys
-              </Text>
-              <Text default inline>
-                If a stream&#39;s feature is not a valid replication key, it will not
-                be set as a bookmark property when applying the feature (from a different
-                stream) as a bookmark to all streams.&nbsp;
-              </Text>
-              {validReplicationKeys.length > 0 && (
-                <>
-                  <Text default inline>
-                    These are the valid replication keys for this stream:
-                  </Text>&nbsp;
-                  <Text inline monospace small>{validReplicationKeys.join(', ')}.</Text>
-                </>
-              )}
-              {validReplicationKeys.length === 0 &&
-                <Text default inline>
-                  This stream has no valid replication keys.
-                </Text>
-              }
-            </Spacing>
           </Spacing>
         )}
+
+        {(hasMultipleStreams && bookmarkProperties?.length > 0) &&
+          <Spacing mb={SPACING_BOTTOM_UNITS}>
+            <Text bold large>
+              Valid replication keys
+            </Text>
+            <Text default inline>
+              If a stream&#39;s feature is not a valid replication key, it will not
+              be set as a bookmark property when applying the feature (from a different
+              stream) as a bookmark to all streams.&nbsp;
+            </Text>
+            {validReplicationKeys.length > 0 && (
+              <>
+                <Text default inline>
+                  These are the valid replication keys for this stream:
+                </Text>&nbsp;
+                <Text inline monospace small>{validReplicationKeys.join(', ')}.</Text>
+              </>
+            )}
+            {validReplicationKeys.length === 0 &&
+              <Text default inline>
+                This stream has no valid replication keys.
+              </Text>
+            }
+          </Spacing>
+        }
 
         <Spacing mb={SPACING_BOTTOM_UNITS}>
           <Spacing mb={1}>

--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
@@ -1020,6 +1020,30 @@ function SchemaTable({
                 }
               </>
             }
+
+            <Spacing my={2}>
+              <Text bold large>
+                Valid replication keys
+              </Text>
+              <Text default inline>
+                If a stream&#39;s feature is not a valid replication key, it will not
+                be set as a bookmark property when applying the feature (from a different
+                stream) as a bookmark to all streams.&nbsp;
+              </Text>
+              {validReplicationKeys.length > 0 && (
+                <>
+                  <Text default inline>
+                    These are the valid replication keys for this stream:
+                  </Text>&nbsp;
+                  <Text inline monospace small>{validReplicationKeys.join(', ')}.</Text>
+                </>
+              )}
+              {validReplicationKeys.length === 0 &&
+                <Text default inline>
+                  This stream has no valid replication keys.
+                </Text>
+              }
+            </Spacing>
           </Spacing>
         )}
 

--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
@@ -45,6 +45,12 @@ import { pluralize } from '@utils/string';
 const SPACING_BOTTOM_UNITS = 5;
 const TOOLTIP_LEFT_SPACING = '4px';
 
+const SHARED_TOOLTIP_PROPS = {
+  lightBackground: true,
+  muted: true,
+  relativePosition: true,
+};
+
 export type SchemaTableProps = {
   bookmarkValues?: { [key: string]: any };
   destination: IntegrationDestinationEnum;
@@ -625,6 +631,7 @@ function SchemaTable({
             </Text>
             <Spacing ml={TOOLTIP_LEFT_SPACING} />
             <Tooltip
+              {...SHARED_TOOLTIP_PROPS}
               label={(
                 <Text>
                   By default, this stream will be saved to your destination under the
@@ -633,8 +640,6 @@ function SchemaTable({
                   </Text>. To change the table name, enter in a different value.
                 </Text>
               )}
-              lightBackground
-              primary
             />
             <Spacing ml={1} />
             <TextInput
@@ -671,6 +676,7 @@ function SchemaTable({
               </Text>
               <Spacing ml={TOOLTIP_LEFT_SPACING} />
               <Tooltip
+                {...SHARED_TOOLTIP_PROPS}
                 label={(
                   <Text>
                     Do you want to synchronize the entire stream (<Text bold inline monospace>
@@ -690,8 +696,6 @@ function SchemaTable({
                     }
                   </Text>
                 )}
-                lightBackground
-                primary
               />
               <Spacing ml={1} />
               <Select
@@ -724,6 +728,7 @@ function SchemaTable({
               </Text>
               <Spacing ml={TOOLTIP_LEFT_SPACING} />
               <Tooltip
+                {...SHARED_TOOLTIP_PROPS}
                 label={(
                   <Text wordBreak>
                     If a new record has the same value as an existing record in
@@ -751,8 +756,6 @@ function SchemaTable({
                     with the new record’s properties.
                   </Text>
                 )}
-                lightBackground
-                primary
               />
               <Spacing ml={1} />
               <Select
@@ -784,6 +787,7 @@ function SchemaTable({
                 </Text>
                 <Spacing ml={TOOLTIP_LEFT_SPACING} />
                 <Tooltip
+                  {...SHARED_TOOLTIP_PROPS}
                   appearBefore
                   label={(
                     <Text>
@@ -791,8 +795,6 @@ function SchemaTable({
                       unique conflict method settings to all selected streams.
                     </Text>
                   )}
-                  lightBackground
-                  primary
                 />
                 <Spacing ml={1} />
                 <Button

--- a/mage_ai/frontend/oracle/components/Tooltip/TooltipWrapper.tsx
+++ b/mage_ai/frontend/oracle/components/Tooltip/TooltipWrapper.tsx
@@ -31,6 +31,7 @@ export type TooltipWrapperProps = {
   minWidth?: number;
   muted?: boolean;
   noHoverOutline?: boolean;
+  relativePosition?: boolean;
   rightPosition?: boolean;
   size?: number;
   topOffset?: number;
@@ -41,6 +42,10 @@ export type TooltipWrapperProps = {
 
 const SHARED_CONTAINER_STYLES = css<TooltipWrapperProps>`
   position: static;
+
+  ${({ relativePosition }) => relativePosition && `
+    position: relative;
+  `}
 
   ${props => props.height && `
     height: ${props.height}px;
@@ -178,6 +183,7 @@ function TooltipWrapper({
   lightBackground,
   minWidth,
   noHoverOutline,
+  relativePosition,
   size = UNIT * 2,
   topOffset,
   visibleDelay = 1000,
@@ -236,6 +242,7 @@ function TooltipWrapper({
         setVisibleInterval(false);
         setVisible(false);
       }}
+      relativePosition={relativePosition}
       size={size}
     >
       {elRendered}


### PR DESCRIPTION
# Description
- If a data integration pipeline had multiple streams and a user tried applying a feature as a bookmark to all streams, the bookmark property may not get applied to the other streams if the other stream did NOT have that particular feature as a "valid replication key" in its metadata, which could be confusing to users wondering if the "Apply to all streams" feature was working properly. This PR adds a section in the schema settings to clarify valid replication keys and how it affects applying a feature as a bookmark to all streams. The "Valid replication keys" section will only be displayed if the integration pipeline has multiple streams and at least 1 bookmark property is selected.
- Bugfix: Fixed tooltip positioning in data integration pipeline schema table.

# How Has This Been Tested?
The `All streams` column header in the `Features` table already included a tooltip mentioning, "Bookmark features must be valid replication keys in other streams."
<img width="836" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/cc048c45-34c5-4ac7-9b3d-8e0197a0bf5c">

"Valid replication keys" section in settings (no valid replication keys in stream):
<img width="833" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/c558f367-d592-43c4-b55a-0063c65456d7">

"Valid replication keys" section (with at least 1 valid replication key in stream):
<img width="825" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/0bc1928b-8935-4817-8e0c-d9924a0ee91d">

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
