### PR TITLE
[sm] Add RabbitMQ as streaming data sink

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -290,6 +290,7 @@
                 "streaming/destinations/mysql",
                 "streaming/destinations/opensearch",
                 "streaming/destinations/postgres",
+                "streaming/destinations/rabbitmq",
                 "streaming/destinations/redshift",
                 "streaming/destinations/snowflake",
                 "streaming/destinations/trino"

--- a/docs/streaming/destinations/rabbitmq.mdx
+++ b/docs/streaming/destinations/rabbitmq.mdx
@@ -1,0 +1,15 @@
+---
+title: "RabbitMQ"
+---
+
+## Basic config
+
+```yaml
+connector_type: rabbitmq
+connection_host: 'localhost'
+connection_port: 5672
+queue_name: 'queue_name'
+username: 'guest'
+password: 'guest'
+amqp_url_virtual_host: '%2f'
+```

--- a/mage_ai/data_preparation/templates/data_exporters/streaming/rabbitmq.yaml
+++ b/mage_ai/data_preparation/templates/data_exporters/streaming/rabbitmq.yaml
@@ -1,0 +1,7 @@
+connector_type: 'rabbitmq'
+connection_host: 'localhost'
+connection_port: 5672
+queue_name: 'default'
+username: 'guest'
+password: 'guest'
+amqp_url_virtual_host: '%2f'

--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/utils.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/utils.tsx
@@ -59,6 +59,7 @@ const getDataSourceTypes = (
         DataSourceTypeEnum.MYSQL,
         DataSourceTypeEnum.OPENSEARCH,
         DataSourceTypeEnum.POSTGRES,
+        DataSourceTypeEnum.RABBITMQ,
         DataSourceTypeEnum.REDSHIFT,
         DataSourceTypeEnum.SNOWFLAKE,
         DataSourceTypeEnum.TRINO,

--- a/mage_ai/streaming/constants.py
+++ b/mage_ai/streaming/constants.py
@@ -37,6 +37,7 @@ class SinkType(str, Enum):
     OPENSEARCH = 'opensearch'
     ORACLEDB = 'oracledb'
     POSTGRES = 'postgres'
+    RABBITMQ = 'rabbitmq'
     REDSHIFT = 'redshift'
     SNOWFLAKE = 'snowflake'
     TRINO = 'trino'

--- a/mage_ai/streaming/sinks/rabbitmq.py
+++ b/mage_ai/streaming/sinks/rabbitmq.py
@@ -1,0 +1,76 @@
+import json
+from dataclasses import dataclass
+from typing import Dict, List
+
+import pika
+
+from mage_ai.shared.config import BaseConfig
+from mage_ai.streaming.sinks.base import BaseSink
+
+
+@dataclass
+class RabbitMQConfig(BaseConfig):
+    connection_host: str
+    connection_port: int
+    queue_name: str
+    username: str = 'guest'
+    password: str = 'guest'
+    amqp_url_virtual_host: str = r'%2f'
+
+
+class RabbitMQSink(BaseSink):
+    config_class = RabbitMQConfig
+
+    def init_client(self):
+        self._print('Start initializing producer.')
+        # Initialize RabbitMQ producer
+        queue_name = self.config.queue_name
+        username = self.config.username
+        password = self.config.password
+        connection_host = self.config.connection_host
+        connection_port = self.config.connection_port
+        vt_host = self.config.amqp_url_virtual_host
+
+        self._print(f'Starting to initialize producer for queue {queue_name}')
+
+        try:
+            generated_url = f"amqp://{username}:{password}@" \
+                            f"{connection_host}:{connection_port}/{vt_host}"
+
+            self._print(f'Trying to connect on {generated_url}')
+            self.connection = pika.BlockingConnection(
+                pika.URLParameters(
+                    generated_url
+                )
+            )
+
+            self.main_channel = self.connection.channel()
+            self._print('Finish initializing producer.')
+        except Exception as e:
+            self._print('Connection Error! Please check RabbitMQ connection')
+            raise e
+
+    def write(self, message: Dict):
+        pass
+
+    def batch_write(self, messages: List[Dict]):
+        if not messages:
+            return
+        self._print(
+            f'Batch ingest {len(messages)} messages. Sample: {messages[0]}'
+        )
+        for message in messages:
+            if isinstance(message, dict):
+                data = message.get('data', message)
+                metadata = message.get('metadata', None)
+            else:
+                data = message
+                metadata = None
+            message_properties = pika.BasicProperties(headers=metadata)
+            self.main_channel.basic_publish(
+                exchange='',
+                routing_key=self.config.queue_name,
+                body=json.dumps(data).encode('utf-8'),
+                properties=message_properties,
+                mandatory=True,
+            )

--- a/mage_ai/streaming/sinks/sink_factory.py
+++ b/mage_ai/streaming/sinks/sink_factory.py
@@ -53,6 +53,10 @@ class SinkFactory:
             from mage_ai.streaming.sinks.postgres import PostgresSink
 
             return PostgresSink(config, **kwargs)
+        elif connector_type == SinkType.RABBITMQ:
+            from mage_ai.streaming.sinks.rabbitmq import RabbitMQSink
+
+            return RabbitMQSink(config, **kwargs)
         elif connector_type in GENERIC_IO_SINK_TYPES:
             from mage_ai.streaming.sinks.generic_io import GenericIOSink
 

--- a/mage_ai/tests/streaming/sinks/test_rabbitmq.py
+++ b/mage_ai/tests/streaming/sinks/test_rabbitmq.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+
+from mage_ai.streaming.sinks.rabbitmq import RabbitMQSink
+from mage_ai.tests.base_test import TestCase
+
+
+class KinesisTests(TestCase):
+    def test_init(self):
+        with patch.object(RabbitMQSink, 'init_client') as mock_init_client:
+            RabbitMQSink(dict(
+                connector_type='rabbitmq',
+                connection_host='localhost',
+                connection_port='5672',
+                queue_name='queue_name',
+                username='guest',
+                password='guest',
+                amqp_url_virtual_host='%2f',
+            ))
+            mock_init_client.assert_called_once()
+
+    def test_init_invalid_config(self):
+        with patch.object(RabbitMQSink, 'init_client') as mock_init_client:
+            with self.assertRaises(Exception) as context:
+                RabbitMQSink(dict(
+                    connector_type='rabbitmq',
+                    connection_port='5672',
+                    queue_name='queue_name',
+                    username='guest',
+                    password='guest',
+                    amqp_url_virtual_host='%2f',
+                ))
+            self.assertTrue(
+                '__init__() missing 1 required positional argument: \'connection_host\''
+                in str(context.exception),
+            )
+            self.assertEqual(mock_init_client.call_count, 0)


### PR DESCRIPTION
# Description
Add RabbitMQ as streaming data sink

## Loading data from one RabbitMQ queue into another
![Screenshot 2023-11-21 at 9 28 12 PM](https://github.com/mage-ai/mage-ai/assets/6594483/f0ab55da-fb08-4818-abc6-9c9175651ba4)
![Screenshot 2023-11-21 at 9 27 43 PM](https://github.com/mage-ai/mage-ai/assets/6594483/64edc891-856f-4613-981d-5c13bf2aa668)

## Loading data from Kafka queue into RabbitMQ queue
![Screenshot 2023-11-21 at 9 32 34 PM](https://github.com/mage-ai/mage-ai/assets/6594483/9b7c4eac-ab47-4aa9-91bf-7418ca1dea93)
![Screenshot 2023-11-21 at 9 31 41 PM](https://github.com/mage-ai/mage-ai/assets/6594483/fcc85e56-a087-4237-a904-a3775712ba82)



# How Has This Been Tested?

- [ Yes ] Tested by running locally
- [ Yes ] Added RabbitMQ streaming sink test

# Checklist
- [ Yes ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ Yes ] I have performed a self-review of my own code
- [ Yes ] I have added unit tests that prove my fix is effective or that my feature works
- [ Yes ] I have commented my code, particularly in hard-to-understand areas
- [ Yes ] I have made corresponding changes to the documentation
- [ Yes ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
