### PR TITLE
Add asynchronous to global hooks run

### DIFF
--- a/mage_ai/data_preparation/models/global_hooks/models.py
+++ b/mage_ai/data_preparation/models/global_hooks/models.py
@@ -386,6 +386,8 @@ class Hook(BaseDataClass):
                     _should_schedule=should_schedule,
                 )
             elif asynchronous:
+                # TODO: invoking the below method will still block the current
+                # operation from completing
                 PipelineExecutor(self.pipeline).execute(global_vars=variables, update_status=False)
             else:
                 self.pipeline.execute_sync(global_vars=variables, update_status=False)

--- a/mage_ai/frontend/components/GlobalHooks/GlobalHookDetail/index.tsx
+++ b/mage_ai/frontend/components/GlobalHooks/GlobalHookDetail/index.tsx
@@ -702,6 +702,7 @@ function GlobalHookDetail({
               description="Select a pipeline that will be executed every time this hook is triggered."
               invalid={attributesTouched && !attributes?.pipeline?.uuid}
               selectInput={{
+                fullWidth: false,
                 monospace: true,
                 onChange: e => setAttributes(prev => ({
                   ...prev,
@@ -720,7 +721,24 @@ function GlobalHookDetail({
                 placeholder: 'Select a pipeline',
                 value: attributes?.pipeline?.uuid,
               }}
-            />
+            >
+              {attributes?.pipeline?.uuid && (
+                <div>
+                  <NextLink
+                    as={`/pipelines/${attributes?.pipeline?.uuid}/edit`}
+                    href={'/pipelines/[pipeline]/edit'}
+                    passHref
+                  >
+                    <Link
+                      block
+                      openNewWindow
+                    >
+                      View pipeline
+                    </Link>
+                  </NextLink>
+                </div>
+              )}
+            </SetupSectionRow>
 
             <SetupSectionRow
               title={attributes?.pipeline?.uuid && !metadata?.snapshot_hash && !metadata?.snapshot_valid
@@ -854,6 +872,42 @@ function GlobalHookDetail({
                   run_settings: {
                     ...prev?.run_settings,
                     with_trigger: valFunc(prev?.run_settings?.with_trigger),
+                  },
+                })),
+              }}
+            />
+
+            <SetupSectionRow
+              title="Run hook asynchronously"
+              description={(
+                <Text muted small>
+                  Hooks will execute the associated pipeline synchronously and
+                  prevent the current resource operation (e.g. API request) from resolving
+                  until all associated hooks for that resource operation are completed.
+
+                  <br />
+
+                  Hooks running synchronously can mutate the input data and output data.
+                  However, it can slow down the user experience in the application.
+
+                  <br />
+
+                  Enable this setting to run hooks asynchronously and
+                  not block the current resource operation from resolving.
+
+                  <br />
+
+                  However, asynchronous hooks cannot mutate the input data or output data.
+                  Use this asynchronous setting when hooks don’t need to mutate data.
+                </Text>
+              )}
+              toggleSwitch={{
+                checked: !!attributes?.run_settings?.asynchronous,
+                onCheck: (valFunc: (val: boolean) => boolean) => setAttributes(prev => ({
+                  ...prev,
+                  run_settings: {
+                    ...prev?.run_settings,
+                    asynchronous: valFunc(prev?.run_settings?.asynchronous),
                   },
                 })),
               }}

--- a/mage_ai/frontend/interfaces/GlobalHookType.ts
+++ b/mage_ai/frontend/interfaces/GlobalHookType.ts
@@ -42,6 +42,7 @@ interface HookStatusType {
 }
 
 interface HookRunSettingsType {
+  asynchronous?: boolean;
   with_trigger?: boolean;
 }
 


### PR DESCRIPTION
# Description
Add a setting to run hook’s pipeline asynchronously.

![CleanShot 2023-11-23 at 01 28 14@2x](https://github.com/mage-ai/mage-ai/assets/1066980/b73ea0d0-95b6-4a4e-8632-adfef8d9e143)

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Added unit test for Global hook


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
