### PR TITLE
Fixed Salesforce Destination Upsert action

### DIFF
--- a/mage_integrations/mage_integrations/destinations/salesforce/README.md
+++ b/mage_integrations/mage_integrations/destinations/salesforce/README.md
@@ -18,6 +18,7 @@ password  |  User/password password| optional|
 security_token | User/password generated security token. Reset under your Account Settings| optional|
 domain | Your Salesforce instance domain. Use 'login' (default) or 'test' (sandbox), or Salesforce My domain.| Required|
 action | How to handle incomming records by default (insert/update/upsert/delete/hard_delete). Default is "insert"| Required|
+external_id_name | External Id name if required to `upsert` records. Default is "Id"| optional|
 allow_failures | Allows the target to continue persisting if a record fails to commit. Default is "False"| optional| 
 table_name | Allows the target to use a different source to this destination. (Read "limitations" section)| optional|
 
@@ -28,3 +29,10 @@ To obtain OAuth credentials, follow this [guide](https://github.com/mage-ai/mage
 ## Limitations
 
 To effectively use a different source to this destination, you must specify the "table_name" parameter on the Configuration section. The table_name <b>must</b> consist of a Salesforce section name (E.G Accounts).
+
+## Allow Failures
+
+If `allow_failures` is set to True, only records that were <b> eligible </b> to be written but were not will be skipped.
+Being eligible means that the record correspond to a given Salesforce object schema and is being executed with a valid action.
+
+Else, if the given Salesforce Bulk result does not correspond to "success" AND `allow_failures` is False, a raise will be called. 

--- a/mage_integrations/mage_integrations/destinations/salesforce/target_salesforce/sinks.py
+++ b/mage_integrations/mage_integrations/destinations/salesforce/target_salesforce/sinks.py
@@ -124,7 +124,8 @@ class SalesforceSink(BatchSink):
 
         try:
             if action == "upsert":
-                results = sf_object_action(batched_data, "Id")
+                results = sf_object_action(batched_data,
+                                           self.config.get('external_id_name', 'Id'))
             else:
                 results = sf_object_action(batched_data)
         except exceptions.SalesforceMalformedRequest as e:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Users reported not being able to execute the `upsert` action while using Salesforce destination.

This was being caused by the current Salesforce Destination target not allowing for a external ID to be selected.
Istead, the target would only use the default `Id` column. For future reference, please refer to salesforce docs [here](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/bulk_api_2_0_upsert.htm?q=upsert)

To fix this, a new optional config named `external_id_name` was added. If it is not provided, the default `Id` strategy is used.

Also added better explanation to the `allow_failures` setting inside README.MD

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
Tested using API Source block -> Salesforce Destination using `Upsert` action

## Sync example
![Screenshot from 2023-12-05 22-06-36](https://github.com/mage-ai/mage-ai/assets/14100959/b1185c41-c9b9-4069-ab85-af5fb51ec76d)

## Upsert result
![Screenshot from 2023-12-05 22-08-05](https://github.com/mage-ai/mage-ai/assets/14100959/0d749883-59df-4d5f-99a3-4c35b9db4d5b)

![Screenshot from 2023-12-05 22-06-52](https://github.com/mage-ai/mage-ai/assets/14100959/40b0eedd-99ce-4b2c-bef3-82191de3b3bc)




# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 
