### PR TITLE
[td] Reduce block at any level UI

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/utils.ts
+++ b/mage_ai/frontend/components/CodeBlock/utils.ts
@@ -296,12 +296,12 @@ export const getMoreActionsItems = (
         });
       }
 
-      if (blocksMapping) {
+      if (blocksMapping || block?.tags) {
         const dynamicChildBlock = upstreamBlocks?.find(
           (uuid: string) => blocksMapping?.[uuid]?.configuration?.dynamic,
         );
 
-        if (dynamicChildBlock) {
+        if (dynamicChildBlock || block?.tags?.includes(String(TagEnum.DYNAMIC_CHILD))) {
           items.push({
             label: () => reduceOutput ? 'Don’t reduce output' : 'Reduce output',
             onClick: () => savePipelineContent({

--- a/mage_ai/frontend/components/CodeBlock/utils.ts
+++ b/mage_ai/frontend/components/CodeBlock/utils.ts
@@ -301,7 +301,7 @@ export const getMoreActionsItems = (
           (uuid: string) => blocksMapping?.[uuid]?.configuration?.dynamic,
         );
 
-        if (dynamicChildBlock || block?.tags?.includes(String(TagEnum.DYNAMIC_CHILD))) {
+        if (dynamicChildBlock || block?.tags?.includes(TagEnum.DYNAMIC_CHILD)) {
           items.push({
             label: () => reduceOutput ? 'Don’t reduce output' : 'Reduce output',
             onClick: () => savePipelineContent({


### PR DESCRIPTION
# Description
You can reduce the output of any dynamic child block no matter the depth; however, the UI didn’t allow for that.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
![CleanShot 2023-11-24 at 01 25 56@2x](https://github.com/mage-ai/mage-ai/assets/1066980/595e7ad2-4ea3-4857-b2cf-44ce9a06a129)

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
