### PR TITLE
[xy] Pass tolerations to job pod.

### DIFF
--- a/mage_ai/services/k8s/job_manager.py
+++ b/mage_ai/services/k8s/job_manager.py
@@ -154,6 +154,7 @@ class JobManager():
         pod_spec.containers = [container]
         mage_server_pod_spec = self.pod_config.spec
         pod_spec.volumes.extend(mage_server_pod_spec.volumes)
+        pod_spec.tolerations = mage_server_pod_spec.tolerations
         pod_spec.node_selector = mage_server_pod_spec.node_selector
         pod_spec.image_pull_secrets = pod_spec.image_pull_secrets if pod_spec.image_pull_secrets \
             else mage_server_pod_spec.image_pull_secrets

--- a/mage_ai/tests/services/k8s/test_job_manager.py
+++ b/mage_ai/tests/services/k8s/test_job_manager.py
@@ -41,6 +41,14 @@ MOCK_POD_CONFIG = V1Pod(
         )],
         restart_policy='Never',
         service_account_name='old_service_account_name',
+        tolerations=[
+            {
+                'effect': 'NoExecute',
+                'key': 'node.kubernetes.io/not-ready',
+                'operator': 'Exists',
+                'toleration_seconds': 300,
+            },
+        ],
         volumes=[],
     )
 )
@@ -187,6 +195,14 @@ class JobManagerTests(TestCase):
                     prefix=None,
                     secret_ref=V1SecretEnvSource(name='mysecret', optional=None),
                 ),
+        ])
+        self.assertEqual(pod_config.tolerations, [
+            {
+                'effect': 'NoExecute',
+                'key': 'node.kubernetes.io/not-ready',
+                'operator': 'Exists',
+                'toleration_seconds': 300,
+            },
         ])
 
         mock_client.V1ResourceRequirements.assert_called_once_with(


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Pass tolerations from main pod to job pod.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with local k8s cluster. Check the tolerations of the job pod. tolerations is correctly passed from main pod to job pod.

**Before the change:**
* main pod 
  <img width="585" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/fd55e467-6514-4476-8a7f-5a731f5a1b78">

* job pod
  <img width="553" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/8b772107-665e-43e9-81ba-4f1caec5f505">


**After the change:**
* job pod
  <img width="574" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/fd80c57b-43c0-4c8f-825f-a23b168124da">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
