### PR TITLE
[td] Enable API operation tests with hooks and add more

### DIFF
--- a/mage_ai/data_preparation/models/global_hooks/constants.py
+++ b/mage_ai/data_preparation/models/global_hooks/constants.py
@@ -1,23 +1,44 @@
+from enum import Enum
+
 from mage_ai.authentication.permissions.constants import EntityName
 
 DISABLED_RESOURCE_TYPES = [
-  EntityName.ALL,
-  EntityName.ALL_EXCEPT_RESERVED,
-  EntityName.File,
-  EntityName.FileContent,
-  EntityName.Folder,
-  EntityName.GlobalHook,
-  EntityName.Oauth,
-  EntityName.OauthAccessToken,
-  EntityName.OauthApplication,
-  EntityName.Permission,
-  EntityName.Role,
-  EntityName.RolePermission,
-  EntityName.Secret,
-  EntityName.Session,
-  EntityName.User,
-  EntityName.UserRole,
-  EntityName.Workspace,
+    EntityName.ALL,
+    EntityName.ALL_EXCEPT_RESERVED,
+]
+
+RESTRICTED_RESOURCE_TYPES = [
+    EntityName.File,
+    EntityName.FileContent,
+    EntityName.Folder,
+    EntityName.GlobalHook,
+    EntityName.Oauth,
+    EntityName.OauthAccessToken,
+    EntityName.OauthApplication,
+    EntityName.Permission,
+    EntityName.Role,
+    EntityName.RolePermission,
+    EntityName.Secret,
+    EntityName.Session,
+    EntityName.User,
+    EntityName.UserRole,
+    EntityName.Workspace,
 ]
 
 RESOURCE_TYPES = [en for en in EntityName if en not in DISABLED_RESOURCE_TYPES]
+
+
+class HookOutputKey(str, Enum):
+    ERROR = 'error'
+    META = 'meta'
+    METADATA = 'metadata'
+    PAYLOAD = 'payload'
+    QUERY = 'query'
+    RESOURCE = 'resource'
+    RESOURCES = 'resources'
+
+
+VALID_KEYS_FOR_INPUT_OUTPUT_DATA_RESTRICTED = [key.value for key in HookOutputKey]
+VALID_KEYS_FOR_INPUT_OUTPUT_DATA_UNRESTRICTED = ['hook']
+VALID_KEYS_FOR_INPUT_OUTPUT_DATA_ALL = \
+    VALID_KEYS_FOR_INPUT_OUTPUT_DATA_RESTRICTED + VALID_KEYS_FOR_INPUT_OUTPUT_DATA_UNRESTRICTED

--- a/mage_ai/data_preparation/models/global_hooks/utils.py
+++ b/mage_ai/data_preparation/models/global_hooks/utils.py
@@ -1,0 +1,21 @@
+from typing import Dict
+
+from mage_ai.authentication.permissions.constants import EntityName
+from mage_ai.data_preparation.models.global_hooks.constants import (
+    DISABLED_RESOURCE_TYPES,
+    RESTRICTED_RESOURCE_TYPES,
+    VALID_KEYS_FOR_INPUT_OUTPUT_DATA_ALL,
+    VALID_KEYS_FOR_INPUT_OUTPUT_DATA_UNRESTRICTED,
+)
+from mage_ai.shared.hash import extract
+
+
+def extract_valid_data(resource_type: EntityName, input_data: Dict) -> Dict:
+    types = DISABLED_RESOURCE_TYPES + RESTRICTED_RESOURCE_TYPES
+    if not resource_type or resource_type in types:
+        return extract(input_data or {}, VALID_KEYS_FOR_INPUT_OUTPUT_DATA_UNRESTRICTED)
+
+    return extract(
+        input_data or {},
+        VALID_KEYS_FOR_INPUT_OUTPUT_DATA_ALL,
+    )

--- a/mage_ai/tests/api/operations/test_operations_with_hooks.py
+++ b/mage_ai/tests/api/operations/test_operations_with_hooks.py
@@ -1,533 +1,533 @@
-# import os
-# import uuid
+import os
+import uuid
 
-# from mage_ai.authentication.permissions.constants import EntityName
-# from mage_ai.data_preparation.models.constants import BlockType, PipelineType
-# from mage_ai.data_preparation.models.global_hooks.models import (
-#     GlobalHooks,
-#     HookCondition,
-#     HookOperation,
-#     HookOutputBlock,
-#     HookOutputKey,
-#     HookOutputSettings,
-#     HookPredicate,
-#     HookStage,
-# )
-# from mage_ai.data_preparation.models.pipeline import Pipeline
-# from mage_ai.data_preparation.models.project.constants import FeatureUUID
-# from mage_ai.data_preparation.repo_manager import get_repo_config
-# from mage_ai.shared.array import find
-# from mage_ai.tests.factory import build_pipeline_with_blocks_and_content
-# from mage_ai.tests.shared.mixins import GlobalHooksMixin, build_content
+from mage_ai.authentication.permissions.constants import EntityName
+from mage_ai.data_preparation.models.constants import BlockType, PipelineType
+from mage_ai.data_preparation.models.global_hooks.constants import HookOutputKey
+from mage_ai.data_preparation.models.global_hooks.models import (
+    GlobalHooks,
+    HookCondition,
+    HookOperation,
+    HookOutputBlock,
+    HookOutputSettings,
+    HookPredicate,
+    HookStage,
+)
+from mage_ai.data_preparation.models.pipeline import Pipeline
+from mage_ai.data_preparation.models.project.constants import FeatureUUID
+from mage_ai.data_preparation.repo_manager import get_repo_config
+from mage_ai.shared.array import find
+from mage_ai.tests.factory import build_pipeline_with_blocks_and_content
+from mage_ai.tests.shared.mixins import GlobalHooksMixin, build_content
 
 
-# class BaseOperationWithHooksTest(GlobalHooksMixin):
-#     model_class = Pipeline
+class BaseOperationWithHooksTest(GlobalHooksMixin):
+    model_class = Pipeline
 
-#     @classmethod
-#     def setUpClass(self):
-#         super().setUpClass()
+    @classmethod
+    def setUpClass(self):
+        super().setUpClass()
 
-#         repo_config = get_repo_config()
-#         repo_config.save(features={
-#             FeatureUUID.GLOBAL_HOOKS.value: True,
-#         })
+        repo_config = get_repo_config()
+        repo_config.save(features={
+            FeatureUUID.GLOBAL_HOOKS.value: True,
+        })
 
-#     def tearDown(self):
-#         file_path = GlobalHooks.file_path()
-#         if os.path.exists(file_path):
-#             os.remove(file_path)
+    def tearDown(self):
+        file_path = GlobalHooks.file_path()
+        if os.path.exists(file_path):
+            os.remove(file_path)
 
-#         if self.pipelines_created_for_testing:
-#             for pipeline in self.pipelines_created_for_testing:
-#                 try:
-#                     pipeline.delete()
-#                 except FileNotFoundError as err:
-#                     print(err)
+        if self.pipelines_created_for_testing:
+            for pipeline in self.pipelines_created_for_testing:
+                try:
+                    pipeline.delete()
+                except FileNotFoundError as err:
+                    print(err)
 
-#     async def test_list(self):
-#         await self.setUpAsync(
-#             block_settings={
-#                 0: dict(content=build_content({
-#                     'type[]': [PipelineType.PYTHON],
-#                 })),
-#             },
-#             operation_type=HookOperation.LIST,
-#             pipeline_type=PipelineType.PYTHON,
-#             predicates_match=[],
-#             predicates_miss=[],
-#         )
+    async def test_list(self):
+        await self.setUpAsync(
+            block_settings={
+                0: dict(content=build_content({
+                    'type[]': [PipelineType.PYTHON],
+                })),
+            },
+            operation_type=HookOperation.LIST,
+            pipeline_type=PipelineType.PYTHON,
+            predicates_match=[],
+            predicates_miss=[],
+        )
 
-#         pipeline3, _blocks = await build_pipeline_with_blocks_and_content(
-#             self,
-#             pipeline_type=PipelineType.PYSPARK,
-#         )
+        pipeline3, _blocks = await build_pipeline_with_blocks_and_content(
+            self,
+            pipeline_type=PipelineType.PYSPARK,
+        )
 
-#         await build_pipeline_with_blocks_and_content(
-#             self,
-#             pipeline_type=PipelineType.STREAMING,
-#         )
+        await build_pipeline_with_blocks_and_content(
+            self,
+            pipeline_type=PipelineType.STREAMING,
+        )
 
-#         response = await self.build_list_operation().execute()
+        response = await self.build_list_operation().execute()
 
-#         pipelines = response['pipelines']
+        pipelines = response['pipelines']
 
-#         self.assertEqual(len(pipelines), 3)
+        self.assertEqual(len(pipelines), 3)
 
-#         for pipeline in [self.pipeline1, self.pipeline2, pipeline3]:
-#             self.assertIsNotNone(find(
-#                 lambda x, pipeline=pipeline: x['uuid'] == pipeline.uuid,
-#                 pipelines,
-#             ))
+        for pipeline in [self.pipeline1, self.pipeline2, pipeline3]:
+            self.assertIsNotNone(find(
+                lambda x, pipeline=pipeline: x['uuid'] == pipeline.uuid,
+                pipelines,
+            ))
 
-#         self.assertEqual(
-#             response['metadata'],
-#             dict(
-#                 powers=dict(fire=1),
-#                 water=dict(level=2),
-#             ),
-#         )
+        self.assertEqual(
+            response['metadata'],
+            dict(
+                powers=dict(fire=1),
+                water=dict(level=2),
+            ),
+        )
 
-#     async def test_create(self):
-#         payload = dict(name=self.faker.unique.name(), type=PipelineType.STREAMING)
-#         name_final = self.faker.unique.name()
+    async def test_create(self):
+        payload = dict(name=self.faker.unique.name(), type=PipelineType.STREAMING)
+        name_final = self.faker.unique.name()
 
-#         await self.setUpAsync(
-#             block_settings={
-#                 0: dict(content=build_content(dict(type=PipelineType.PYSPARK))),
-#                 1: dict(content=build_content(dict(name=name_final))),
-#             },
-#             hook_settings=lambda data: {
-#                 0: dict(
-#                     outputs=[
-#                         HookOutputSettings.load(
-#                             block=HookOutputBlock.load(uuid=data['blocks1'][0].uuid),
-#                             key=HookOutputKey.PAYLOAD,
-#                         ),
-#                         HookOutputSettings.load(
-#                             block=HookOutputBlock.load(uuid=data['blocks1'][1].uuid),
-#                             key=HookOutputKey.PAYLOAD,
-#                         ),
-#                     ],
-#                     pipeline=dict(
-#                         uuid=data['pipeline1'].uuid,
-#                     ),
-#                 ),
-#             },
-#             operation_type=HookOperation.CREATE,
-#             predicates_match=[
-#                 [
-#                     HookPredicate.load(resource=dict(
-#                         type=PipelineType.STREAMING.value,
-#                     )),
-#                 ],
-#                 [
-#                     HookPredicate.load(resource=dict(
-#                         name=name_final,
-#                     )),
-#                 ],
-#             ],
-#             predicates_miss=[
-#                 [
-#                     HookPredicate.load(resource=dict(
-#                         name=uuid.uuid4().hex,
-#                     )),
-#                 ],
-#             ],
-#         )
+        await self.setUpAsync(
+            block_settings={
+                0: dict(content=build_content(dict(type=PipelineType.PYSPARK))),
+                1: dict(content=build_content(dict(name=name_final))),
+            },
+            hook_settings=lambda data: {
+                0: dict(
+                    outputs=[
+                        HookOutputSettings.load(
+                            block=HookOutputBlock.load(uuid=data['blocks1'][0].uuid),
+                            key=HookOutputKey.PAYLOAD,
+                        ),
+                        HookOutputSettings.load(
+                            block=HookOutputBlock.load(uuid=data['blocks1'][1].uuid),
+                            key=HookOutputKey.PAYLOAD,
+                        ),
+                    ],
+                    pipeline=dict(
+                        uuid=data['pipeline1'].uuid,
+                    ),
+                ),
+            },
+            operation_type=HookOperation.CREATE,
+            predicates_match=[
+                [
+                    HookPredicate.load(resource=dict(
+                        type=PipelineType.STREAMING.value,
+                    )),
+                ],
+                [
+                    HookPredicate.load(resource=dict(
+                        name=name_final,
+                    )),
+                ],
+            ],
+            predicates_miss=[
+                [
+                    HookPredicate.load(resource=dict(
+                        name=uuid.uuid4().hex,
+                    )),
+                ],
+            ],
+        )
 
-#         response = await self.build_create_operation(payload=payload).execute()
-#         pipeline = response['pipeline']
-#         self.assertEqual(pipeline['name'], name_final)
-#         self.assertEqual(pipeline['type'], PipelineType.PYSPARK.value)
+        response = await self.build_create_operation(payload=payload).execute()
+        pipeline = response['pipeline']
+        self.assertEqual(pipeline['name'], name_final)
+        self.assertEqual(pipeline['type'], PipelineType.PYSPARK.value)
 
-#         self.assertEqual(
-#             response['metadata'],
-#             dict(
-#                 powers=dict(fire=1),
-#                 water=dict(level=2),
-#             ),
-#         )
+        self.assertEqual(
+            response['metadata'],
+            dict(
+                powers=dict(fire=1),
+                water=dict(level=2),
+            ),
+        )
 
-#         Pipeline.get(pipeline['uuid']).delete()
+        Pipeline.get(pipeline['uuid']).delete()
 
-#     async def test_detail(self):
-#         name_final = self.faker.unique.name()
+    async def test_detail(self):
+        name_final = self.faker.unique.name()
 
-#         await self.setUpAsync(
-#             block_settings={
-#                 0: dict(content=build_content(dict())),
-#                 1: dict(content=build_content(dict())),
-#                 2: dict(content=build_content(dict(
-#                     name=name_final,
-#                     type=PipelineType.PYSPARK,
-#                 ))),
-#             },
-#             hook_settings=lambda data: {
-#                 2: dict(
-#                     outputs=[
-#                         HookOutputSettings.load(
-#                             block=HookOutputBlock.load(uuid=data['blocks1'][2].uuid),
-#                             key=HookOutputKey.RESOURCE,
-#                         ),
-#                     ],
-#                     pipeline=dict(
-#                         uuid=data['pipeline1'].uuid,
-#                     ),
-#                 ),
-#                 3: dict(
-#                     outputs=[
-#                         HookOutputSettings.load(
-#                             block=HookOutputBlock.load(uuid=data['blocks2'][3].uuid),
-#                             key=HookOutputKey.METADATA,
-#                         ),
-#                     ],
-#                     pipeline=dict(
-#                         uuid=data['pipeline2'].uuid,
-#                     ),
-#                 ),
-#             },
-#             operation_type=HookOperation.DETAIL,
-#             pipeline_type=PipelineType.PYTHON.value,
-#             predicates_match=[
-#                 [
-#                     HookPredicate.load(resource=dict(
-#                         type=PipelineType.PYTHON.value,
-#                     )),
-#                 ],
-#                 [
-#                     HookPredicate.load(resource=dict(
-#                         name=PipelineType.PYSPARK.value,
-#                     )),
-#                 ],
-#             ],
-#             predicates_miss=[
-#                 [
-#                     HookPredicate.load(resource=dict(
-#                         name=uuid.uuid4().hex,
-#                     )),
-#                 ],
-#             ],
-#         )
+        await self.setUpAsync(
+            block_settings={
+                0: dict(content=build_content(dict())),
+                1: dict(content=build_content(dict())),
+                2: dict(content=build_content(dict(
+                    name=name_final,
+                    type=PipelineType.PYSPARK,
+                ))),
+            },
+            hook_settings=lambda data: {
+                2: dict(
+                    outputs=[
+                        HookOutputSettings.load(
+                            block=HookOutputBlock.load(uuid=data['blocks1'][2].uuid),
+                            key=HookOutputKey.RESOURCE,
+                        ),
+                    ],
+                    pipeline=dict(
+                        uuid=data['pipeline1'].uuid,
+                    ),
+                ),
+                3: dict(
+                    outputs=[
+                        HookOutputSettings.load(
+                            block=HookOutputBlock.load(uuid=data['blocks2'][3].uuid),
+                            key=HookOutputKey.METADATA,
+                        ),
+                    ],
+                    pipeline=dict(
+                        uuid=data['pipeline2'].uuid,
+                    ),
+                ),
+            },
+            operation_type=HookOperation.DETAIL,
+            pipeline_type=PipelineType.PYTHON.value,
+            predicates_match=[
+                [
+                    HookPredicate.load(resource=dict(
+                        type=PipelineType.PYTHON.value,
+                    )),
+                ],
+                [
+                    HookPredicate.load(resource=dict(
+                        name=PipelineType.PYSPARK.value,
+                    )),
+                ],
+            ],
+            predicates_miss=[
+                [
+                    HookPredicate.load(resource=dict(
+                        name=uuid.uuid4().hex,
+                    )),
+                ],
+            ],
+        )
 
-#         response = await self.build_detail_operation(self.pipeline2.uuid).execute()
-#         pipeline = response['pipeline']
-#         self.assertEqual(pipeline['name'], name_final)
-#         self.assertEqual(pipeline['type'], PipelineType.PYSPARK.value)
+        response = await self.build_detail_operation(self.pipeline2.uuid).execute()
+        pipeline = response['pipeline']
+        self.assertEqual(pipeline['name'], name_final)
+        self.assertEqual(pipeline['type'], PipelineType.PYSPARK.value)
 
-#         self.assertEqual(
-#             response['metadata'],
-#             dict(level=2),
-#         )
+        self.assertEqual(
+            response['metadata'],
+            dict(level=2),
+        )
 
-#     async def test_update(self):
-#         description_init = self.faker.unique.name()
-#         description_final = self.faker.unique.name()
-#         tags_init = ['fire']
-#         tags_final = ['water']
-#         uuid_final = self.faker.unique.name()
+    async def test_update(self):
+        description_init = self.faker.unique.name()
+        description_final = self.faker.unique.name()
+        tags_init = ['fire']
+        tags_final = ['water']
+        uuid_final = self.faker.unique.name()
 
-#         payload = dict(description=description_init, tags=tags_init)
+        payload = dict(description=description_init, tags=tags_init)
 
-#         await self.setUpAsync(
-#             block_settings={
-#                 0: dict(content=build_content(dict(
-#                     description=description_final,
-#                 ))),
-#                 1: dict(content=build_content(dict(
-#                     tags=tags_final,
-#                 ))),
-#                 2: dict(content=build_content(dict(
-#                     uuid=uuid_final,
-#                 ))),
-#             },
-#             hook_settings=lambda data: {
-#                 0: dict(
-#                     outputs=[
-#                         HookOutputSettings.load(
-#                             block=HookOutputBlock.load(uuid=data['blocks1'][0].uuid),
-#                             key=HookOutputKey.PAYLOAD,
-#                         ),
-#                     ],
-#                     pipeline=dict(
-#                         uuid=data['pipeline1'].uuid,
-#                     ),
-#                 ),
-#                 1: dict(
-#                     outputs=[
-#                         HookOutputSettings.load(
-#                             block=HookOutputBlock.load(uuid=data['blocks1'][1].uuid),
-#                             key=HookOutputKey.PAYLOAD,
-#                         ),
-#                     ],
-#                     pipeline=dict(
-#                         uuid=data['pipeline1'].uuid,
-#                     ),
-#                 ),
-#                 2: dict(
-#                     outputs=[
-#                         HookOutputSettings.load(
-#                             block=HookOutputBlock.load(uuid=data['blocks1'][2].uuid),
-#                             key=HookOutputKey.RESOURCE,
-#                         ),
-#                     ],
-#                     pipeline=dict(
-#                         uuid=data['pipeline1'].uuid,
-#                     ),
-#                 ),
-#                 3: dict(
-#                     outputs=[
-#                         HookOutputSettings.load(
-#                             block=HookOutputBlock.load(uuid=data['blocks2'][3].uuid),
-#                             key=HookOutputKey.METADATA,
-#                         ),
-#                     ],
-#                     pipeline=dict(
-#                         uuid=data['pipeline2'].uuid,
-#                     ),
-#                 ),
-#             },
-#             operation_type=HookOperation.UPDATE,
-#             pipeline_type=PipelineType.PYTHON.value,
-#             predicates_match=[
-#                 [
-#                     HookPredicate.load(resource=dict(
-#                         type=PipelineType.PYTHON.value,
-#                     )),
-#                 ],
-#             ],
-#             predicates_miss=[
-#                 [
-#                     HookPredicate.load(resource=dict(
-#                         name=uuid.uuid4().hex,
-#                     )),
-#                 ],
-#             ],
-#         )
+        await self.setUpAsync(
+            block_settings={
+                0: dict(content=build_content(dict(
+                    description=description_final,
+                ))),
+                1: dict(content=build_content(dict(
+                    tags=tags_final,
+                ))),
+                2: dict(content=build_content(dict(
+                    uuid=uuid_final,
+                ))),
+            },
+            hook_settings=lambda data: {
+                0: dict(
+                    outputs=[
+                        HookOutputSettings.load(
+                            block=HookOutputBlock.load(uuid=data['blocks1'][0].uuid),
+                            key=HookOutputKey.PAYLOAD,
+                        ),
+                    ],
+                    pipeline=dict(
+                        uuid=data['pipeline1'].uuid,
+                    ),
+                ),
+                1: dict(
+                    outputs=[
+                        HookOutputSettings.load(
+                            block=HookOutputBlock.load(uuid=data['blocks1'][1].uuid),
+                            key=HookOutputKey.PAYLOAD,
+                        ),
+                    ],
+                    pipeline=dict(
+                        uuid=data['pipeline1'].uuid,
+                    ),
+                ),
+                2: dict(
+                    outputs=[
+                        HookOutputSettings.load(
+                            block=HookOutputBlock.load(uuid=data['blocks1'][2].uuid),
+                            key=HookOutputKey.RESOURCE,
+                        ),
+                    ],
+                    pipeline=dict(
+                        uuid=data['pipeline1'].uuid,
+                    ),
+                ),
+                3: dict(
+                    outputs=[
+                        HookOutputSettings.load(
+                            block=HookOutputBlock.load(uuid=data['blocks2'][3].uuid),
+                            key=HookOutputKey.METADATA,
+                        ),
+                    ],
+                    pipeline=dict(
+                        uuid=data['pipeline2'].uuid,
+                    ),
+                ),
+            },
+            operation_type=HookOperation.UPDATE,
+            pipeline_type=PipelineType.PYTHON.value,
+            predicates_match=[
+                [
+                    HookPredicate.load(resource=dict(
+                        type=PipelineType.PYTHON.value,
+                    )),
+                ],
+            ],
+            predicates_miss=[
+                [
+                    HookPredicate.load(resource=dict(
+                        name=uuid.uuid4().hex,
+                    )),
+                ],
+            ],
+        )
 
-#         response = await self.build_update_operation(
-#             self.pipeline2.uuid,
-#             payload=dict(pipeline=payload),
-#         ).execute()
-#         pipeline = response['pipeline']
-#         self.assertEqual(pipeline['description'], description_final)
-#         self.assertEqual(pipeline['tags'], ['water'])
-#         self.assertEqual(pipeline['uuid'], uuid_final)
+        response = await self.build_update_operation(
+            self.pipeline2.uuid,
+            payload=dict(pipeline=payload),
+        ).execute()
+        pipeline = response['pipeline']
+        self.assertEqual(pipeline['description'], description_final)
+        self.assertEqual(pipeline['tags'], ['water'])
+        self.assertEqual(pipeline['uuid'], uuid_final)
 
-#         self.assertEqual(
-#             response['metadata'],
-#             dict(level=2),
-#         )
+        self.assertEqual(
+            response['metadata'],
+            dict(level=2),
+        )
 
-#     async def test_delete(self):
-#         name_final = uuid.uuid4().hex
-#         uuid_final = uuid.uuid4().hex
+    async def test_delete(self):
+        name_final = uuid.uuid4().hex
+        uuid_final = uuid.uuid4().hex
 
-#         await self.setUpAsync(
-#             block_settings={
-#                 0: dict(content=build_content(dict(
-#                     name=name_final,
-#                 ))),
-#                 1: dict(content=build_content(dict(
-#                     name='should not be this value because hook1 only runs on failure condition',
-#                 ))),
-#                 2: dict(content=build_content(dict(
-#                     uuid=uuid_final,
-#                 ))),
-#             },
-#             hook_settings=lambda data: {
-#                 0: dict(
-#                     conditions=[HookCondition.SUCCESS, HookCondition.FAILURE],
-#                     outputs=[
-#                         HookOutputSettings.load(
-#                             block=HookOutputBlock.load(uuid=data['blocks1'][0].uuid),
-#                             key=HookOutputKey.RESOURCE,
-#                         ),
-#                     ],
-#                     pipeline=dict(
-#                         uuid=data['pipeline1'].uuid,
-#                     ),
-#                     stages=[HookStage.BEFORE, HookStage.AFTER],
-#                 ),
-#                 1: dict(
-#                     conditions=[HookCondition.FAILURE],
-#                     outputs=[
-#                         HookOutputSettings.load(
-#                             block=HookOutputBlock.load(uuid=data['blocks1'][1].uuid),
-#                             key=HookOutputKey.RESOURCE,
-#                         ),
-#                     ],
-#                     pipeline=dict(
-#                         uuid=data['pipeline1'].uuid,
-#                     ),
-#                     stages=[HookStage.BEFORE, HookStage.AFTER],
-#                 ),
-#                 2: dict(
-#                     outputs=[
-#                         HookOutputSettings.load(
-#                             block=HookOutputBlock.load(uuid=data['blocks1'][2].uuid),
-#                             key=HookOutputKey.RESOURCE,
-#                         ),
-#                     ],
-#                     pipeline=dict(
-#                         uuid=data['pipeline1'].uuid,
-#                     ),
-#                 ),
-#                 3: dict(
-#                     outputs=[
-#                         HookOutputSettings.load(
-#                             block=HookOutputBlock.load(uuid=data['blocks1'][3].uuid),
-#                             key=HookOutputKey.METADATA,
-#                         ),
-#                     ],
-#                     pipeline=dict(
-#                         uuid=data['pipeline1'].uuid,
-#                     ),
-#                 ),
-#             },
-#             operation_type=HookOperation.DELETE,
-#             pipeline_type=PipelineType.PYTHON.value,
-#             predicates_match=[
-#                 [
-#                     HookPredicate.load(resource=dict(
-#                         type=PipelineType.PYTHON.value,
-#                     )),
-#                 ],
-#             ],
-#             predicates_miss=[
-#                 [
-#                     HookPredicate.load(resource=dict(
-#                         name=uuid.uuid4().hex,
-#                     )),
-#                 ],
-#             ],
-#         )
+        await self.setUpAsync(
+            block_settings={
+                0: dict(content=build_content(dict(
+                    name=name_final,
+                ))),
+                1: dict(content=build_content(dict(
+                    name='should not be this value because hook1 only runs on failure condition',
+                ))),
+                2: dict(content=build_content(dict(
+                    uuid=uuid_final,
+                ))),
+            },
+            hook_settings=lambda data: {
+                0: dict(
+                    conditions=[HookCondition.SUCCESS, HookCondition.FAILURE],
+                    outputs=[
+                        HookOutputSettings.load(
+                            block=HookOutputBlock.load(uuid=data['blocks1'][0].uuid),
+                            key=HookOutputKey.RESOURCE,
+                        ),
+                    ],
+                    pipeline=dict(
+                        uuid=data['pipeline1'].uuid,
+                    ),
+                    stages=[HookStage.BEFORE, HookStage.AFTER],
+                ),
+                1: dict(
+                    conditions=[HookCondition.FAILURE],
+                    outputs=[
+                        HookOutputSettings.load(
+                            block=HookOutputBlock.load(uuid=data['blocks1'][1].uuid),
+                            key=HookOutputKey.RESOURCE,
+                        ),
+                    ],
+                    pipeline=dict(
+                        uuid=data['pipeline1'].uuid,
+                    ),
+                    stages=[HookStage.BEFORE, HookStage.AFTER],
+                ),
+                2: dict(
+                    outputs=[
+                        HookOutputSettings.load(
+                            block=HookOutputBlock.load(uuid=data['blocks1'][2].uuid),
+                            key=HookOutputKey.RESOURCE,
+                        ),
+                    ],
+                    pipeline=dict(
+                        uuid=data['pipeline1'].uuid,
+                    ),
+                ),
+                3: dict(
+                    outputs=[
+                        HookOutputSettings.load(
+                            block=HookOutputBlock.load(uuid=data['blocks1'][3].uuid),
+                            key=HookOutputKey.METADATA,
+                        ),
+                    ],
+                    pipeline=dict(
+                        uuid=data['pipeline1'].uuid,
+                    ),
+                ),
+            },
+            operation_type=HookOperation.DELETE,
+            pipeline_type=PipelineType.PYTHON.value,
+            predicates_match=[
+                [
+                    HookPredicate.load(resource=dict(
+                        type=PipelineType.PYTHON.value,
+                    )),
+                ],
+            ],
+            predicates_miss=[
+                [
+                    HookPredicate.load(resource=dict(
+                        name=uuid.uuid4().hex,
+                    )),
+                ],
+            ],
+        )
 
-#         response = await self.build_delete_operation(self.pipeline2.uuid).execute()
-#         pipeline = response['pipeline']
-#         self.assertEqual(pipeline['name'], name_final)
-#         self.assertEqual(pipeline['uuid'], uuid_final)
+        response = await self.build_delete_operation(self.pipeline2.uuid).execute()
+        pipeline = response['pipeline']
+        self.assertEqual(pipeline['name'], name_final)
+        self.assertEqual(pipeline['uuid'], uuid_final)
 
-#         self.assertEqual(
-#             response['metadata'],
-#             dict(level=2),
-#         )
+        self.assertEqual(
+            response['metadata'],
+            dict(level=2),
+        )
 
-#         error = False
-#         try:
-#             Pipeline.get(self.pipeline2.uuid)
-#         except Exception:
-#             error = True
-#         self.assertTrue(error)
+        error = False
+        try:
+            Pipeline.get(self.pipeline2.uuid)
+        except Exception:
+            error = True
+        self.assertTrue(error)
 
-#     async def test_update_pipeline_blocks(self):
-#         color = uuid.uuid4().hex
-#         configuration = dict(power=uuid.uuid4().hex)
+    async def test_update_pipeline_blocks(self):
+        color = uuid.uuid4().hex
+        configuration = dict(power=uuid.uuid4().hex)
 
-#         await self.setUpAsync(
-#             block_settings={
-#                 0: dict(content=build_content(dict(
-#                     color=color,
-#                 ))),
-#                 1: dict(content=build_content(dict(
-#                     configuration=configuration,
-#                 ))),
-#                 2: dict(
-#                     content=build_content(dict()),
-#                     block_type=BlockType.DATA_EXPORTER.value,
-#                 ),
-#             },
-#             hook_settings=lambda data: {
-#                 0: dict(
-#                     outputs=[
-#                         HookOutputSettings.load(
-#                             block=HookOutputBlock.load(uuid=data['blocks1'][0].uuid),
-#                             key=HookOutputKey.PAYLOAD,
-#                         ),
-#                     ],
-#                     pipeline=dict(
-#                         uuid=data['pipeline1'].uuid,
-#                     ),
-#                 ),
-#                 1: dict(
-#                     outputs=[
-#                         HookOutputSettings.load(
-#                             block=HookOutputBlock.load(uuid=data['blocks1'][1].uuid),
-#                             key=HookOutputKey.PAYLOAD,
-#                         ),
-#                     ],
-#                     pipeline=dict(
-#                         uuid=data['pipeline1'].uuid,
-#                     ),
-#                 ),
-#                 2: dict(
-#                     outputs=[
-#                         HookOutputSettings.load(
-#                             block=HookOutputBlock.load(uuid=data['blocks1'][2].uuid),
-#                             key=HookOutputKey.PAYLOAD,
-#                         ),
-#                     ],
-#                     pipeline=dict(
-#                         uuid=data['pipeline1'].uuid,
-#                     ),
-#                     stages=[HookStage.BEFORE],
-#                 ),
-#             },
-#             operation_type=HookOperation.UPDATE_ANYWHERE,
-#             pipeline_type=PipelineType.PYTHON.value,
-#             predicates_match=[
-#                 [
-#                     HookPredicate.load(resource=dict(
-#                         type=BlockType.DATA_LOADER.value,
-#                     )),
-#                 ],
-#                 [
-#                     HookPredicate.load(resource=dict(
-#                         type=BlockType.TRANSFORMER.value,
-#                     )),
-#                 ],
-#             ],
-#             predicates_miss=[
-#                 [
-#                     HookPredicate.load(resource=dict(
-#                         type=BlockType.MARKDOWN.value,
-#                     )),
-#                 ],
-#             ],
-#             resource_type=EntityName.Block,
-#         )
+        await self.setUpAsync(
+            block_settings={
+                0: dict(content=build_content(dict(
+                    color=color,
+                ))),
+                1: dict(content=build_content(dict(
+                    configuration=configuration,
+                ))),
+                2: dict(
+                    content=build_content(dict()),
+                    block_type=BlockType.DATA_EXPORTER.value,
+                ),
+            },
+            hook_settings=lambda data: {
+                0: dict(
+                    outputs=[
+                        HookOutputSettings.load(
+                            block=HookOutputBlock.load(uuid=data['blocks1'][0].uuid),
+                            key=HookOutputKey.PAYLOAD,
+                        ),
+                    ],
+                    pipeline=dict(
+                        uuid=data['pipeline1'].uuid,
+                    ),
+                ),
+                1: dict(
+                    outputs=[
+                        HookOutputSettings.load(
+                            block=HookOutputBlock.load(uuid=data['blocks1'][1].uuid),
+                            key=HookOutputKey.PAYLOAD,
+                        ),
+                    ],
+                    pipeline=dict(
+                        uuid=data['pipeline1'].uuid,
+                    ),
+                ),
+                2: dict(
+                    outputs=[
+                        HookOutputSettings.load(
+                            block=HookOutputBlock.load(uuid=data['blocks1'][2].uuid),
+                            key=HookOutputKey.PAYLOAD,
+                        ),
+                    ],
+                    pipeline=dict(
+                        uuid=data['pipeline1'].uuid,
+                    ),
+                    stages=[HookStage.BEFORE],
+                ),
+            },
+            operation_type=HookOperation.UPDATE_ANYWHERE,
+            pipeline_type=PipelineType.PYTHON.value,
+            predicates_match=[
+                [
+                    HookPredicate.load(resource=dict(
+                        type=BlockType.DATA_LOADER.value,
+                    )),
+                ],
+                [
+                    HookPredicate.load(resource=dict(
+                        type=BlockType.TRANSFORMER.value,
+                    )),
+                ],
+            ],
+            predicates_miss=[
+                [
+                    HookPredicate.load(resource=dict(
+                        type=BlockType.MARKDOWN.value,
+                    )),
+                ],
+            ],
+            resource_type=EntityName.Block,
+        )
 
-#         blocks = []
-#         for block in self.pipeline2.blocks_by_uuid.values():
-#             data = block.to_dict()
-#             data['color'] = 'should not be this unless data exporter'
-#             data['configuration'] = dict(power='should not be this unless data exporter')
-#             blocks.append(data)
+        blocks = []
+        for block in self.pipeline2.blocks_by_uuid.values():
+            data = block.to_dict()
+            data['color'] = 'should not be this unless data exporter'
+            data['configuration'] = dict(power='should not be this unless data exporter')
+            blocks.append(data)
 
-#         payload = dict(blocks=blocks)
+        payload = dict(blocks=blocks)
 
-#         response = await self.build_update_operation(
-#             self.pipeline2.uuid,
-#             payload=dict(pipeline=payload),
-#             query=dict(
-#                 update_content=[True],
-#             ),
-#         ).execute()
-#         pipeline = response['pipeline']
-#         blocks_from_response = pipeline['blocks']
+        response = await self.build_update_operation(
+            self.pipeline2.uuid,
+            payload=dict(pipeline=payload),
+            query=dict(
+                update_content=[True],
+            ),
+        ).execute()
+        pipeline = response['pipeline']
+        blocks_from_response = pipeline['blocks']
 
-#         block21, block22, block23, block24 = self.blocks2
-#         for block in [block21, block22, block24]:
-#             block_from_response = find(
-#                 lambda x, block=block: x['uuid'] == block.uuid,
-#                 blocks_from_response,
-#             )
-#             self.assertEqual(block_from_response['color'], color)
-#             self.assertEqual(block_from_response['configuration'], configuration)
+        block21, block22, block23, block24 = self.blocks2
+        for block in [block21, block22, block24]:
+            block_from_response = find(
+                lambda x, block=block: x['uuid'] == block.uuid,
+                blocks_from_response,
+            )
+            self.assertEqual(block_from_response['color'], color)
+            self.assertEqual(block_from_response['configuration'], configuration)
 
-#         block_from_response = find(
-#             lambda x: x['uuid'] == block23.uuid,
-#             blocks_from_response,
-#         )
-#         self.assertEqual(block_from_response['color'], blocks[2]['color'])
-#         self.assertEqual(block_from_response['configuration'], blocks[2]['configuration'])
+        block_from_response = find(
+            lambda x: x['uuid'] == block23.uuid,
+            blocks_from_response,
+        )
+        self.assertEqual(block_from_response['color'], blocks[2]['color'])
+        self.assertEqual(block_from_response['configuration'], blocks[2]['configuration'])

--- a/mage_ai/tests/data_preparation/models/global_hooks/test_utils.py
+++ b/mage_ai/tests/data_preparation/models/global_hooks/test_utils.py
@@ -1,0 +1,33 @@
+import uuid
+
+from mage_ai.authentication.permissions.constants import EntityName
+from mage_ai.data_preparation.models.global_hooks.constants import (
+    DISABLED_RESOURCE_TYPES,
+    RESTRICTED_RESOURCE_TYPES,
+    VALID_KEYS_FOR_INPUT_OUTPUT_DATA_ALL,
+)
+from mage_ai.data_preparation.models.global_hooks.utils import extract_valid_data
+from mage_ai.shared.hash import ignore_keys
+from mage_ai.tests.base_test import AsyncDBTestCase
+
+
+class GlobalHookUtilsTest(AsyncDBTestCase):
+    def test_extract_valid_data(self):
+        data = dict(
+            mage=uuid.uuid4().hex,
+        )
+
+        for key in VALID_KEYS_FOR_INPUT_OUTPUT_DATA_ALL:
+            data[key] = uuid.uuid4().hex
+
+        types = DISABLED_RESOURCE_TYPES + RESTRICTED_RESOURCE_TYPES
+        for entity_name in EntityName:
+            if entity_name in [EntityName.ALL, EntityName.ALL_EXCEPT_RESERVED]:
+                continue
+
+            extracted_data = extract_valid_data(entity_name, data)
+
+            if entity_name in types:
+                self.assertEqual(extracted_data, dict(hook=data['hook']))
+            else:
+                self.assertEqual(extracted_data, ignore_keys(data, ['mage']))

--- a/mage_ai/tests/shared/mixins.py
+++ b/mage_ai/tests/shared/mixins.py
@@ -5,13 +5,13 @@ from typing import Callable, Dict, List
 
 from mage_ai.authentication.permissions.constants import EntityName
 from mage_ai.data_preparation.models.constants import PipelineType
+from mage_ai.data_preparation.models.global_hooks.constants import HookOutputKey
 from mage_ai.data_preparation.models.global_hooks.models import (
     GlobalHooks,
     Hook,
     HookCondition,
     HookOperation,
     HookOutputBlock,
-    HookOutputKey,
     HookOutputSettings,
     HookPredicate,
     HookStage,


### PR DESCRIPTION
# Description
- For restricted resource types, remove the input and output data
- Add tests for restricted resource types
- Uncomment API operation tests for using hooks

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
