### PR TITLE
[td] Add upstream block dependencies for dynamic child blocks at runtime

### DIFF
--- a/mage_ai/api/resources/BlockResource.py
+++ b/mage_ai/api/resources/BlockResource.py
@@ -267,6 +267,11 @@ class BlockResource(GenericResource):
                                     ':'.join(parts_new),
                                 )
 
+                    if metrics.get('dynamic_upstream_block_uuids'):
+                        block_mapping[block_run_block_uuid]['uuids'].extend(
+                            metrics.get('dynamic_upstream_block_uuids') or [],
+                        )
+
                     # If it should reduce, then all the children have 1 downstream.
                     if should_reduce_output(block):
                         for db in block.downstream_blocks:

--- a/mage_ai/data_preparation/models/block/utils.py
+++ b/mage_ai/data_preparation/models/block/utils.py
@@ -201,6 +201,14 @@ def create_block_runs_from_dynamic_block(
                 else:
                     arr.append(upstream_block.uuid)
 
+            if metadata.get('upstream_blocks'):
+                for up_uuid in (metadata.get('upstream_blocks') or []):
+                    up_block = block.pipeline.get_block(up_uuid)
+                    if up_block:
+                        arr.append(up_uuid)
+                    else:
+                        arr.append(f'{downstream_block.uuid}:{up_uuid}')
+
             block_run = create_block_run_from_dynamic_child(
                 downstream_block,
                 pipeline_run,

--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/buildTableSidekick.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/buildTableSidekick.tsx
@@ -3,17 +3,19 @@ import BlockType, { OutputType } from '@interfaces/BlockType';
 import ButtonTabs, { TabType } from '@oracle/components/Tabs/ButtonTabs';
 import DataTable from '@components/DataTable';
 import DependencyGraph from '@components/DependencyGraph';
+import Divider from '@oracle/elements/Divider';
 import FlexContainer from '@oracle/components/FlexContainer';
 import PipelineType from '@interfaces/PipelineType';
 import Spacing from '@oracle/elements/Spacing';
 import Spinner from '@oracle/components/Spinner';
 import Text from '@oracle/elements/Text';
 import { DataTypeEnum } from '@interfaces/KernelOutputType';
+import { HEADER_HEIGHT } from '@components/shared/Header/index.style';
 import { PADDING_UNITS } from '@oracle/styles/units/spacing';
 import { TABLE_COLUMN_HEADER_HEIGHT } from '@components/Sidekick/index.style';
 import { TABS_HEIGHT_OFFSET } from '@components/PipelineRun/shared/buildTableSidekick';
 import { createBlockStatus } from '@components/Triggers/utils';
-import { isJsonString } from '@utils/string';
+import { alphabet, isJsonString } from '@utils/string';
 import { sortByKey } from '@utils/array';
 
 export const TAB_TREE = { uuid: 'Dependency tree' };
@@ -69,6 +71,8 @@ export default function({
   const arr = [];
   const tabsMoreInner = [];
 
+  const alpha = alphabet();
+
   if (!loadingData) {
     const outputsByType = {};
 
@@ -88,7 +92,7 @@ export default function({
     sortByKey(
       Object.entries(outputsByType),
       ([_, d]) => d.priority,
-    )?.forEach(([dataTypeInit, d]) => {
+    )?.forEach(([dataTypeInit, d], idx1: number) => {
       const {
         outputs: outputsInGroup,
       } = d;
@@ -101,7 +105,7 @@ export default function({
         type: dataType,
       }, idx: number) => {
         const emptyOutputMessageEl = (
-          <Spacing key={`output-empty-${idx}`} ml={2}>
+          <Spacing key={`output-empty-${idx1}-${idx}`} ml={2}>
             <Text>
               This block run has no output.
             </Text>
@@ -119,7 +123,7 @@ export default function({
               columnHeaderHeight={renderColumnHeader ? TABLE_COLUMN_HEADER_HEIGHT : 0}
               columns={columns}
               height={height - heightOffset - 90}
-              key={`output-table-${idx}`}
+              key={`output-table-${idx1}-${idx}`}
               noBorderBottom
               noBorderLeft
               noBorderRight
@@ -136,7 +140,7 @@ export default function({
 
           const blockOutputText = !!textData
             ? (
-              <Spacing key={`output-text-${idx}`} ml={2}>
+              <Spacing key={`output-text-${idx1}-${idx}`} ml={2}>
                 <Text monospace>
                   <pre>
                     {parsedText}
@@ -149,20 +153,22 @@ export default function({
           el = blockOutputText;
         }
 
+        const letter = alpha[idx1];
+
         // If output is text, group them into 1 tab
         if (DataTypeEnum.TEXT === dataTypeInit) {
           arrGroup.push(el);
 
           if (idx === 0) {
             tabsMoreInner.push({
-              uuid: `Block output ${idx + 1}`,
+              uuid: `Block output ${idx + 1}${letter}`,
             });
           }
         } else {
           arr.push(el);
 
           tabsMoreInner.push({
-            uuid: `Block output ${idx + 1}`,
+            uuid: `Block output ${idx + 1}${letter}`,
           });
         }
       });
@@ -194,33 +200,39 @@ export default function({
       <div
         style={{
           position: 'fixed',
-          top: '50px',
+          top: HEADER_HEIGHT,
         }}
       >
         {showTabs && (
-          <Spacing py={PADDING_UNITS}>
-            <ButtonTabs
-              onClickTab={setSelectedTab}
-              selectedTabUUID={selectedTab?.uuid}
-              tabs={selectedRun ? tabsUse : [TAB_TREE]}
-            />
-          </Spacing>
+          <>
+            <Spacing py={0}>
+              <ButtonTabs
+                onClickTab={setSelectedTab}
+                regularSizeText
+                selectedTabUUID={selectedTab?.uuid}
+                tabs={selectedRun ? tabsUse : [TAB_TREE]}
+                underlineStyle
+              />
+            </Spacing>
+          </>
         )}
       </div>
 
       <div
         style={{
           position: 'relative',
-          top: '75px',
+          top: TABS_HEIGHT_OFFSET,
         }}
       >
+        {showTabs && <Divider light />}
+
         {(!selectedRun || TAB_TREE.uuid === selectedTab?.uuid) && (
           <DependencyGraph
             {...updatedProps}
             blocksOverride={blocksOverride}
             enablePorts={false}
             height={height}
-            heightOffset={(heightOffset || 0) + (showTabs ? TABS_HEIGHT_OFFSET : 0)}
+            heightOffset={(heightOffset || 0) + (showTabs ? (TABS_HEIGHT_OFFSET + 1) : 0)}
             pipeline={pipeline}
           />
         )}
@@ -234,7 +246,11 @@ export default function({
                 </FlexContainer>
               </Spacing>
             )}
-            {!loadingData && blockOutputToShow}
+            {!loadingData && (
+              <Spacing py={PADDING_UNITS}>
+                {blockOutputToShow}
+              </Spacing>
+            )}
           </>
         )}
       </div>

--- a/mage_ai/frontend/components/PipelineRun/shared/buildTableSidekick.tsx
+++ b/mage_ai/frontend/components/PipelineRun/shared/buildTableSidekick.tsx
@@ -12,7 +12,7 @@ import {
 import { createBlockStatus } from '@components/Triggers/utils';
 import { isEmptyObject, isObject } from '@utils/hash';
 
-export const TABS_HEIGHT_OFFSET = 76;
+export const TABS_HEIGHT_OFFSET = 44;
 const TAB_DETAILS = { uuid: 'Run details' };
 const TAB_TREE = { uuid: 'Dependency tree' };
 export const TABS = [
@@ -110,6 +110,7 @@ export default function({
             onClickTab={setSelectedTab}
             selectedTabUUID={selectedTab?.uuid}
             tabs={TABS}
+            underlineStyle
           />
         </Spacing>
       )}

--- a/mage_ai/frontend/components/shared/Header/index.tsx
+++ b/mage_ai/frontend/components/shared/Header/index.tsx
@@ -172,6 +172,14 @@ function Header({
     return branch;
   }, [branch]);
 
+  const hasAvatarEmoji = useMemo(() => {
+    if (!userFromLocalStorage || !userFromLocalStorage?.avatar) {
+      return false;
+    }
+
+    return !/[A-Za-z0-9]+/.exec(userFromLocalStorage?.avatar || '');
+  }, [userFromLocalStorage]);
+
   const hasAvatarAndNotEmoji = useMemo(() => {
     if (!userFromLocalStorage || !userFromLocalStorage?.avatar) {
       return false;
@@ -392,17 +400,22 @@ function Header({
                     position: 'relative',
                   }}
                 >
-                  <FlexContainer>
+                  <FlexContainer alignItems="center" flexDirection="row">
                     <LinkStyle
                       onClick={() => setUserMenuVisible(true)}
                       ref={refUserMenu}
                     >
-                      <Circle
-                        color={BLUE_TRANSPARENT}
-                        size={4 * UNIT}
-                      >
-                        {avatarMemo}
-                      </Circle>
+                      {hasAvatarEmoji && userFromLocalStorage?.avatar?.length >= 2
+                        ? avatarMemo
+                        : (
+                          <Circle
+                            color={BLUE_TRANSPARENT}
+                            size={4 * UNIT}
+                          >
+                            {avatarMemo}
+                          </Circle>
+                        )
+                      }
                     </LinkStyle>
 
                     <FlyoutMenu

--- a/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.style.ts
+++ b/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.style.ts
@@ -27,6 +27,7 @@ export const TabsContainerStyle = styled.div<{
 
 export const SelectedUnderlineStyle = styled.div<{
   backgroundColor?: string;
+  backgroundColorPrimary?: boolean;
   selected?: boolean;
 }>`
   border-radius: 6px;

--- a/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.tsx
+++ b/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.tsx
@@ -29,6 +29,7 @@ type ButtonTabsProps = {
   tabs: TabType[];
   underlineColor?: string;
   underlineStyle?: boolean;
+  uppercase?: boolean;
 };
 
 function ButtonTabs({
@@ -43,6 +44,7 @@ function ButtonTabs({
   tabs,
   underlineColor,
   underlineStyle,
+  uppercase = true,
 }: ButtonTabsProps, ref) {
   const tabEls = useMemo(() => {
     const tabCount: number = tabs.length;
@@ -75,6 +77,7 @@ function ButtonTabs({
             default={!selected}
             noWrapping
             small={!regularSizeText}
+            uppercase={uppercase}
           >
             {displayText}
           </Text>


### PR DESCRIPTION
# Description
Dynamic child blocks can have additional upstream dependencies at runtime.

# How Has This Been Tested?

![CleanShot 2023-11-30 at 21 32 40@2x](https://github.com/mage-ai/mage-ai/assets/1066980/841f6138-4e5d-48c1-8704-24d96011155e)

# Pipeline
```yaml
blocks:
- all_upstream_blocks_executed: true
  color: teal
  configuration: {}
  downstream_blocks:
  - dynamic_block_normal
  - dynamic_block_with_children_with_dynamic_upstream
  executor_config: null
  executor_type: local_python
  has_callback: false
  language: python
  name: data for dynamic blocks
  retry_config: null
  status: executed
  timeout: null
  type: custom
  upstream_blocks: []
  uuid: data_for_dynamic_blocks
- all_upstream_blocks_executed: true
  color: null
  configuration:
    dynamic: true
  downstream_blocks:
  - dynamic_child_with_dynamic_upstream
  executor_config: null
  executor_type: local_python
  has_callback: false
  language: python
  name: dynamic block with children with dynamic upstream
  retry_config: null
  status: updated
  timeout: null
  type: data_loader
  upstream_blocks:
  - data_for_dynamic_blocks
  uuid: dynamic_block_with_children_with_dynamic_upstream
- all_upstream_blocks_executed: true
  color: null
  configuration: {}
  downstream_blocks: []
  executor_config: null
  executor_type: local_python
  has_callback: false
  language: python
  name: dynamic child that other dynamic child depends on
  retry_config: null
  status: executed
  timeout: null
  type: transformer
  upstream_blocks:
  - dynamic_block_normal
  uuid: dynamic_child_that_other_dynamic_child_depends_on
- all_upstream_blocks_executed: false
  color: null
  configuration:
    reduce_output: true
  downstream_blocks:
  - reduce_output_from_dynamic_child_upstream
  executor_config: null
  executor_type: local_python
  has_callback: false
  language: python
  name: dynamic child with dynamic upstream
  retry_config: null
  status: executed
  timeout: null
  type: transformer
  upstream_blocks:
  - dynamic_block_with_children_with_dynamic_upstream
  uuid: dynamic_child_with_dynamic_upstream
- all_upstream_blocks_executed: false
  color: null
  configuration: {}
  downstream_blocks: []
  executor_config: null
  executor_type: local_python
  has_callback: false
  language: python
  name: reduce output from dynamic child upstream
  retry_config: null
  status: executed
  timeout: null
  type: data_exporter
  upstream_blocks:
  - dynamic_child_with_dynamic_upstream
  uuid: reduce_output_from_dynamic_child_upstream
- all_upstream_blocks_executed: true
  color: blue
  configuration:
    dynamic: true
  downstream_blocks:
  - dynamic_child_that_other_dynamic_child_depends_on
  executor_config: null
  executor_type: local_python
  has_callback: false
  language: python
  name: dynamic block normal
  retry_config: null
  status: executed
  timeout: null
  type: custom
  upstream_blocks:
  - data_for_dynamic_blocks
  uuid: dynamic_block_normal
callbacks: []
concurrency_config: {}
conditionals: []
created_at: '2023-12-01 04:15:55.516377+00:00'
data_integration: null
description: null
executor_config: {}
executor_count: 1
executor_type: null
extensions: {}
name: floral pine
notification_config: {}
retry_config: {}
run_pipeline_in_one_process: false
settings:
  triggers: null
spark_config: {}
tags: []
type: python
updated_at: '2023-12-01 05:31:10'
uuid: floral_pine
widgets: []
```

# `data_for_dynamic_blocks`
```python
@custom
def build_dynamic_children(*args, **kwargs):
    data_arr = []
    metadata_arr = []

    for i in range(3):
        block_uuid = f'block_{i}'
        data = dict(order=i, items=[1, 2, 3])
        metadata = dict(block_uuid=block_uuid)
        
        data_arr.append(data)
        metadata_arr.append(metadata)

    return [
        data_arr,
        metadata_arr,
    ]
```

# `dynamic_block_with_children_with_dynamic_upstream`
```python
@data_loader
def build_dynamic_children(data_and_metadata, *args, **kwargs):
    data_arr0, metadata_arr0 = data_and_metadata

    data_arr = []
    metadata_arr = []

    for i in range(3):
        block_uuid = f'block_{i}'
        data = dict(order=i, items=[1, 2, 3])
        metadata = dict(block_uuid=block_uuid)

        up_uuids = []

        if len(metadata_arr0) and i < len(metadata_arr0):
            block_uuid_more = metadata_arr0[i].get('block_uuid')
            if block_uuid_more:
                up_uuids.append(f'dynamic_child_that_other_dynamic_child_depends_on:{block_uuid_more}')
        
        if i >= 1:
            up_uuids.extend([md['block_uuid'] for md in metadata_arr[:i]])
        
        if len(up_uuids) >= 1:
            metadata['upstream_blocks'] = up_uuids
                
        
        data_arr.append(data)
        metadata_arr.append(metadata)

    return [
        data_arr,
        metadata_arr,
    ]
```

# `dynamic_child_that_other_dynamic_child_depends_on`
```python
@transformer
def transform(data, *args, **kwargs):
    return data
```

# `dynamic_child_with_dynamic_upstream`
```python
@transformer
def transform(data, *args, **kwargs):
    return data['items']
```

# `reduce_output_from_dynamic_child_upstream`
```python
@data_exporter
def export_data(data, *args, **kwargs):
    arr = []
    for arr2 in data:
        arr += arr2

    return arr
```

# `dynamic_block_normal`
```python
@custom
def build_dynamic_children(data_and_metadata, *args, **kwargs):
    data_arr, metadata_arr = data_and_metadata

    return [
        data_arr,
        metadata_arr,
    ]
```


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
