### PR TITLE
[jk] Update logic for valid replication keys in integration pipelines

### DIFF
--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
@@ -474,7 +474,7 @@ function SchemaTable({
 
                   if (bookmarkProperties?.includes(columnName)
                     && !stream?.bookmark_properties?.includes(columnName)
-                    && currStreamReplicationKeys.includes(columnName)
+                    && (currStreamReplicationKeys.includes(columnName) || currStreamReplicationKeys.length === 0)
                   ) {
                     stream.bookmark_properties = [columnName].concat(stream.bookmark_properties || []);
                   } else if (!bookmarkProperties?.includes(columnName)
@@ -1029,9 +1029,10 @@ function SchemaTable({
               Valid replication keys
             </Text>
             <Text default inline>
-              If a stream&#39;s feature is not a valid replication key, it will not
-              be set as a bookmark property when applying the feature (from a different
-              stream) as a bookmark to all streams.&nbsp;
+              If a stream&#39;s schema specifies its valid replication keys and a feature
+              is not a valid replication key, it will not be set as a bookmark property
+              when applying the feature (from a different stream) as a bookmark to all
+              streams.&nbsp;
             </Text>
             {validReplicationKeys.length > 0 && (
               <>
@@ -1043,7 +1044,8 @@ function SchemaTable({
             )}
             {validReplicationKeys.length === 0 &&
               <Text default inline>
-                This stream has no valid replication keys.
+                This stream did not specify any valid replication keys, so all features
+                can be used as bookmark properties.
               </Text>
             }
           </Spacing>

--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/SchemaTable.tsx
@@ -1030,7 +1030,7 @@ function SchemaTable({
             </Text>
             <Text default inline>
               If a stream&#39;s schema specifies its valid replication keys and a feature
-              is not a valid replication key, it will not be set as a bookmark property
+              is not a valid replication key, that feature will not be set as a bookmark property
               when applying the feature (from a different stream) as a bookmark to all
               streams.&nbsp;
             </Text>


### PR DESCRIPTION
# Description
- If the valid replication keys for a stream's schema in a data integration pipeline is empty, any of the stream's features/columns can be bookmark properties. This allows other stream's columns to be marked as bookmark properties when using the "apply bookmark to all streams" feature. Previously, no column for another stream would be applied as a bookmark property when using the "apply to all streams" feature if the other stream's `valid_replication_keys` list was empty, so this PR fixes that.

# How Has This Been Tested?
Applying bookmark to all streams when the other streams have an empty `valid_replication_keys` list: 
![apply bookmark to other streams](https://github.com/mage-ai/mage-ai/assets/78053898/0d051d81-7569-4e31-9810-2249d690afb0)

Updated description for "Valid replication keys" (not empty list):
<img width="790" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/9690cf40-c312-4027-aa6c-677b0ddecb2d">

Updated description for "Valid replication keys" (empty list):
<img width="813" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/075f88b9-3702-4aa3-b742-1d7eeb46d6ee">


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
