### PR TITLE
[jk] Only show Backfills in vertical nav for standard (python) pipelines

### DIFF
--- a/mage_ai/frontend/components/Dashboard/VerticalNavigation.tsx
+++ b/mage_ai/frontend/components/Dashboard/VerticalNavigation.tsx
@@ -160,7 +160,7 @@ const DEFAULT_NAV_ITEMS = ({
       items: miscItems,
     },
   ];
-}
+};
 
 export type NavigationItem = {
   Icon?: any;

--- a/mage_ai/frontend/components/PipelineDetailPage/utils.ts
+++ b/mage_ai/frontend/components/PipelineDetailPage/utils.ts
@@ -43,16 +43,6 @@ export function buildNavigationItems(
       },
     },
     {
-      Icon: BackfillV2,
-      id: PageNameEnum.BACKFILLS,
-      isSelected: () => PageNameEnum.BACKFILLS === pageName,
-      label: () => 'Backfills',
-      linkProps: {
-        as: `/pipelines/${pipelineUUID}/backfills`,
-        href: '/pipelines/[pipeline]/backfills',
-      },
-    },
-    {
       Icon: Logs,
       id: PageNameEnum.PIPELINE_LOGS,
       isSelected: () => PageNameEnum.PIPELINE_LOGS === pageName,
@@ -73,6 +63,19 @@ export function buildNavigationItems(
       },
     },
   ];
+
+  if (PipelineTypeEnum.PYTHON === pipeline?.type) {
+    navigationItems.splice(2, 0, {
+      Icon: BackfillV2,
+      id: PageNameEnum.BACKFILLS,
+      isSelected: () => PageNameEnum.BACKFILLS === pageName,
+      label: () => 'Backfills',
+      linkProps: {
+        as: `/pipelines/${pipelineUUID}/backfills`,
+        href: '/pipelines/[pipeline]/backfills',
+      },
+    });
+  }
 
   if (PipelineTypeEnum.INTEGRATION === pipeline?.type) {
     navigationItems.unshift({


### PR DESCRIPTION
# Description
- Backfills is only supported for standard/python pipelines, so this PR hides the Backfills section from the left vertical navigation in other pipeline types (i.e. streaming and integration pipelines).

# How Has This Been Tested?
Standard pipeline nav (Backfills visible):
<img width="326" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/83571a2d-1304-4670-a23a-7bc8d275bcbb">

Streaming pipeline nav (Backfills hidden):
<img width="282" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/306d2c71-96fd-4f01-ac49-18afa450efd6">

Integration pipeline nav (Backfills hidden):
<img width="358" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/d9f67d6f-9d56-47f5-bcfe-d8475d3decb7">

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
