### PR TITLE
Added url protocol option to rabbitmq streaming

### DIFF
--- a/docs/streaming/destinations/rabbitmq.mdx
+++ b/docs/streaming/destinations/rabbitmq.mdx
@@ -12,4 +12,5 @@ queue_name: 'queue_name'
 username: 'guest'
 password: 'guest'
 amqp_url_virtual_host: '%2f'
+url_protocol: 'amqp'
 ```

--- a/docs/streaming/sources/rabbitmq.mdx
+++ b/docs/streaming/sources/rabbitmq.mdx
@@ -13,6 +13,7 @@ queue_name: 'default'
 username: 'guest'
 password: 'guest'
 amqp_url_virtual_host: '%2f'
+url_protocol: 'amqp'
 ```
 
 You can even control some of the RabbitMQ consumer configurations using the following fields.

--- a/mage_ai/streaming/sinks/rabbitmq.py
+++ b/mage_ai/streaming/sinks/rabbitmq.py
@@ -15,6 +15,7 @@ class RabbitMQConfig(BaseConfig):
     queue_name: str
     username: str = 'guest'
     password: str = 'guest'
+    url_protocol: str = 'amqp'
     amqp_url_virtual_host: str = r'%2f'
 
 
@@ -29,12 +30,13 @@ class RabbitMQSink(BaseSink):
         password = self.config.password
         connection_host = self.config.connection_host
         connection_port = self.config.connection_port
+        url_protocol = self.config.url_protocol
         vt_host = self.config.amqp_url_virtual_host
 
         self._print(f'Starting to initialize producer for queue {queue_name}')
 
         try:
-            generated_url = f"amqp://{username}:{password}@" \
+            generated_url = f"{url_protocol}://{username}:{password}@" \
                             f"{connection_host}:{connection_port}/{vt_host}"
 
             self._print(f'Trying to connect on {generated_url}')

--- a/mage_ai/streaming/sources/rabbitmq.py
+++ b/mage_ai/streaming/sources/rabbitmq.py
@@ -3,9 +3,10 @@ from dataclasses import dataclass
 from typing import Callable, Dict
 
 import pika
+from pika.exceptions import AMQPConnectionError
+
 from mage_ai.shared.config import BaseConfig
 from mage_ai.streaming.sources.base import BaseSource
-from pika.exceptions import AMQPConnectionError
 
 
 @dataclass
@@ -24,6 +25,7 @@ class RabbitMQConfig(BaseConfig):
     username: str = 'guest'
     password: str = 'guest'
     amqp_url_virtual_host: str = r'%2f'
+    url_protocol: str = 'amqp'
     consume_config: ConsumeConfig = None
 
     @classmethod
@@ -43,13 +45,14 @@ class RabbitMQSource(BaseSource):
         password = self.config.password
         connection_host = self.config.connection_host
         connection_port = self.config.connection_port
+        url_protocol = self.config.url_protocol
         vt_host = self.config.amqp_url_virtual_host
 
         self._print(f'Starting to initialize consumer for queue {queue_name}')
 
         try:
 
-            generated_url = f"amqp://{username}:{password}@" \
+            generated_url = f"{url_protocol}://{username}:{password}@" \
                             f"{connection_host}:{connection_port}/{vt_host}"
 
             self._print(f'Trying to connect on {generated_url}')


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This PR adds a new setting to both sink and source RabbitMQ blocks

Now users can specify whether they want to use the standard `amqp` or `amqps` protocol


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 
