### PR TITLE
[td] Gracefully access dictionaries in the Oauth Policy

### DIFF
--- a/mage_ai/api/policies/OauthPolicy.py
+++ b/mage_ai/api/policies/OauthPolicy.py
@@ -46,12 +46,12 @@ class OauthPolicy(BasePolicy, UserPermissionMixIn):
             ),
             {
                 OauthScope.CLIENT_PUBLIC: {
-                    OperationType.DETAIL: config[OauthScope.CLIENT_PUBLIC][
-                        OperationType.DETAIL
-                    ],
-                    OperationType.LIST: config[OauthScope.CLIENT_PUBLIC][
-                        OperationType.LIST
-                    ],
+                    OperationType.DETAIL: (config.get(
+                        OauthScope.CLIENT_PUBLIC,
+                    ) or {}).get(OperationType.DETAIL) or {},
+                    OperationType.LIST: (config.get(
+                        OauthScope.CLIENT_PUBLIC,
+                    ) or {}).get(OperationType.LIST) or {},
                 },
             },
         )

--- a/mage_ai/tests/api/policies/test_oauth_policy.py
+++ b/mage_ai/tests/api/policies/test_oauth_policy.py
@@ -1,0 +1,38 @@
+from mage_ai.api.constants import AttributeOperationType
+from mage_ai.api.policies.OauthPolicy import OauthPolicy
+from mage_ai.api.presenters.OauthPresenter import OauthPresenter
+from mage_ai.tests.base_test import AsyncDBTestCase
+
+
+class OauthPolicyTestCase(AsyncDBTestCase):
+    def test_attribute_rule_with_permissions(self):
+        error = False
+
+        try:
+            write_attributes = [
+                'action_type',
+                'provider',
+                'token',
+            ]
+            for key in write_attributes:
+                OauthPolicy.attribute_rule_with_permissions(
+                    AttributeOperationType.WRITE,
+                    key,
+                )
+
+            read_attributes = OauthPresenter.default_attributes
+            for key in read_attributes:
+                OauthPolicy.attribute_rule_with_permissions(
+                    AttributeOperationType.READ,
+                    key,
+                )
+
+            for key in ['doesn’t exist', 'mage']:
+                OauthPolicy.attribute_rule_with_permissions(
+                    AttributeOperationType.QUERY,
+                    key,
+                )
+        except Exception:
+            error = True
+
+        self.assertFalse(error)


### PR DESCRIPTION
# Description
An error was occurring on AWS for a user.

Need to gracefully access dictionaries.

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
