### PR TITLE
[Enhancement] Add queue_subscription support for nats jetstream streaming source

### DIFF
--- a/mage_ai/data_preparation/executors/streaming_pipeline_executor.py
+++ b/mage_ai/data_preparation/executors/streaming_pipeline_executor.py
@@ -180,6 +180,16 @@ class StreamingPipelineExecutor(PipelineExecutor):
                 **merge_dict(global_vars, kwargs),
             )
 
+        async def handle_event_async(message, **kwargs):
+            outputs_by_block = dict()
+            outputs_by_block[self.source_block.uuid] = [message]
+
+            handle_batch_events_recursively(
+                self.source_block,
+                outputs_by_block,
+                **merge_dict(global_vars, kwargs),
+            )
+
         def handle_event(message, **kwargs):
             outputs_by_block = dict()
             outputs_by_block[self.source_block.uuid] = [message]
@@ -195,12 +205,11 @@ class StreamingPipelineExecutor(PipelineExecutor):
             if source.consume_method == SourceConsumeMethod.BATCH_READ:
                 source.batch_read(handler=handle_batch_events)
             elif source.consume_method == SourceConsumeMethod.READ_ASYNC:
-                try:
-                    loop = asyncio.get_running_loop()
-                    loop.run_until_complete(source.read_async(handler=handle_event))
-                except Exception as exc:
-                    print(exc)
-                    asyncio.run(source.read_async(handler=handle_event))
+                loop = asyncio.get_event_loop()
+                if loop is not None:
+                    loop.run_until_complete(source.read_async(handler=handle_event_async))
+                else:
+                    asyncio.run(source.read_async(handler=handle_event_async))
             elif source.consume_method == SourceConsumeMethod.READ:
                 source.read(handler=handle_event)
         finally:

--- a/mage_ai/data_preparation/templates/data_loaders/streaming/nats.yaml
+++ b/mage_ai/data_preparation/templates/data_loaders/streaming/nats.yaml
@@ -3,8 +3,16 @@ server_url: "nats://localhost:4222"
 subject: subject_name
 stream_name: stream_name
 
-# Optional: Batch size and timeout for reading messages
+# Optional: Consumer type, available types: PULL and PUSH. Use PULL if not provided
+consumer_type: PULL
+
+# Optional: Push consumer configuration
 batch_size: 100
+
+# Optional: Pull consumer configuration
+use_queue_group: true
+
+# Optional: Consumer timeout reading messages
 timeout: 5
 
 # Optional: TLS configuration
@@ -16,5 +24,5 @@ use_tls: false
 # Optional: NKEY seed string
 # nkeys_seed_str: "SUAPAEYJQOQHJ4"
 
-# Optional: Consumer name for pull-based subscription
+# Optional: Consumer name for durable consumer identifier, use stream name if not provided
 consumer_name: "my_consumer"

--- a/mage_ai/data_preparation/templates/data_loaders/streaming/nats.yaml
+++ b/mage_ai/data_preparation/templates/data_loaders/streaming/nats.yaml
@@ -6,10 +6,10 @@ stream_name: stream_name
 # Optional: Consumer type, available types: PULL and PUSH. Defined as PULL by default
 consumer_type: PULL
 
-# Optional: Push consumer configuration
+# Optional: Pull consumer configuration
 batch_size: 100
 
-# Optional: Pull consumer configuration
+# Optional: Push consumer configuration
 use_queue_group: true
 
 # Optional: Consumer timeout reading messages

--- a/mage_ai/data_preparation/templates/data_loaders/streaming/nats.yaml
+++ b/mage_ai/data_preparation/templates/data_loaders/streaming/nats.yaml
@@ -3,7 +3,7 @@ server_url: "nats://localhost:4222"
 subject: subject_name
 stream_name: stream_name
 
-# Optional: Consumer type, available types: PULL and PUSH. Use PULL if not provided
+# Optional: Consumer type, available types: PULL and PUSH. Defined as PULL by default
 consumer_type: PULL
 
 # Optional: Push consumer configuration
@@ -24,5 +24,5 @@ use_tls: false
 # Optional: NKEY seed string
 # nkeys_seed_str: "SUAPAEYJQOQHJ4"
 
-# Optional: Consumer name for durable consumer identifier, use stream name if not provided
+# Optional: Consumer name for a durable consumer identifier, will use stream name if not provided
 consumer_name: "my_consumer"

--- a/mage_ai/streaming/sources/nats_js.py
+++ b/mage_ai/streaming/sources/nats_js.py
@@ -6,11 +6,11 @@ from dataclasses import dataclass
 from typing import Callable, Dict, Optional
 
 import nats
-from nats.errors import NoServersError
+from nats.errors import NoServersError, TimeoutError
 
 from mage_ai.shared.config import BaseConfig
 from mage_ai.streaming.constants import DEFAULT_BATCH_SIZE, DEFAULT_TIMEOUT_MS
-from mage_ai.streaming.sources.base import BaseSource
+from mage_ai.streaming.sources.base import BaseSource, SourceConsumeMethod
 
 
 @dataclass
@@ -19,6 +19,12 @@ class SSLConfig:
     certfile: str = None
     keyfile: str = None
     check_hostname: bool = False
+
+
+@dataclass
+class ConsumerType:
+    PULL = "PULL"
+    PUSH = "PUSH"
 
 
 @dataclass
@@ -32,9 +38,11 @@ class NATSConfig(BaseConfig):
     consumer_name: Optional[str] = None
     batch_size: int = DEFAULT_BATCH_SIZE
     timeout: int = DEFAULT_TIMEOUT_MS / 1000  # Convert to seconds
+    consumer_type: ConsumerType = ConsumerType.PULL
+    use_queue_group: bool = True
 
     @classmethod
-    def parse_config(self, config: Dict) -> Dict:
+    def parse_config(self, config: Dict = None) -> Dict:
         ssl_config = config.get('ssl_config')
         if ssl_config and type(ssl_config) is dict:
             config['ssl_config'] = SSLConfig(**ssl_config)
@@ -49,6 +57,13 @@ class NATSSource(BaseSource):
         self.thread = threading.Thread(target=self.start_loop, daemon=True)
         self.thread.start()
         super().__init__(config)
+        self.set_consumer_type()
+
+    def set_consumer_type(self):
+        if self.config.consumer_type == ConsumerType.PUSH:
+            self.consume_method = SourceConsumeMethod.READ
+        else:
+            self.consume_method = SourceConsumeMethod.BATCH_READ
 
     def start_loop(self):
         asyncio.set_event_loop(self.loop)
@@ -88,9 +103,6 @@ class NATSSource(BaseSource):
             self.nc = await nats.connect(**connect_opts)
             self.js = self.nc.jetstream()
 
-            # Default consumer_name to stream_name if not provided
-            consumer_name = self.config.consumer_name or self.config.stream_name
-
             # Check if the stream exists, and create it if it doesn't
             try:
                 await self.js.stream_info(self.config.stream_name)
@@ -102,12 +114,32 @@ class NATSSource(BaseSource):
                         subjects=[self.config.subject],
                     )
 
-            self.psub = await self.js.pull_subscribe(self.config.subject, consumer_name)
+            # Default consumer_name to stream_name if not provided
+            consumer_name = self.config.consumer_name or self.config.stream_name
+            if self.config.consumer_type == ConsumerType.PULL:
+                self.sub = await self.js.pull_subscribe(self.config.subject, consumer_name)
+                return
+
+            subs_options = {
+                "stream": self.config.stream_name,
+                "subject": self.config.subject,
+                "durable": consumer_name,
+                "manual_ack": True,
+            }
+
+            # since the nats-py does not support difference value of queue and durable options,
+            # so for the queue options value use the value of durable
+            if self.config.use_queue_group:
+                subs_options["queue"] = consumer_name
+
+            self.sub = await self.js.subscribe(**subs_options)
 
         except NoServersError as e:
             self._print(f'Caught NoServersError while connecting to NATS server: {e}')
         except Exception as e:
             self._print(f'Caught exception while connecting to NATS server: {e}')
+        finally:
+            self._print(f'Connected to NATS server at {self.nc.connected_url.netloc}')
 
     # Define callback methods
     async def disconnected_cb(self):
@@ -165,24 +197,36 @@ class NATSSource(BaseSource):
             self.stop_loop()
 
     def read(self, handler: Callable):
-        self.init_client()
-
         try:
             while True:
-                messages = self.fetch_messages()
-                if messages:
-                    for data, msg in messages:
-                        handler(data)  # Process each decoded message
-
-                        # Acknowledge the original message
-                        asyncio.run_coroutine_threadsafe(msg.ack(), self.loop)
+                self._print("Fetching messages...")
+                msg = self.fetch_message()
+                if not msg:
+                    self._print("No message fetched, re-fetching...")
+                    break
+                handler(msg)    # Process decoded message
         finally:
             self.close_client()
             self.stop_loop()
 
+    # fetch message from queue subscribe asynchronously
+    async def afetch_message(self):
+        try:
+            msg = await self.sub.next_msg(self.config.timeout)
+            # Acknowledge message before return decoded message
+            await msg.ack()
+            return msg.data.decode()
+        except TimeoutError:
+            return None
+
+    # fetch message from queue subscribe synchronously
+    def fetch_message(self):
+        future = asyncio.run_coroutine_threadsafe(self.afetch_message(), self.loop)
+        return future.result()
+
     async def afetch_messages(self):
         try:
-            msgs = await self.psub.fetch(self.config.batch_size, timeout=self.config.timeout)
+            msgs = await self.sub.fetch(self.config.batch_size, timeout=self.config.timeout)
             # Return a tuple of (decoded_message, message)
             return [(json.loads(msg.data.decode()), msg) for msg in msgs]
         except nats.errors.TimeoutError:

--- a/mage_ai/streaming/sources/nats_js.py
+++ b/mage_ai/streaming/sources/nats_js.py
@@ -127,8 +127,7 @@ class NATSSource(BaseSource):
                 "manual_ack": True,
             }
 
-            # since the nats-py does not support difference value of queue and durable options,
-            # so for the queue options value use the value of durable
+            # nats-py requires the value of 'queue' to be the same as 'durable'
             if self.config.use_queue_group:
                 subs_options["queue"] = consumer_name
 

--- a/mage_ai/streaming/sources/nats_js.py
+++ b/mage_ai/streaming/sources/nats_js.py
@@ -1,4 +1,5 @@
 import asyncio
+import enum
 import json
 import ssl
 import threading
@@ -21,8 +22,7 @@ class SSLConfig:
     check_hostname: bool = False
 
 
-@dataclass
-class ConsumerType:
+class ConsumerType(str, enum.Enum):
     PULL = "PULL"
     PUSH = "PUSH"
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
https://github.com/mage-ai/mage-ai/issues/4122 implementation, a configurable nats jetstream subscription method, that support for PULL and PUSH consumer type with queue group options.

New Configuration:
- consumer_type: define what the type of consumer you want, available types: PULL and PUSH, the default is PULL.
- use_queue_group: this is the configuration for a PUSH consumer. If set to True, it allows the consumer to use a queue group.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- tested locally by creating NATS streaming pipeline with new configuration.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@mfreeman451 @wangxiaoyou1993 
