### PR TITLE
[sm] Add ActiveMQ as streaming data sink

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -273,6 +273,7 @@
             {
               "group": "Destinations",
               "pages": [
+                "streaming/destinations/activemq",
                 "streaming/destinations/amazon-s3",
                 "streaming/destinations/bigquery",
                 "streaming/destinations/clickhouse",

--- a/docs/streaming/destinations/activemq.mdx
+++ b/docs/streaming/destinations/activemq.mdx
@@ -1,0 +1,14 @@
+---
+title: "ActiveMQ"
+---
+
+## Basic config
+
+```yaml
+connector_type: activemq
+connection_host: 'localhost'
+connection_port: 61613
+queue_name: 'queue_name'
+username: 'admin'
+password: 'admin'
+```

--- a/mage_ai/data_preparation/templates/data_exporters/streaming/activemq.yaml
+++ b/mage_ai/data_preparation/templates/data_exporters/streaming/activemq.yaml
@@ -1,0 +1,6 @@
+connector_type: 'activemq'
+connection_host: 'localhost'
+connection_port: 61613
+queue_name: 'default'
+username: 'admin'
+password: 'admin'

--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/utils.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/utils.tsx
@@ -43,6 +43,7 @@ const getDataSourceTypes = (
         DataSourceTypeEnum.MONGODB
       ],
       [BlockTypeEnum.DATA_EXPORTER]: [
+        DataSourceTypeEnum.ACTIVEMQ,
         DataSourceTypeEnum.AZURE_DATA_LAKE,
         DataSourceTypeEnum.BIGQUERY,
         DataSourceTypeEnum.CLICKHOUSE,

--- a/mage_ai/streaming/constants.py
+++ b/mage_ai/streaming/constants.py
@@ -18,6 +18,7 @@ class SourceType(str, Enum):
 
 
 class SinkType(str, Enum):
+    ACTIVEMQ = 'activemq'
     AMAZON_S3 = 'amazon_s3'
     AZURE_DATA_LAKE = 'azure_data_lake'
     BIGQUERY = 'bigquery'

--- a/mage_ai/streaming/sinks/activemq.py
+++ b/mage_ai/streaming/sinks/activemq.py
@@ -1,0 +1,69 @@
+import json
+from dataclasses import dataclass
+from typing import Dict, List
+
+import stomp
+from stomp.exception import ConnectFailedException
+
+from mage_ai.shared.config import BaseConfig
+from mage_ai.streaming.sinks.base import BaseSink
+
+
+@dataclass
+class ActiveMQConfig(BaseConfig):
+    connection_host: str
+    connection_port: int
+    queue_name: str
+    username: str = 'admin'
+    password: str = 'admin'
+
+
+class ActiveMQSink(BaseSink):
+    config_class = ActiveMQConfig
+
+    def init_client(self):
+        self._print('Start initializing producer.')
+        # Initialize ActiveMQ producer
+        queue_name = self.config.queue_name
+        username = self.config.username
+        password = self.config.password
+        connection_host = self.config.connection_host
+        connection_port = self.config.connection_port
+
+        self._print(f'Starting to initialize producer for queue {queue_name}')
+
+        try:
+            conn = stomp.Connection11([(connection_host, connection_port)])
+            self._print('Connecting to broker')
+            conn.connect(username, password, wait=True)
+            self.connection = conn
+
+            self._print('Connected to broker')
+
+        except ConnectFailedException:
+            self._print('Connection Error! Please check broker connection')
+            raise ConnectFailedException
+        except Exception as e:
+            self._print(e)
+            raise e
+
+    def write(self, message: Dict):
+        pass
+
+    def batch_write(self, messages: List[Dict]):
+        if not messages:
+            return
+        self._print(
+            f'Batch ingest {len(messages)} messages. Sample: {messages[0]}'
+        )
+        for message in messages:
+            if isinstance(message, dict):
+                data = message.get('data', message)
+                metadata = message.get('metadata', None)
+            else:
+                data = message
+                metadata = None
+            self.connection.send(destination=f'/queue/{self.config.queue_name}',
+                                 body=json.dumps(data).encode('utf-8'),
+                                 headers=metadata,
+                                 )

--- a/mage_ai/streaming/sinks/sink_factory.py
+++ b/mage_ai/streaming/sinks/sink_factory.py
@@ -7,7 +7,11 @@ class SinkFactory:
     @classmethod
     def get_sink(self, config: Dict, **kwargs):
         connector_type = config['connector_type']
-        if connector_type == SinkType.AMAZON_S3:
+        if connector_type == SinkType.ACTIVEMQ:
+            from mage_ai.streaming.sinks.activemq import ActiveMQSink
+
+            return ActiveMQSink(config, **kwargs)
+        elif connector_type == SinkType.AMAZON_S3:
             from mage_ai.streaming.sinks.amazon_s3 import AmazonS3Sink
 
             return AmazonS3Sink(config, **kwargs)

--- a/mage_ai/tests/streaming/sinks/test_activemq.py
+++ b/mage_ai/tests/streaming/sinks/test_activemq.py
@@ -1,0 +1,34 @@
+from unittest.mock import patch
+
+from mage_ai.streaming.sinks.activemq import ActiveMQSink
+from mage_ai.tests.base_test import TestCase
+
+
+class ActiveMQTests(TestCase):
+    def test_init(self):
+        with patch.object(ActiveMQSink, 'init_client') as mock_init_client:
+            ActiveMQSink(dict(
+                connector_type='activemq',
+                connection_host='localhost',
+                connection_port='61613',
+                queue_name='queue_name',
+                username='admin',
+                password='admin',
+            ))
+            mock_init_client.assert_called_once()
+
+    def test_init_invalid_config(self):
+        with patch.object(ActiveMQSink, 'init_client') as mock_init_client:
+            with self.assertRaises(Exception) as context:
+                ActiveMQSink(dict(
+                    connector_type='activemq',
+                    connection_port='61613',
+                    queue_name='queue_name',
+                    username='admin',
+                    password='admin',
+                ))
+            self.assertTrue(
+                '__init__() missing 1 required positional argument: \'connection_host\''
+                in str(context.exception),
+            )
+            self.assertEqual(mock_init_client.call_count, 0)


### PR DESCRIPTION
# Description
Add ActiveMQ as streaming data sink
![Screenshot 2023-12-07 at 11 25 55 AM](https://github.com/mage-ai/mage-ai/assets/6594483/28a808b3-e350-49a9-a749-604b45bf107c)

# How Has This Been Tested?

- [x] Tested by running locally (screenshots attached)
- [x] Added corresponding test cases


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
