### PR TITLE
[jk] Reset page after applying pipeline filters

### DIFF
--- a/mage_ai/frontend/components/Logs/Toolbar/constants.ts
+++ b/mage_ai/frontend/components/Logs/Toolbar/constants.ts
@@ -1,7 +1,5 @@
 import { LogRangeEnum } from '@interfaces/LogType';
 
-export const LIMIT_PARAM = '_limit';
-export const OFFSET_PARAM = '_offset';
 export const LOG_ITEMS_PER_PAGE = 100;
 export const LOG_FILE_COUNT_INTERVAL = 20;
 

--- a/mage_ai/frontend/components/Logs/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/Logs/Toolbar/index.tsx
@@ -13,12 +13,11 @@ import TextInput from '@oracle/elements/Inputs/TextInput';
 import usePrevious from '@utils/usePrevious';
 import { LogRangeEnum } from '@interfaces/LogType';
 import {
-  LIMIT_PARAM,
-  OFFSET_PARAM,
   LOG_FILE_COUNT_INTERVAL,
   LOG_RANGE_SEC_INTERVAL_MAPPING,
   SPECIFIC_LOG_RANGES,
 } from './constants';
+import { MetaQueryEnum } from '@api/constants';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { calculateStartTimestamp } from '@utils/number';
 import {
@@ -50,8 +49,8 @@ type LogToolbarProps = {
 };
 
 const SHARED_LOG_QUERY_PARAMS = {
-  [LIMIT_PARAM]: LOG_FILE_COUNT_INTERVAL,
-  [OFFSET_PARAM]: 0,
+  [MetaQueryEnum.LIMIT]: LOG_FILE_COUNT_INTERVAL,
+  [MetaQueryEnum.OFFSET]: 0,
 };
 
 export const SHARED_BUTTON_PROPS = {

--- a/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
@@ -75,6 +75,7 @@ type ToolbarProps = {
   query?: {
     [keyof: string]: string[];
   };
+  resetLimitOnFilterApply?: boolean;
   resetPageOnFilterApply?: boolean;
   secondaryButtonProps?: {
     beforeIcon?: JSX.Element;
@@ -106,6 +107,7 @@ function Toolbar({
   onClickFilterDefaults,
   onFilterApply,
   query = {},
+  resetLimitOnFilterApply,
   resetPageOnFilterApply,
   secondaryButtonProps,
   searchProps,
@@ -249,6 +251,7 @@ function Toolbar({
       options={filterOptionsEnabledMapping}
       parentRef={filterButtonMenuRef}
       query={query}
+      resetLimitOnApply={resetLimitOnFilterApply}
       resetPageOnApply={resetPageOnFilterApply}
       setOpen={setFilterButtonMenuOpen}
       toggleValueMapping={filterValueLabelMapping}
@@ -280,6 +283,7 @@ function Toolbar({
     onClickFilterDefaults,
     onFilterApply,
     query,
+    resetLimitOnFilterApply,
     resetPageOnFilterApply,
   ]);
 

--- a/mage_ai/frontend/oracle/components/ToggleMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/ToggleMenu/index.tsx
@@ -16,7 +16,8 @@ import {
   ToggleValueStyle,
 } from './index.style';
 import { ChevronRight } from '@oracle/icons';
-import { goToWithFilters } from '@utils/routing';
+import { GoToWithFiltersProps, goToWithFilters } from '@utils/routing';
+import { MetaQueryEnum } from '@api/constants';
 import { capitalize, removeUnderscore } from '@utils/string';
 
 type ToggleMenuProps = {
@@ -37,6 +38,7 @@ type ToggleMenuProps = {
   };
   parentRef: React.RefObject<any>;
   query: { [keyof: string]: string[] };
+  resetLimitOnApply?: boolean;
   resetPageOnApply?: boolean;
   setOpen: (open: boolean) => void;
   toggleValueMapping?: {
@@ -56,6 +58,7 @@ function ToggleMenu({
   options = {},
   parentRef,
   query,
+  resetLimitOnApply,
   resetPageOnApply,
   setOpen,
   toggleValueMapping,
@@ -158,14 +161,20 @@ function ToggleMenu({
                   updatedQuery,
                 );
 
+                const filterQueryOptions: GoToWithFiltersProps = {
+                  addingMultipleValues: true,
+                  pushHistory: true,
+                  resetLimitParams: resetLimitOnApply,
+                  resetPage: resetPageOnApply,
+                };
+                if (query?.[MetaQueryEnum.LIMIT]) {
+                  filterQueryOptions.itemsPerPage = +query?.[MetaQueryEnum.LIMIT];
+                }
                 goToWithFilters(
                   query,
                   updatedQuery,
-                  {
-                    addingMultipleValues: true,
-                    pushHistory: true,
-                    resetPage: resetPageOnApply,
-                  });
+                  filterQueryOptions,
+                );
               }}
               secondary
             >

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -31,12 +31,11 @@ import api from '@api';
 import dark from '@oracle/styles/themes/dark';
 import usePrevious from '@utils/usePrevious';
 import {
-  LIMIT_PARAM,
-  OFFSET_PARAM,
   LOG_FILE_COUNT_INTERVAL,
   LOG_RANGE_SEC_INTERVAL_MAPPING,
 } from '@components/Logs/Toolbar/constants';
 import { LOCAL_STORAGE_KEY_AUTO_SCROLL_LOGS } from '@storage/constants';
+import { MetaQueryEnum } from '@api/constants';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { TabType } from '@oracle/components/Tabs/ButtonTabs';
@@ -232,8 +231,8 @@ function PipelineLogsPage({
   useEffect(() => {
     if (onlyLoadPastDayLogs) {
       goToWithQuery({
-        [LIMIT_PARAM]: LOG_FILE_COUNT_INTERVAL,
-        [OFFSET_PARAM]: 0,
+        [MetaQueryEnum.LIMIT]: LOG_FILE_COUNT_INTERVAL,
+        [MetaQueryEnum.OFFSET]: 0,
         start_timestamp: dayAgoTimestamp,
       });
     }
@@ -276,8 +275,8 @@ function PipelineLogsPage({
       );
       goToWithQuery({
         ...q,
-        [LIMIT_PARAM]: newLimit,
-        [OFFSET_PARAM]: newOffset,
+        [MetaQueryEnum.LIMIT]: newLimit,
+        [MetaQueryEnum.OFFSET]: newOffset,
       });
     }
   }, [greaterLogCount, limit, offset, q, totalBlockRunLogCount, totalPipelineRunLogCount]);
@@ -292,8 +291,8 @@ function PipelineLogsPage({
       newOffset = Math.max(0, (offset - LOG_FILE_COUNT_INTERVAL));
       goToWithQuery({
         ...q,
-        [LIMIT_PARAM]: newLimit,
-        [OFFSET_PARAM]: newOffset,
+        [MetaQueryEnum.LIMIT]: newLimit,
+        [MetaQueryEnum.OFFSET]: newOffset,
       });
     }
   }, [greaterLogCount, limit, offset, q]);

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -43,12 +43,12 @@ import {
   PipeIcon,
   Refresh,
 } from '@oracle/icons';
-import { FlyoutMenuItemType } from '@oracle/components/FlyoutMenu';
-import { OFFSET_PARAM, goToWithQuery } from '@utils/routing';
 import {
   CANCEL_ALL_RUNNING_PIPELINE_RUNS_UUID,
   PageNameEnum,
 } from '@components/PipelineDetailPage/constants';
+import { FlyoutMenuItemType } from '@oracle/components/FlyoutMenu';
+import { MetaQueryEnum } from '@api/constants';
 import { PipelineStatusEnum, PipelineTypeEnum } from '@interfaces/PipelineType';
 import { POPUP_MENU_WIDTH, SEARCH_INPUT_PROPS } from '@components/shared/Table/Toolbar/constants';
 import { RunStatus as RunStatusEnum } from '@interfaces/BlockRunType';
@@ -57,6 +57,7 @@ import { TAB_URL_PARAM } from '@oracle/components/Tabs';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { VerticalDividerStyle } from '@oracle/elements/Divider/index.style';
 import { displayErrorFromReadResponse, onSuccess } from '@api/utils/response';
+import { goToWithQuery } from '@utils/routing';
 import { ignoreKeys, isEqual } from '@utils/hash';
 import { queryFromUrl, queryString } from '@utils/url';
 
@@ -171,7 +172,7 @@ function PipelineRuns({
     [TAB_URL_PARAM, 'page', SortQueryEnum.SORT_COL_IDX, SortQueryEnum.SORT_DIRECTION],
   );
   if (isPipelineRunsTab) {
-    blockRunsRequestQuery = ignoreKeys(blockRunsRequestQuery, [OFFSET_PARAM, 'status']);
+    blockRunsRequestQuery = ignoreKeys(blockRunsRequestQuery, [MetaQueryEnum.OFFSET, 'status']);
   }
   const sortColumnIndexQuery = q?.[SortQueryEnum.SORT_COL_IDX];
   const sortDirectionQuery = q?.[SortQueryEnum.SORT_DIRECTION];
@@ -197,7 +198,7 @@ function PipelineRuns({
     pipelineRunsRequestQuery.status = q.status;
   }
   if (!isPipelineRunsTab) {
-    pipelineRunsRequestQuery = ignoreKeys(pipelineRunsRequestQuery, [OFFSET_PARAM]);
+    pipelineRunsRequestQuery = ignoreKeys(pipelineRunsRequestQuery, [MetaQueryEnum.OFFSET]);
   }
   const {
     data: dataPipelineRuns,

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -924,6 +924,7 @@ function PipelineListPage() {
       }}
       // @ts-ignore
       query={query}
+      resetLimitOnFilterApply
       searchProps={{
         onChange: setSearchText,
         value: searchText,
@@ -943,6 +944,7 @@ function PipelineListPage() {
     router,
     searchText,
     selectedPipeline,
+    setSearchText,
     showInputModal,
     tags,
   ]);
@@ -1633,7 +1635,7 @@ function PipelineListPage() {
             const val = (idx + 1) * ROW_LIMIT;
 
             return (
-              <option value={val}>
+              <option key={val} value={val}>
                 {val}
               </option>
             );
@@ -1651,7 +1653,7 @@ function PipelineListPage() {
       dataUse = dataPipelinesFromHistory;
     }
     const count = dataUse?.metadata?.count || 0;
-    const limit = query?.[MetaQueryEnum.LIMIT] || ROW_LIMIT
+    const limit = query?.[MetaQueryEnum.LIMIT] || ROW_LIMIT;
     const offset = query?.[MetaQueryEnum.OFFSET] || 0;
     const totalPages = Math.ceil(count / limit);
 

--- a/mage_ai/frontend/utils/routing.ts
+++ b/mage_ai/frontend/utils/routing.ts
@@ -71,6 +71,15 @@ export function goToWithQuery(query, opts: GoToWithQueryProps = {}) {
   });
 }
 
+export type GoToWithFiltersProps = {
+  addingMultipleValues?: boolean;
+  isList?: boolean,
+  itemsPerPage?: number,
+  pushHistory?: boolean,
+  resetLimitParams?: boolean,
+  resetPage?: boolean,
+};
+
 export function goToWithFilters(
   query: any,
   additionalQuery: any,
@@ -79,16 +88,9 @@ export function goToWithFilters(
     isList,
     itemsPerPage,
     pushHistory = false,
-    resetLimitParams,
+    resetLimitParams = false,
     resetPage = false,
-  }: {
-    addingMultipleValues?: boolean;
-    isList?: boolean,
-    itemsPerPage?: number,
-    pushHistory?: boolean,
-    resetLimitParams?: boolean,
-    resetPage?: boolean,
-  },
+  }: GoToWithFiltersProps,
 ) {
   let updatedQuery = { ...query };
 

--- a/mage_ai/frontend/utils/routing.ts
+++ b/mage_ai/frontend/utils/routing.ts
@@ -1,5 +1,6 @@
 import Router from 'next/router';
 
+import { MetaQueryEnum } from '@api/constants';
 import {
   queryFromUrl,
   queryString,
@@ -12,8 +13,6 @@ type GoToWithQueryProps = {
   replaceParams?: boolean;
 };
 
-export const LIMIT_PARAM = '_limit';
-export const OFFSET_PARAM = '_offset';
 const ITEMS_PER_PAGE = 20;
 
 export function goToWithQuery(query, opts: GoToWithQueryProps = {}) {
@@ -129,8 +128,8 @@ export function goToWithFilters(
   }
 
   if (resetLimitParams) {
-    updatedQuery[LIMIT_PARAM] = itemsPerPage || ITEMS_PER_PAGE;
-    updatedQuery[OFFSET_PARAM] = 0;
+    updatedQuery[MetaQueryEnum.LIMIT] = itemsPerPage || ITEMS_PER_PAGE;
+    updatedQuery[MetaQueryEnum.OFFSET] = 0;
   }
 
   goToWithQuery(updatedQuery, { pushHistory });


### PR DESCRIPTION
# Description
If applying a filter on the Pipelines Dashboard while on a later page and the total number of filtered pipelines is too few to require the current page number, no pipelines will be visible (see "Before" gif below for example). This PR resets the query `_offset` after applying a pipeline filter to make sure any applicable pipelines will be visible.

# How Has This Been Tested?
Before (pipelines hidden until you click on a previous page):
![Before - pipeline filter](https://github.com/mage-ai/mage-ai/assets/78053898/f24a41d3-6ad7-4d8c-b063-f7ce5edb87d9)

After (page resets):
![After - pipeline filter](https://github.com/mage-ai/mage-ai/assets/78053898/392b5d45-1b25-4a4b-acd3-ea1cf7b24c04)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
