### PR TITLE
[dy] Default to using environment variables for git and workspace settings

### DIFF
--- a/mage_ai/data_preparation/repo_manager.py
+++ b/mage_ai/data_preparation/repo_manager.py
@@ -255,16 +255,26 @@ def get_repo_config(repo_path=None) -> RepoConfig:
 
 
 def get_project_type(repo_path=None) -> ProjectType:
+    from mage_ai.settings.repo import MAGE_PROJECT_TYPE_ENV_VAR
     try:
-        return get_repo_config(repo_path=repo_path).project_type
+        project_type_from_env = os.getenv(MAGE_PROJECT_TYPE_ENV_VAR)
+        if project_type_from_env:
+            return ProjectType(project_type_from_env)
+        else:
+            return get_repo_config(repo_path=repo_path).project_type
     except Exception:
         # default to standalone project type
         return ProjectType.STANDALONE
 
 
 def get_cluster_type(repo_path=None) -> Optional[ClusterType]:
+    from mage_ai.settings.repo import MAGE_CLUSTER_TYPE_ENV_VAR
     try:
-        return get_repo_config(repo_path=repo_path).cluster_type
+        cluster_type_from_env = os.getenv(MAGE_CLUSTER_TYPE_ENV_VAR)
+        if cluster_type_from_env:
+            return ClusterType(cluster_type_from_env)
+        else:
+            return get_repo_config(repo_path=repo_path).cluster_type
     except Exception:
         # default to None
         return None

--- a/mage_ai/data_preparation/sync/__init__.py
+++ b/mage_ai/data_preparation/sync/__init__.py
@@ -32,6 +32,8 @@ class GitConfig(BaseConfig):
     ssh_private_key_secret_name: str = GIT_SSH_PRIVATE_KEY_SECRET_NAME
     ssh_public_key_secret_name: str = GIT_SSH_PUBLIC_KEY_SECRET_NAME
     access_token_secret_name: str = GIT_ACCESS_TOKEN_SECRET_NAME
+    # Force Mage to show git integration panel in the UI
+    enable_git_integration: bool = False
     # This is not necessary anymore, but leaving it for backwards compatibility
     type: str = 'git'
 

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -95,7 +95,13 @@ from mage_ai.settings import (
     SHELL_COMMAND,
     USE_UNIQUE_TERMINAL,
 )
-from mage_ai.settings.repo import DEFAULT_MAGE_DATA_DIR, get_repo_name, set_repo_path
+from mage_ai.settings.repo import (
+    DEFAULT_MAGE_DATA_DIR,
+    MAGE_CLUSTER_TYPE_ENV_VAR,
+    MAGE_PROJECT_TYPE_ENV_VAR,
+    get_repo_name,
+    set_repo_path,
+)
 from mage_ai.shared.constants import ENV_VAR_INSTANCE_TYPE, InstanceType
 from mage_ai.shared.io import chmod
 from mage_ai.shared.logger import LoggingLevel
@@ -648,8 +654,8 @@ if __name__ == '__main__':
     manage = args.manage_instance == '1'
     dbt_docs = args.dbt_docs_instance == '1'
     instance_type = os.getenv(ENV_VAR_INSTANCE_TYPE, args.instance_type)
-    project_type = os.getenv('PROJECT_TYPE', ProjectType.STANDALONE)
-    cluster_type = os.getenv('CLUSTER_TYPE')
+    project_type = os.getenv(MAGE_PROJECT_TYPE_ENV_VAR, ProjectType.STANDALONE)
+    cluster_type = os.getenv(MAGE_CLUSTER_TYPE_ENV_VAR)
 
     start_server(
         host=host,

--- a/mage_ai/settings/repo.py
+++ b/mage_ai/settings/repo.py
@@ -3,6 +3,9 @@ import sys
 
 from mage_ai.shared.environments import is_test
 
+MAGE_PROJECT_TYPE_ENV_VAR = 'PROJECT_TYPE'
+MAGE_CLUSTER_TYPE_ENV_VAR = 'CLUSTER_TYPE'
+
 """
 Moved from repo_manager because repo_manager has too many dependencies
 which can cause circular import errors.


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

For git settings and workspace settings, I'm changing Mage to default to the environment variable values if they exist. These values are saved to project config, but I think it makes more sense to default to the env var value since those are specifically set by the user when configuring their mage projects.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
