### PR TITLE
[jk] Fix block sorting bug

### DIFF
--- a/mage_ai/frontend/components/DependencyGraph/utils.ts
+++ b/mage_ai/frontend/components/DependencyGraph/utils.ts
@@ -302,7 +302,7 @@ export function buildNodesEdgesPorts({
   blocks?.forEach((block: BlockType) => {
     if (block?.upstream_blocks?.length >= 1) {
       const arr = block?.upstream_blocks || [];
-      const key = sortByKey(arr, uuid => uuid).join(',');
+      const key = sortByKey([...arr], uuid => uuid).join(',');
 
       if (!(key in mappingUpstreamBlockSet)) {
         mappingUpstreamBlockSet[key] = {


### PR DESCRIPTION
# Description
- The upstream blocks in a pipeline were getting sorted automatically, affecting the order of the upstream blocks despite its order in the pipeline's `metadata.yaml` file. The order of the upstream blocks can be important, so this PR fixes the auto-sorting bug so that the upstream block order will be based on its order in the pipeline `metadata.yaml` file.

# How Has This Been Tested?
Before (the upstream block order for block `natural_familiar` should be the order that the blocks appear in the pipeline in this scenario, but the upstream block order is based on alphabetical name order):
![image](https://github.com/mage-ai/mage-ai/assets/78053898/a01c23d7-c9e5-4f8d-92b4-7e8b9b2d24e6)

After (upstream block ordering can be changed and ordering reflects order in pipeline):
![image](https://github.com/mage-ai/mage-ai/assets/78053898/a6214f7d-05d7-466e-851d-858a5630773e)
Is consistent with order in metadata.yaml:
```
upstream_blocks:
- knightly_music
- spirited_merchant
- cold_phoenix
uuid: natural_familiar
```

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
