### PR TITLE
Added Supabase Storage Sink

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -292,6 +292,7 @@
                 "streaming/destinations/postgres",
                 "streaming/destinations/redshift",
                 "streaming/destinations/snowflake",
+                "streaming/destinations/supabase-storage",
                 "streaming/destinations/trino"
               ]
             }

--- a/docs/streaming/destinations/supabase-storage.mdx
+++ b/docs/streaming/destinations/supabase-storage.mdx
@@ -1,0 +1,73 @@
+---
+title: "Supabase Storage"
+---
+
+## Basic config
+
+```yaml
+connector_type: supabase_storage
+bucket: bucket
+prefix: prefix
+url: url
+api_key: api_key
+login_type: password
+password: password
+email: email
+file_options: null
+file_type: 'parquet'
+buffer_size_mb: 5
+buffer_timeout_seconds: 300
+```
+
+* `bucket`: The Supabase Storage bucket you want to use to store the data.
+* `prefix`: The Supabase Storage path prefix.
+* `url`: The Supabase connection url.
+* `api_key`: The Supabase API key.
+* `login_type`: Supabase login type. Please read `Authentication` for more information.
+* `password`: Supabase user password.
+* `email`: Supabase user email.
+* `file_options`: Supabase Storage upload header. Default is: {"content-type": "text/csv"}.
+* `file_type`: `parquet` or `csv`.
+* `buffer_size_mb` and `buffer_timeout_seconds`: Mage puts messages in a buffer before uploading to supabase.
+  You can configure the size and timeout of the buffer to control the file size and the delay.
+
+## Configure time-based partition
+
+```yaml
+date_partition_format: "%Y%m%dT%H"
+
+```
+
+If you want to store the Supabase Storage data in time-based paratition folders. You can add `date_partition_format`
+to the config. Example values: `%Y%m%d`, `%Y%m%dT%H`.
+
+
+## Authentication
+There are 3 authentication types:
+ - password
+ - otp
+ - oauth
+
+For more reference, please check the [supabase docs](https://supabase.com/docs/reference/python/auth-signinwithpassword)
+
+### Password authentication
+```yaml
+login_type: password
+password: your_password
+email: your_email
+```
+
+### OAuth authentication
+```yaml
+login_type: oauth
+auth_provider: your_auth_provider
+options: dict containing oauth login options
+```
+
+### OTP authentication
+```yaml
+login_type: otp
+phone: your_phone
+email: your_email
+options: dict containing otp login options
+```

--- a/mage_ai/data_preparation/templates/data_exporters/streaming/supabase_storage.yaml
+++ b/mage_ai/data_preparation/templates/data_exporters/streaming/supabase_storage.yaml
@@ -1,0 +1,12 @@
+connector_type: supabase_storage
+bucket: bucket
+prefix: prefix
+url: url
+api_key: api_key
+login_type: password
+password: password
+email: email
+file_options: null
+file_type: 'parquet'
+buffer_size_mb: 5
+buffer_timeout_seconds: 300

--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/utils.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/utils.tsx
@@ -61,6 +61,7 @@ const getDataSourceTypes = (
         DataSourceTypeEnum.POSTGRES,
         DataSourceTypeEnum.REDSHIFT,
         DataSourceTypeEnum.SNOWFLAKE,
+        DataSourceTypeEnum.SUPABASE_STORAGE,
         DataSourceTypeEnum.TRINO,
       ],
       [BlockTypeEnum.TRANSFORMER]: [

--- a/mage_ai/frontend/interfaces/DataSourceType.ts
+++ b/mage_ai/frontend/interfaces/DataSourceType.ts
@@ -33,6 +33,7 @@ export enum DataSourceTypeEnum {
   REDSHIFT = 'redshift',
   S3 = 's3',
   SNOWFLAKE = 'snowflake',
+  SUPABASE_STORAGE = 'supabase_storage',
   TRINO = 'trino',
 }
 
@@ -69,6 +70,7 @@ export const DATA_SOURCE_TYPE_HUMAN_READABLE_NAME_MAPPING = {
   [DataSourceTypeEnum.REDSHIFT]: 'Amazon Redshift',
   [DataSourceTypeEnum.S3]: 'Amazon S3',
   [DataSourceTypeEnum.SNOWFLAKE]: 'Snowflake',
+  [DataSourceTypeEnum.SUPABASE_STORAGE]: 'Supabase Storage',
   [DataSourceTypeEnum.TRINO]: 'Trino',
 };
 
@@ -101,6 +103,7 @@ export const DATA_SOURCE_TYPES: { [blockType in BlockTypeEnum]?: DataSourceTypeE
     DataSourceTypeEnum.REDSHIFT,
     DataSourceTypeEnum.BIGQUERY,
     DataSourceTypeEnum.SNOWFLAKE,
+    DataSourceTypeEnum.SUPABASE_STORAGE,
     DataSourceTypeEnum.MYSQL,
     DataSourceTypeEnum.POSTGRES,
   ],

--- a/mage_ai/streaming/constants.py
+++ b/mage_ai/streaming/constants.py
@@ -39,6 +39,7 @@ class SinkType(str, Enum):
     POSTGRES = 'postgres'
     REDSHIFT = 'redshift'
     SNOWFLAKE = 'snowflake'
+    SUPABASE_STORAGE = 'supabase_storage'
     TRINO = 'trino'
 
 

--- a/mage_ai/streaming/sinks/sink_factory.py
+++ b/mage_ai/streaming/sinks/sink_factory.py
@@ -53,6 +53,10 @@ class SinkFactory:
             from mage_ai.streaming.sinks.postgres import PostgresSink
 
             return PostgresSink(config, **kwargs)
+        elif connector_type == SinkType.SUPABASE_STORAGE:
+            from mage_ai.streaming.sinks.supabase_storage import SupabaseStorageSink
+
+            return SupabaseStorageSink(config, **kwargs)
         elif connector_type in GENERIC_IO_SINK_TYPES:
             from mage_ai.streaming.sinks.generic_io import GenericIOSink
 

--- a/mage_ai/streaming/sinks/supabase_storage.py
+++ b/mage_ai/streaming/sinks/supabase_storage.py
@@ -1,0 +1,157 @@
+import os
+import sys
+import threading
+import time
+import traceback
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from io import BytesIO
+from typing import Dict, List
+
+import pandas as pd
+import supabase
+
+from mage_ai.shared.config import BaseConfig
+from mage_ai.streaming.sinks.base import BaseSink
+
+
+@dataclass
+class SupabaseConfigSink(BaseConfig):
+    bucket: str
+    prefix: str
+    url: str
+    api_key: str
+    file_options: str = None
+    file_type: str = 'parquet'
+    buffer_size_mb: int = 5
+    buffer_timeout_seconds: int = 300
+    date_partition_format: str = None
+    login_type: str = 'password'
+    password: str = None
+    email: str = None
+    phone: str = None
+    auth_provider: str = None
+    options: str = None
+
+
+class SupabaseStorageSink(BaseSink):
+    config_class = SupabaseConfigSink
+
+    def init_client(self):
+        self.last_upload_time = None
+
+        self.timer = threading.Timer(
+            self.config.buffer_timeout_seconds,
+            self.upload_data_to_supabase
+        )
+
+        self.timer.start()
+
+        self.client = supabase.Client(self.config.url, self.config.api_key)
+
+        if self.config.login_type == 'password':
+            if self.config.password and self.config.email:
+                self.client.auth.sign_in_with_password({
+                    'email': self.config.email,
+                    'password': self.config.password
+                })
+            elif self.config.password and self.config.phone:
+                # TODO
+                # Password and Phone login type
+                # Require a Token validation after the initial sign_in_with_password
+                raise Exception('Phone and token login not supported')
+            else:
+                raise Exception('Missing Password OR email settings for password login type')
+        elif self.config.login_type == 'otp':
+            if self.config.phone or self.config.email:
+                self.client.auth.sign_in_with_otp({
+                    'phone': self.config.phone,
+                    'email': self.config.email,
+                    'options': self.config.options
+                })
+            else:
+                raise Exception('You must provide either an email \
+                                or phone number for otp login type')
+        elif self.config.login_type == 'oauth':
+            self.client.auth.sign_in_with_oauth({
+                'provider': self.config.auth_provider,
+                'options': self.config.options
+            })
+        else:
+            raise Exception('invalid login_type. Valid types are: password, otp, oauth')
+
+        if self.buffer:
+            self.upload_data_to_supabase()
+
+    def destroy(self):
+        try:
+            self.timer.cancel()
+        except Exception:
+            traceback.print_exc()
+
+    def write(self, message: Dict):
+        self._print(f'Ingest data {message}, time={time.time()}')
+        self.write_buffer([message])
+
+    def batch_write(self, messages: List[Dict]):
+        if not messages:
+            return
+        self._print(
+            f'Batch ingest {len(messages)} records, time={time.time()}. Sample: {messages[0]}')
+        self.write_buffer(messages)
+
+        if self.config.buffer_size_mb and \
+                sys.getsizeof(self.buffer) >= self.config.buffer_size_mb * 1_000_000:
+            self.upload_data_to_supabase()
+            return
+
+    def upload_data_to_supabase(self):
+        self.__reset_timer()
+        if not self.buffer:
+            return
+        self._print(f'Upload {len(self.buffer)} records to Supabase storage.')
+
+        df = pd.DataFrame(self.buffer)
+        buffer = BytesIO()
+        if self.config.file_type == 'parquet':
+            df.to_parquet(buffer)
+        elif self.config.file_type == 'csv':
+            df.to_csv(buffer, index=False)
+        else:
+            raise Exception(f'File type {self.config.file_type} is not supported.')
+
+        buffer.seek(0)
+
+        curr_time = datetime.now(timezone.utc)
+
+        filename = curr_time.strftime('%Y%m%d-%H%M%S')
+        filename = f'{filename}.{self.config.file_type}'
+
+        object_key = self.config.prefix
+
+        date_partition_format = self.config.date_partition_format
+        if date_partition_format:
+            object_key = os.path.join(object_key, curr_time.strftime(date_partition_format))
+
+        object_key = os.path.join(object_key, filename)
+
+        self.client.storage.from_(self.config.bucket).upload(
+            file=buffer.getvalue(),
+            path=object_key,
+            file_options=self.config.file_options
+        )
+
+        self.clear_buffer()
+
+    def __reset_timer(self):
+        try:
+            self.timer.cancel()
+        except Exception:
+            traceback.print_exc()
+
+        self.timer = threading.Timer(
+            self.config.buffer_timeout_seconds,
+            self.upload_data_to_supabase
+
+        )
+        self.timer.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ dask>=2022.2.0
 datadog==0.44.0
 freezegun==1.2.2
 great_expectations==0.15.50
-httpx
+httpx==0.23.1
 inflection==0.5.1
 ipykernel==6.15.0
 ipython==7.34.0
@@ -66,7 +66,10 @@ kubernetes==25.3.0
 langchain>=0.0.222; python_version >= '3.8'
 mysql-connector-python==8.0.31
 openai>=0.27.8, <1.0.0
+opentelemetry-exporter-prometheus>=1.12.0rc1
+opentelemetry-instrumentation-tornado>=0.41b0
 oracledb==1.3.1
+pinotdb==5.1.0
 prometheus_client>=0.18.0
 psycopg2==2.9.3
 psycopg2-binary==2.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ dask>=2022.2.0
 datadog==0.44.0
 freezegun==1.2.2
 great_expectations==0.15.50
-httpx==0.23.1
+httpx
 inflection==0.5.1
 ipykernel==6.15.0
 ipython==7.34.0
@@ -66,10 +66,7 @@ kubernetes==25.3.0
 langchain>=0.0.222; python_version >= '3.8'
 mysql-connector-python==8.0.31
 openai>=0.27.8, <1.0.0
-opentelemetry-exporter-prometheus>=1.12.0rc1
-opentelemetry-instrumentation-tornado>=0.41b0
 oracledb==1.3.1
-pinotdb==5.1.0
 prometheus_client>=0.18.0
 psycopg2==2.9.3
 psycopg2-binary==2.9.3
@@ -101,6 +98,7 @@ pika==1.3.1
 pymongo==4.3.3
 elasticsearch==8.9.0
 stomp.py==8.1.0
+supabase==2.1.1
 
 # DBT
 dbt-bigquery==1.4.3


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Added Supabase Storage Sink to Streaming Pipelines.

Supabase has 2 main 'services' that provide data storage/consumption:
1. A Internal POSTGREs Database
2. A Internal S3-like file storage database

The internal POSTGREs database can be accessed via psycopg2, which makes the access already available to all Mage users via postgresql data blocks.
However, that's not the case for the S3-like storage database.

This PR aims to add the Supabase Storage sink class to support streaming operations.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
Tested using RabbitMQ source -> Simple transformer block -> Supabase Storage Sink

## Logs Example
![Screenshot from 2023-12-05 04-48-49](https://github.com/mage-ai/mage-ai/assets/14100959/aee1b502-9450-4254-b599-be5f1afcc3b7)

## Supabase Storage Example
![Screenshot from 2023-12-05 04-49-11](https://github.com/mage-ai/mage-ai/assets/14100959/2d579b7a-7ed2-4c0b-a766-702330045a1a)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 
