### PR TITLE
[dy] Remove double quotes for postgres

### DIFF
--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -164,6 +164,7 @@ class Postgres(BaseSQL):
 
     def table_exists(self, schema_name: str, table_name: str) -> bool:
         with self.conn.cursor() as cur:
+            table_name = table_name.replace('"', '')
             cur.execute(
                 f'SELECT * FROM pg_tables WHERE schemaname = \'{schema_name}\' AND '
                 f'tablename = \'{table_name}\''

--- a/mage_integrations/mage_integrations/destinations/sql/base.py
+++ b/mage_integrations/mage_integrations/destinations/sql/base.py
@@ -371,6 +371,7 @@ class Destination(BaseDestination):
         return self.records_inserted, self.records_updated
 
     def _wrap_with_quotes(self, name):
+        name = name.replace('"', '')
         return f'{self.quote}{name}{self.quote}'
 
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Some users may be manually adding double quotes for tables that have capitalized letters. We will account for this by removing double quotes in cases where they are not needed or we are already adding them.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with postgres data exporter, sql block, and integration destination


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
