### PR TITLE
[dy] Update url logic for workspace manager

### DIFF
--- a/mage_ai/api/presenters/WorkspacePresenter.py
+++ b/mage_ai/api/presenters/WorkspacePresenter.py
@@ -19,6 +19,7 @@ class WorkspacePresenter(BasePresenter):
                 'name',
                 'repo_path',
                 'success',
+                'url',
                 *[f.name for f in fields(KubernetesWorkspaceConfig)],
                 *[f.name for f in fields(CloudRunWorkspaceConfig)],
                 *[f.name for f in fields(EcsWorkspaceConfig)],

--- a/mage_ai/cluster_manager/kubernetes/workload_manager.py
+++ b/mage_ai/cluster_manager/kubernetes/workload_manager.py
@@ -73,7 +73,7 @@ class WorkloadManager:
             pass
 
         try:
-            config.load_kube_config()
+            config.load_kube_config('/home/src/testfiles/kubeconfig')
         except Exception:
             pass
 
@@ -83,7 +83,9 @@ class WorkloadManager:
         services = self.core_client.list_namespaced_service(self.namespace).items
         workloads_list = []
 
-        stateful_sets = self.apps_client.list_namespaced_stateful_set(self.namespace).items
+        stateful_sets = self.apps_client.list_namespaced_stateful_set(
+            self.namespace
+        ).items
         stateful_set_mapping = dict()
         for ss in stateful_sets:
             try:
@@ -123,11 +125,12 @@ class WorkloadManager:
                         try:
                             if node_name:
                                 items = self.core_client.list_node(
-                                    field_selector=f'metadata.name={node_name}').items
+                                    field_selector=f'metadata.name={node_name}'
+                                ).items
                                 node = items[0]
                                 ip = find(
                                     lambda a: a.type == 'ExternalIP',
-                                    node.status.addresses
+                                    node.status.addresses,
                                 ).address
                                 if ip:
                                     node_port = service.spec.ports[0].node_port
@@ -188,12 +191,7 @@ class WorkloadManager:
         ingress_name = workspace_config.ingress_name
 
         volumes = []
-        volume_mounts = [
-            {
-                'name': 'mage-data',
-                'mountPath': '/home/src'
-            }
-        ]
+        volume_mounts = [{'name': 'mage-data', 'mountPath': '/home/src'}]
 
         env_vars = self.__populate_env_vars(
             name,
@@ -207,7 +205,9 @@ class WorkloadManager:
         lifecycle_config = workspace_config.lifecycle_config or LifecycleConfig()
         if lifecycle_config.post_start:
             if lifecycle_config.post_start.hook_path:
-                post_start_file_name = os.path.basename(lifecycle_config.post_start.hook_path)
+                post_start_file_name = os.path.basename(
+                    lifecycle_config.post_start.hook_path
+                )
                 volume_mounts.append(
                     {
                         'name': 'lifecycle-hooks',
@@ -230,18 +230,13 @@ class WorkloadManager:
                         'exec': {
                             'command': post_start_command,
                         }
-                    }
+                    },
                 }
 
         mage_container_config = {
             'name': f'{name}-container',
             'image': 'mageai/mageai:latest',
-            'ports': [
-                {
-                    'containerPort': 6789,
-                    'name': 'web'
-                }
-            ],
+            'ports': [{'containerPort': 6789, 'name': 'web'}],
             'volumeMounts': volume_mounts,
             **container_config,
         }
@@ -266,7 +261,7 @@ class WorkloadManager:
                             'name': 'lifecycle-hooks',
                             'mountPath': '/app/initial-config.json',
                             'subPath': 'initial-config.json',
-                        }
+                        },
                     ],
                     'env': [
                         {
@@ -276,7 +271,7 @@ class WorkloadManager:
                         {
                             'name': KUBE_NAMESPACE,
                             'value': os.getenv(KUBE_NAMESPACE, 'default'),
-                        }
+                        },
                     ],
                 }
             )
@@ -294,32 +289,23 @@ class WorkloadManager:
                         '/cloud_sql_proxy',
                         '-log_debug_stdout',
                         f'-instances={os.getenv(CLOUD_SQL_CONNECTION_NAME)}=tcp:5432',
-                        f'-credential_file=/secrets/{credential_file_path}'
+                        f'-credential_file=/secrets/{credential_file_path}',
                     ],
-                    'securityContext': {
-                        'runAsNonRoot': True
-                    },
-                    'resources': {
-                        'requests': {
-                            'memory': '1Gi',
-                            'cpu': '1'
-                        }
-                    },
+                    'securityContext': {'runAsNonRoot': True},
+                    'resources': {'requests': {'memory': '1Gi', 'cpu': '1'}},
                     'volumeMounts': [
                         {
                             'name': 'service-account-volume',
                             'mountPath': '/secrets/',
-                            'readOnly': True
+                            'readOnly': True,
                         }
-                    ]
+                    ],
                 }
             )
             volumes.append(
                 {
                     'name': 'service-account-volume',
-                    'secret': {
-                        'secretName': os.getenv(SERVICE_ACCOUNT_SECRETS_NAME)
-                    }
+                    'secret': {'secretName': os.getenv(SERVICE_ACCOUNT_SECRETS_NAME)},
                 }
             )
 
@@ -343,8 +329,8 @@ class WorkloadManager:
                                 **({'mode': 0o0755} if key.endswith('.sh') else {}),
                             }
                             for key in config_map
-                        ]
-                    }
+                        ],
+                    },
                 }
             )
 
@@ -362,45 +348,28 @@ class WorkloadManager:
         stateful_set = {
             'apiVersion': 'apps/v1',
             'kind': 'StatefulSet',
-            'metadata': {
-                'name': name,
-                'labels': {
-                    'app': name
-                }
-            },
+            'metadata': {'name': name, 'labels': {'app': name}},
             'spec': {
-                'selector': {
-                    'matchLabels': {
-                        'app': name
-                    }
-                },
+                'selector': {'matchLabels': {'app': name}},
                 'replicas': 1,
                 'minReadySeconds': 10,
                 'template': {
-                    'metadata': {
-                        'labels': {
-                            'app': name
-                        }
-                    },
-                    'spec': stateful_set_template_spec
+                    'metadata': {'labels': {'app': name}},
+                    'spec': stateful_set_template_spec,
                 },
                 'volumeClaimTemplates': [
                     {
-                        'metadata': {
-                            'name': 'mage-data'
-                        },
+                        'metadata': {'name': 'mage-data'},
                         'spec': {
                             'accessModes': [storage_access_mode],
                             'storageClassName': storage_class_name,
                             'resources': {
-                                'requests': {
-                                    'storage': storage_request_size
-                                }
-                            }
-                        }
+                                'requests': {'storage': storage_request_size}
+                            },
+                        },
                     }
-                ]
-            }
+                ],
+            },
         }
 
         self.apps_client.create_namespaced_stateful_set(self.namespace, stateful_set)
@@ -409,8 +378,9 @@ class WorkloadManager:
 
         annotations = {}
         if os.getenv(KUBE_SERVICE_GCP_BACKEND_CONFIG):
-            annotations[GCP_BACKEND_CONFIG_ANNOTATION] = \
-                os.getenv(KUBE_SERVICE_GCP_BACKEND_CONFIG)
+            annotations[GCP_BACKEND_CONFIG_ANNOTATION] = os.getenv(
+                KUBE_SERVICE_GCP_BACKEND_CONFIG
+            )
 
         service = {
             'apiVersion': 'v1',
@@ -421,7 +391,7 @@ class WorkloadManager:
                     'app': name,
                     'dev-instance': '1',
                 },
-                'annotations': annotations
+                'annotations': annotations,
             },
             'spec': {
                 'ports': [
@@ -430,14 +400,14 @@ class WorkloadManager:
                         'port': 6789,
                     }
                 ],
-                'selector': {
-                    'app': name
-                },
-                'type': os.getenv(KUBE_SERVICE_TYPE, NODE_PORT_SERVICE_TYPE)
-            }
+                'selector': {'app': name},
+                'type': os.getenv(KUBE_SERVICE_TYPE, NODE_PORT_SERVICE_TYPE),
+            },
         }
 
-        k8s_service = self.core_client.create_namespaced_service(self.namespace, service)
+        k8s_service = self.core_client.create_namespaced_service(
+            self.namespace, service
+        )
 
         try:
             if ingress_name:
@@ -454,7 +424,9 @@ class WorkloadManager:
         service_name: str,
         workspace_name: str,
     ) -> None:
-        ingress = self.networking_client.read_namespaced_ingress(ingress_name, self.namespace)
+        ingress = self.networking_client.read_namespaced_ingress(
+            ingress_name, self.namespace
+        )
         rule = ingress.spec.rules[0]
         paths = rule.http.paths
         paths.insert(
@@ -462,31 +434,55 @@ class WorkloadManager:
             client.V1HTTPIngressPath(
                 backend=client.V1IngressBackend(
                     service=client.V1IngressServiceBackend(
-                        name=service_name,
-                        port=client.V1ServiceBackendPort(
-                            number=6789
-                        )
+                        name=service_name, port=client.V1ServiceBackendPort(number=6789)
                     )
                 ),
                 path=f'/{workspace_name}',
                 path_type='Prefix',
-            )
+            ),
         )
         ingress.spec.rules[0] = client.V1IngressRule(
             host=rule.host,
             http=client.V1HTTPIngressRuleValue(paths=paths),
         )
-        self.networking_client.patch_namespaced_ingress(ingress_name, self.namespace, ingress)
+        self.networking_client.patch_namespaced_ingress(
+            ingress_name, self.namespace, ingress
+        )
 
-    def delete_workload(self, name: str):
+    def delete_workload(self, name: str, ingress_name: str = None):
         self.apps_client.delete_namespaced_stateful_set(name, self.namespace)
         self.core_client.delete_namespaced_service(f'{name}-service', self.namespace)
         try:
-            self.core_client.delete_namespaced_config_map(f'{name}-hooks', self.namespace)
+            self.core_client.delete_namespaced_config_map(
+                f'{name}-hooks', self.namespace
+            )
         except ApiException as ex:
             # The delete operation will return a 404 response if the config map does not exist
             if ex.status != 404:
                 raise
+
+        try:
+            if ingress_name:
+                ingress = self.networking_client.read_namespaced_ingress(
+                    ingress_name, self.namespace
+                )
+                rule = ingress.spec.rules[0]
+                paths = rule.http.paths
+                for path in paths:
+                    if path.backend.service.name == f'{name}-service':
+                        paths.remove(path)
+                        break
+                ingress.spec.rules[0] = client.V1IngressRule(
+                    host=rule.host,
+                    http=client.V1HTTPIngressRuleValue(paths=paths),
+                )
+                self.networking_client.patch_namespaced_ingress(
+                    ingress_name, self.namespace, ingress
+                )
+        except Exception as ex:
+            raise Exception(
+                'Failed to delete workspace path from ingress, you may need to manually delete it'
+            ) from ex
 
     def get_workload_activity(self, name: str) -> Dict:
         pods = self.core_client.list_namespaced_pod(self.namespace).items
@@ -527,12 +523,16 @@ class WorkloadManager:
 
     def scale_down_workload(self, name: str) -> None:
         self.apps_client.patch_namespaced_stateful_set(
-            name, namespace=self.namespace, body={'spec': {'replicas': 0}},
+            name,
+            namespace=self.namespace,
+            body={'spec': {'replicas': 0}},
         )
 
     def restart_workload(self, name: str) -> None:
         self.apps_client.patch_namespaced_stateful_set(
-            name, namespace=self.namespace, body={'spec': {'replicas': 1}},
+            name,
+            namespace=self.namespace,
+            body={'spec': {'replicas': 1}},
         )
 
     def create_hooks_config_map(
@@ -546,7 +546,9 @@ class WorkloadManager:
         if pre_start_script_path:
             if not mage_container_config:
                 raise ConfigurationError('The container config can not be empty')
-            self.__validate_pre_start_script(pre_start_script_path, mage_container_config)
+            self.__validate_pre_start_script(
+                pre_start_script_path, mage_container_config
+            )
 
             with open(pre_start_script_path, 'r', encoding='utf-8') as f:
                 pre_start_script = f.read()
@@ -567,11 +569,10 @@ class WorkloadManager:
                 'data': config_map_data,
                 'metadata': {
                     'name': f'{name}-hooks',
-                }
+                },
             }
             self.core_client.create_namespaced_config_map(
-                namespace=self.namespace,
-                body=config_map
+                namespace=self.namespace, body=config_map
             )
 
         return config_map_data
@@ -588,7 +589,9 @@ class WorkloadManager:
         except Exception as ex:
             raise Exception(f'Pre-start script is invalid: {str(ex)}')
 
-        spec = importlib.util.spec_from_file_location('pre_start', pre_start_script_path)
+        spec = importlib.util.spec_from_file_location(
+            'pre_start', pre_start_script_path
+        )
         module = importlib.util.module_from_spec(spec)
 
         try:
@@ -602,7 +605,9 @@ class WorkloadManager:
                 f', error: {str(ex)}'
             )
         except Exception as ex:
-            raise ConfigurationError(f'Pre-start script validation failed with error: {str(ex)}')
+            raise ConfigurationError(
+                f'Pre-start script validation failed with error: {str(ex)}'
+            )
 
     def __populate_env_vars(
         self,
@@ -619,20 +624,26 @@ class WorkloadManager:
             }
         ]
         if set_base_path:
-            env_vars.append({
-                'name': 'MAGE_BASE_PATH',
-                'value': name,
-            })
+            env_vars.append(
+                {
+                    'name': 'MAGE_BASE_PATH',
+                    'value': name,
+                }
+            )
         if project_type:
-            env_vars.append({
-                'name': 'PROJECT_TYPE',
-                'value': project_type,
-            })
+            env_vars.append(
+                {
+                    'name': 'PROJECT_TYPE',
+                    'value': project_type,
+                }
+            )
         if project_uuid:
-            env_vars.append({
-                'name': 'PROJECT_UUID',
-                'value': project_uuid,
-            })
+            env_vars.append(
+                {
+                    'name': 'PROJECT_UUID',
+                    'value': project_uuid,
+                }
+            )
 
         connection_url_secrets_name = os.getenv(CONNECTION_URL_SECRETS_NAME)
         if connection_url_secrets_name:
@@ -642,9 +653,9 @@ class WorkloadManager:
                     'valueFrom': {
                         'secretKeyRef': {
                             'name': connection_url_secrets_name,
-                            'key': 'connection_url'
+                            'key': 'connection_url',
                         }
-                    }
+                    },
                 }
             )
 
@@ -653,50 +664,47 @@ class WorkloadManager:
             KUBE_NAMESPACE,
         ]:
             if os.getenv(var) is not None:
-                env_vars.append({
-                    'name': var,
-                    'value': str(os.getenv(var)),
-                })
+                env_vars.append(
+                    {
+                        'name': var,
+                        'value': str(os.getenv(var)),
+                    }
+                )
 
         # For connecting to CloudSQL PostgreSQL database.
         db_secrets_name = os.getenv(DB_SECRETS_NAME)
         if db_secrets_name:
-            env_vars.extend([
-                {
-                    'name': PG_DB_USER,
-                    'valueFrom': {
-                        'secretKeyRef': {
-                            'name': db_secrets_name,
-                            'key': 'username'
-                        }
-                    }
-                },
-                {
-                    'name': PG_DB_PASS,
-                    'valueFrom': {
-                        'secretKeyRef': {
-                            'name': db_secrets_name,
-                            'key': 'password'
-                        }
-                    }
-                },
-                {
-                    'name': PG_DB_NAME,
-                    'valueFrom': {
-                        'secretKeyRef': {
-                            'name': db_secrets_name,
-                            'key': 'database'
-                        }
-                    }
-                }
-            ])
+            env_vars.extend(
+                [
+                    {
+                        'name': PG_DB_USER,
+                        'valueFrom': {
+                            'secretKeyRef': {'name': db_secrets_name, 'key': 'username'}
+                        },
+                    },
+                    {
+                        'name': PG_DB_PASS,
+                        'valueFrom': {
+                            'secretKeyRef': {'name': db_secrets_name, 'key': 'password'}
+                        },
+                    },
+                    {
+                        'name': PG_DB_NAME,
+                        'valueFrom': {
+                            'secretKeyRef': {'name': db_secrets_name, 'key': 'database'}
+                        },
+                    },
+                ]
+            )
 
         if container_config and 'env' in container_config:
             env_vars += container_config['env']
 
         return env_vars
 
-    def __get_configurable_parameters(self, workspace_config: KubernetesWorkspaceConfig) -> Dict:
+    def __get_configurable_parameters(
+        self, workspace_config: KubernetesWorkspaceConfig
+    ) -> Dict:
         service_account_name_default = None
         storage_class_name_default = None
         storage_access_mode_default = None
@@ -729,8 +737,10 @@ class WorkloadManager:
         return dict(
             service_account_name=workspace_config.service_account_name
             or service_account_name_default,
-            storage_class_name=workspace_config.storage_class_name or storage_class_name_default,
-            storage_access_mode=workspace_config.storage_access_mode or storage_access_mode_default,
+            storage_class_name=workspace_config.storage_class_name
+            or storage_class_name_default,
+            storage_access_mode=workspace_config.storage_access_mode
+            or storage_access_mode_default,
             storage_request_size=storage_request_size,
         )
 
@@ -747,9 +757,7 @@ class WorkloadManager:
         pv = {
             'apiVersion': 'v1',
             'kind': 'PersistentVolume',
-            'metadata': {
-                'name': f'{name}-pv'
-            },
+            'metadata': {'name': f'{name}-pv'},
             'spec': {
                 'capacity': {
                     'storage': storage_request_size,
@@ -769,14 +777,14 @@ class WorkloadManager:
                                     {
                                         'key': 'kubernetes.io/hostname',
                                         'operator': 'In',
-                                        'values': hostnames
+                                        'values': hostnames,
                                     }
                                 ]
                             }
                         ]
                     }
-                }
-            }
+                },
+            },
         }
         persistent_volumes = self.core_client.list_persistent_volume().items
         for volume in persistent_volumes:

--- a/mage_ai/cluster_manager/workspace/kubernetes.py
+++ b/mage_ai/cluster_manager/workspace/kubernetes.py
@@ -101,29 +101,11 @@ class KubernetesWorkspace(Workspace):
         ingress_name = config.get('ingress_name')
         try:
             if ingress_name:
-                ingress = (
-                    self.workload_manager.networking_client.read_namespaced_ingress(
-                        ingress_name,
-                        self.workload_manager.namespace,
-                    )
+                url = self.workload_manager.get_url_from_ingress(
+                    ingress_name,
+                    self.name,
                 )
-                rule = ingress.spec.rules[0]
-                host = rule.host
-
-                tls_enabled = False
-                try:
-                    tls = ingress.spec.tls[0]
-                    tls_enabled = host in tls.hosts
-                except Exception:
-                    pass
-
-                paths = rule.http.paths
-                for path in paths:
-                    if path.backend.service.name == f'{self.name}-service':
-                        prefix = 'https' if tls_enabled else 'http'
-                        url = f'{prefix}://{host}{path.path}'
-                        config['url'] = url
-                        break
+                config['url'] = url
         except Exception:
             pass
 

--- a/mage_ai/cluster_manager/workspace/kubernetes.py
+++ b/mage_ai/cluster_manager/workspace/kubernetes.py
@@ -80,7 +80,9 @@ class KubernetesWorkspace(Workspace):
         return cls(name)
 
     def delete(self, **kwargs):
-        self.workload_manager.delete_workload(self.name)
+        self.workload_manager.delete_workload(
+            self.name, ingress_name=self.config.ingress_name
+        )
 
         super().delete(**kwargs)
 
@@ -99,9 +101,11 @@ class KubernetesWorkspace(Workspace):
         ingress_name = config.get('ingress_name')
         try:
             if ingress_name:
-                ingress = self.workload_manager.networking_client.read_namespaced_ingress(
-                    ingress_name,
-                    self.workload_manager.namespace,
+                ingress = (
+                    self.workload_manager.networking_client.read_namespaced_ingress(
+                        ingress_name,
+                        self.workload_manager.namespace,
+                    )
                 )
                 rule = ingress.spec.rules[0]
                 host = rule.host

--- a/mage_ai/cluster_manager/workspace/kubernetes.py
+++ b/mage_ai/cluster_manager/workspace/kubernetes.py
@@ -80,11 +80,12 @@ class KubernetesWorkspace(Workspace):
         return cls(name)
 
     def delete(self, **kwargs):
-        self.workload_manager.delete_workload(
-            self.name, ingress_name=self.config.ingress_name
-        )
-
-        super().delete(**kwargs)
+        try:
+            self.workload_manager.delete_workload(
+                self.name, ingress_name=self.config.ingress_name
+            )
+        finally:
+            super().delete(**kwargs)
 
     def stop(self, **kwargs):
         self.workload_manager.scale_down_workload(self.name)

--- a/mage_ai/frontend/interfaces/WorkspaceType.ts
+++ b/mage_ai/frontend/interfaces/WorkspaceType.ts
@@ -13,4 +13,5 @@ export default interface WorkspaceType {
   name: string;
   project_uuid?: string;
   repo_path?: string;
+  url?: string;
 }

--- a/mage_ai/frontend/pages/manage/index.tsx
+++ b/mage_ai/frontend/pages/manage/index.tsx
@@ -315,7 +315,7 @@ function WorkspacePage() {
             uuid: 'Type',
           },
           {
-            uuid: 'Public IP address',
+            uuid: 'URL/IP',
           },
           {
             uuid: 'Open',
@@ -325,17 +325,22 @@ function WorkspacePage() {
             uuid: 'Actions',
           },
         ]}
-        rows={workspaces?.map(({ instance }: WorkspaceType) => {
+        rows={workspaces?.map(({ instance, url }: WorkspaceType) => {
           const {
             ip,
             name,
             status,
             type,
           } = instance;
-
-          let link = `http://${ip}`;
-          if (clusterType === 'ecs') {
-            link = `http://${ip}:6789`;
+          
+          const ipOrUrl = url || ip;
+          
+          let link = ipOrUrl;
+          if (ipOrUrl && !ipOrUrl.includes('http')) {
+            link = `http://${ipOrUrl}`;
+            if (clusterType === 'ecs') {
+              link = `http://${ipOrUrl}:6789`;
+            }
           }
 
           return [
@@ -364,10 +369,10 @@ function WorkspacePage() {
             <Text
               key="ip"
             >
-              {ip}
+              {ipOrUrl || 'N/A'}
             </Text>,
             <Button
-              disabled={!ip}
+              disabled={!ipOrUrl}
               iconOnly
               key="open_button"
               onClick={() => window.open(link)}

--- a/mage_ai/tests/cluster_manager/kubernetes/test_workload_manager.py
+++ b/mage_ai/tests/cluster_manager/kubernetes/test_workload_manager.py
@@ -41,12 +41,7 @@ def get_custom_configs(config):
             mage_container_config={
                 'name': 'test-container',
                 'image': 'mageai/mageai:latest',
-                'ports': [
-                    {
-                        'containerPort': 6789,
-                        'name': 'web'
-                    }
-                ],
+                'ports': [{'containerPort': 6789, 'name': 'web'}],
             },
         )
         self.mock_core_client.create_namespaced_config_map.assert_called_once()
@@ -75,12 +70,7 @@ def wrong_function_name(config):
                 mage_container_config={
                     'name': 'test-container',
                     'image': 'mageai/mageai:latest',
-                    'ports': [
-                        {
-                            'containerPort': 6789,
-                            'name': 'web'
-                        }
-                    ],
+                    'ports': [{'containerPort': 6789, 'name': 'web'}],
                 },
             )
             self.assertTrue(
@@ -117,3 +107,34 @@ def wrong_function_name(config):
             self.mock_core_client.create_namespaced_config_map.assert_not_called()
 
         os.remove(pre_start_script_path)
+
+    def test_get_url_from_ingress(self):
+        # Set up test data
+        ingress_name = 'example-ingress'
+        workload_name = 'example-workload'
+
+        # Mock the read_namespaced_ingress method to return a mock Ingress object
+        mock_ingress = MagicMock()
+        mock_ingress.spec.rules[0].host = 'example-host'
+        mock_ingress.spec.tls = [MagicMock(hosts=['example-host'])]
+
+        mock_path = MagicMock()
+        mock_path.backend.service.name = f'{workload_name}-service'
+        mock_path.path = '/example-path'
+        mock_ingress.spec.rules[0].http.paths = [mock_path]
+        self.mock_networking_client.read_namespaced_ingress.return_value = mock_ingress
+
+        client.NetworkingV1Api = MagicMock(return_value=self.mock_networking_client)
+        mock_workload_manager = WorkloadManager()
+
+        # Call the function
+        result = mock_workload_manager.get_url_from_ingress(ingress_name, workload_name)
+
+        # Assert the expected result
+        expected_result = 'https://example-host/example-path'
+        self.assertEqual(result, expected_result)
+
+        # Assert that the read_namespaced_ingress method was called with the correct arguments
+        self.mock_networking_client.read_namespaced_ingress.assert_called_once_with(
+            ingress_name, mock_workload_manager.namespace
+        )


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

For kubernetes workspaces, if the workspace config has an `ingress_name`, then we will try to get the url to access the workspace when fetching the workspace. Also, remove the service from the ingress when deleting the workspace.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with a kubernetes workspace and ingress
![Screenshot 2023-12-11 at 3 23 21 PM](https://github.com/mage-ai/mage-ai/assets/14357209/e0275978-2483-43f9-b3eb-7e3eee8fc53e)
- [x] Unit tests


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
