### PR TITLE
[td] Don’t save error details in the block run DB

### DIFF
--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -1255,10 +1255,16 @@ class BlockExecutor:
             if status == BlockRun.BlockRunStatus.COMPLETED:
                 update_kwargs['completed_at'] = datetime.now(tz=pytz.UTC)
 
-            if BlockRun.BlockRunStatus.FAILED == status and error_details:
-                update_kwargs['metrics'] = merge_dict(block_run.metrics or {}, dict(
-                    __error_details=error_details,
-                ))
+            # Cannot save raw value in DB; it breaks:
+            # sqlalchemy.exc.StatementError:
+            # (builtins.TypeError) Object of type Py4JJavaError is not JSON serializable
+            # [SQL: UPDATE block_run SET updated_at=CURRENT_TIMESTAMP, status=?, metrics=?
+            # WHERE block_run.id = ?]
+
+            # if BlockRun.BlockRunStatus.FAILED == status and error_details:
+            #     update_kwargs['metrics'] = merge_dict(block_run.metrics or {}, dict(
+            #         __error_details=error_details,
+            #     ))
 
             block_run.update(**update_kwargs)
             return

--- a/mage_ai/data_preparation/models/global_hooks/models.py
+++ b/mage_ai/data_preparation/models/global_hooks/models.py
@@ -422,9 +422,14 @@ class Hook(BaseDataClass):
             if pipeline_run and pipeline_run.block_runs:
                 for block_run in pipeline_run.block_runs:
                     block_run.refresh()
+                    # Cannot save raw value in DB; it breaks:
+                    # sqlalchemy.exc.StatementError:
+                    # (builtins.TypeError) Object of type Py4JJavaError is not JSON serializable
+                    # [SQL: UPDATE block_run SET updated_at=CURRENT_TIMESTAMP, status=?, metrics=?
+                    # WHERE block_run.id = ?]
 
-                    if block_run.metrics.get('__error_details'):
-                        error_details_arr.append(block_run.metrics.get('__error_details'))
+                    # if block_run.metrics.get('__error_details'):
+                    #     error_details_arr.append(block_run.metrics.get('__error_details'))
 
             self.status = HookStatus.load(error=err, errors=error_details_arr)
 


### PR DESCRIPTION
# Description
When trying to persist a block run,

```
sqlalchemy.exc.StatementError: (builtins.TypeError) Object of type Py4JJavaError is not JSON serializable

[SQL: UPDATE block_run SET updated_at=CURRENT_TIMESTAMP, status=?, metrics=? WHERE block_run.id = ?]

[parameters: [{'metrics': {'__error_details': {'error': Py4JJavaError('An error occurred while calling o84.parquet.

', JavaObject id=o85)}}, 'status': <BlockRunStatus.FAILED: 'failed'>, 'block_run_id': 1395}]]
```

Cannot save arbitrary error details in the database


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
