### PR TITLE
[xy] Allow using block configuration when run_pipeline_in_one_process is true

### DIFF
--- a/mage_ai/data_preparation/executors/pipeline_executor.py
+++ b/mage_ai/data_preparation/executors/pipeline_executor.py
@@ -1,5 +1,8 @@
 import asyncio
+from datetime import datetime
 from typing import Dict, List
+
+import pytz
 
 from mage_ai.data_preparation.executors.block_executor import BlockExecutor
 from mage_ai.data_preparation.logging.logger import DictLogger
@@ -93,6 +96,12 @@ class PipelineExecutor:
                     block_uuid=block_run.block_uuid,
                     execution_partition=self.execution_partition,
                 )
+                block_run_data = dict(status=BlockRun.BlockRunStatus.RUNNING)
+                if not block_run.started_at or \
+                        (block_run.metrics and not block_run.metrics.get('controller')):
+                    block_run_data['started_at'] = datetime.now(tz=pytz.UTC)
+
+                block_run.update(**block_run_data)
                 BlockExecutor(**executor_kwargs).execute(
                     block_run_id=block_run.id,
                     global_vars=global_vars,

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -2496,6 +2496,34 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
         return variable_mapping
 
     def __enrich_global_vars(self, global_vars: Dict = None) -> Dict:
+        """
+        Enriches the provided global variables dictionary with additional context, Spark session,
+        environment, configuration, and an empty context dictionary.
+
+        Args:
+            global_vars (Optional[Dict]): A dictionary of global variables to be enriched.
+                If not provided, an empty dictionary is created.
+
+        Returns:
+            Dict: The enriched global variables dictionary.
+
+        Raises:
+            (Optional): Any specific exceptions that may be raised during the execution.
+
+        This method checks if the pipeline type is DATABRICKS or if the environment is a Spark
+        environment. If true, it adds the Spark session to the global variables if not already
+        present.
+
+        If 'env' is not in the global variables, it adds the environment information using the
+        'get_env()' function.
+
+        Adds the block configuration to the global variables.
+
+        If 'context' is not in global_vars, it adds an empty context dictionary.
+
+        The final enriched global variables dictionary is assigned to the object's 'global_vars'
+        attribute and returned.
+        """
         if global_vars is None:
             global_vars = dict()
         if ((self.pipeline is not None and self.pipeline.type == PipelineType.DATABRICKS) or
@@ -2506,8 +2534,7 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
                     global_vars['spark'] = spark
         if 'env' not in global_vars:
             global_vars['env'] = get_env()
-        if 'configuration' not in global_vars:
-            global_vars['configuration'] = self.configuration
+        global_vars['configuration'] = self.configuration
         if 'context' not in global_vars:
             global_vars['context'] = dict()
 

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -2507,9 +2507,6 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
         Returns:
             Dict: The enriched global variables dictionary.
 
-        Raises:
-            (Optional): Any specific exceptions that may be raised during the execution.
-
         This method checks if the pipeline type is DATABRICKS or if the environment is a Spark
         environment. If true, it adds the Spark session to the global variables if not already
         present.


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
* Allow using block configuration when run_pipeline_in_one_process is true
* Update block run status and start time in pipeline executor.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with run_pipeline_in_one_process is true. The block configuration is not shared across blocks anymore.



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
