### PR TITLE
[dy] Resolve pipeline schedules N+1 query issue

### DIFF
--- a/mage_ai/api/policies/PipelineSchedulePolicy.py
+++ b/mage_ai/api/policies/PipelineSchedulePolicy.py
@@ -33,7 +33,10 @@ class PipelineSchedulePolicy(BasePolicy):
     @property
     def entity(self):
         if self.resource and self.resource.model:
-            return Entity.PIPELINE, self.resource.model.pipeline_uuid
+            if isinstance(self.resource.model, dict):
+                return Entity.PIPELINE, self.resource.model.get('pipeline_uuid')
+            else:
+                return Entity.PIPELINE, self.resource.model.pipeline_uuid
 
         return Entity.PROJECT, get_project_uuid()
 

--- a/mage_ai/api/presenters/PipelineSchedulePresenter.py
+++ b/mage_ai/api/presenters/PipelineSchedulePresenter.py
@@ -24,32 +24,24 @@ class PipelineSchedulePresenter(BasePresenter):
 
     async def present(self, **kwargs):
         display_format = kwargs['format']
-        data = self.model.to_dict()
-        next_execution_date = self.model.next_execution_date()
 
-        if constants.LIST == display_format:
-            data = self.model.to_dict(include_attributes=[
-                'event_matchers',
-                'last_pipeline_run_status',
-                'pipeline_in_progress_runs_count',
-                'pipeline_runs_count',
-            ])
-            data['tags'] = sorted([tag.name for tag in self.get_tag_associations])
-            data['next_pipeline_run_date'] = next_execution_date
-
-            return data
-        elif display_format in [constants.DETAIL, constants.UPDATE]:
+        if display_format in [constants.DETAIL, constants.UPDATE]:
             data = self.model.to_dict(include_attributes=[
                 'event_matchers',
             ])
             data['tags'] = sorted([tag.name for tag in self.get_tag_associations])
-            data['next_pipeline_run_date'] = next_execution_date
+            data['next_pipeline_run_date'] = self.model.next_execution_date()
 
             return data
         elif 'with_runtime_average' == display_format:
+            data = self.model.to_dict()
             data['runtime_average'] = self.model.runtime_average()
             data['tags'] = sorted([tag.name for tag in self.get_tag_associations])
-            data['next_pipeline_run_date'] = next_execution_date
+            data['next_pipeline_run_date'] = self.model.next_execution_date()
+        elif isinstance(self.model, dict):
+            data = self.model
+        else:
+            data = self.model.to_dict()
 
         return data
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

This PR changes how we fetch certain fields on the pipeline_schedules LIST endpoint. The `pipeline_runs_count`, `pipeline_in_progress_runs_count` and `tags` were all being fetched individually for every pipeline schedule that was being returned, so I changed the logic to instead fetch these fields once for all schedules.

There doesn't seem to be a major performance improvement on the requests because the pipeline_schedule requests generally include a small limit for pagination purposes. I'm also not sure if my implementation of the queries is optimal, so there could be an issue there as well.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with /api/pipeline_schedules endpoint
- [x] Verified pipeline schedule unit tests are still working


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
