### PR TITLE
[jk] Update local timezone project setting from header

### DIFF
--- a/docs/development/project/local-timezone.mdx
+++ b/docs/development/project/local-timezone.mdx
@@ -12,11 +12,15 @@ time.
 
 1. Go to your project's `Settings` page (with the wrench icon) from the
 left vertical navigation panel.
-2. Under the "Features" section, click the toggle to turn the `display_local_timezone`
+2. Under the "Features" section, click the toggle to turn the `Display local timezone`
 setting on.
 3. Then click the blue `Save project settings` button to save and persist the
 new settings. If you do not click this button, you will lose any changes when
 leaving the page.
+
+- Alternatively (starting with v0.9.48), you can simply click on the time in the header
+and toggle on the `Display local timezone` setting from the dropdown menu. This may
+require a page refresh for the timestamps to change to UTC or local time.
 
 <Info>
   Please note that certain pages (e.g. a pipeline's Monitor page) or components

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -52,12 +52,12 @@ import {
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
 import { capitalize } from '@utils/string';
 import { datetimeInLocalTimezone } from '@utils/date';
+import { displayLocalOrUtcTime } from '@components/Triggers/utils';
 import {
   getFormattedVariable,
   getFormattedVariables,
 } from '@components/Sidekick/utils';
 import { getRunStatusTextProps } from '@components/shared/Table/constants';
-import { getTimeInUTCString } from '@components/Triggers/utils';
 import { goToWithQuery } from '@utils/routing';
 import { isEmptyObject } from '@utils/hash';
 import { isViewer } from '@utils/session';
@@ -300,10 +300,7 @@ function BackfillDetail({
             monospace
             small
           >
-            {displayLocalTimezone
-              ? datetimeInLocalTimezone(startDatetime, displayLocalTimezone)
-              : getTimeInUTCString(startDatetime)
-            }
+            {displayLocalOrUtcTime(startDatetime, displayLocalTimezone)}
           </Text>,
         ],
         [
@@ -322,10 +319,7 @@ function BackfillDetail({
             monospace
             small
           >
-            {displayLocalTimezone
-              ? datetimeInLocalTimezone(endDatetime, displayLocalTimezone)
-              : getTimeInUTCString(endDatetime)
-            }
+            {displayLocalOrUtcTime(endDatetime, displayLocalTimezone)}
           </Text>,
         ],
         [

--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -15,10 +15,10 @@ import {
   getRunStatusTextProps,
 } from '@components/shared/Table/constants';
 import { UNIT } from '@oracle/styles/units/spacing';
-import { datetimeInLocalTimezone, utcStringToElapsedTime } from '@utils/date';
-import { getTimeInUTCString } from '@components/Triggers/utils';
+import { displayLocalOrUtcTime } from '@components/Triggers/utils';
 import { isViewer } from '@utils/session';
 import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
+import { utcStringToElapsedTime } from '@utils/date';
 
 type BackfillsTableProps = {
   pipeline: {
@@ -114,15 +114,9 @@ function BackfillsTable({
           <Text default key="backfill" monospace small>
             {(startDatetime && endDatetime) && (
               <>
-                {displayLocalTimezone
-                  ? datetimeInLocalTimezone(startDatetime, displayLocalTimezone)
-                  : getTimeInUTCString(startDatetime)
-                }
+                {displayLocalOrUtcTime(startDatetime, displayLocalTimezone)}
                 &nbsp;-&nbsp;
-                {displayLocalTimezone
-                  ? datetimeInLocalTimezone(endDatetime, displayLocalTimezone)
-                  : getTimeInUTCString(endDatetime)
-                }
+                {displayLocalOrUtcTime(endDatetime, displayLocalTimezone)}
               </>
             )}
             {!(startDatetime && endDatetime) && <>&#8212;</>}
@@ -135,10 +129,8 @@ function BackfillsTable({
             title={startedAt ? utcStringToElapsedTime(startedAt) : null}
           >
             {startedAt
-              ? (displayLocalTimezone
-                ? datetimeInLocalTimezone(startedAt, displayLocalTimezone)
-                : getTimeInUTCString(startedAt)
-              ): (
+              ? displayLocalOrUtcTime(startedAt, displayLocalTimezone)
+              : (
                 <>&#8212;</>
               )
             }
@@ -151,10 +143,8 @@ function BackfillsTable({
             title={completedAt ? utcStringToElapsedTime(completedAt) : null}
           >
             {completedAt
-              ? (displayLocalTimezone
-                ? datetimeInLocalTimezone(completedAt, displayLocalTimezone)
-                : getTimeInUTCString(completedAt)
-              ): (
+              ? displayLocalOrUtcTime(completedAt, displayLocalTimezone)
+              : (
                 <>&#8212;</>
               )
             }

--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -130,9 +130,7 @@ function BackfillsTable({
           >
             {startedAt
               ? displayLocalOrUtcTime(startedAt, displayLocalTimezone)
-              : (
-                <>&#8212;</>
-              )
+              : <>&#8212;</>
             }
           </Text>,
           <Text
@@ -144,9 +142,7 @@ function BackfillsTable({
           >
             {completedAt
               ? displayLocalOrUtcTime(completedAt, displayLocalTimezone)
-              : (
-                <>&#8212;</>
-              )
+              : <>&#8212;</>
             }
           </Text>,
         ];

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -611,9 +611,7 @@ function PipelineRunsTable({
                   >
                     {startedAt
                       ? displayLocalOrUtcTime(startedAt, displayLocalTimezone)
-                      : (
-                        <>&#8212;</>
-                      )
+                      : <>&#8212;</>
                     }
                   </Text>,
                   <Text
@@ -624,9 +622,7 @@ function PipelineRunsTable({
                   >
                     {completedAt
                       ? displayLocalOrUtcTime(completedAt, displayLocalTimezone)
-                      : (
-                        <>&#8212;</>
-                      )
+                      : <>&#8212;</>
                     }
                   </Text>,
                   <Text
@@ -723,9 +719,7 @@ function PipelineRunsTable({
                   >
                     {executionDate
                       ? displayLocalOrUtcTime(executionDate, displayLocalTimezone)
-                      : (
-                        <>&#8212;</>
-                      )
+                      : <>&#8212;</>
                     }
                   </Text>,
                   <Text
@@ -736,9 +730,7 @@ function PipelineRunsTable({
                   >
                     {startedAt
                       ? displayLocalOrUtcTime(startedAt, displayLocalTimezone)
-                      : (
-                        <>&#8212;</>
-                      )
+                      : <>&#8212;</>
                     }
                   </Text>,
                   <Text
@@ -749,9 +741,7 @@ function PipelineRunsTable({
                   >
                     {completedAt
                       ? displayLocalOrUtcTime(completedAt, displayLocalTimezone)
-                      : (
-                        <>&#8212;</>
-                      )
+                      : <>&#8212;</>
                     }
                   </Text>,
                   <Text

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -45,14 +45,14 @@ import { PopupContainerStyle } from './Table.style';
 import { ScheduleTypeEnum } from '@interfaces/PipelineScheduleType';
 import { TableContainerStyle } from '@components/shared/Table/index.style';
 import { UNIT } from '@oracle/styles/units/spacing';
-import { datetimeInLocalTimezone, timeDifference, utcStringToElapsedTime } from '@utils/date';
-import { getTimeInUTCString } from '@components/Triggers/utils';
+import { displayLocalOrUtcTime } from '@components/Triggers/utils';
 import { indexBy } from '@utils/array';
 import { isViewer } from '@utils/session';
 import { onSuccess } from '@api/utils/response';
 import { pauseEvent } from '@utils/events';
 import { queryFromUrl } from '@utils/url';
 import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
+import { timeDifference, utcStringToElapsedTime } from '@utils/date';
 import { useKeyboardContext } from '@context/Keyboard';
 
 const SHARED_DATE_FONT_PROPS = {
@@ -610,10 +610,8 @@ function PipelineRunsTable({
                     title={startedAt ? utcStringToElapsedTime(startedAt) : null}
                   >
                     {startedAt
-                      ? (displayLocalTimezone
-                        ? datetimeInLocalTimezone(startedAt, displayLocalTimezone)
-                        : getTimeInUTCString(startedAt)
-                      ): (
+                      ? displayLocalOrUtcTime(startedAt, displayLocalTimezone)
+                      : (
                         <>&#8212;</>
                       )
                     }
@@ -625,10 +623,8 @@ function PipelineRunsTable({
                     title={completedAt ? utcStringToElapsedTime(completedAt) : null}
                   >
                     {completedAt
-                      ? (displayLocalTimezone
-                        ? datetimeInLocalTimezone(completedAt, displayLocalTimezone)
-                        : getTimeInUTCString(completedAt)
-                      ): (
+                      ? displayLocalOrUtcTime(completedAt, displayLocalTimezone)
+                      : (
                         <>&#8212;</>
                       )
                     }
@@ -726,10 +722,8 @@ function PipelineRunsTable({
                     title={executionDate ? utcStringToElapsedTime(executionDate) : null}
                   >
                     {executionDate
-                      ? (displayLocalTimezone
-                        ? datetimeInLocalTimezone(executionDate, displayLocalTimezone)
-                        : getTimeInUTCString(executionDate)
-                      ): (
+                      ? displayLocalOrUtcTime(executionDate, displayLocalTimezone)
+                      : (
                         <>&#8212;</>
                       )
                     }
@@ -741,10 +735,8 @@ function PipelineRunsTable({
                     title={startedAt ? utcStringToElapsedTime(startedAt) : null}
                   >
                     {startedAt
-                      ? (displayLocalTimezone
-                        ? datetimeInLocalTimezone(startedAt, displayLocalTimezone)
-                        : getTimeInUTCString(startedAt)
-                      ): (
+                      ? displayLocalOrUtcTime(startedAt, displayLocalTimezone)
+                      : (
                         <>&#8212;</>
                       )
                     }
@@ -756,10 +748,8 @@ function PipelineRunsTable({
                     title={completedAt ? utcStringToElapsedTime(completedAt) : null}
                   >
                     {completedAt
-                      ? (displayLocalTimezone
-                        ? datetimeInLocalTimezone(completedAt, displayLocalTimezone)
-                        : getTimeInUTCString(completedAt)
-                      ): (
+                      ? displayLocalOrUtcTime(completedAt, displayLocalTimezone)
+                      : (
                         <>&#8212;</>
                       )
                     }

--- a/mage_ai/frontend/components/PipelineDetail/Syncs/SyncRow/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Syncs/SyncRow/index.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 
-import BlockRunType, { RunStatus as RunStatusBlockRun } from '@interfaces/BlockRunType';
 import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
 import Headline from '@oracle/elements/Headline';
@@ -12,23 +11,24 @@ import Spacing from '@oracle/elements/Spacing';
 import Spinner from '@oracle/components/Spinner';
 import Text from '@oracle/elements/Text';
 import dark from '@oracle/styles/themes/dark';
-import { Check } from '@oracle/icons';
 import {
   BarStyle,
   RowStyle,
   StatusStyle,
 } from './index.style';
+import { Check } from '@oracle/icons';
 import { UNIT } from '@oracle/styles/units/spacing';
-import {
-  numberWithCommas,
-  pluralize,
-  prettyUnitOfTime,
-} from '@utils/string';
+import { displayLocalOrUtcTime } from '@components/Triggers/utils';
 import {
   getRecordsData,
   pipelineRunProgress,
   pipelineRunRuntime,
 } from '@utils/models/pipelineRun';
+import {
+  numberWithCommas,
+  prettyUnitOfTime,
+} from '@utils/string';
+import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
 
 type SyncRowProps = {
   onSelect: (id: number) => void;
@@ -42,7 +42,6 @@ function SyncRow({
   selected,
 }: SyncRowProps) {
   const {
-    block_runs: blockRuns,
     created_at: createdAt,
     status,
   } = pipelineRun;
@@ -52,8 +51,9 @@ function SyncRow({
     pipeline: {},
     source: null,
   }, [pipelineRun]);
-  const metricsBlocks = useMemo(() => metrics.blocks || {}, [metrics]);
   const metricsPipeline = useMemo(() => metrics.pipeline || {}, [metrics]);
+  const displayLocalTimezone = shouldDisplayLocalTimezone();
+  console.log('displayLocalTimezone:', displayLocalTimezone);
 
   const destination: string = metrics.destination;
   const source: string = metrics.source;
@@ -98,7 +98,7 @@ function SyncRow({
         <Flex flex={1} flexDirection="column">
           <Spacing ml={3} py={3}>
             <Headline bold level={5} monospace>
-              {createdAt}
+              {displayLocalOrUtcTime(createdAt, displayLocalTimezone)}
             </Headline>
 
             <Spacing fullWidth={false} mt={2}>
@@ -128,7 +128,7 @@ function SyncRow({
 
             {Object.values(errors).length >= 1 && (
               <Spacing mt={1}>
-                {Object.entries(errors).map(([stream, obj], idx) => (
+                {Object.entries(errors).map(([stream, obj]) => (
                   <Text
                     key={stream}
                     monospace

--- a/mage_ai/frontend/components/PipelineDetail/Syncs/SyncRow/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Syncs/SyncRow/index.tsx
@@ -53,7 +53,6 @@ function SyncRow({
   }, [pipelineRun]);
   const metricsPipeline = useMemo(() => metrics.pipeline || {}, [metrics]);
   const displayLocalTimezone = shouldDisplayLocalTimezone();
-  console.log('displayLocalTimezone:', displayLocalTimezone);
 
   const destination: string = metrics.destination;
   const source: string = metrics.source;

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -935,7 +935,7 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
               {addNewBlocksMemo}
             </div>
           )}
-        </CodeBlock>
+        </CodeBlock>,
       );
     });
 

--- a/mage_ai/frontend/components/ServerTimeDropdown/index.style.tsx
+++ b/mage_ai/frontend/components/ServerTimeDropdown/index.style.tsx
@@ -77,4 +77,5 @@ export const ToggleGroupStyle = styled.div`
 export const ToggleDropdownCellStyle = styled(DropdownCellStyle)`
   justify-content: flex-start;
   gap: 12px;
+  padding-right: ${UNIT * 1.25}px;
 `;

--- a/mage_ai/frontend/components/Triggers/utils.ts
+++ b/mage_ai/frontend/components/Triggers/utils.ts
@@ -15,7 +15,10 @@ import {
   ScheduleTypeEnum,
 } from '@interfaces/PipelineScheduleType';
 import { TimeType } from '@oracle/components/Calendar';
-import { getDayRangeForCurrentMonth } from '@utils/date';
+import {
+  datetimeInLocalTimezone,
+  getDayRangeForCurrentMonth,
+} from '@utils/date';
 import { ignoreKeys } from '@utils/hash';
 import { rangeSequential } from '@utils/array';
 
@@ -125,6 +128,15 @@ export function getTimeInUTCString(dateTime: string) {
   const datetimeString = momentObj.format(DATE_FORMAT_LONG_T_SEP);
 
   return datetimeString;
+}
+
+export function displayLocalOrUtcTime(
+  datetime: string,
+  displayLocalTimezone: boolean,
+) {
+  return displayLocalTimezone
+    ? datetimeInLocalTimezone(datetime, displayLocalTimezone)
+    : getTimeInUTCString(datetime);
 }
 
 export enum TimeUnitEnum {

--- a/mage_ai/frontend/components/settings/workspace/Preferences.tsx
+++ b/mage_ai/frontend/components/settings/workspace/Preferences.tsx
@@ -20,11 +20,11 @@ import Tooltip from '@oracle/components/Tooltip';
 import api from '@api';
 import { ContainerStyle } from './index.style';
 import { Edit } from '@oracle/icons';
-import { ICON_SIZE_MEDIUM, ICON_SIZE_SMALL } from '@oracle/styles/units/icons';
+import { ICON_SIZE_SMALL } from '@oracle/styles/units/icons';
+import { LOCAL_TIMEZONE_TOOLTIP_PROPS, storeLocalTimezoneSetting } from './utils';
 import { PADDING_UNITS, UNITS_BETWEEN_SECTIONS } from '@oracle/styles/units/spacing';
 import { capitalizeRemoveUnderscoreLower } from '@utils/string';
 import { onSuccess } from '@api/utils/response';
-import { storeLocalTimezoneSetting } from './utils';
 import { useError } from '@context/Error';
 
 type PreferencesProps = {
@@ -262,14 +262,7 @@ function Preferences({
                   {k === FeatureUUIDEnum.LOCAL_TIMEZONE &&
                     <Spacing ml={1}>
                       <Tooltip
-                        block
-                        description="Display dates in local timezone. Please note that certain pages
-                          (e.g. Monitor page) or components (e.g. Pipeline run bar charts) may still
-                          be in UTC time. Dates in local time will have a timezone offset in the
-                          timestamp (e.g. -07:00)."
-                        lightBackground
-                        muted
-                        size={ICON_SIZE_MEDIUM}
+                        {...LOCAL_TIMEZONE_TOOLTIP_PROPS}
                       />
                     </Spacing>
                   }

--- a/mage_ai/frontend/components/settings/workspace/utils.ts
+++ b/mage_ai/frontend/components/settings/workspace/utils.ts
@@ -1,5 +1,17 @@
+import { ICON_SIZE_MEDIUM } from '@oracle/styles/units/icons';
 import { LOCAL_STORAGE_KEY_DISPLAY_LOCAL_TIMEZONE } from '@storage/constants';
 import { get, set } from '@storage/localStorage';
+
+export const LOCAL_TIMEZONE_TOOLTIP_PROPS = {
+  block: true,
+  description: 'Display dates in local timezone. Please note that certain pages'
+    + ' (e.g. Monitor page) or components (e.g. Pipeline run bar charts) may still'
+    + ' be in UTC time. Dates in local time will have a timezone offset in the'
+    + ' timestamp (e.g. -07:00).',
+  lightBackground: true,
+  muted: true,
+  size: ICON_SIZE_MEDIUM,
+};
 
 export function shouldDisplayLocalTimezone(): boolean {
   const displayLocalTimezone = get(LOCAL_STORAGE_KEY_DISPLAY_LOCAL_TIMEZONE, null);

--- a/mage_ai/frontend/components/shared/Header/index.tsx
+++ b/mage_ai/frontend/components/shared/Header/index.tsx
@@ -278,7 +278,9 @@ function Header({
             )}
 
             <Spacing ml={1}>
-              <ServerTimeDropdown />
+              <ServerTimeDropdown
+                projectName={project?.name}
+              />
             </Spacing>
 
             {version && typeof(version) !== 'undefined' && (

--- a/mage_ai/frontend/components/shared/Table/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/index.tsx
@@ -608,6 +608,7 @@ function Table({
                     lightBackground
                     maxWidth={tooltipWidth}
                     muted
+                    relativePosition
                     widthFitContent={fitTooltipContentWidth}
                   />
                 </Spacing>

--- a/mage_ai/frontend/storage/constants.ts
+++ b/mage_ai/frontend/storage/constants.ts
@@ -17,9 +17,6 @@ export const LOCAL_STORAGE_KEY_DISPLAY_LOCAL_TIMEZONE = 'display_local_timezone'
 
 export const LOCAL_STORAGE_KEY_HIDE_PUBLIC_DEMO_WARNING = 'hide_public_demo_warning';
 
-export const LOCAL_STORAGE_KEY_DISPLAY_LOCAL_SERVER_TIME =
-  'display_local_server_time';
-
 export const LOCAL_STORAGE_KEY_INCLUDE_SERVER_TIME_SECONDS =
   'include_server_time_seconds';
 

--- a/mage_ai/frontend/storage/serverTime.ts
+++ b/mage_ai/frontend/storage/serverTime.ts
@@ -1,16 +1,7 @@
 import { 
-  LOCAL_STORAGE_KEY_DISPLAY_LOCAL_SERVER_TIME, 
   LOCAL_STORAGE_KEY_INCLUDE_SERVER_TIME_SECONDS, 
 } from '@storage/constants';
 import { get, setLocalStorageValue } from '@storage/localStorage';
-
-export function shouldDisplayLocalServerTime(): boolean {
-  return get(LOCAL_STORAGE_KEY_DISPLAY_LOCAL_SERVER_TIME, false);
-}
-
-export function storeDisplayLocalServerTime(value: boolean): boolean {
-  return setLocalStorageValue(LOCAL_STORAGE_KEY_DISPLAY_LOCAL_SERVER_TIME, value);
-}
 
 export function shouldIncludeServerTimeSeconds(): boolean {
   return get(LOCAL_STORAGE_KEY_INCLUDE_SERVER_TIME_SECONDS, false);


### PR DESCRIPTION
# Description
- Previously, toggling the local time setting from the header would only change between displaying the current time as UTC or the local timezone. This PR updates this "Display local timezone" toggle in the header so that it actually updates the app's local timezone setting, which displays datetimes in various pages as the local timezone or in UTC. This setting can also be found under the project settings as "Display local timezone".
- Fixes the datetimes in the Syncs page to also display local timezone for the datetimes accordingly. This page was previously not accounted for when adding the local timezone project setting.

# How Has This Been Tested?
![display local timezone from header](https://github.com/mage-ai/mage-ai/assets/78053898/51510aab-b8aa-462d-9944-a9227ff89037)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
