### PR TITLE
Added kafka streaming source offset and partition options

### DIFF
--- a/docs/streaming/sources/kafka.mdx
+++ b/docs/streaming/sources/kafka.mdx
@@ -14,8 +14,30 @@ include_metadata: false
 api_version: "0.10.2"
 batch_size: 100
 timeout_ms: 500
+auto_offset_reset: latest # Optional
+max_partition_fetch_bytes: 1048576 # Optional
+offset: None # Optional
+offset_value: None # Optional
+partitions: # Optional
+  - {"topic": "test", "partition": 1}
 ```
+### Offset Configuration
+If using the `offset` config, the `partitions` config is required.
 
+`offset` config has 4 optional values:
+  1. beginning
+  2. end
+  3. int
+  4. timestamp
+
+Both `beginning` and `end` set the consumer to consume data from the beginning and end of the queue, respectively.
+Also, they do not require `offset_value`
+
+`int` config set the consumer to consume data from the given offset value inside the queue.
+This value correspond to the numeric position inside each partition.
+
+`timestamp` config set the consumer to consume data from the given offset timestamp value inside the queue.
+This value correspond to the timestamp of the message (Unit should be milliseconds since beginning of the epoch)
 
 ## SSL authentication
 

--- a/docs/streaming/sources/kafka.mdx
+++ b/docs/streaming/sources/kafka.mdx
@@ -16,9 +16,10 @@ batch_size: 100
 timeout_ms: 500
 auto_offset_reset: latest # Optional
 max_partition_fetch_bytes: 1048576 # Optional
-offset: None # Optional
-offset_value: None # Optional
-partitions: # Optional
+offset:  # Optional
+- value: None # Optional
+- type: "int"
+- partitions: # Optional
   - {"topic": "test", "partition": 1}
 ```
 ### Offset Configuration

--- a/mage_ai/streaming/sources/kafka.py
+++ b/mage_ai/streaming/sources/kafka.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Callable, Dict, List
 
-from kafka import KafkaConsumer
+from kafka import KafkaConsumer, TopicPartition
 
 from mage_ai.shared.config import BaseConfig
 from mage_ai.streaming.constants import DEFAULT_BATCH_SIZE, DEFAULT_TIMEOUT_MS
@@ -42,6 +42,7 @@ class KafkaConfig(BaseConfig):
     api_version: str = '0.10.2'
     batch_size: int = DEFAULT_BATCH_SIZE
     timeout_ms: int = DEFAULT_TIMEOUT_MS
+    auto_offset_reset: str = 'latest'
     include_metadata: bool = False
     security_protocol: SecurityProtocol = None
     ssl_config: SSLConfig = None
@@ -49,6 +50,10 @@ class KafkaConfig(BaseConfig):
     serde_config: SerDeConfig = None
     topic: str = None
     topics: List = field(default_factory=list)
+    offset: str = None
+    offset_value: int = None
+    max_partition_fetch_bytes: int = 1048576
+    partitions: dict = None
 
     @classmethod
     def parse_config(self, config: Dict) -> Dict:
@@ -71,12 +76,17 @@ class KafkaSource(BaseSource):
         if not self.config.topic and not self.config.topics:
             raise Exception('Please specify topic or topics in the Kafka config.')
 
+        if self.config.offset and not self.config.partitions:
+            raise Exception('Please specify topic partitions')
+
         self._print('Start initializing consumer.')
         # Initialize kafka consumer
         consumer_kwargs = dict(
             group_id=self.config.consumer_group,
             bootstrap_servers=self.config.bootstrap_server,
             api_version=self.config.api_version,
+            auto_offset_reset=self.config.auto_offset_reset,
+            max_partition_fetch_bytes=self.config.max_partition_fetch_bytes,
             enable_auto_commit=True,
         )
         if self.config.security_protocol == SecurityProtocol.SSL:
@@ -163,7 +173,38 @@ class KafkaSource(BaseSource):
             message = self.__deserialize_message(message.value)
         return message
 
+    def _handle_offsets(self):
+        self._print('Configuring consumer offset')
+        self.consumer.unsubscribe()
+        partitions = [TopicPartition(partition['topic'], partition['partition']) for partition
+                      in self.config.partitions]
+        self._print(f'{partitions}')
+        self.consumer.assign(partitions=partitions)
+
+        offset_type = self.config.offset
+        offset_value = self.config.offset_value
+
+        if offset_type == 'int':
+            for partition in partitions:
+                self.consumer.seek(partition=partition,
+                                   offset=offset_value)
+        elif offset_type == 'timestamp':
+            timestamps = {partition: offset_value for partition in partitions}
+            # Retrieve each partition offset for given time
+            offset_times = self.consumer.offsets_for_times(timestamps)
+
+            for partition in partitions:
+                self.consumer.seek(partition=partition,
+                                   offset=offset_times[partition].offset)
+        elif offset_type == 'beginning':
+            self.consumer.seek_to_beginning()
+
+        elif offset_type == 'end':
+            self.consumer.seek_to_end()
+
     def read(self, handler: Callable):
+        if self.config.offset:
+            self._handle_offsets()
         self._print('Start consuming single messages.')
         for message in self.consumer:
             self.__print_message(message)
@@ -171,6 +212,8 @@ class KafkaSource(BaseSource):
             handler(message)
 
     async def read_async(self, handler: Callable):
+        if self.config.offset:
+            self._handle_offsets()
         self._print('Start consuming messages asynchronously.')
         for message in self.consumer:
             self.__print_message(message)
@@ -178,6 +221,8 @@ class KafkaSource(BaseSource):
             await handler(message)
 
     def batch_read(self, handler: Callable):
+        if self.config.offset:
+            self._handle_offsets()
         self._print('Start consuming messages in batches.')
         if self.config.batch_size > 0:
             batch_size = self.config.batch_size

--- a/mage_ai/tests/streaming/sources/test_kafka.py
+++ b/mage_ai/tests/streaming/sources/test_kafka.py
@@ -31,6 +31,8 @@ class KafkaTests(TestCase):
             group_id='test_group',
             bootstrap_servers='test_server',
             api_version='0.10.2',
+            auto_offset_reset='latest',
+            max_partition_fetch_bytes=1048576,
             enable_auto_commit=True,
         )
 
@@ -52,6 +54,8 @@ class KafkaTests(TestCase):
             group_id='test_group',
             bootstrap_servers='test_server',
             api_version='0.10.2',
+            auto_offset_reset='latest',
+            max_partition_fetch_bytes=1048576,
             enable_auto_commit=True,
         )
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This PR contemplates three issues (#4069 #4114 #4040)

## Offset handling
Kafka source will now allow for offset configuration along with 
partition settings.
These offsets being:

1. Beginning
2. End
3. Int
4. Timestamp

This allows users to set specific positions inside a topic to consume data

offset handling corresponds to #4114 and #4069

## Auto Offset reset
in #4069 user requested a similar behaviour to the auto_offset_reset python function
The specified function in the issue seems to be from Spark.
With that, the whole content of the issue is solved inside Offset Handling, but this 
setting was added to prevent future issues

## Max Partition fetch bytes
Added max_partition_fetch_bytes settings along with auto_offset_reset.

this corresponds to #4040


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
Tested using a local kafka broker and Dummy sink.

## Beginning offset
For this test, 10 messages were written with a producer, counting from 1 to 10 **before** running the pipeline
**Expected behaviour**: All 10 messages are displayed 

![Screenshot from 2023-12-19 18-19-54](https://github.com/mage-ai/mage-ai/assets/14100959/d8a162d8-4606-409e-8dfb-67654651dfe7)

![Screenshot from 2023-12-19 18-22-27](https://github.com/mage-ai/mage-ai/assets/14100959/f56a1074-52eb-47e4-a82f-3af184141bee)

**Result**: All 10 messages were displayed

## End offset
For this test, 10 messages were written with a producer, counting from 1 to 10 **before** running the pipeline,
And one message (11) **after** running the pipeline.
**Expected behaviour**: Only the message containing 11 is displayed

![Screenshot from 2023-12-19 18-39-20](https://github.com/mage-ai/mage-ai/assets/14100959/58520c16-5b60-4c32-a2ea-87a3ef254f3c)

![Screenshot from 2023-12-19 18-40-02](https://github.com/mage-ai/mage-ai/assets/14100959/37b0f702-3ac0-4319-9245-94825d2ecf59)

**Result**: The message containing 11 is displayed

## Int offset
For this test, 12 messages were written with a producer, counting from 1 to 12 **before** running the pipeline
Only one partition is being used to simplify the expected behaviour
**Expected behaviour**: Only the messages from and after 1:12 (partition number and position) should be displayed

![Screenshot from 2023-12-19 18-52-15](https://github.com/mage-ai/mage-ai/assets/14100959/c3821f5a-2bab-41de-af31-5cd78e7f4021)

![Screenshot from 2023-12-19 18-52-24](https://github.com/mage-ai/mage-ai/assets/14100959/17e46997-0d14-443b-abc2-2dc31834d7c1)

**Result**: The message from 1:12 is displayed

## Timestamp offset
For this test, 11 messages were written with a producer, counting from 1 to 11 **before** running the pipeline
Only one partition is being used to simplify the expected behaviour
**Expected behaviour**: Only the messages from and after the given timestamp should be displayed
( the selected timestamp corresponds to the last message timestamp ) 

![Screenshot from 2023-12-19 19-08-58](https://github.com/mage-ai/mage-ai/assets/14100959/a5457c98-849c-4c0e-81ff-4ad9a8c0ecc2)

![Screenshot from 2023-12-19 19-09-06](https://github.com/mage-ai/mage-ai/assets/14100959/d338f027-356f-4a68-a236-3aaa68eb10a6)

**Result**: The message from the given timestamp is displayed

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation


cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 
