### PR TITLE
[xh]Qdrant integration for data loader and exporter

### DIFF
--- a/docs/integrations/databases/Qdrant.mdx
+++ b/docs/integrations/databases/Qdrant.mdx
@@ -18,7 +18,8 @@ default:
 
 1. Create a new pipeline or open an existing pipeline.
 2. Add a data loader or data exporter with Template. Under "Databases" category you can
- find the "Qdrant" template.
+ find the "Qdrant" template. Data loader and exporter use `SentenceTransformer` 'all-MiniLM-L6-v2'
+as default embeddinng function.
 
 - Qdrant data loader arguments:
   - limit_results (int): Number of results to return.

--- a/docs/integrations/databases/Qdrant.mdx
+++ b/docs/integrations/databases/Qdrant.mdx
@@ -17,22 +17,25 @@ default:
 ## Using Python block
 
 1. Create a new pipeline or open an existing pipeline.
-2. Add a data loader or data exporter with Template. Under "Databases" category you can
- find the "Qdrant" template. Data loader and exporter use `SentenceTransformer` 'all-MiniLM-L6-v2'
-as default embeddinng function.
+2. Add a data loader or data exporter using the Qdrant template under the "Databases" category.
+Both the data loader and exporter use SentenceTransformer 'all-MiniLM-L6-v2' as the default embedding function.
+3. Add your customized code into the loader, exporter or add extra transformer blocks.
+4. Run the block.
+
+## Available functions
 
 - Qdrant data loader arguments:
   - limit_results (int): Number of results to return.
   - query_vector (List): vector lit used for query.
-  - collection_name (str): name of the collection. Defaults to the name defined in io_config.yaml.
+  - collection_name (str): name of the collection. Default to use the name defined in io_config.yaml.
 
 - Qdrant data exporter arguments:
   - df (DataFrame): Data to export.
-  - collection_name (str): name of the collection.
+  - document_column (str): Column name containinng documents to export.
+  - id_column (str): Column name of the id. Default will use index in df.
+  - vector_column (str): Column name of the vector. Will use default encoder to auto generate query vector.
+  - collection_name (str): name of the collection. Deafult to use the name defined in io_config.yaml.
   - vector_size (int): dimension size of vector.
   - distance (models.Distance): distance metric to use.
 
 At the same time there is `create_collection` function can be used in your block to create new collection.
-
-3. Add your customized code into the loader, exporter or add extra transformer blocks.
-4. Run the block.

--- a/docs/integrations/databases/Qdrant.mdx
+++ b/docs/integrations/databases/Qdrant.mdx
@@ -1,0 +1,37 @@
+---
+title: "Qdrant"
+sidebarTitle: "Qdrant"
+---
+
+## Credentials
+
+Open the file named `io_config.yaml` at the root of your Mage project and enter qdrant required fields:
+
+```yaml
+version: 0.1.1
+default:
+  QDRANT_COLLECTION: collection_name
+  QDRANT_PATH: path of the qdrant persisitant storage
+```
+
+## Using Python block
+
+1. Create a new pipeline or open an existing pipeline.
+2. Add a data loader or data exporter with Template. Under "Databases" category you can
+ find the "Qdrant" template.
+
+- Qdrant data loader arguments:
+  - limit_results (int): Number of results to return.
+  - query_vector (List): vector lit used for query.
+  - collection_name (str): name of the collection. Defaults to the name defined in io_config.yaml.
+
+- Qdrant data exporter arguments:
+  - df (DataFrame): Data to export.
+  - collection_name (str): name of the collection.
+  - vector_size (int): dimension size of vector.
+  - distance (models.Distance): distance metric to use.
+
+At the same time there is `create_collection` function can be used in your block to create new collection.
+
+3. Add your customized code into the loader, exporter or add extra transformer blocks.
+4. Run the block.

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -355,6 +355,7 @@
                 "integrations/databases/MySQL",
                 "integrations/databases/Pinot",
                 "integrations/databases/PostgreSQL",
+                "integrations/databases/Qdrant",
                 "integrations/databases/Redshift",
                 "integrations/databases/S3",
                 "integrations/databases/Snowflake",

--- a/mage_ai/data_preparation/templates/constants.py
+++ b/mage_ai/data_preparation/templates/constants.py
@@ -229,6 +229,13 @@ TEMPLATES_ONLY_FOR_V2 = [
     ),
     dict(
         block_type=BlockType.DATA_LOADER,
+        groups=[GROUP_DATABASES],
+        language=BlockLanguage.PYTHON,
+        name='Qdrant',
+        path='data_loaders/qdrant.py',
+    ),
+    dict(
+        block_type=BlockType.DATA_LOADER,
         description='Fetch data from an API request.',
         language=BlockLanguage.PYTHON,
         name='API',
@@ -586,6 +593,13 @@ TEMPLATES_ONLY_FOR_V2 = [
         language=BlockLanguage.PYTHON,
         name='PostgreSQL',
         path='data_exporters/postgres.py',
+    ),
+    dict(
+        block_type=BlockType.DATA_EXPORTER,
+        groups=[GROUP_DATABASES],
+        language=BlockLanguage.PYTHON,
+        name='Qdrant',
+        path='data_exporters/qdrant.py',
     ),
     # Sensors
     dict(

--- a/mage_ai/data_preparation/templates/data_exporters/qdrant.py
+++ b/mage_ai/data_preparation/templates/data_exporters/qdrant.py
@@ -3,9 +3,9 @@ from os import path
 from pandas import DataFrame
 
 from mage_ai.settings.repo import get_repo_path
-from sentence_transformers import SentenceTransformer
 from mage_ai.io.config import ConfigFileLoader
 from mage_ai.io.qdrant import Qdrant
+from sentence_transformers import SentenceTransformer
 
 if 'data_exporter' not in globals():
     from mage_ai.data_preparation.decorators import data_exporter
@@ -14,18 +14,17 @@ if 'data_exporter' not in globals():
 @data_exporter
 def export_data_to_qdrant(df: DataFrame, **kwargs) -> None:
     """
-    Template for write data to Qdrant.
+    Template to write data into Qdrant.
     """
     config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
-    # Update following collection name and vector size according to your requirement.
+    # Update following collection name or the default value in io_config will be used.
     collection_name = 'new_colletion'
-    # set default dimension based on default embeding function.
-    encoder = SentenceTransformer('all-MiniLM-L6-v2')
-    vector_size = encoder.get_sentence_embedding_dimension()
+    # Column contains the document to save.
+    document_column = 'payload'
 
     Qdrant.with_config(ConfigFileLoader(config_path, config_profile)).export(
         df,
         collection_name=collection_name,
-        vector_size=vector_size,
+        document_column=document_column,
     )

--- a/mage_ai/data_preparation/templates/data_exporters/qdrant.py
+++ b/mage_ai/data_preparation/templates/data_exporters/qdrant.py
@@ -1,0 +1,28 @@
+from os import path
+
+from pandas import DataFrame
+
+from mage_ai.settings.repo import get_repo_path
+from mage_ai.io.config import ConfigFileLoader
+from mage_ai.io.qdrant import Qdrant
+
+if 'data_exporter' not in globals():
+    from mage_ai.data_preparation.decorators import data_exporter
+
+
+@data_exporter
+def export_data_to_qdrant(df: DataFrame, **kwargs) -> None:
+    """
+    Template for write data to Qdrant.
+    """
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
+    config_profile = 'default'
+    # Update following collection name and vector size according to your requirement.
+    collection_name = 'new_colletion'
+    vector_size = 4
+
+    Qdrant.with_config(ConfigFileLoader(config_path, config_profile)).export(
+        df,
+        collection_name=collection_name,
+        vector_size=vector_size,
+    )

--- a/mage_ai/data_preparation/templates/data_exporters/qdrant.py
+++ b/mage_ai/data_preparation/templates/data_exporters/qdrant.py
@@ -3,6 +3,7 @@ from os import path
 from pandas import DataFrame
 
 from mage_ai.settings.repo import get_repo_path
+from sentence_transformers import SentenceTransformer
 from mage_ai.io.config import ConfigFileLoader
 from mage_ai.io.qdrant import Qdrant
 
@@ -19,7 +20,9 @@ def export_data_to_qdrant(df: DataFrame, **kwargs) -> None:
     config_profile = 'default'
     # Update following collection name and vector size according to your requirement.
     collection_name = 'new_colletion'
-    vector_size = 4
+    # set default dimension based on default embeding function.
+    encoder = SentenceTransformer('all-MiniLM-L6-v2')
+    vector_size = encoder.get_sentence_embedding_dimension()
 
     Qdrant.with_config(ConfigFileLoader(config_path, config_profile)).export(
         df,

--- a/mage_ai/data_preparation/templates/data_loaders/qdrant.py
+++ b/mage_ai/data_preparation/templates/data_loaders/qdrant.py
@@ -1,0 +1,28 @@
+{% extends "data_loaders/default.jinja" %}
+{% block imports %}
+from mage_ai.settings.repo import get_repo_path
+from mage_ai.io.config import ConfigFileLoader
+from mage_ai.io.qdrant import Qdrant
+from os import path
+{{ super() -}}
+{% endblock %}
+
+
+{% block content %}
+@data_loader
+def load_data_from_qdrant(*args, **kwargs):
+    """
+    Template for loading data from Qdrant.
+    """
+    # vector used to query qdrant.
+    query_vector = [0.1, 0.2, 0.3, 0.4, 0.5, -0.6]
+    # number of results to return.
+    limit_results = 3
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
+    config_profile = 'default'
+
+    return Qdrant.with_config(ConfigFileLoader(config_path, config_profile)).load(
+        limit_results=limit_results,
+        query_vector=query_vector,
+        collection_name='test_collection')
+{% endblock %}

--- a/mage_ai/data_preparation/templates/data_loaders/qdrant.py
+++ b/mage_ai/data_preparation/templates/data_loaders/qdrant.py
@@ -3,6 +3,7 @@
 from mage_ai.settings.repo import get_repo_path
 from mage_ai.io.config import ConfigFileLoader
 from mage_ai.io.qdrant import Qdrant
+from sentence_transformers import SentenceTransformer
 from os import path
 {{ super() -}}
 {% endblock %}
@@ -14,8 +15,10 @@ def load_data_from_qdrant(*args, **kwargs):
     """
     Template for loading data from Qdrant.
     """
+    # Use all-MiniLM-L6-v2 embedding model as default.
+    encoder = SentenceTransformer('all-MiniLM-L6-v2')
+    query_vector = encoder.encode('Test query').tolist()
     # vector used to query qdrant.
-    query_vector = [0.1, 0.2, 0.3, 0.4, 0.5, -0.6]
     # number of results to return.
     limit_results = 3
     config_path = path.join(get_repo_path(), 'io_config.yaml')

--- a/mage_ai/data_preparation/templates/data_loaders/qdrant.py
+++ b/mage_ai/data_preparation/templates/data_loaders/qdrant.py
@@ -8,24 +8,26 @@ from os import path
 {{ super() -}}
 {% endblock %}
 
+DEFAULT_MODEL = 'all-MiniLM-L6-v2'
 
 {% block content %}
 @data_loader
 def load_data_from_qdrant(*args, **kwargs):
     """
-    Template for loading data from Qdrant.
+    Template to load data from Qdrant.
     """
     # Use all-MiniLM-L6-v2 embedding model as default.
-    encoder = SentenceTransformer('all-MiniLM-L6-v2')
+    encoder = SentenceTransformer(DEFAULT_MODEL)
+    # Generate vector for query.
     query_vector = encoder.encode('Test query').tolist()
-    # vector used to query qdrant.
     # number of results to return.
     limit_results = 3
     config_path = path.join(get_repo_path(), 'io_config.yaml')
     config_profile = 'default'
+    collection_name = 'test_collection'
 
     return Qdrant.with_config(ConfigFileLoader(config_path, config_profile)).load(
         limit_results=limit_results,
         query_vector=query_vector,
-        collection_name='test_collection')
+        collection_name=collection_name)
 {% endblock %}

--- a/mage_ai/data_preparation/templates/repo/io_config.yaml
+++ b/mage_ai/data_preparation/templates/repo/io_config.yaml
@@ -83,6 +83,9 @@ default:
   POSTGRES_PASSWORD: password
   POSTGRES_HOST: hostname
   POSTGRES_PORT: 5432
+  # Qdrant
+  QDRANT_COLLECTION: collection
+  QDRANT_PATH: path
   # Redshift
   REDSHIFT_SCHEMA: public # Optional
   REDSHIFT_DBNAME: redshift_db_name

--- a/mage_ai/io/base.py
+++ b/mage_ai/io/base.py
@@ -29,6 +29,7 @@ class DataSource(str, Enum):
     OPENSEARCH = 'opensearch'
     PINOT = 'pinot'
     POSTGRES = 'postgres'
+    QDRANT = 'qdrant'
     REDSHIFT = 'redshift'
     S3 = 's3'
     SNOWFLAKE = 'snowflake'

--- a/mage_ai/io/config.py
+++ b/mage_ai/io/config.py
@@ -87,6 +87,9 @@ class ConfigKey(str, Enum):
     PINOT_SCHEME = 'PINOT_SCHEME'
     PINOT_USER = 'PINOT_USER'
 
+    QDRANT_COLLECTION = 'QDRANT_COLLECTION'
+    QDRANT_PATH = 'QDRANT_PATH'
+
     POSTGRES_CONNECTION_METHOD = 'POSTGRES_CONNECTION_METHOD'
     POSTGRES_CONNECT_TIMEOUT = 'POSTGRES_CONNECT_TIMEOUT'
     POSTGRES_DBNAME = 'POSTGRES_DBNAME'
@@ -335,6 +338,7 @@ class VerboseConfigKey(str, Enum):
     REDSHIFT = 'Redshift'
     SNOWFLAKE = 'Snowflake'
     SPARK = 'Spark'
+    QDRANT = 'Qdrant'
 
 
 class ConfigFileLoader(BaseConfigLoader):
@@ -410,6 +414,8 @@ class ConfigFileLoader(BaseConfigLoader):
         ConfigKey.POSTGRES_PORT: (VerboseConfigKey.POSTGRES, 'port'),
         ConfigKey.POSTGRES_SCHEMA: (VerboseConfigKey.POSTGRES, 'schema'),
         ConfigKey.POSTGRES_USER: (VerboseConfigKey.POSTGRES, 'user'),
+        ConfigKey.QDRANT_COLLECTION: (VerboseConfigKey.QDRANT, 'collection'),
+        ConfigKey.QDRANT_PATH: (VerboseConfigKey.QDRANT, 'path'),
         ConfigKey.SNOWFLAKE_ACCOUNT: (VerboseConfigKey.SNOWFLAKE, 'account'),
         ConfigKey.SNOWFLAKE_DEFAULT_DB: (VerboseConfigKey.SNOWFLAKE, 'database'),
         ConfigKey.SNOWFLAKE_DEFAULT_SCHEMA: (VerboseConfigKey.SNOWFLAKE, 'schema'),

--- a/mage_ai/io/qdrant.py
+++ b/mage_ai/io/qdrant.py
@@ -3,9 +3,12 @@ from typing import List
 from pandas import DataFrame
 from qdrant_client import QdrantClient
 from qdrant_client.http import models
+from sentence_transformers import SentenceTransformer
 
 from mage_ai.io.base import BaseIO
 from mage_ai.io.config import BaseConfigLoader, ConfigKey
+
+DEFAULT_EMBEDDING_MODEL = 'all-MiniLM-L6-v2'
 
 
 class Qdrant(BaseIO):
@@ -20,10 +23,8 @@ class Qdrant(BaseIO):
         """
         super().__init__(verbose=verbose)
         self.collection = collection
-        if path is None:
-            self.client = QdrantClient(':memory:')
-        else:
-            self.client = QdrantClient(path=path)
+        self.path = path
+        self.open()
 
     @classmethod
     def with_config(cls, config: BaseConfigLoader) -> 'Qdrant':
@@ -38,17 +39,17 @@ class Qdrant(BaseIO):
             distance: models.Distance = None,
             collection_name: str = None):
         """
-            Create collection in qdrant db.
-            Args:
-                vector_size (int): dimension size of the vector.
-                distance (models.Distance): distance metric to use.
-                collection_name (str): name of the collection.
-                Defaults to the name defined in io_config.yaml.
-            Returns:
-                collection created.
+        Create collection in qdrant db.
+        Args:
+            vector_size (int): dimension size of the vector.
+            distance (models.Distance): distance metric to use.
+            collection_name (str): name of the collection.
+            Defaults to the name defined in io_config.yaml.
+        Returns:
+            collection created.
         """
-        collection_name = self.collection if collection_name is None else collection_name
-        distance = models.Distance.COSINE if distance is None else distance
+        collection_name = collection_name or self.collection
+        distance = distance or models.Distance.COSINE
         return self.client.create_collection(
             collection_name=collection_name,
             vectors_config=models.VectorParams(
@@ -64,17 +65,17 @@ class Qdrant(BaseIO):
         **kwargs,
     ) -> DataFrame:
         """
-            Loads the data from Qdrant with query_vector.
-            Args:
-                limit_results (int): Number of results to return.
-                query_vector (List): vector list used to query.
-                collection_name (str): name of the collection.
-                Defaults to the name defined in io_config.yaml.
-            Returns:
-                DataFrame: Data frame object loaded with data from qdrant
+        Loads the data from Qdrant with query_vector.
+        Args:
+            limit_results (int): Number of results to return.
+            query_vector (List): vector list used to query.
+            collection_name (str): name of the collection.
+            Defaults to the name defined in io_config.yaml.
+        Returns:
+            DataFrame: Data frame object loaded with data from qdrant
         """
         # Assume collection is already created and exists.
-        collection_name = self.collection if collection_name is None else collection_name
+        collection_name = collection_name or self.collection
 
         hitted_results = self.client.search(
             collection_name=collection_name,
@@ -82,7 +83,6 @@ class Qdrant(BaseIO):
             limit=limit_results,
             with_vectors=True,
         )
-        self.client.close()
 
         output_df = {}
         output_df['id'] = [hit.id for hit in hitted_results]
@@ -95,34 +95,48 @@ class Qdrant(BaseIO):
     def export(
         self,
         df: DataFrame,
+        document_column: str,
+        id_column: str = None,
+        vector_column: str = None,
         collection_name: str = None,
         vector_size: int = None,
         distance: models.Distance = None,
         **kwargs,
     ) -> None:
         """
-            Save data into Qdrant.
-            Args:
-                df (DataFrame): Data to export.
-                collection_name (str): name of the collection.
-                vector_size (int): dimension size of vector.
-                distance (models.Distance): distance metric to use.
+        Save data into Qdrant.
+        Args:
+            df (DataFrame): Data to export.
+            document_column (str): Column name containinng documents to export.
+            id_column (str): Column name of the id. Default will use index in df.
+            vector_column (str): Column name of the vector. Will use default
+            encoder to auto generate query vector to auto generate query vector.
+            collection_name (str): name of the collection.
+            vector_size (int): dimension size of vector.
+            distance (models.Distance): distance metric to use.
         """
-        collection_name = self.collection if collection_name is None else collection_name
+        collection_name = collection_name or self.collection
+        encoder = SentenceTransformer(DEFAULT_EMBEDDING_MODEL)
 
         try:
             self.client.get_collection(collection_name)
         except ValueError:
             print(f'Creating collection: {collection_name}')
             self.create_collection(
-                vector_size=vector_size,
+                vector_size=vector_size or encoder.get_sentence_embedding_dimension(),
                 distance=distance,
                 collection_name=collection_name,
             )
 
-        payloads = df['payload'].tolist()
-        ids = df['id'].tolist()
-        vectors = df['vector'].tolist()
+        payloads = df[document_column].tolist()
+        if id_column is None:
+            ids = [x for x in df.index.tolist()]
+        else:
+            ids = df[id_column].tolist()
+        if vector_column is None:
+            vectors = [encoder.encode(str(x)).tolist() for x in payloads]
+        else:
+            vectors = df[vector_column].tolist()
 
         self.client.upsert(
             collection_name=collection_name,
@@ -132,5 +146,28 @@ class Qdrant(BaseIO):
                 vectors=vectors,
             ),
         )
+
+    def __del__(self):
+        self.close()
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def open(self) -> None:
+        """
+        Opens an underlying connection to Qdrannt.
+        """
+        if self.path is None:
+            self.client = QdrantClient(':memory:')
+        else:
+            self.client = QdrantClient(path=self.path)
+
+    def close(self) -> None:
+        """
+        Close the underlying connection to Qdrant.
+        """
         self.client.close()
-        return

--- a/mage_ai/io/qdrant.py
+++ b/mage_ai/io/qdrant.py
@@ -1,0 +1,136 @@
+from typing import List
+
+from pandas import DataFrame
+from qdrant_client import QdrantClient
+from qdrant_client.http import models
+
+from mage_ai.io.base import BaseIO
+from mage_ai.io.config import BaseConfigLoader, ConfigKey
+
+
+class Qdrant(BaseIO):
+    def __init__(
+            self,
+            collection: str,
+            path: str = None,
+            verbose: bool = True,
+            **kwargs,) -> None:
+        """
+        Initializes connection to qdrant db.
+        """
+        super().__init__(verbose=verbose)
+        self.collection = collection
+        if path is None:
+            self.client = QdrantClient(':memory:')
+        else:
+            self.client = QdrantClient(path=path)
+
+    @classmethod
+    def with_config(cls, config: BaseConfigLoader) -> 'Qdrant':
+        return cls(
+            collection=config[ConfigKey.QDRANT_COLLECTION],
+            path=config[ConfigKey.QDRANT_PATH],
+        )
+
+    def create_collection(
+            self,
+            vector_size: int,
+            distance: models.Distance = None,
+            collection_name: str = None):
+        """
+            Create collection in qdrant db.
+            Args:
+                vector_size (int): dimension size of the vector.
+                distance (models.Distance): distance metric to use.
+                collection_name (str): name of the collection.
+                Defaults to the name defined in io_config.yaml.
+            Returns:
+                collection created.
+        """
+        collection_name = self.collection if collection_name is None else collection_name
+        distance = models.Distance.COSINE if distance is None else distance
+        return self.client.create_collection(
+            collection_name=collection_name,
+            vectors_config=models.VectorParams(
+                size=vector_size,
+                distance=distance),
+        )
+
+    def load(
+        self,
+        limit_results: int,
+        query_vector: List,
+        collection_name: str = None,
+        **kwargs,
+    ) -> DataFrame:
+        """
+            Loads the data from Qdrant with query_vector.
+            Args:
+                limit_results (int): Number of results to return.
+                query_vector (List): vector lit used for query.
+                collection_name (str): name of the collection.
+                Defaults to the name defined in io_config.yaml.
+            Returns:
+                DataFrame: Data frame object loaded with data from qdrant
+        """
+        # Assume collection is already created and exists.
+        collection_name = self.collection if collection_name is None else collection_name
+
+        hitted_results = self.client.search(
+            collection_name=collection_name,
+            query_vector=query_vector,
+            limit=limit_results,
+            with_vectors=True,
+        )
+        self.client.close()
+
+        output_df = {}
+        output_df['id'] = [hit.id for hit in hitted_results]
+        output_df['payload'] = [hit.payload for hit in hitted_results]
+        output_df['score'] = [hit.score for hit in hitted_results]
+        output_df['vector'] = [hit.vector for hit in hitted_results]
+
+        return DataFrame.from_dict(output_df)
+
+    def export(
+        self,
+        df: DataFrame,
+        collection_name: str = None,
+        vector_size: int = None,
+        distance: models.Distance = None,
+        **kwargs,
+    ) -> None:
+        """
+            Save data into Qdrant.
+            Args:
+                df (DataFrame): Data to export.
+                collection_name (str): name of the collection.
+                vector_size (int): dimension size of vector.
+                distance (models.Distance): distance metric to use.
+        """
+        collection_name = self.collection if collection_name is None else collection_name
+
+        try:
+            self.client.get_collection(collection_name)
+        except ValueError:
+            print(f'Creating collection: {collection_name}')
+            self.create_collection(
+                vector_size=vector_size,
+                distance=distance,
+                collection_name=collection_name,
+            )
+
+        payloads = df['payload'].tolist()
+        ids = df['id'].tolist()
+        vectors = df['vector'].tolist()
+
+        self.client.upsert(
+            collection_name=collection_name,
+            points=models.Batch(
+                ids=ids,
+                payloads=payloads,
+                vectors=vectors,
+            ),
+        )
+        self.client.close()
+        return

--- a/mage_ai/io/qdrant.py
+++ b/mage_ai/io/qdrant.py
@@ -67,7 +67,7 @@ class Qdrant(BaseIO):
             Loads the data from Qdrant with query_vector.
             Args:
                 limit_results (int): Number of results to return.
-                query_vector (List): vector lit used for query.
+                query_vector (List): vector list used to query.
                 collection_name (str): name of the collection.
                 Defaults to the name defined in io_config.yaml.
             Returns:

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,6 +76,7 @@ psycopg2==2.9.3
 psycopg2-binary==2.9.3
 pydruid==0.6.5
 pyodbc==4.0.35
+qdrant-client>=1.6.9
 redshift-connector==2.0.909
 snowflake-connector-python==3.2.1
 sshtunnel==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,6 +78,7 @@ pydruid==0.6.5
 pyodbc==4.0.35
 qdrant-client>=1.6.9
 redshift-connector==2.0.909
+sentence-transformers>=2.2.2
 snowflake-connector-python==3.2.1
 sshtunnel==0.4.0
 tables==3.7.0

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,9 @@ setuptools.setup(
             'psycopg2-binary==2.9.3',
             'sshtunnel==0.4.0',
         ],
+        'qdrant': [
+            'qdrant-client>=1.6.9',
+        ],
         'redshift': [
             'boto3==1.26.60',
             'redshift-connector==2.0.909',

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setuptools.setup(
         ],
         'qdrant': [
             'qdrant-client>=1.6.9',
+            'sentence-transformers>=2.2.2',
         ],
         'redshift': [
             'boto3==1.26.60',
@@ -180,8 +181,10 @@ setuptools.setup(
             'pydruid==0.6.5',
             'pymongo==4.3.3',
             'pyodbc==4.0.35',
+            'qdrant-client>=1.6.9',
             'redshift-connector==2.0.909',
             'requests_aws4auth==1.1.2',
+            'sentence-transformers>=2.2.2',
             'snowflake-connector-python==3.2.1',
             'sshtunnel==0.4.0',
             'stomp.py==8.1.0',


### PR DESCRIPTION
# Description
- Add new data loader template and explorter template for Qdrant.
- Add io/qdrant.py script to support the load and exporter function.


# How Has This Been Tested?
Mage UI Loader:
![qdrant_loader](https://github.com/mage-ai/mage-ai/assets/5386254/6ffa2629-5c65-4e95-a2bc-c4743a87ae07)

 Exporter, number of reords written by exporter:
![qdrant_exporter](https://github.com/mage-ai/mage-ai/assets/5386254/2e0cf419-7395-4ae1-ade1-4fb50427c320)

With auto generation vector list to query:
![qdrant_exporter_data_inserted](https://github.com/mage-ai/mage-ai/assets/5386254/a75bc543-9800-4e3a-bfc7-439ec2953eb3)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
@wangxiaoyou1993 
