### PR TITLE
[jk] Add top padding to file code editor

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
@@ -638,7 +638,7 @@ function CodeOutput({
             <CodeEditor
               autoHeight
               language={FileExtensionEnum.SQL}
-              padding
+              padding={UNIT * 2}
               readOnly
               value={sql}
               width="100%"

--- a/mage_ai/frontend/components/CodeEditor/index.style.tsx
+++ b/mage_ai/frontend/components/CodeEditor/index.style.tsx
@@ -9,12 +9,12 @@ export const SINGLE_LINE_HEIGHT = 21;
 
 export const ContainerStyle = styled.div<{
   hideDuplicateMenuItems?: boolean;
-  padding?: boolean;
+  padding?: number;
 }>`
   font-family: ${FONT_FAMILY_REGULAR};
 
-  ${props => props.padding && `
-    padding-top: ${UNIT * 2}px;
+  ${props => (typeof props.padding === 'number' && props.padding > 0) && `
+    padding-top: ${props.padding}px;
     background-color: ${(props.theme.background || dark.background).codeTextarea};
   `}
 

--- a/mage_ai/frontend/components/CodeEditor/index.tsx
+++ b/mage_ai/frontend/components/CodeEditor/index.tsx
@@ -79,7 +79,7 @@ type CodeEditorProps = {
   onContentSizeChangeCallback?: () => void;
   onMountCallback?: () => void;
   onSave?: (value: string) => void;
-  padding?: boolean;
+  padding?: number;
   placeholder?: string;
   readOnly?: boolean;
   shortcuts?: ((monaco: any, editor: any) => void)[];

--- a/mage_ai/frontend/components/FileEditor/index.tsx
+++ b/mage_ai/frontend/components/FileEditor/index.tsx
@@ -229,6 +229,7 @@ function FileEditor({
           onSave={(value: string) => {
             saveFile(value, file);
           }}
+          padding={10}
           selected
           textareaFocused
           value={isJsonString(file?.content)

--- a/mage_ai/frontend/components/FileVersions/index.tsx
+++ b/mage_ai/frontend/components/FileVersions/index.tsx
@@ -17,7 +17,7 @@ import Spinner from '@oracle/components/Spinner';
 import Table from '@components/shared/Table';
 import Text from '@oracle/elements/Text';
 import api from '@api';
-import { PADDING_UNITS } from '@oracle/styles/units/spacing';
+import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { buildFileExtensionRegExp } from '@components/FileEditor/utils';
 import { dateFormatLongFromUnixTimestamp } from '@utils/date';
 import { isJsonString } from '@utils/string';
@@ -207,7 +207,7 @@ function FileVersions({
           <CodeEditor
             autoHeight
             language={FILE_EXTENSION_TO_LANGUAGE_MAPPING[fileExtension]}
-            padding
+            padding={UNIT * 2}
             readOnly
             value={isJsonString(content)
               ? JSON.stringify(JSON.parse(content), null, 2)


### PR DESCRIPTION
# Description
- Add some top padding to the Code Editor for individual files.

# How Has This Been Tested?
<img width="813" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/f14560f7-7581-449d-a932-d084f12565da">


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
@MageKai 
