### PR TITLE
[td] Fix files not being selected in notebook

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -833,6 +833,8 @@ function PipelineDetailPage({
     setSelectedFilePath(filePathFromUrl);
   }, [
     filePathFromUrl,
+    // This dependency is required or else the effect will not trigger on updated query parameters.
+    qUrl,
   ]);
   useEffect(() => {
     if (!equals(filePathsFromUrl, selectedFilePaths)) {
@@ -841,6 +843,8 @@ function PipelineDetailPage({
   }, [
     filePathsFromUrl,
     selectedFilePaths,
+    // This dependency is required or else the effect will not trigger on updated query parameters.
+    qUrl,
   ]);
 
   const [createPipeline] = useMutation(


### PR DESCRIPTION
# Description
Clicking a file in the file browser from the notebook opens the file to be edited.

The URL will include the file path.

The notebook page suppose to update the component state to be the value of the file path in the URL. However, the hook that supposes to update that internal state was not being triggered.

Solution is to add the query object as a dependency to the `useEffect` that is setting the state.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested manually in the UI


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
