### PR TITLE
[td] Remove qdrant-client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ setuptools.setup(
             'pydruid==0.6.5',
             'pymongo==4.3.3',
             'pyodbc==4.0.35',
-            'qdrant-client>=1.6.9',
+            # 'qdrant-client>=1.6.9',
             'redshift-connector==2.0.909',
             'requests_aws4auth==1.1.2',
             'sentence-transformers>=2.2.2',


### PR DESCRIPTION
# Description
`qdrant-client` requires `importlib-metadata` with Python >= 3.8.

Mage is set to require Python >= 3.7.
```
 > [linux/amd64 7/9] RUN   tag=$(tail -n 1 /tmp/constants.py) &&   VERSION=$(echo "$tag" | tr -d "'") &&   pip3 install --no-cache-dir "mage-ai[all]==$VERSION" &&   rm /tmp/constants.py:
83.32   File "/usr/local/lib/python3.10/site-packages/pip/_vendor/resolvelib/resolvers.py", line 481, in resolve
83.32     state = resolution.resolve(requirements, max_rounds=max_rounds)
83.32   File "/usr/local/lib/python3.10/site-packages/pip/_vendor/resolvelib/resolvers.py", line 373, in resolve
83.32     failure_causes = self._attempt_to_pin_criterion(name)
83.32   File "/usr/local/lib/python3.10/site-packages/pip/_vendor/resolvelib/resolvers.py", line 227, in _attempt_to_pin_criterion
83.32     raise InconsistentCandidate(candidate, criterion)
83.32 pip._vendor.resolvelib.resolvers.InconsistentCandidate: Provided candidate LinkCandidate('https://files.pythonhosted.org/packages/59/9b/ecce94952ab5ea74c31dcf9ccf78ccd484eebebef06019bf8cb579ab4519/importlib_metadata-6.11.0-py3-none-any.whl (from https://pypi.org/simple/importlib-metadata/) (requires-python:>=3.8)') does not satisfy SpecifierRequirement('importlib-metadata>=1.7.0'), SpecifierRequirement('importlib-metadata>=4.13.0'), SpecifierRequirement('importlib-metadata~=6.0.0')
83.42 
Notice: 83.42 [notice] A new release of pip is available: 23.0.1 -> 23.3.2
Notice: 83.42 [notice] To update, run: pip install --upgrade pip
```