### PR TITLE
[xy] Fix executing conditional blocks with pipeline executor.

### DIFF
--- a/mage_ai/data_preparation/executors/pipeline_executor.py
+++ b/mage_ai/data_preparation/executors/pipeline_executor.py
@@ -111,6 +111,8 @@ class PipelineExecutor:
             return asyncio.create_task(execute_block())
 
         while not pipeline_run.all_blocks_completed(allow_blocks_to_fail):
+            # Update the statuses of the block runs to CONDITION_FAILED or UPSTREAM_FAILED.
+            pipeline_run.update_block_run_statuses(pipeline_run.initial_block_runs)
             executable_block_runs = pipeline_run.executable_block_runs(
                 allow_blocks_to_fail=allow_blocks_to_fail,
             )

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -902,6 +902,77 @@ class PipelineRun(BaseModel):
 
         return executable_block_runs
 
+    def update_block_run_statuses(self, block_runs: List['BlockRun']) -> None:
+        """Update the statuses of the block runs to CONDITION_FAILED or UPSTREAM_FAILED.
+
+        This method updates the statuses of the block runs based on the pipeline run's block runs.
+        It retrieves the block UUIDs for failed block runs and conditionally failed block runs.
+        It maps the block run statuses to their corresponding block UUIDs.
+
+        The method iterates overthe provided block runs and checks if their dynamic upstream block
+        UUIDs or upstream block UUIDs match the failed or conditionally failed block UUIDs.
+        * If there is a match, the block run's status is updated accordingly.
+        * If no updates are made for a block run, it is added to the list of not updated block runs.
+
+        The method refreshes the pipeline run and continues iterating through block runs until no
+        more updates can be made.
+
+        Args:
+            block_runs (List[BlockRun]): A list of block runs to update.
+
+        Returns:
+            None
+        """
+        pipeline = self.pipeline
+
+        failed_block_uuids = set(
+            b.block_uuid for b in self.block_runs
+            if b.status in [
+                BlockRun.BlockRunStatus.UPSTREAM_FAILED,
+                BlockRun.BlockRunStatus.FAILED,
+            ]
+        )
+        condition_failed_block_uuids = set(
+            b.block_uuid for b in self.block_runs
+            if b.status in [
+                BlockRun.BlockRunStatus.CONDITION_FAILED,
+            ]
+        )
+
+        statuses = {
+            BlockRun.BlockRunStatus.CONDITION_FAILED: condition_failed_block_uuids,
+            BlockRun.BlockRunStatus.UPSTREAM_FAILED: failed_block_uuids,
+        }
+        not_updated_block_runs = []
+        for block_run in block_runs:
+            updated_status = False
+            dynamic_upstream_block_uuids = block_run.metrics and block_run.metrics.get(
+                'dynamic_upstream_block_uuids',
+            )
+
+            for status, block_uuids in statuses.items():
+                upstream_block_uuids = []
+                if dynamic_upstream_block_uuids:
+                    upstream_block_uuids = dynamic_upstream_block_uuids
+                else:
+                    block = pipeline.get_block(block_run.block_uuid)
+                    if block:
+                        upstream_block_uuids = block.upstream_block_uuids
+                if any(
+                    b in block_uuids
+                    for b in upstream_block_uuids
+                ):
+                    block_run.update(status=status)
+                    updated_status = True
+
+            if not updated_status:
+                not_updated_block_runs.append(block_run)
+
+        self.refresh()
+        # keep iterating through block runs until no more updates can be made
+        if len(block_runs) != len(not_updated_block_runs):
+            self.update_block_run_statuses(not_updated_block_runs)
+
     @classmethod
     @safe_db_query
     def active_runs_for_pipelines(


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix executing conditional blocks with pipeline executor.

When running conditional blocks in pipeline executor (run_pipeline_in_one_process: true), the pipeline execution could get stuck because it doesn't update the downstream block status of the failed conditional block. This PR fixes this issue.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with the pipeline with multiple conditional blocks and run_pipeline_in_one_process: true. The pipeline execution completed successfully. 
<img width="347" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/3f995259-906d-4223-9b20-326d8668f1ae">


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
