### PR TITLE
[dy] Close modal after saving

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
@@ -96,8 +96,9 @@ function ConfigureBlock({
       ...blockAttributes,
       name: blockAttributes?.name || defaultName,
     });
-  }, [blockAttributes, defaultName, onSave]);
-
+    onClose();
+  }, [blockAttributes, defaultName, onClose, onSave]);
+    
   useEffect(() => {
     const handleKeyDown = (event) => {
       event.stopPropagation();


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Close modal after pressing "Save and add block" so that users don't accidentally press it multiple times.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc: @johnson-mage 
<!-- Optionally mention someone to let them know about this pull request -->
