### PR TITLE
[td] Support interpolating environment variables in SQL blocks

### DIFF
--- a/mage_ai/data_preparation/models/block/sql/utils/shared.py
+++ b/mage_ai/data_preparation/models/block/sql/utils/shared.py
@@ -10,9 +10,12 @@ from mage_ai.data_preparation.models.block.sql.constants import (
     CONFIG_KEY_UPSTREAM_BLOCK_CONFIGURATION_TABLE_NAME,
 )
 from mage_ai.data_preparation.models.constants import BlockLanguage, BlockType
+from mage_ai.data_preparation.shared.utils import get_template_vars
+from mage_ai.data_preparation.templates.utils import get_variable_for_template
 from mage_ai.data_preparation.variable_manager import get_variable
 from mage_ai.io.config import ConfigFileLoader
 from mage_ai.settings.repo import get_repo_path
+from mage_ai.shared.hash import merge_dict
 
 MAGE_SEMI_COLON = '__MAGE_SEMI_COLON__'
 
@@ -228,7 +231,21 @@ def interpolate_input(
 def interpolate_vars(query, global_vars=None):
     if global_vars is None:
         global_vars = dict()
-    return Template(query, undefined=StrictUndefined).render(**global_vars)
+
+    return Template(
+        query,
+        undefined=StrictUndefined,
+    ).render(
+        variables=lambda x, p=None, v=global_vars: get_variable_for_template(
+            x,
+            parse=p,
+            variables=v,
+        ),
+        **merge_dict(
+            global_vars,
+            get_template_vars(),
+        ),
+    )
 
 
 def table_name_parts(


### PR DESCRIPTION
# Description
Support interpolating environment variables in SQL blocks using the following syntax:

```sql
SELECT 
    '{{ env_var("ENV") }}' AS test
    , '{{ variables("test") }}' AS test2
    , {{ test }} AS test3
```

# How Has This Been Tested?

![CleanShot 2023-11-25 at 03 35 06@2x](https://github.com/mage-ai/mage-ai/assets/1066980/ef86da48-a92e-4ee7-9358-810ffeb32542)

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
