### PR TITLE
[dy] Remove itertools groupby

### DIFF
--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from math import ceil
 from statistics import stdev
-from typing import Dict, List
+from typing import DefaultDict, Dict, List
 
 import dateutil.parser
 import pytz
@@ -929,7 +929,7 @@ class PipelineRun(BaseModel):
         self,
         pipeline_uuids: List[str],
         include_block_runs: bool = False,
-    ) -> Dict[str, List['PipelineRun']]:
+    ) -> DefaultDict[str, List['PipelineRun']]:
         """
         Get a dictionary of active pipeline runs grouped by pipeline uuid.
         """

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -1,9 +1,9 @@
 import asyncio
+import collections
 import enum
 import traceback
 import uuid
 from datetime import datetime, timedelta, timezone
-from itertools import groupby
 from math import ceil
 from statistics import stdev
 from typing import Dict, List
@@ -938,9 +938,9 @@ class PipelineRun(BaseModel):
             pipeline_uuids,
             include_block_runs=include_block_runs,
         )
-        grouped = {}
-        for key, runs in groupby(active_runs, key=lambda x: x.pipeline_uuid):
-            grouped[key] = list(runs)
+        grouped = collections.defaultdict(list)
+        for run in active_runs:
+            grouped[run.pipeline_uuid].append(run)
         return grouped
 
     @classmethod

--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -1,8 +1,8 @@
 import asyncio
+import collections
 import os
 import traceback
 from datetime import datetime, timedelta
-from itertools import groupby
 from typing import Any, Dict, List, Set, Tuple
 
 import pytz
@@ -1451,10 +1451,9 @@ def schedule_all():
     active_pipeline_uuids = list(set([s.pipeline_uuid for s in active_pipeline_schedules]))
     pipeline_runs_by_pipeline = PipelineRun.active_runs_for_pipelines_grouped(active_pipeline_uuids)
 
-    pipeline_schedules_by_pipeline = {
-        key: list(runs)
-        for key, runs in groupby(active_pipeline_schedules, key=lambda x: x.pipeline_uuid)
-    }
+    pipeline_schedules_by_pipeline = collections.defaultdict(list)
+    for schedule in active_pipeline_schedules:
+        pipeline_schedules_by_pipeline[schedule.pipeline_uuid].append(schedule)
 
     # Iterate through pipeline schedules by pipeline to handle pipeline run limits for
     # each pipeline.

--- a/mage_ai/tests/orchestration/db/models/test_schedules.py
+++ b/mage_ai/tests/orchestration/db/models/test_schedules.py
@@ -918,6 +918,69 @@ class PipelineRunTests(DBTestCase):
             set([pipeline_run.id, pipeline_run2.id, pipeline_run4.id]),
         )
 
+    def test_active_runs_for_pipelines_grouped(self):
+        create_pipeline_with_blocks(
+            'test active run grouped 1',
+            self.repo_path,
+        )
+        create_pipeline_with_blocks(
+            'test active run grouped 2',
+            self.repo_path,
+        )
+        pipeline_run = create_pipeline_run_with_schedule(
+            pipeline_uuid='test_active_run_grouped_1',
+        )
+        pipeline_run.update(status=PipelineRun.PipelineRunStatus.RUNNING)
+        pipeline_schedule = pipeline_run.pipeline_schedule
+        pipeline_run2 = create_pipeline_run_with_schedule(
+            pipeline_uuid='test_active_run_grouped_2',
+        )
+        pipeline_schedule2 = pipeline_run2.pipeline_schedule
+        pipeline_run2.update(status=PipelineRun.PipelineRunStatus.RUNNING)
+        create_pipeline_run_with_schedule(
+            pipeline_uuid='test_active_run_grouped_1',
+            pipeline_schedule_id=pipeline_schedule.id,
+        )
+        pipeline_run3 = create_pipeline_run_with_schedule(
+            pipeline_uuid='test_active_run_grouped_1',
+            pipeline_schedule_id=pipeline_schedule.id,
+        )
+        pipeline_run3.update(status=PipelineRun.PipelineRunStatus.RUNNING)
+        pipeline_run4 = create_pipeline_run_with_schedule(
+            pipeline_uuid='test_active_run_grouped_2',
+            pipeline_schedule_id=pipeline_schedule2.id,
+        )
+        pipeline_run4.update(status=PipelineRun.PipelineRunStatus.RUNNING)
+
+        results1 = PipelineRun.active_runs_for_pipelines_grouped(
+            pipeline_uuids=['test_active_run_grouped_1'],
+        )
+        results2 = PipelineRun.active_runs_for_pipelines_grouped(
+            pipeline_uuids=['test_active_run_grouped_2'],
+        )
+        results3 = PipelineRun.active_runs_for_pipelines_grouped(
+            pipeline_uuids=['test_active_run_grouped_1', 'test_active_run_grouped_2'],
+        )
+        self.assertEqual(len(results1), 1)
+        self.assertEqual(
+            set([r.id for r in results1['test_active_run_grouped_1']]),
+            set([pipeline_run.id, pipeline_run3.id]),
+        )
+        self.assertEqual(len(results2), 1)
+        self.assertEqual(
+            set([r.id for r in results2['test_active_run_grouped_2']]),
+            set([pipeline_run2.id, pipeline_run4.id]),
+        )
+        self.assertEqual(len(results3), 2)
+        self.assertEqual(
+            set([r.id for r in results3['test_active_run_grouped_1']]),
+            set([pipeline_run.id, pipeline_run3.id]),
+        )
+        self.assertEqual(
+            set([r.id for r in results3['test_active_run_grouped_2']]),
+            set([pipeline_run2.id, pipeline_run4.id]),
+        )
+
 
 class BlockRunTests(DBTestCase):
     @classmethod


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Remove itertools.groupby because it wasn't behaving how I expected. This was causing bugs when scheduling triggers.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally to make sure schedules were still being triggered
- [x] Unit tests


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
