### PR TITLE
[td] Support different operators when comparing bookmark properties

### DIFF
--- a/mage_ai/data_integrations/sources/constants.py
+++ b/mage_ai/data_integrations/sources/constants.py
@@ -1,3 +1,6 @@
+from mage_ai.data_integrations.utils.settings import get_uuid
+from mage_ai.shared.hash import index_by
+
 SQL_SOURCES = [
     dict(name='BigQuery'),
     dict(
@@ -10,6 +13,8 @@ SQL_SOURCES = [
     dict(name='Redshift'),
     dict(name='Snowflake'),
 ]
+
+SQL_SOURCES_MAPPING = index_by(get_uuid, SQL_SOURCES)
 
 SOURCES = sorted([
     dict(name='Amazon S3'),

--- a/mage_ai/frontend/components/DataIntegrationModal/StreamDetail/StreamDetailOverview.tsx
+++ b/mage_ai/frontend/components/DataIntegrationModal/StreamDetail/StreamDetailOverview.tsx
@@ -399,63 +399,83 @@ function StreamDetailOverview({
                   >=
                 </Text>).
                 <br />
+                If the bookmark property is also a unique constraint,
+                then the default operator is greater than (<Text
+                  inline
+                  monospace
+                  muted
+                  small
+                >
+                  >
+                </Text>).
+                <br />
                 Change the operator that is used when determining which records to sync based on the bookmark value from the most recently completed sync.
               </Text>
             </Spacing>
 
-            {bookmarkProperties?.map((column: string) => (
-              <Spacing key={column} mt={PADDING_UNITS}>
-                <FlexContainer alignItems="center">
-                  <Text default monospace>
-                    <Text
-                      inline
+            {bookmarkProperties?.map((column: string) => {
+              let operatorValue;
+              if (bookmarkPropertyOperators?.[column]) {
+                operatorValue = bookmarkPropertyOperators?.[column];
+              } else if (uniqueConstraints && uniqueConstraints?.includes(column)) {
+                operatorValue = PredicateOperatorEnum.GREATER_THAN;
+              } else {
+                operatorValue = PredicateOperatorEnum.GREATER_THAN_OR_EQUALS;
+              }
+              return (
+                <Spacing key={column} mt={PADDING_UNITS}>
+                  <FlexContainer alignItems="center">
+                    <Text default monospace>
+                      <Text
+                        inline
+                        monospace
+                        muted
+                      >
+                        {'{new_record}'}.
+                      </Text>{column}
+                    </Text>
+
+                    <Spacing mr={PADDING_UNITS} />
+
+                    <Select
+                      compact
+                      defaultColor
                       monospace
-                      muted
+                      onChange={e => updateValue('bookmark_property_operators', {
+                        ...bookmarkPropertyOperators,
+                        [column]: e.target.value,
+                      })}
+                      value={operatorValue}
                     >
-                      {'{new_record}'}.
-                    </Text>{column}
-                  </Text>
+                      {[
+                        PredicateOperatorEnum.EQUALS,
+                        PredicateOperatorEnum.GREATER_THAN,
+                        PredicateOperatorEnum.GREATER_THAN_OR_EQUALS,
+                        PredicateOperatorEnum.LESS_THAN,
+                        PredicateOperatorEnum.LESS_THAN_OR_EQUALS,
+                        PredicateOperatorEnum.NOT_EQUALS,
+                      ].map(value => (
+                        <option key={value} value={value}>
+                          {OPERATOR_LABEL_MAPPING[value]}
+                        </option>
+                      ))}
+                    </Select>
 
-                  <Spacing mr={PADDING_UNITS} />
+                    <Spacing mr={PADDING_UNITS} />
 
-                  <Select
-                    compact
-                    defaultColor
-                    monospace
-                    onChange={e => updateValue('bookmark_property_operators', {
-                      ...bookmarkPropertyOperators,
-                      [column]: e.target.value,
-                    })}
-                    value={bookmarkPropertyOperators?.[column] || PredicateOperatorEnum.GREATER_THAN_OR_EQUALS}
-                  >
-                    {[
-                      PredicateOperatorEnum.EQUALS,
-                      PredicateOperatorEnum.GREATER_THAN,
-                      PredicateOperatorEnum.GREATER_THAN_OR_EQUALS,
-                      PredicateOperatorEnum.LESS_THAN,
-                      PredicateOperatorEnum.LESS_THAN_OR_EQUALS,
-                      PredicateOperatorEnum.NOT_EQUALS,
-                    ].map(value => (
-                      <option key={value} value={value}>
-                        {OPERATOR_LABEL_MAPPING[value]}
-                      </option>
-                    ))}
-                  </Select>
-
-                  <Spacing mr={PADDING_UNITS} />
-
-                  <Text default monospace>
-                    <Text
-                      inline
-                      monospace
-                      muted
-                    >
-                      {'{bookmark}'}.
-                    </Text>{column}
-                  </Text>
-                </FlexContainer>
-              </Spacing>
-            ))}
+                    <Text default monospace>
+                      <Text
+                        inline
+                        monospace
+                        muted
+                      >
+                        {'{bookmark}'}.
+                      </Text>{column}
+                    </Text>
+                  </FlexContainer>
+                </Spacing>
+              );
+            })}
           </SectionStyle>
         </Spacing>
       )}

--- a/mage_ai/frontend/components/DataIntegrationModal/StreamDetail/StreamDetailOverview.tsx
+++ b/mage_ai/frontend/components/DataIntegrationModal/StreamDetail/StreamDetailOverview.tsx
@@ -396,7 +396,7 @@ function StreamDetailOverview({
                   muted
                   small
                 >
-                  >=
+                  {'>='}
                 </Text>).
                 <br />
                 If the bookmark property is also a unique constraint,
@@ -406,7 +406,7 @@ function StreamDetailOverview({
                   muted
                   small
                 >
-                  >
+                  {'>'}
                 </Text>).
                 <br />
                 Change the operator that is used when determining which records to sync based on the bookmark value from the most recently completed sync.

--- a/mage_ai/frontend/components/DataIntegrationModal/StreamDetail/StreamDetailOverview.tsx
+++ b/mage_ai/frontend/components/DataIntegrationModal/StreamDetail/StreamDetailOverview.tsx
@@ -19,14 +19,15 @@ import {
   ReplicationMethodEnum,
   UniqueConflictMethodEnum,
 } from '@interfaces/IntegrationSourceType';
-import { SectionStyle } from './index.style';
-import { StreamsOverviewProps } from '../StreamsOverview';
-import { StreamType } from '@interfaces/IntegrationSourceType';
+import { OPERATOR_LABEL_MAPPING, PredicateOperatorEnum } from '@interfaces/GlobalHookType';
 import {
   PADDING_UNITS,
   UNIT,
   UNITS_BETWEEN_SECTIONS,
 } from '@oracle/styles/units/spacing';
+import { SectionStyle } from './index.style';
+import { StreamsOverviewProps } from '../StreamsOverview';
+import { StreamType } from '@interfaces/IntegrationSourceType';
 import { capitalizeRemoveUnderscoreLower, pluralize } from '@utils/string';
 import {
   getSchemaPropertiesWithMetadata,
@@ -60,6 +61,7 @@ function StreamDetailOverview({
   const {
     auto_add_new_fields: autoAddNewFields,
     bookmark_properties: bookmarkProperties,
+    bookmark_property_operators: bookmarkPropertyOperators,
     destination_table: destinationTableInit,
     disable_column_type_check: disableColumnTypeCheck,
     key_properties: keyProperties,
@@ -374,6 +376,89 @@ function StreamDetailOverview({
           </Spacing>
         </SectionStyle>
       </Spacing>
+
+      {dataIntegration?.sql
+        && ReplicationMethodEnum.INCREMENTAL === replicationMethod
+        && bookmarkProperties?.length >= 1
+        && (
+        <Spacing mb={PADDING_UNITS}>
+          <SectionStyle>
+            <Text default uppercase>
+              Bookmark property operators
+            </Text>
+
+            <Spacing mt={1}>
+              <Text muted small>
+                By default, new records are compared to the bookmark property value using the
+                operator greater than or equals (<Text
+                  inline
+                  monospace
+                  muted
+                  small
+                >
+                  >=
+                </Text>).
+                <br />
+                Change the operator that is used when determining which records to sync based on the bookmark value from the most recently completed sync.
+              </Text>
+            </Spacing>
+
+            {bookmarkProperties?.map((column: string) => (
+              <Spacing key={column} mt={PADDING_UNITS}>
+                <FlexContainer alignItems="center">
+                  <Text default monospace>
+                    <Text
+                      inline
+                      monospace
+                      muted
+                    >
+                      {'{new_record}'}.
+                    </Text>{column}
+                  </Text>
+
+                  <Spacing mr={PADDING_UNITS} />
+
+                  <Select
+                    compact
+                    defaultColor
+                    monospace
+                    onChange={e => updateValue('bookmark_property_operators', {
+                      ...bookmarkPropertyOperators,
+                      [column]: e.target.value,
+                    })}
+                    value={bookmarkPropertyOperators?.[column] || PredicateOperatorEnum.GREATER_THAN_OR_EQUALS}
+                  >
+                    {[
+                      PredicateOperatorEnum.EQUALS,
+                      PredicateOperatorEnum.GREATER_THAN,
+                      PredicateOperatorEnum.GREATER_THAN_OR_EQUALS,
+                      PredicateOperatorEnum.LESS_THAN,
+                      PredicateOperatorEnum.LESS_THAN_OR_EQUALS,
+                      PredicateOperatorEnum.NOT_EQUALS,
+                    ].map(value => (
+                      <option key={value} value={value}>
+                        {OPERATOR_LABEL_MAPPING[value]}
+                      </option>
+                    ))}
+                  </Select>
+
+                  <Spacing mr={PADDING_UNITS} />
+
+                  <Text default monospace>
+                    <Text
+                      inline
+                      monospace
+                      muted
+                    >
+                      {'{bookmark}'}.
+                    </Text>{column}
+                  </Text>
+                </FlexContainer>
+              </Spacing>
+            ))}
+          </SectionStyle>
+        </Spacing>
+      )}
 
       <Spacing mb={PADDING_UNITS}>
         <SectionStyle>

--- a/mage_ai/frontend/interfaces/BlockType.ts
+++ b/mage_ai/frontend/interfaces/BlockType.ts
@@ -287,6 +287,7 @@ export default interface BlockType {
       destination?: string;
       name?: string;
       source?: string;
+      sql?: boolean;
     };
     dbt?: {
       block?: {

--- a/mage_ai/frontend/interfaces/IntegrationSourceType.ts
+++ b/mage_ai/frontend/interfaces/IntegrationSourceType.ts
@@ -1,6 +1,7 @@
 import BlockType from './BlockType';
 import PipelineRunType from './PipelineRunType';
 import PipelineScheduleType from './PipelineScheduleType';
+import { PredicateOperatorEnum } from './GlobalHookType';
 
 export enum ReplicationMethodEnum {
   FULL_TABLE = 'FULL_TABLE',
@@ -105,6 +106,9 @@ export interface MetadataType {
 export interface StreamType {
   auto_add_new_fields?: boolean;
   bookmark_properties?: string[];
+  bookmark_property_operators?: {
+    [column: string]: PredicateOperatorEnum;
+  };
   destination_table?: string;
   disable_column_type_check?: boolean;
   key_properties?: string[];

--- a/mage_integrations/mage_integrations/sources/catalog.py
+++ b/mage_integrations/mage_integrations/sources/catalog.py
@@ -1,5 +1,5 @@
 import json
-from typing import List
+from typing import Dict, List
 
 from singer import catalog
 
@@ -10,8 +10,9 @@ class CatalogEntry(catalog.CatalogEntry):
     def __init__(
         self,
         auto_add_new_fields: bool = False,
-        disable_column_type_check: bool = None,
         bookmark_properties: List[str] = None,
+        bookmark_property_operators: Dict = None,
+        disable_column_type_check: bool = None,
         partition_keys: List[str] = None,
         run_in_parallel: bool = False,
         unique_conflict_method: str = None,
@@ -21,6 +22,7 @@ class CatalogEntry(catalog.CatalogEntry):
         super().__init__(**kwargs)
         self.auto_add_new_fields = False
         self.bookmark_properties = bookmark_properties
+        self.bookmark_property_operators = bookmark_property_operators
         self.disable_column_type_check = disable_column_type_check
         self.partition_keys = partition_keys
         self.run_in_parallel = run_in_parallel
@@ -89,6 +91,7 @@ class Catalog(catalog.Catalog):
             entry = CatalogEntry()
             entry.auto_add_new_fields = stream.get('auto_add_new_fields')
             entry.bookmark_properties = stream.get('bookmark_properties')
+            entry.bookmark_property_operators = stream.get('bookmark_property_operators')
             entry.database = stream.get('database_name')
             entry.disable_column_type_check = stream.get('disable_column_type_check')
             entry.is_view = stream.get('is_view')

--- a/mage_integrations/mage_integrations/sources/sql/constants.py
+++ b/mage_integrations/mage_integrations/sources/sql/constants.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class PredicateOperator(str, Enum):
+    EQUALS = 'EQUALS'
+    GREATER_THAN = 'GREATER_THAN'
+    GREATER_THAN_OR_EQUALS = 'GREATER_THAN_OR_EQUALS'
+    LESS_THAN = 'LESS_THAN'
+    LESS_THAN_OR_EQUALS = 'LESS_THAN_OR_EQUALS'
+    NOT_EQUALS = 'NOT_EQUALS'

--- a/mage_integrations/mage_integrations/sources/sql/utils.py
+++ b/mage_integrations/mage_integrations/sources/sql/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Union
 
 from mage_integrations.sources.constants import (
     COLUMN_FORMAT_DATETIME,
@@ -8,6 +8,7 @@ from mage_integrations.sources.constants import (
     COLUMN_TYPE_NUMBER,
     COLUMN_TYPE_OBJECT,
 )
+from mage_integrations.sources.sql.constants import PredicateOperator
 from mage_integrations.utils.array import find
 
 
@@ -56,3 +57,21 @@ def wrap_column_in_quotes(column):
         return f'"{column}"'
 
     return column
+
+
+def predicate_operator_uuid_to_comparison_operator(operator: Union[PredicateOperator, str]) -> str:
+    if isinstance(operator, str):
+        operator = PredicateOperator(operator)
+
+    if PredicateOperator.EQUALS == operator:
+        return '='
+    if PredicateOperator.GREATER_THAN == operator:
+        return '>'
+    if PredicateOperator.GREATER_THAN_OR_EQUALS == operator:
+        return '>='
+    if PredicateOperator.LESS_THAN == operator:
+        return '<'
+    if PredicateOperator.LESS_THAN_OR_EQUALS == operator:
+        return '<='
+    if PredicateOperator.NOT_EQUALS == operator:
+        return '!='


### PR DESCRIPTION
# Description
For SQL sources, change the operator used when comparing new records to the bookmark property value.

# How Has This Been Tested?
![CleanShot 2023-11-25 at 02 41 54@2x](https://github.com/mage-ai/mage-ai/assets/1066980/c68b08a0-9b12-41ea-9053-06522bec9794)

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
