### PR TITLE
[jk] Fix stale pipeline message not appearing

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -248,6 +248,7 @@ function PipelineDetailPage({
   const [pipelineMessages, setPipelineMessages] = useState<KernelOutputType[]>([]);
 
   // Pipeline
+  // eslint-disable-next-line prefer-const
   let pipeline;
   const pipelineUUIDPrev = usePrevious(pipelineUUID);
   const {
@@ -354,11 +355,10 @@ function PipelineDetailPage({
   const [sideBySideEnabledState, setSideBySideEnabledState] = useState<boolean>(
     get(LOCAL_STORAGE_KEY_PIPELINE_EDITOR_SIDE_BY_SIDE_ENABLED, false),
   );
-  const sideBySideEnabled = useMemo(() => {
-    return !isDataIntegration
-      && featureEnabled?.(featureUUIDs?.NOTEBOOK_BLOCK_OUTPUT_SPLIT_VIEW)
-      && sideBySideEnabledState;
-  }, [
+  const sideBySideEnabled = useMemo(() => !isDataIntegration
+    && featureEnabled?.(featureUUIDs?.NOTEBOOK_BLOCK_OUTPUT_SPLIT_VIEW)
+    && sideBySideEnabledState,
+  [
     featureEnabled,
     featureUUIDs,
     isDataIntegration,
@@ -435,6 +435,8 @@ function PipelineDetailPage({
       }, ANIMATION_DURATION_CONTENT + 1);
     }
   }, [
+    dispatchEventChanged,
+    dispatchEventChangedOutput,
     localStorageHiddenBlocksKey,
     setHiddenBlocksState,
     sideBySideEnabled,
@@ -469,7 +471,7 @@ function PipelineDetailPage({
   ]);
 
   const [pipelineLastSaved, setPipelineLastSaved] = useState<number>(null);
-  const [pipelineLastSavedState, setPipelineLastSavedState] = useState<number>(Number(utcNowDate({ dateObj: true })));
+  const [pipelineLastSavedState, setPipelineLastSavedState] = useState<number>(moment().utc().unix());
   const [pipelineContentTouched, setPipelineContentTouched] = useState<boolean>(false);
 
   const [showStalePipelineMessageModal, hideStalePipelineMessageModal] = useModal(() => (
@@ -922,9 +924,8 @@ function PipelineDetailPage({
       showStalePipelineMessageModal();
       return;
     }
-    const utcNowDateObj = utcNowDate({ dateObj: true });
     const utcNowDateString = utcNowDate();
-    setPipelineLastSavedState(Number(utcNowDateObj));
+    setPipelineLastSavedState(moment().utc().unix());
 
     const blocksByExtensions = {};
     const blocksByUUID = {};
@@ -1881,14 +1882,14 @@ function PipelineDetailPage({
     return func();
   }, [
     createBlock,
+    featureEnabled,
+    featureUUIDs?.NOTEBOOK_BLOCK_OUTPUT_SPLIT_VIEW,
     fetchFileTree,
     fetchPipeline,
     isDataIntegration,
     openFile,
     pipeline,
     savePipelineContent,
-    setBlocks,
-    setErrors,
     sideBySideEnabled,
   ]);
 
@@ -3103,6 +3104,7 @@ function PipelineDetailPage({
       );
     }
   }, [
+    kernel,
     mainContainerWidth,
     page,
     pipelineContentTouched,


### PR DESCRIPTION
# Description
- If multiple tabs/windows of the same pipeline were open, a stale pipeline message modal should appear if the user tries to save an outdated pipeline. This feature stopped working at some point, so this PR fixes that so it appears again.

# How Has This Been Tested?
Multiple tabs of same pipeline open, cannot save the outdated pipeline:
![stale pipeline](https://github.com/mage-ai/mage-ai/assets/78053898/c774e19d-8885-4daf-a172-e7ef911b9d17)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
