### PR TITLE
[td] Disable error and UI limiting dynamic blocks

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/utils.ts
+++ b/mage_ai/frontend/components/CodeBlock/utils.ts
@@ -279,7 +279,6 @@ export const getMoreActionsItems = (
       if (!isDBT
         && BlockTypeEnum.GLOBAL_DATA_PRODUCT !== blockType
         && savePipelineContent
-        && (dynamic || otherDynamicBlocks.length === 0)
       ) {
         items.push({
           label: () => dynamic ? 'Disable block as dynamic' : 'Set block as dynamic',


### PR DESCRIPTION
# Description
Mage throws an error when trying to add too many dynamic blocks.

The UI hides the option of making a block dynamic if there are too many.

Removed these limitations.

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
