### PR TITLE
[mp] add user guide and update tutorial to explain blocks

### DIFF
--- a/docs/_snippets/whats-a-block.mdx
+++ b/docs/_snippets/whats-a-block.mdx
@@ -1,0 +1,20 @@
+Blocks are just Python files that live in your project. You can navigate through your blocks on the left side of the screen, drag and drop them into your pipeline, or create new ones from the pipeline editor.
+
+Blocks are reusable, atomic peices of code that perform certain actions. Changing one block _will_ change it everywhere it's used, but don't worry, it's easy to detach blocks to separate instances if necessary.
+
+Blocks can be used to perform a variety of actions, from simple data transformations to complex machine learning models. You can even use blocks to run custom code, or to connect to external services.
+
+Within a block, the _decorated_ function (`custom`, `loader`, `transformer`, etc) will be executed. The first argument to the function _must_ be a dataframe or JSON serializable object. The function can return a dataframe or JSON serializable object, or it can return nothing.
+
+You can think of this function like a python `main()` function, when we run the block, this function will be executed. For example, the following block will return the first 10 rows of the dataframe passed in:
+
+```python
+from pandas import DataFrame
+
+
+@transformer
+def transform_df(df: DataFrame, *args, **kwargs) -> DataFrame:
+    return df.iloc[:10]
+```
+
+Other code outside the block will be executed, but it _will_ not be returned. You can read more about blocks [here](/design/blocks).

--- a/docs/data-integrations/destinations/overview.mdx
+++ b/docs/data-integrations/destinations/overview.mdx
@@ -18,3 +18,7 @@ Destinations are defined in the `mage_integrations/destinations/` directory.
 
 All destinations should be a subclass of the `Destination` class defined in
 `mage_integrations/destinations/base.py`.
+
+## Contribute
+
+Want to learn about contributing a destination? Read on [here](/contributing/data-integrations/add-new-destination)!

--- a/docs/data-integrations/sources/overview.mdx
+++ b/docs/data-integrations/sources/overview.mdx
@@ -25,3 +25,7 @@ Sources are defined in the `mage_integrations/sources/` directory.
 
 All sources should be a subclass of the `Source` class defined in
 `mage_integrations/sources/base.py`.
+
+## Contribute
+
+Want to learn about contributing a source? Read on [here](/contributing/data-integrations/add-new-source)!

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -126,7 +126,11 @@ If you haven't already, open a browser to `http://localhost:6789`. From the pipe
 <img src="https://github.com/mage-ai/assets/blob/main/quickstart/open-pipeline.gif?raw=True"/>
 </p>
 
-Select the first cell by clicking it and select the "play" icon in the top right to run the cell. You've just ran your first Mage block & loaded data from a dataset!
+Select the first block by clicking it and select the "play" icon in the top right to run the block. You've just ran your first Mage block & loaded data from a dataset!
+
+<Accordion title="🤔 What's a block?">
+<Snippet file="whats-a-block.mdx"/>
+</Accordion>
 
 Do the same for the following cells in the pipeline to transform and export the data. Congrats, you're now a Mage ninja! 🥷
 

--- a/docs/guides/community-examples.mdx
+++ b/docs/guides/community-examples.mdx
@@ -14,6 +14,10 @@ In her post, Xiaoxu introduces the concept of a _communication lifecycle_ for da
 
 Sri Nikitha walks through a demo of Mage: from installation to a sample pipeline that loads data from a NYC taxi dataset, transforms it, and exports to BigQuery. 
 
+### [Postgres to Snowflake Data Transfer](https://sudsy-pail-0c7.notion.site/Data-Migration-Tutorial-using-Mage-46c027b4095d4c9c8216c566eee3c3a4)
+
+Jafar Sharif walks through a tutorial on how to transfer data from Postgres to Snowflake using Mage, including some core ETL functionality. A quick and fun read!
+
 ## Video Tutorials
 
 ### How To Create Data Pipelines in Mage
@@ -57,3 +61,4 @@ Arul discusses the process of constructing an ETL (extract-transform-load) pipel
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen
 ></iframe>
+

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -180,15 +180,13 @@
               "group": "Sources",
               "pages": [
                 "data-integrations/sources/overview",
-                "data-integrations/sources/add-new-source",
                 "data-integrations/sources/postgresql"
               ]
             },
             {
               "group": "Destinations",
               "pages": [
-                "data-integrations/destinations/overview",
-                "data-integrations/destinations/add-new-destination"
+                "data-integrations/destinations/overview"
               ]
             },
             "data-integrations/batch-pipelines"


### PR DESCRIPTION
# Description

This PR adds a user's guide on ETL to our community support, cleans up a few things in the `mint.json`, and adds a verbose description of "what is a block" to our guide.