### PR TITLE
[jk] Display error in UI when variables directories configured incorrectly

### DIFF
--- a/mage_ai/api/presenters/PipelinePresenter.py
+++ b/mage_ai/api/presenters/PipelinePresenter.py
@@ -66,6 +66,14 @@ class PipelinePresenter(BasePresenter):
                     FeatureUUID.DATA_INTEGRATION_IN_BATCH_PIPELINE,
                 )
 
+            include_variables_dir = query.get('include_variables_dir', [False])
+            if include_variables_dir:
+                include_variables_dir = include_variables_dir[0]
+
+            include_remote_variables_dir = query.get('include_remote_variables_dir', [False])
+            if include_remote_variables_dir:
+                include_remote_variables_dir = include_remote_variables_dir[0]
+
             return await self.model.to_dict_async(
                 include_block_catalog=include_block_catalog,
                 include_block_metadata=include_block_metadata,
@@ -77,6 +85,8 @@ class PipelinePresenter(BasePresenter):
                 include_extensions=include_extensions,
                 include_outputs=include_outputs,
                 include_outputs_spark=include_outputs_spark,
+                include_remote_variables_dir=include_remote_variables_dir,
+                include_variables_dir=include_variables_dir,
                 sample_count=DATAFRAME_SAMPLE_COUNT_PREVIEW,
             )
         elif constants.UPDATE == display_format:

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -729,6 +729,8 @@ class Pipeline:
         include_extensions: bool = False,
         include_outputs: bool = False,
         include_outputs_spark: bool = False,
+        include_remote_variables_dir: bool = False,
+        include_variables_dir: bool = False,
         sample_count: int = None,
     ):
         shared_kwargs = dict(
@@ -790,6 +792,12 @@ class Pipeline:
                     ),
                 )
             data.update(extensions=extensions_data)
+
+        if include_variables_dir:
+            data.update(variables_dir=self.variables_dir)
+
+        if include_remote_variables_dir:
+            data.update(remote_variables_dir=self.remote_variables_dir)
 
         return merge_dict(self.to_dict_base(), data)
 

--- a/mage_ai/frontend/api/utils/response.ts
+++ b/mage_ai/frontend/api/utils/response.ts
@@ -164,11 +164,18 @@ export function displayErrorFromReadResponse(
     linksFinal = linksFinal.concat(tooManyOpenFilesErrLink);
   }
   if (data?.error) {
-    setErrors?.({
-      errors: parseErrorFromResponse(data),
-      links: linksFinal,
-      response: data,
-    });
+    if (data?.error?.displayMessage) {
+      setErrors?.({
+        displayMessage: data.error.displayMessage,
+        links: linksFinal,
+      });
+    } else {
+      setErrors?.({
+        errors: parseErrorFromResponse(data),
+        links: linksFinal,
+        response: data,
+      });
+    }
   } else {
     setErrors?.(null);
   }

--- a/mage_ai/frontend/components/ErrorPopup/index.tsx
+++ b/mage_ai/frontend/components/ErrorPopup/index.tsx
@@ -131,7 +131,7 @@ function ErrorPopup({
         </Spacing>
       )}
 
-      {errors && (
+      {(errors && errors?.[0] !== '') && (
         <Spacing mt={2}>
           <Text bold large>
             Stack trace (<Link

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1333,6 +1333,13 @@ function PipelineDetailPage({
       dataWithPotentialError = dataDataProviders;
     } else if ((pipeline?.variables_dir?.includes('.mage_data')
       || pipeline?.remote_variables_dir === 'None') && !filePathFromUrl) {
+      /*
+       * If the variables_dir is not provided in the metadata.yaml project config file,
+       * the default Mage data directory (.mage_data) is used, so we check for that value.
+       * The remote_variables_dir property is not required to have a value, but if an
+       * empty variable is accidentally used, its value may be assigned to "None", which
+       * would not be the intended directory.
+       */
       dataWithPotentialError = {
         error: {
           displayMessage: 'The variables_dir or remote_variables_dir might be empty or '


### PR DESCRIPTION
# Description
- In the project's `metadata.yaml` configuration file, it could be difficult or cryptic to identify that the `variables_dir` or `remote_variables_dir` was configured incorrectly (e.g. due to an empty variable or missing value). This PR checks for issues with those properties and displays an error in the UI with a link to the config file, allowing a user to easily fix their project's configuration.

# How Has This Been Tested?
Tested with an empty `variables_dir` in the config file, as well as an empty interpolated variable for the `remote_variables_dir`:
![misconfigured variables directories](https://github.com/mage-ai/mage-ai/assets/78053898/1704087d-c98c-4d11-860f-2c59a3f759b2)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
