### PR TITLE
[jk] Hide "Unique" and "Key" columns for certain data integration destination blocks

### DIFF
--- a/mage_ai/frontend/components/DataIntegrationModal/StreamDetail/StreamDetailSchemaProperties.tsx
+++ b/mage_ai/frontend/components/DataIntegrationModal/StreamDetail/StreamDetailSchemaProperties.tsx
@@ -22,7 +22,7 @@ import {
   SchemaPropertyType,
   StreamType,
 } from '@interfaces/IntegrationSourceType';
-import { DESTINATIONS_NO_UNIQUE_OR_KEY_SUPPORT } from '@interfaces/DataSourceType';
+import { DESTINATIONS_NO_UNIQUE_OR_KEY_SUPPORT } from '@interfaces/IntegrationSourceType';
 import { PADDING_UNITS, UNIT, UNITS_BETWEEN_SECTIONS } from '@oracle/styles/units/spacing';
 import {
   PropertyColumnMoreType,

--- a/mage_ai/frontend/components/DataIntegrationModal/StreamDetail/StreamDetailSchemaProperties.tsx
+++ b/mage_ai/frontend/components/DataIntegrationModal/StreamDetail/StreamDetailSchemaProperties.tsx
@@ -201,7 +201,7 @@ function StreamDetailSchemaProperties({
             ...md?.metadata,
             ...opts,
           },
-        }
+        };
 
         return acc;
       }, {});
@@ -249,7 +249,7 @@ function StreamDetailSchemaProperties({
       });
     }
 
-    columnFlexInner.push(...[null, null])
+    columnFlexInner.push(...[null, null]);
     columnsInner.push(...[
       {
         center: true,
@@ -362,7 +362,6 @@ function StreamDetailSchemaProperties({
     setCoordinates,
     setPropertyFocused,
     stream,
-    updateStreamInBlock,
   ]);
 
   const rows = useMemo(() => schemaPropertiesSortedArray?.map(({
@@ -504,11 +503,8 @@ function StreamDetailSchemaProperties({
     keyPropertiesMapping,
     partitionKeysMapping,
     renderTypes,
-    schemaProperties,
     schemaPropertiesSortedArray,
     setBlockAttributes,
-    setCoordinates,
-    setPropertyFocused,
     stream,
     uniqueConstraintsMapping,
   ]);
@@ -726,7 +722,6 @@ function StreamDetailSchemaProperties({
   }, [
     renderTypes,
     selectedPropertiesToMerge,
-    setSelectedPropertiesToMerge,
     updateColumnsInSelectedPropertiesToMerge,
   ]);
 
@@ -806,7 +801,7 @@ function StreamDetailSchemaProperties({
 
     const rowsNewColumnsSettings = sortByKey(
       Object.entries(newColumnSettings),
-      ([column,]) => column,
+      ([column]) => column,
     ).map(([
       column,
       property,
@@ -872,36 +867,33 @@ function StreamDetailSchemaProperties({
     diffs,
     renderTableConflict,
     schemaProperties,
-    stream,
   ]);
 
-  const tableMemo = useMemo(() => {
-    return (
-      <Table
-        columnFlex={columnFlex}
-        columns={columns}
-        highlightRowOnHover
-        isSelectedRow={(index: number) => getSchemaPropertyAndHighlightedByIndex(
-          index,
-        )?.highlighted}
-        menu={rowMenu}
-        onClickRow={(index: number) => {
-          const {
-            column,
-            highlighted,
-          } = getSchemaPropertyAndHighlightedByIndex(index);
+  const tableMemo = useMemo(() => (
+    <Table
+      columnFlex={columnFlex}
+      columns={columns}
+      highlightRowOnHover
+      isSelectedRow={(index: number) => getSchemaPropertyAndHighlightedByIndex(
+        index,
+      )?.highlighted}
+      menu={rowMenu}
+      onClickRow={(index: number) => {
+        const {
+          column,
+          highlighted,
+        } = getSchemaPropertyAndHighlightedByIndex(index);
 
-          setHighlightedColumnsMapping(prev => highlighted
-            ? ignoreKeys(prev, [column])
-            : { ...prev, [column]: true }
-          );
-        }}
-        ref={refTable}
-        rows={rows}
-        stickyHeader
-      />
-    );
-  }, [
+        setHighlightedColumnsMapping(prev => highlighted
+          ? ignoreKeys(prev, [column])
+          : { ...prev, [column]: true }
+        );
+      }}
+      ref={refTable}
+      rows={rows}
+      stickyHeader
+    />
+    ), [
     columnFlex,
     columns,
     getSchemaPropertyAndHighlightedByIndex,

--- a/mage_ai/frontend/components/DataIntegrationModal/StreamSchemaPropertiesEditor/index.tsx
+++ b/mage_ai/frontend/components/DataIntegrationModal/StreamSchemaPropertiesEditor/index.tsx
@@ -16,7 +16,7 @@ import {
 } from '@utils/models/block';
 import { BackgroundStyle } from '../index.style';
 import { COLUMN_TYPES, ReplicationMethodEnum } from '@interfaces/IntegrationSourceType';
-import { DESTINATIONS_NO_UNIQUE_OR_KEY_SUPPORT } from '@interfaces/DataSourceType';
+import { DESTINATIONS_NO_UNIQUE_OR_KEY_SUPPORT } from '@interfaces/IntegrationSourceType';
 import { InputTypeEnum } from '../constants';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { StreamDetailProps } from '../StreamDetail/constants';

--- a/mage_ai/frontend/components/DataIntegrationModal/StreamSchemaPropertiesEditor/index.tsx
+++ b/mage_ai/frontend/components/DataIntegrationModal/StreamSchemaPropertiesEditor/index.tsx
@@ -7,11 +7,6 @@ import Spacing from '@oracle/elements/Spacing';
 import StreamSettingsEditorTable from '../StreamSettingsEditorTable';
 import StreamTableSelector from '../StreamTableSelector';
 import Text from '@oracle/elements/Text';
-import { BackgroundStyle } from '../index.style';
-import { InputTypeEnum } from '../constants';
-import { StreamDetailProps } from '../StreamDetail/constants';
-import { COLUMN_TYPES } from '@interfaces/IntegrationSourceType';
-import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import {
   AttributeUUIDEnum,
   AttributesMappingType,
@@ -19,9 +14,15 @@ import {
   getParentStreamID,
   getStreamID,
 } from '@utils/models/block';
+import { BackgroundStyle } from '../index.style';
+import { COLUMN_TYPES, ReplicationMethodEnum } from '@interfaces/IntegrationSourceType';
+import { DESTINATIONS_NO_UNIQUE_OR_KEY_SUPPORT } from '@interfaces/DataSourceType';
+import { InputTypeEnum } from '../constants';
+import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
+import { StreamDetailProps } from '../StreamDetail/constants';
 import { capitalizeRemoveUnderscoreLower, pluralize } from '@utils/string';
 import { ignoreKeys } from '@utils/hash';
-import { sortByKey } from '@utils/array';
+import { rangeSequential, sortByKey } from '@utils/array';
 
 type StreamSchemaPropertiesEditorProps = {
   attributesMapping: AttributesMappingType;
@@ -32,6 +33,7 @@ type StreamSchemaPropertiesEditorProps = {
 
 function StreamSchemaPropertiesEditor({
   attributesMapping,
+  block,
   highlightedColumnsMapping,
   selectedStreamMapping,
   setAttributesMapping,
@@ -41,6 +43,12 @@ function StreamSchemaPropertiesEditor({
   streamMapping,
   updateStreamsInCatalog,
 }: StreamSchemaPropertiesEditorProps & StreamDetailProps) {
+  const blockDestinationType = block?.metadata?.data_integration?.destination;
+  const supportsUniqueAndKeyProperties = useMemo(() =>
+    !DESTINATIONS_NO_UNIQUE_OR_KEY_SUPPORT.includes(blockDestinationType),
+    [blockDestinationType],
+  );
+
   useEffect(() => {
     if (stream && !selectedStreamMapping) {
       const id = getStreamID(stream || {});
@@ -70,65 +78,92 @@ function StreamSchemaPropertiesEditor({
     stream,
   ]);
 
-  const tableMemo = useMemo(() => (
-    <StreamSettingsEditorTable
-      attributes={[
+  const usingIncrementalReplication = useMemo(() =>
+    stream?.replication_method === ReplicationMethodEnum.INCREMENTAL,
+    [stream?.replication_method],
+  );
+  const tableMemo = useMemo(() => {
+    const streamSettingAttributes = [
+      {
+        label: () => 'Include property when syncing',
+        inputType: InputTypeEnum.CHECKBOX,
+        uuid: AttributeUUIDEnum.PROPERTY_SELECTED,
+      },
+      {
+        label: () => 'Partition key',
+        inputType: InputTypeEnum.CHECKBOX,
+        uuid: AttributeUUIDEnum.PARTITION_KEYS,
+      },
+      ...COLUMN_TYPES.map((columnType: string) => ({
+        label: () => capitalizeRemoveUnderscoreLower(columnType),
+        inputType: InputTypeEnum.CHECKBOX,
+        uuid: columnType,
+      })),
+    ];
+
+    if (usingIncrementalReplication) {
+      streamSettingAttributes.splice(1, 0,
         {
-          label: () => 'Include property when syncing',
+          label: () => 'Bookmark property',
           inputType: InputTypeEnum.CHECKBOX,
-          uuid: AttributeUUIDEnum.PROPERTY_SELECTED,
+          uuid: AttributeUUIDEnum.BOOKMARK_PROPERTIES,
         },
+      );
+    }
+
+    if (supportsUniqueAndKeyProperties) {
+      streamSettingAttributes.splice(1, 0,
         {
           label: () => 'Unique constraint',
           inputType: InputTypeEnum.CHECKBOX,
           uuid: AttributeUUIDEnum.UNIQUE_CONSTRAINTS,
         },
         {
-          label: () => 'Bookmark property',
-          inputType: InputTypeEnum.CHECKBOX,
-          uuid: AttributeUUIDEnum.BOOKMARK_PROPERTIES,
-        },
-        {
           label: () => 'Key property',
           inputType: InputTypeEnum.CHECKBOX,
           uuid: AttributeUUIDEnum.KEY_PROPERTIES,
         },
-        {
-          label: () => 'Partition key',
-          inputType: InputTypeEnum.CHECKBOX,
-          uuid: AttributeUUIDEnum.PARTITION_KEYS,
-        },
-        ...COLUMN_TYPES.map((columnType: string) => ({
-          label: () => capitalizeRemoveUnderscoreLower(columnType),
-          inputType: InputTypeEnum.CHECKBOX,
-          uuid: columnType,
-        })),
-      ]}
-      attributesMapping={attributesMapping}
-      rowGroupHeaders={[
-        'Options',
-        'Column types',
-      ]}
-      rowsGroupedByIndex={[
-        [0, 1, 2, 3],
-        COLUMN_TYPES?.map((_, idx: number) => idx + 4),
-      ]}
-      setAttributesMapping={setAttributesMapping}
-    />
-  ), [
-    attributesMapping,
-    setAttributesMapping,
-  ]);
+      );
+    }
 
-  const streamsTableMemo = useMemo(() => {
+    let optionsRowGroupingIndexCount = 2;
+    if (usingIncrementalReplication) {
+      optionsRowGroupingIndexCount += 1;
+    }
+    if (supportsUniqueAndKeyProperties) {
+      optionsRowGroupingIndexCount += 2;
+    }
+    const optionsRowGroupingIndexes = rangeSequential(optionsRowGroupingIndexCount);
+
     return (
-      <StreamTableSelector
-        selectedStreamMapping={selectedStreamMapping}
-        setSelectedStreamMapping={setSelectedStreamMapping}
-        streamMapping={streamMapping}
+      <StreamSettingsEditorTable
+        attributes={streamSettingAttributes}
+        attributesMapping={attributesMapping}
+        rowGroupHeaders={[
+          'Options',
+          'Column types',
+        ]}
+        rowsGroupedByIndex={[
+          optionsRowGroupingIndexes,
+          COLUMN_TYPES?.map((_, idx: number) => idx + optionsRowGroupingIndexCount),
+        ]}
+        setAttributesMapping={setAttributesMapping}
       />
     );
   }, [
+    attributesMapping,
+    setAttributesMapping,
+    supportsUniqueAndKeyProperties,
+    usingIncrementalReplication,
+  ]);
+
+  const streamsTableMemo = useMemo(() => (
+    <StreamTableSelector
+      selectedStreamMapping={selectedStreamMapping}
+      setSelectedStreamMapping={setSelectedStreamMapping}
+      streamMapping={streamMapping}
+    />
+    ), [
     selectedStreamMapping,
     setSelectedStreamMapping,
     streamMapping,

--- a/mage_ai/frontend/components/DataIntegrationModal/StreamSchemaPropertiesEditor/index.tsx
+++ b/mage_ai/frontend/components/DataIntegrationModal/StreamSchemaPropertiesEditor/index.tsx
@@ -163,7 +163,7 @@ function StreamSchemaPropertiesEditor({
       setSelectedStreamMapping={setSelectedStreamMapping}
       streamMapping={streamMapping}
     />
-    ), [
+  ), [
     selectedStreamMapping,
     setSelectedStreamMapping,
     streamMapping,

--- a/mage_ai/frontend/components/DataIntegrationModal/index.tsx
+++ b/mage_ai/frontend/components/DataIntegrationModal/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation } from 'react-query';
 
-import BlockType, { BlockTypeEnum, BlockLanguageEnum } from '@interfaces/BlockType';
+import BlockType, { BlockTypeEnum } from '@interfaces/BlockType';
 import Breadcrumbs from '@components/Breadcrumbs';
 import Button from '@oracle/elements/Button';
 import ButtonTabs, { TabType } from '@oracle/components/Tabs/ButtonTabs';
@@ -23,22 +23,16 @@ import StreamGrid from './StreamGrid';
 import StreamOverviewEditor from './StreamOverviewEditor';
 import StreamSchemaPropertiesEditor from './StreamSchemaPropertiesEditor';
 import StreamsOverview from './StreamsOverview';
-import Table from '@components/shared/Table';
 import Text from '@oracle/elements/Text';
 import TextInput from '@oracle/elements/Inputs/TextInput';
 import ToggleSwitch from '@oracle/elements/Inputs/ToggleSwitch';
 import TripleLayout from '@components/TripleLayout';
 import api from '@api';
-import { CatalogType, StreamType } from '@interfaces/IntegrationSourceType';
 import {
-  Check,
   Close,
   CubeWithArrowDown,
   DocumentIcon,
-  Lightning,
-  PlugAPI,
   Search,
-  Settings,
   SettingsWithKnobs,
   Sun,
   Table as TableIcon,
@@ -67,13 +61,10 @@ import {
 import {
   PADDING_UNITS,
   UNIT,
-  UNITS_BETWEEN_ITEMS_IN_SECTIONS,
-  UNITS_BETWEEN_SECTIONS,
 } from '@oracle/styles/units/spacing';
 import {
   AttributesMappingType,
   ColumnsMappingType,
-  StreamDifferencesType,
   StreamMapping,
   buildStreamMapping,
   getAllStreamsFromStreamMapping,
@@ -82,33 +73,34 @@ import {
   getStreamFromStreamMapping,
   getStreamID,
   getStreamIDWithParentStream,
-  isStreamInMappings,
   isStreamSelected,
-  mergeSchemaProperties,
   noStreamsAnywhere as noStreamsAnywhereFunc,
-  updateStreamInBlock,
   updateStreamMappingWithPropertyAttributeValues,
   updateStreamMappingWithStreamAttributes,
-  updateStreamMetadata,
 } from '@utils/models/block';
-import { capitalizeRemoveUnderscoreLower } from '@utils/string';
-import { get, set } from '@storage/localStorage';
+import { StreamType } from '@interfaces/IntegrationSourceType';
+import { get } from '@storage/localStorage';
 import { getColorsForBlockType } from '@components/CodeBlock/index.style';
-import { equals, groupBy, indexBy, intersection, remove, sortByKey } from '@utils/array';
+import { indexBy, intersection, remove, sortByKey } from '@utils/array';
 import { ignoreKeys, isEmptyObject, selectKeys } from '@utils/hash';
 import { onSuccess } from '@api/utils/response';
 import { useError } from '@context/Error';
 import { useWindowSize } from '@utils/sizes';
 
-type DataIntegrationModal = {
+type DataIntegrationModalProps = {
   block: BlockType;
   defaultMainNavigationTab?: MainNavigationTabEnum | string;
   defaultMainNavigationTabSub?: string;
   defaultSubTab?: string;
   onChangeBlock?: (block: BlockType) => void;
+  onChangeCodeBlock?: (type: string, uuid: string, value: string) => void;
   onClose?: () => void;
-  onSaveBlock?: () => void;
+  onSaveBlock?: (block: BlockType) => void;
   pipeline: PipelineType;
+  savePipelineContent?: (payload?: {
+    block?: BlockType;
+    pipeline?: PipelineType;
+  }) => Promise<any>;
   setContent?: (content: string) => void;
 } & CredentialsProps;
 
@@ -126,7 +118,7 @@ function DataIntegrationModal({
   pipeline,
   savePipelineContent,
   setContent,
-}) {
+}: DataIntegrationModalProps) {
   const mainContainerRef = useRef(null);
   const refAfterHeader = useRef(null);
   const refAfterFooter = useRef(null);
@@ -198,7 +190,6 @@ function DataIntegrationModal({
 
     return query;
   }, [
-    dataIntegrationType,
     dataIntegrationUUID,
   ]);
 
@@ -292,7 +283,7 @@ function DataIntegrationModal({
 
       callback?.(updated);
 
-      return updated;;
+      return updated;
     }), [
       setBlockAttributes,
     ]);
@@ -325,7 +316,7 @@ function DataIntegrationModal({
       streams,
     ]);
 
-  const componentUUID = useMemo(() => `DataIntegrationModal/${blockUUID}`, blockUUID);
+  const componentUUID = useMemo(() => `DataIntegrationModal/${blockUUID}`, [blockUUID]);
   const localStorageKeyAfter =
     useMemo(() => `block_layout_after_width_${componentUUID}`, [componentUUID]);
   const localStorageKeyBefore =
@@ -386,7 +377,7 @@ function DataIntegrationModal({
       });
     }
 
-    return SUB_TABS_FOR_STREAM_DETAIL()
+    return SUB_TABS_FOR_STREAM_DETAIL();
   }, [
     selectedMainNavigationTab,
     selectedMainNavigationTabSub,
@@ -481,14 +472,13 @@ function DataIntegrationModal({
         selectedMainNavigationTabSub: mainNavigationTabSub,
         selectedSubTab: subTabUse,
       };
-    }
+    };
 
     setAllTabs((allTabsPrev) => setAllTabsFunc(
       input(allTabsPrev),
       allTabsPrev,
     ));
   }, [
-    selectedMainNavigationTabSub,
     setHighlightedColumnsMapping,
     streamsFromCatalogMapping,
     subTabsForStreamDetail,
@@ -510,6 +500,7 @@ function DataIntegrationModal({
     defaultMainNavigationTab,
     defaultMainNavigationTabSub,
     defaultSubTab,
+    getSubTabForMainNavigationTab,
     selectedMainNavigationTab,
     setSelectedMainNavigationTab,
   ]);
@@ -646,7 +637,7 @@ function DataIntegrationModal({
           && (!parentStreamID || selectedMainNavigationTabSub === parentStreamID);
 
         arr.push(
-          <Divider key={`${uuid}-divider-top`} light />
+          <Divider key={`${uuid}-divider-top`} light />,
         );
 
         arr.push(
@@ -686,12 +677,12 @@ function DataIntegrationModal({
                 </FlexContainer>
               </Spacing>
             </Link>
-          </NavigationStyle>
+          </NavigationStyle>,
         );
 
         if (idx === streamsCount - 1) {
           arr.push(
-            <Divider key={`${uuid}-divider-last`} light />
+            <Divider key={`${uuid}-divider-last`} light />,
           );
         }
       });
@@ -733,7 +724,7 @@ function DataIntegrationModal({
               streams: streamsInit,
             } = integrationSource;
 
-            setStreamsFetched(streamsInit)
+            setStreamsFetched(streamsInit);
           },
           onErrorCallback: (response, errors) => showError({
             errors,
@@ -755,78 +746,75 @@ function DataIntegrationModal({
 
   const [searchText, setSearchText] = useState<string>(null);
 
-  const subheaderEl = useMemo(() => {
-    return (
-      <div ref={refSubheader}>
-        {subtabs?.length >= 1 && (
-          <Spacing p={PADDING_UNITS} >
-            <ButtonTabs
-              noPadding
-              onClickTab={({ uuid }) => setSelectedMainNavigationTab(prev => ({
-                ...prev,
-                selectedSubTab: uuid,
-              }))}
-              regularSizeText
-              selectedTabUUID={selectedSubTab}
-              tabs={subtabs}
+  const subheaderEl = useMemo(() => (
+    <div ref={refSubheader}>
+      {subtabs?.length >= 1 && (
+        <Spacing p={PADDING_UNITS} >
+          <ButtonTabs
+            noPadding
+            onClickTab={({ uuid }) => setSelectedMainNavigationTab(prev => ({
+              ...prev,
+              selectedSubTab: uuid,
+            }))}
+            regularSizeText
+            selectedTabUUID={selectedSubTab}
+            tabs={subtabs}
+          />
+        </Spacing>
+      )}
+
+      {!subtabs?.length && MainNavigationTabEnum.STREAMS === selectedMainNavigationTab && (
+        <FlexContainer
+          alignItems="center"
+          justifyContent="space-between"
+        >
+          <Flex flex={1}>
+            <TextInput
+              beforeIcon={<Search muted={!searchText?.length} size={2 * UNIT} />}
+              fullWidth
+              noBackground
+              noBorder
+              noBorderRadiusBottom
+              noBorderRadiusTop
+              onChange={e => setSearchText(e?.target?.value)}
+              paddingHorizontal={UNIT * PADDING_UNITS}
+              paddingVertical={UNIT * PADDING_UNITS}
+              placeholder="Type the name of the stream to filter..."
+              value={searchText || ''}
             />
-          </Spacing>
-        )}
+          </Flex>
 
-        {!subtabs?.length && MainNavigationTabEnum.STREAMS === selectedMainNavigationTab && (
-          <FlexContainer
-            alignItems="center"
-            justifyContent="space-between"
-          >
-            <Flex flex={1}>
-              <TextInput
-                beforeIcon={<Search muted={!searchText?.length} size={2 * UNIT} />}
-                fullWidth
-                noBackground
-                noBorder
-                noBorderRadiusBottom
-                noBorderRadiusTop
-                onChange={e => setSearchText(e?.target?.value)}
-                paddingHorizontal={UNIT * PADDING_UNITS}
-                paddingVertical={UNIT * PADDING_UNITS}
-                placeholder="Type the name of the stream to filter..."
-                value={searchText || ''}
-              />
-            </Flex>
+          {searchText?.length >= 1 && (
+            <Button
+              iconOnly
+              noPadding
+              noBackground
+              noBorder
+              onClick={() => setSearchText(null)}
+            >
+              <Close default size={2 * UNIT} />
+            </Button>
+          )}
 
-            {searchText?.length >= 1 && (
+          {!noStreamsAnywhere && (
+            <Spacing px={PADDING_UNITS}>
               <Button
-                iconOnly
-                noPadding
-                noBackground
-                noBorder
-                onClick={() => setSearchText(null)}
+                beforeIcon={<CubeWithArrowDown size={2 * UNIT} />}
+                compact
+                loading={isLoadingFetchIntegrationSource}
+                onClick={() => fetchIntegrationSource()}
+                primary
               >
-                <Close default size={2 * UNIT} />
+                Fetch streams
               </Button>
-            )}
+            </Spacing>
+          )}
+        </FlexContainer>
+      )}
 
-            {!noStreamsAnywhere && (
-              <Spacing px={PADDING_UNITS}>
-                <Button
-                  beforeIcon={<CubeWithArrowDown size={2 * UNIT} />}
-                  compact
-                  loading={isLoadingFetchIntegrationSource}
-                  onClick={() => fetchIntegrationSource()}
-                  primary
-                >
-                  Fetch streams
-                </Button>
-              </Spacing>
-            )}
-          </FlexContainer>
-        )}
-
-        <Divider light />
-      </div>
-    );
-  }, [
-    blockUUID,
+      <Divider light />
+    </div>
+  ), [
     fetchIntegrationSource,
     isLoadingFetchIntegrationSource,
     noStreamsAnywhere,
@@ -835,6 +823,7 @@ function DataIntegrationModal({
     selectedMainNavigationTab,
     selectedSubTab,
     setSearchText,
+    setSelectedMainNavigationTab,
     subtabs,
   ]);
 
@@ -924,8 +913,6 @@ function DataIntegrationModal({
     isOnConfigurationCredentials,
     isOnStreamDetailSchemaProperties,
     isOnStreamsOverview,
-    selectedMainNavigationTab,
-    selectedSubTab,
     streams,
   ]);
 
@@ -990,7 +977,7 @@ function DataIntegrationModal({
         && blockContentFromBlockProp !== null
         )
           ? blockContentFromBlockProp
-          : blockContentFromBlockAttributes
+          : blockContentFromBlockAttributes,
       );
     }
   }, [
@@ -1300,11 +1287,11 @@ function DataIntegrationModal({
                     Upstream blocks can still be selected to have its data ingested.
                     This is toggled and configured in the <Link
                       bold
-                      primary
-                      preventDefault
                       onClick={() => setSelectedMainNavigationTab(() => ({
                         selectedMainNavigationTab: MainNavigationTabEnum.STREAMS,
                       }))}
+                      preventDefault
+                      primary
                     >
                       Streams
                     </Link> section.
@@ -1361,9 +1348,11 @@ function DataIntegrationModal({
           blocksMapping={blocksMapping}
           onChangeBlock={onChangeBlock}
           selectedStreamMapping={selectedStreamMapping}
-          setSelectedMainNavigationTab={(selectedMainNavigationTab: MainNavigationTabEnum) => setSelectedMainNavigationTab(prev => ({
-            selectedMainNavigationTab,
-          }))}
+          setSelectedMainNavigationTab={
+            (selectedMainNavigationTab: MainNavigationTabEnum) => setSelectedMainNavigationTab(prev => ({
+              selectedMainNavigationTab,
+            }))
+          }
           setSelectedStreamMapping={setSelectedStreamMapping}
           streamMapping={streamsFromCatalogMapping}
           updateStreamsInCatalog={updateStreamsInCatalog}
@@ -1372,7 +1361,6 @@ function DataIntegrationModal({
     }
   }, [
     blockAttributes,
-    blockLanguage,
     blockType,
     blockUUID,
     blockUpstreamBlocks,
@@ -1384,9 +1372,7 @@ function DataIntegrationModal({
     isLoadingFetchIntegrationSource,
     noStreamsAnywhere,
     onChangeBlock,
-    pipelineUUID,
     selectedMainNavigationTab,
-    selectedMainNavigationTabSub,
     selectedStreamMapping,
     selectedSubTab,
     setDataIntegrationConfigurationForInputs,
@@ -1454,7 +1440,7 @@ function DataIntegrationModal({
                     streamMappingUpdated = updateStreamMappingWithStreamAttributes(
                       selectedStreamMapping,
                       attributesMapping,
-                    )
+                    );
                   }
 
                   updateStreamsInCatalog(
@@ -1503,6 +1489,7 @@ function DataIntegrationModal({
     setAttributesMapping,
     setHighlightedColumnsMapping,
     setSelectedStreamMapping,
+    updateStreamsInCatalog,
   ]);
 
   const after = useMemo(() => {
@@ -1567,10 +1554,9 @@ function DataIntegrationModal({
     isOnConfigurationCredentials,
     isOnStreamDetailSchemaProperties,
     isOnStreamsOverview,
+    selectedMainNavigationTab,
+    selectedMainNavigationTabSub,
     selectedStreamMapping,
-    setAttributesMapping,
-    setHighlightedColumnsMapping,
-    setSelectedStreamMapping,
     streamsFromCatalogMapping,
     updateStreamsInCatalog,
   ]);
@@ -1703,12 +1689,12 @@ function DataIntegrationModal({
         afterFooter={afterFooter}
         afterFooterBottomOffset={afterFooterBottom}
         afterHeader={(
-          <Spacing ref={refAfterHeader} px={1}>
+          <Spacing px={1} ref={refAfterHeader}>
             {afterHeader}
           </Spacing>
         )}
-        afterHeightOffset={0}
         afterHeaderOffset={0}
+        afterHeightOffset={0}
         afterHidden={afterHidden}
         afterInnerHeightMinus={
           // After header is always 48
@@ -1748,6 +1734,6 @@ function DataIntegrationModal({
       </TripleLayout>
     </ContainerStyle>
   );
-};
+}
 
 export default DataIntegrationModal;

--- a/mage_ai/frontend/components/DataIntegrationModal/index.tsx
+++ b/mage_ai/frontend/components/DataIntegrationModal/index.tsx
@@ -385,7 +385,7 @@ function DataIntegrationModal({
   ]);
 
   const getSubTabForMainNavigationTab =
-    useCallback((mainNavigationTab: MainNavigationTabEnum): TabType[] => {
+    useCallback((mainNavigationTab: MainNavigationTabEnum | string): TabType[] => {
       if (mainNavigationTab in SUB_TABS_BY_MAIN_NAVIGATION_TAB) {
         return SUB_TABS_BY_MAIN_NAVIGATION_TAB[mainNavigationTab];
       }

--- a/mage_ai/frontend/interfaces/BlockType.ts
+++ b/mage_ai/frontend/interfaces/BlockType.ts
@@ -284,9 +284,9 @@ export default interface BlockType {
       config?: {
         [key: string]: number | string;
       };
-      destination?: string;
+      destination?: DataSourceTypeEnum;
       name?: string;
-      source?: string;
+      source?: DataSourceTypeEnum;
       sql?: boolean;
     };
     dbt?: {

--- a/mage_ai/frontend/interfaces/BlockType.ts
+++ b/mage_ai/frontend/interfaces/BlockType.ts
@@ -6,6 +6,7 @@ import { ConfigurationType } from './ChartBlockType';
 import { DataSourceTypeEnum } from './DataSourceType';
 import { DataTypeEnum } from './KernelOutputType';
 import { ExecutorTypeEnum } from '@interfaces/ExecutorType';
+import { IntegrationDestinationEnum, IntegrationSourceEnum } from './IntegrationSourceType';
 
 export enum TagEnum {
   CONDITION = 'condition',
@@ -284,9 +285,9 @@ export default interface BlockType {
       config?: {
         [key: string]: number | string;
       };
-      destination?: DataSourceTypeEnum;
+      destination?: IntegrationDestinationEnum;
       name?: string;
-      source?: DataSourceTypeEnum;
+      source?: IntegrationSourceEnum;
       sql?: boolean;
     };
     dbt?: {

--- a/mage_ai/frontend/interfaces/DataSourceType.ts
+++ b/mage_ai/frontend/interfaces/DataSourceType.ts
@@ -72,6 +72,12 @@ export const DATA_SOURCE_TYPE_HUMAN_READABLE_NAME_MAPPING = {
   [DataSourceTypeEnum.TRINO]: 'Trino',
 };
 
+export const DESTINATIONS_NO_UNIQUE_OR_KEY_SUPPORT: DataSourceTypeEnum[] = [
+  DataSourceTypeEnum.GOOGLE_CLOUD_STORAGE,
+  DataSourceTypeEnum.KAFKA,
+  DataSourceTypeEnum.S3,
+];
+
 export const DATA_SOURCE_TYPES: { [blockType in BlockTypeEnum]?: DataSourceTypeEnum[] } = {
   [BlockTypeEnum.DATA_LOADER]: [
     DataSourceTypeEnum.GENERIC,

--- a/mage_ai/frontend/interfaces/DataSourceType.ts
+++ b/mage_ai/frontend/interfaces/DataSourceType.ts
@@ -2,6 +2,7 @@ import { BlockTypeEnum } from './BlockType';
 
 export enum DataSourceTypeEnum {
   ACTIVEMQ = 'activemq',
+  AMAZON_S3 = 'amazon_s3',    // Used for the source/destination type of a data integration block
   AMAZON_SQS = 'amazon_sqs',
   API = 'api',
   AZURE_BLOB_STORAGE = 'azure_blob_storage',
@@ -31,7 +32,7 @@ export enum DataSourceTypeEnum {
   POSTGRES = 'postgres',
   RABBITMQ = 'rabbitmq',
   REDSHIFT = 'redshift',
-  S3 = 's3',
+  S3 = 's3',    // Also refers to Amazon S3
   SNOWFLAKE = 'snowflake',
   TRINO = 'trino',
 }
@@ -73,9 +74,9 @@ export const DATA_SOURCE_TYPE_HUMAN_READABLE_NAME_MAPPING = {
 };
 
 export const DESTINATIONS_NO_UNIQUE_OR_KEY_SUPPORT: DataSourceTypeEnum[] = [
+  DataSourceTypeEnum.AMAZON_S3,
   DataSourceTypeEnum.GOOGLE_CLOUD_STORAGE,
   DataSourceTypeEnum.KAFKA,
-  DataSourceTypeEnum.S3,
 ];
 
 export const DATA_SOURCE_TYPES: { [blockType in BlockTypeEnum]?: DataSourceTypeEnum[] } = {

--- a/mage_ai/frontend/interfaces/DataSourceType.ts
+++ b/mage_ai/frontend/interfaces/DataSourceType.ts
@@ -2,7 +2,6 @@ import { BlockTypeEnum } from './BlockType';
 
 export enum DataSourceTypeEnum {
   ACTIVEMQ = 'activemq',
-  AMAZON_S3 = 'amazon_s3',    // Used for the source/destination type of a data integration block
   AMAZON_SQS = 'amazon_sqs',
   API = 'api',
   AZURE_BLOB_STORAGE = 'azure_blob_storage',
@@ -32,7 +31,7 @@ export enum DataSourceTypeEnum {
   POSTGRES = 'postgres',
   RABBITMQ = 'rabbitmq',
   REDSHIFT = 'redshift',
-  S3 = 's3',    // Also refers to Amazon S3
+  S3 = 's3',
   SNOWFLAKE = 'snowflake',
   TRINO = 'trino',
 }
@@ -72,12 +71,6 @@ export const DATA_SOURCE_TYPE_HUMAN_READABLE_NAME_MAPPING = {
   [DataSourceTypeEnum.SNOWFLAKE]: 'Snowflake',
   [DataSourceTypeEnum.TRINO]: 'Trino',
 };
-
-export const DESTINATIONS_NO_UNIQUE_OR_KEY_SUPPORT: DataSourceTypeEnum[] = [
-  DataSourceTypeEnum.AMAZON_S3,
-  DataSourceTypeEnum.GOOGLE_CLOUD_STORAGE,
-  DataSourceTypeEnum.KAFKA,
-];
 
 export const DATA_SOURCE_TYPES: { [blockType in BlockTypeEnum]?: DataSourceTypeEnum[] } = {
   [BlockTypeEnum.DATA_LOADER]: [

--- a/mage_ai/frontend/interfaces/IntegrationSourceType.ts
+++ b/mage_ai/frontend/interfaces/IntegrationSourceType.ts
@@ -151,12 +151,21 @@ export enum IntegrationSourceEnum {
 }
 
 export enum IntegrationDestinationEnum {
+  AMAZON_S3 = 'amazon_s3',
   BIGQUERY = 'bigquery',
   DELTA_LAKE_S3 = 'delta_lake_s3',
+  GOOGLE_CLOUD_STORAGE = 'google_cloud_storage',
+  KAFKA = 'kafka',
   MYSQL = 'mysql',
   POSTGRESQL = 'postgresql',
   SNOWFLAKE = 'snowflake',
 }
+
+export const DESTINATIONS_NO_UNIQUE_OR_KEY_SUPPORT: IntegrationDestinationEnum[] = [
+  IntegrationDestinationEnum.AMAZON_S3,
+  IntegrationDestinationEnum.GOOGLE_CLOUD_STORAGE,
+  IntegrationDestinationEnum.KAFKA,
+];
 
 export interface StreamStateData {
   block: BlockType;


### PR DESCRIPTION
# Description
- Data integration data exporter blocks in standard pipelines with certain destination types (i.e. `amazon_s3`, `google_cloud_storage`, and `kafka`) don't support unique constraints or key properties on columns, so it could be confusing to users having those settings there in the schema configuration. This PR hides those settings if the destination type does not support it.
- Clean up `Schema properties` tab in data integration block configuration modal: "Partition key" setting should be under "Options", and `uuid` was missing from the "Column types". The "Bookmark property" bulk edit option only appears when the stream's replication method is set to "Incremental".

# How Has This Been Tested?
All the screenshots below are from data exporter data integration destination blocks in a standard pipeline.

### Destination type with unique constraints and key properties supported
MySQL destination block with incremental replication method (`Unique`, `Key`, and `Bookmark` columns visible):
<img width="1498" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/84e1bd4f-5e07-49c3-bb4a-6fb6b977dc0d">

### Destination type with unique constraints and key properties NOT supported
Amazon S3 destination block with full table replication method  (`Unique`, `Key`, and `Bookmark` columns NOT visible):
<img width="1499" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/2e6ffec0-867b-4ca9-a2dd-22187ade5b34">
Kafka destination block with incremental replication method  (`Unique` and `Key` columns not visible):
<img width="1499" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/6efd1eae-e583-4d12-aba1-2b4571c2f23e">
Google Cloud Storage destination block with full table replication method:
<img width="1499" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/dfb67c0a-3ffb-431b-a3e0-f0921b6bf61b">


## BEFORE
Amazon S3 destination block with full table replication method (`Unique` and `Key` columns still visible, "Bookmark property" under bulk edit option even though not relevant to selected stream, "Partition key" incorrectly under column types, and "uuid" missing from column types):
<img width="1498" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/69ed9394-38b2-4d0d-a5aa-9530461af08d">

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
