### PR TITLE
[jk] Update DownloadPolicy to allow downloading pipeline zip files

### DIFF
--- a/mage_ai/api/presenters/DownloadPresenter.py
+++ b/mage_ai/api/presenters/DownloadPresenter.py
@@ -3,6 +3,7 @@ from mage_ai.api.presenters.BasePresenter import BasePresenter
 
 class DownloadPresenter(BasePresenter):
     default_attributes = [
+        'token',
         'uri',
     ]
 


### PR DESCRIPTION
# Description
- Fix DownloadPolicy error preventing downloading pipeline zip files when using app as non-owner role.
- Related to https://github.com/mage-ai/mage-ai/pull/3813

# How Has This Been Tested?
- Tested pipeline downloads were working.

Before (policy error):
![image](https://github.com/mage-ai/mage-ai/assets/78053898/fe897ba6-e449-4797-94c6-1a87f7cdfeba)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
