### PR TITLE
[dy] Fix block runs page when there are a large number of block runs

### DIFF
--- a/mage_ai/api/policies/BlockPolicy.py
+++ b/mage_ai/api/policies/BlockPolicy.py
@@ -142,6 +142,14 @@ BlockPolicy.allow_write([
 ], condition=lambda policy: policy.has_at_least_editor_role_and_pipeline_edit_access())
 
 BlockPolicy.allow_query([
+    'block_uuid[]',
+], scopes=[
+    OauthScope.CLIENT_PRIVATE,
+], on_action=[
+    constants.LIST,
+], condition=lambda policy: policy.has_at_least_viewer_role())
+
+BlockPolicy.allow_query([
     'block_type',
     'data_integration_type',
     'data_integration_uuid',

--- a/mage_ai/api/resources/BlockResource.py
+++ b/mage_ai/api/resources/BlockResource.py
@@ -588,20 +588,21 @@ class BlockResource(GenericResource):
         limit = int((meta or {}).get(META_KEY_LIMIT, 0))
         offset = int((meta or {}).get(META_KEY_OFFSET, 0))
 
-        if not limit:
-            return total_results
+        final_results = total_results
+        has_next = False
+        if limit > 0:
+            start_idx = offset
+            end_idx = start_idx + limit
 
-        start_idx = offset
-        end_idx = start_idx + limit
+            results = total_results[start_idx:(end_idx + 1)]
 
-        results = total_results[start_idx:(end_idx + 1)]
-
-        results_size = len(results)
-        has_next = results_size > limit
-        final_end_idx = results_size - 1 if has_next else results_size
+            results_size = len(results)
+            has_next = results_size > limit
+            final_end_idx = results_size - 1 if has_next else results_size
+            final_results = results[0:final_end_idx]
 
         result_set = self.build_result_set(
-            results[0:final_end_idx],
+            final_results,
             user,
             **kwargs,
         )

--- a/mage_ai/api/resources/BlockResource.py
+++ b/mage_ai/api/resources/BlockResource.py
@@ -3,6 +3,7 @@ import urllib.parse
 from typing import Dict
 
 from mage_ai.api.errors import ApiError
+from mage_ai.api.operations.constants import META_KEY_LIMIT, META_KEY_OFFSET
 from mage_ai.api.resources.GenericResource import GenericResource
 from mage_ai.cache.block import BlockCache
 from mage_ai.cache.block_action_object import BlockActionObjectCache
@@ -48,6 +49,12 @@ class BlockResource(GenericResource):
     def collection(self, query_arg, meta, user, **kwargs):
         parent_model = kwargs.get('parent_model')
 
+        block_uuids = query_arg.get('block_uuid[]', [])
+        if block_uuids:
+            block_uuids = block_uuids[0]
+        if block_uuids:
+            block_uuids = set(block_uuids.split(','))
+
         block_count_by_base_uuid = {}
         block_dicts_by_uuid = {}
         data_integration_sets_by_uuid = {}
@@ -57,7 +64,8 @@ class BlockResource(GenericResource):
 
         if isinstance(parent_model, Pipeline):
             for block_uuid, block in parent_model.blocks_by_uuid.items():
-                block_dicts_by_uuid[block_uuid] = block.to_dict()
+                if not block_uuids or block_uuid in block_uuids:
+                    block_dicts_by_uuid[block_uuid] = block.to_dict()
 
         if isinstance(parent_model, PipelineRun):
             block_mapping = {}
@@ -70,6 +78,8 @@ class BlockResource(GenericResource):
 
                 for block_run in parent_model.block_runs:
                     block_run_block_uuid = block_run.block_uuid
+                    if block_uuids and block_run_block_uuid not in block_uuids:
+                        continue
                     block = pipeline.get_block(block_run_block_uuid)
                     if not block:
                         continue
@@ -569,6 +579,37 @@ class BlockResource(GenericResource):
             user,
             **kwargs,
         )
+
+    @classmethod
+    async def process_collection(self, query_arg, meta, user, **kwargs):
+        total_results = self.collection(query_arg, meta, user, **kwargs)
+        total_count = len(total_results)
+
+        limit = int((meta or {}).get(META_KEY_LIMIT, 0))
+        offset = int((meta or {}).get(META_KEY_OFFSET, 0))
+
+        if not limit:
+            return total_results
+
+        start_idx = offset
+        end_idx = start_idx + limit
+
+        results = total_results[start_idx:(end_idx + 1)]
+
+        results_size = len(results)
+        has_next = results_size > limit
+        final_end_idx = results_size - 1 if has_next else results_size
+
+        result_set = self.build_result_set(
+            results[0:final_end_idx],
+            user,
+            **kwargs,
+        )
+        result_set.metadata = {
+            'count': total_count,
+            'next': has_next,
+        }
+        return result_set
 
     @classmethod
     @safe_db_query

--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/buildTableSidekick.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/buildTableSidekick.tsx
@@ -79,7 +79,7 @@ export default function({
         outputsByType[dataType] = {
           outputs: [],
           priority: Object.keys(outputsByType).length,
-        }
+        };
       }
 
       outputsByType[dataType].outputs.push(output);

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
@@ -59,10 +59,6 @@ function PipelineBlockRuns({
   const [selectedTabSidekick, setSelectedTabSidekick] = useState<TabType>(TABS_SIDEKICK[0]);
   const [errors, setErrors] = useState<ErrorsType>(null);
 
-  const { data: dataBlocks } = api.blocks.pipeline_runs.list(pipelineRunProp?.id, {}, {
-    refreshInterval: 5000,
-  });
-
   const pipelineUUID = pipelineProp.uuid;
   const { data: dataPipeline } = api.pipelines.detail(pipelineUUID, {
     includes_content: false,
@@ -115,6 +111,14 @@ function PipelineBlockRuns({
     { refreshInterval: 5000 },
   );
   const blockRuns = useMemo(() => dataBlockRuns?.block_runs || [], [dataBlockRuns]);
+
+  const blockUuids = blockRuns.map(({ block_uuid }) => block_uuid);
+  const blockUuidArg = useMemo(() => blockUuids, [blockUuids]);
+
+  const { data: dataBlocks } = api.blocks.pipeline_runs.list(pipelineRunProp?.id, {
+    _limit: 30,
+    block_uuid: blockUuidArg,
+  }, {});
 
   const [updatePipelineRun, { isLoading: isLoadingUpdatePipelineRun }]: any = useMutation(
     api.pipeline_runs.useUpdate(pipelineRunId),

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/[run]/index.tsx
@@ -116,7 +116,7 @@ function PipelineBlockRuns({
   const blockUuidArg = useMemo(() => blockUuids, [blockUuids]);
 
   const { data: dataBlocks } = api.blocks.pipeline_runs.list(pipelineRunProp?.id, {
-    _limit: 30,
+    _limit: ROW_LIMIT,
     block_uuid: blockUuidArg,
   }, {});
 
@@ -217,7 +217,7 @@ function PipelineBlockRuns({
   const buildSidekick = useCallback(props => buildTableSidekick({
     ...props,
     blockRuns,
-    blocksOverride: dataBlocks?.blocks,
+    blocksOverride: totalBlockRuns <= ROW_LIMIT && dataBlocks?.blocks,
     loadingData: loadingOutput,
     outputs: dataOutput?.outputs,
     selectedRun,
@@ -232,6 +232,7 @@ function PipelineBlockRuns({
     selectedRun,
     selectedTabSidekick,
     setSelectedTabSidekick,
+    totalBlockRuns,
   ]);
 
   return (


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

The block runs page was loading very slowly when there are a large number of block runs, for example in an integration pipeline with many streams/batches. The block runs page was attempting to render every single block run in the dependency graph which would cause the page to hang or load slowly. This PR updates the dependency graph to only try to render every block run if there fewer than a set number of block runs.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with a pipeline run with thousands of block runs


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
