### PR TITLE
[dy] Fix external cloud storage logs for k8s blocks

### DIFF
--- a/mage_ai/data_preparation/logging/gcs_logger_manager.py
+++ b/mage_ai/data_preparation/logging/gcs_logger_manager.py
@@ -67,4 +67,4 @@ class GCSLoggerManager(LoggerManager):
     def upload_logs(self, key: str, logs: str):
         bucket = self.gcs_client.get_bucket(self.gcs_config.bucket)
         blob = bucket.blob(key)
-        blob.upload_from_string(self.stream.getvalue())
+        blob.upload_from_string(logs)

--- a/mage_ai/data_preparation/logging/gcs_logger_manager.py
+++ b/mage_ai/data_preparation/logging/gcs_logger_manager.py
@@ -64,8 +64,7 @@ class GCSLoggerManager(LoggerManager):
         """
         return self.get_logs()
 
-    def output_logs_to_destination(self):
-        key = self.get_log_filepath()
+    def upload_logs(self, key: str, logs: str):
         bucket = self.gcs_client.get_bucket(self.gcs_config.bucket)
         blob = bucket.blob(key)
         blob.upload_from_string(self.stream.getvalue())

--- a/mage_ai/data_preparation/logging/logger_manager.py
+++ b/mage_ai/data_preparation/logging/logger_manager.py
@@ -273,13 +273,13 @@ class LoggerManager:
     def output_logs_to_destination(self) -> None:
         """
         Fetch existing logs from the destination if they exist and
-        upload logs to the configured destination.
+        upload logs from the stream to the configured destination.
         """
-        existing_logs = self.get_logs().get('content')
+        if self.stream:
+            existing_logs = self.get_logs().get('content')
+            new_logs = self.stream.getvalue()
+            if existing_logs:
+                new_logs = existing_logs + '\n' + new_logs
 
-        new_logs = self.stream.getvalue()
-        if existing_logs:
-            new_logs = existing_logs + '\n' + new_logs
-
-        key = self.get_log_filepath()
-        self.upload_logs(key, new_logs)
+            key = self.get_log_filepath()
+            self.upload_logs(key, new_logs)

--- a/mage_ai/data_preparation/logging/logger_manager.py
+++ b/mage_ai/data_preparation/logging/logger_manager.py
@@ -259,9 +259,27 @@ class LoggerManager:
             *[file.to_dict_async(include_content=True) for file in files]
         )
 
-    def output_logs_to_destination(self):
+    def upload_logs(self, key: str, logs: str) -> None:
         """
-        Output logs to the configured destination.
+        Upload logs to the configured destination.
         (Placeholder, this function is not implemented yet.)
+
+        Args:
+            key (str): key to upload to logs to in the destination
+            logs (str): logs to upload
         """
         pass
+
+    def output_logs_to_destination(self) -> None:
+        """
+        Fetch existing logs from the destination if they exist and
+        upload logs to the configured destination.
+        """
+        existing_logs = self.get_logs().get('content')
+
+        new_logs = self.stream.getvalue()
+        if existing_logs:
+            new_logs = existing_logs + '\n' + new_logs
+
+        key = self.get_log_filepath()
+        self.upload_logs(key, new_logs)

--- a/mage_ai/data_preparation/logging/s3_logger_manager.py
+++ b/mage_ai/data_preparation/logging/s3_logger_manager.py
@@ -66,6 +66,6 @@ class S3LoggerManager(LoggerManager):
         """
         return self.get_logs()
 
-    def output_logs_to_destination(self):
+    def upload_logs(self, key: str, logs: str):
         key = self.get_log_filepath()
-        self.s3_client.upload(key, self.stream.getvalue())
+        self.s3_client.upload(key, logs)

--- a/mage_ai/data_preparation/logging/s3_logger_manager.py
+++ b/mage_ai/data_preparation/logging/s3_logger_manager.py
@@ -67,5 +67,4 @@ class S3LoggerManager(LoggerManager):
         return self.get_logs()
 
     def upload_logs(self, key: str, logs: str):
-        key = self.get_log_filepath()
         self.s3_client.upload(key, logs)

--- a/mage_ai/services/k8s/job_manager.py
+++ b/mage_ai/services/k8s/job_manager.py
@@ -11,7 +11,6 @@ from mage_ai.services.k8s.constants import (
     DEFAULT_NAMESPACE,
     KUBE_CONTAINER_NAME,
     KUBE_POD_NAME_ENV_VAR,
-    KUBE_POD_NAMESPACE_ENV_VAR,
 )
 from mage_ai.shared.hash import merge_dict
 
@@ -36,7 +35,7 @@ class JobManager():
 
         self.pod_config = self.core_api_client.read_namespaced_pod(
             name=os.getenv(KUBE_POD_NAME_ENV_VAR),
-            namespace=os.getenv(KUBE_POD_NAMESPACE_ENV_VAR),
+            namespace=self.namespace,
         )
         self.container_name = KUBE_CONTAINER_NAME
 

--- a/mage_ai/services/k8s/job_manager.py
+++ b/mage_ai/services/k8s/job_manager.py
@@ -11,6 +11,7 @@ from mage_ai.services.k8s.constants import (
     DEFAULT_NAMESPACE,
     KUBE_CONTAINER_NAME,
     KUBE_POD_NAME_ENV_VAR,
+    KUBE_POD_NAMESPACE_ENV_VAR,
 )
 from mage_ai.shared.hash import merge_dict
 
@@ -35,7 +36,7 @@ class JobManager():
 
         self.pod_config = self.core_api_client.read_namespaced_pod(
             name=os.getenv(KUBE_POD_NAME_ENV_VAR),
-            namespace=self.namespace,
+            namespace=os.getenv(KUBE_POD_NAMESPACE_ENV_VAR, self.namespace),
         )
         self.container_name = KUBE_CONTAINER_NAME
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

When using external cloud storage for blocks that use the k8s executor, the logs for the block were not getting uploaded correctly. This was happening because the logs were getting written to the destination twice, so the logs in the 1st write were getting overwritten. This PR will try to fetch logs from the destination first and append the new logs to the existing logs if they exist.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with a block using a k8s executor and S3 external log storage
Before:
![Screenshot 2023-12-05 at 11 57 07 AM](https://github.com/mage-ai/mage-ai/assets/14357209/a86e6c07-4874-4f7f-be8a-44691276fc44)

After:
![Screenshot 2023-12-05 at 3 13 12 PM](https://github.com/mage-ai/mage-ai/assets/14357209/90b16192-1a36-48e1-83c8-3b5f3976e663)


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
