### PR TITLE
[jk] View or hide hidden files in file browser

### DIFF
--- a/mage_ai/frontend/components/FileBrowser/FileHeaderMenu/index.style.ts
+++ b/mage_ai/frontend/components/FileBrowser/FileHeaderMenu/index.style.ts
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+import dark from '@oracle/styles/themes/dark';
+import { BORDER_WIDTH, BORDER_STYLE } from '@oracle/styles/units/borders';
+import { UNIT } from '@oracle/styles/units/spacing';
+
+export const FileHeaderMenuContainerStyle = styled.div`
+  height: 100%;
+  width: 100%;
+  position: relative;
+  padding: ${UNIT / 2}px;
+
+  ${props => `
+    border-bottom: ${BORDER_WIDTH}px ${BORDER_STYLE} ${(props.theme || dark).borders.medium};
+  `}
+`;

--- a/mage_ai/frontend/components/FileBrowser/FileHeaderMenu/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/FileHeaderMenu/index.tsx
@@ -14,6 +14,7 @@ import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
 import { FileHeaderMenuContainerStyle } from './index.style';
 import { PreviewHidden, PreviewOpen } from '@oracle/icons';
+import { SHARED_FILE_HEADER_BUTTON_PROPS } from '@components/PipelineDetail/FileHeaderMenu/constants';
 
 type FileHeaderMenuProps = {
   showHiddenFiles?: boolean;
@@ -65,13 +66,10 @@ function FileHeaderMenu({
         >
           <div style={{ position: 'relative' }}>
             <Button
-              compact
-              highlightOnHoverAlt
+              {...SHARED_FILE_HEADER_BUTTON_PROPS}
               noBackground={highlightedIndex !== 0}
-              noBorder
               onClick={() => setHighlightedIndex(val => val === 0 ? null : 0)}
               onMouseEnter={() => setHighlightedIndex(val => val !== null ? 0 : null)}
-              padding="4px 12px"
               ref={refView}
             >
               <Text default>

--- a/mage_ai/frontend/components/FileBrowser/FileHeaderMenu/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/FileHeaderMenu/index.tsx
@@ -1,0 +1,97 @@
+import {
+  Dispatch,
+  SetStateAction,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import Button from '@oracle/elements/Button';
+import ClickOutside from '@oracle/components/ClickOutside';
+import FlexContainer from '@oracle/components/FlexContainer';
+import FlyoutMenu from '@oracle/components/FlyoutMenu';
+import Spacing from '@oracle/elements/Spacing';
+import Text from '@oracle/elements/Text';
+import { FileHeaderMenuContainerStyle } from './index.style';
+import { PreviewHidden, PreviewOpen } from '@oracle/icons';
+
+type FileHeaderMenuProps = {
+  showHiddenFiles?: boolean;
+  setShowHiddenFiles?: Dispatch<SetStateAction<boolean>>;
+};
+
+function FileHeaderMenu({
+  setShowHiddenFiles,
+  showHiddenFiles,
+}: FileHeaderMenuProps) {
+  const [highlightedIndex, setHighlightedIndex] = useState(null);
+  const refView = useRef(null);
+
+  const viewItems = useMemo(() => [
+    {
+      label: () => (
+        <FlexContainer alignItems="center">
+          {showHiddenFiles
+            ? <PreviewOpen success />
+            : <PreviewHidden muted />
+          }
+
+          <Spacing mr={1} />
+
+          <Text noWrapping>
+            Hidden files
+          </Text>
+        </FlexContainer>
+      ),
+      onClick: () => {
+        setShowHiddenFiles(prevState => !prevState);
+      },
+      uuid: 'Hidden files',
+    },
+  ], [setShowHiddenFiles, showHiddenFiles]);
+
+  return (
+    <FileHeaderMenuContainerStyle>
+      <ClickOutside
+        onClickOutside={() => setHighlightedIndex(null)}
+        open
+        style={{
+          width: 'fit-content',
+        }}
+      >
+        <FlexContainer
+          alignItems="center"
+          fullHeight
+        >
+          <div style={{ position: 'relative' }}>
+            <Button
+              compact
+              highlightOnHoverAlt
+              noBackground={highlightedIndex !== 0}
+              noBorder
+              onClick={() => setHighlightedIndex(val => val === 0 ? null : 0)}
+              onMouseEnter={() => setHighlightedIndex(val => val !== null ? 0 : null)}
+              padding="4px 12px"
+              ref={refView}
+            >
+              <Text default>
+                View
+              </Text>
+            </Button>
+
+            <FlyoutMenu
+              alternateBackground
+              items={viewItems}
+              onClickCallback={() => setHighlightedIndex(null)}
+              open={highlightedIndex === 0}
+              parentRef={refView}
+              uuid="FileBrowser/FileHeaderMenu/view"
+            />
+          </div>
+        </FlexContainer>
+      </ClickOutside>
+    </FileHeaderMenuContainerStyle>
+  );
+}
+
+export default FileHeaderMenu;

--- a/mage_ai/frontend/components/FileBrowser/Folder/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/Folder/index.tsx
@@ -185,7 +185,7 @@ function Folder({
       name,
       uuidCombined,,
     ]);
-  const uuid = useMemo(() => uuidCombinedUse?.join('/'), [uuidCombinedUse])
+  const uuid = useMemo(() => uuidCombinedUse?.join('/'), [uuidCombinedUse]);
 
   const folderStates = get(LOCAL_STORAGE_KEY_FOLDERS_STATE, {});
   const refChildren = useRef(null);

--- a/mage_ai/frontend/components/FileBrowser/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/index.tsx
@@ -715,7 +715,7 @@ function FileBrowser({
   return (
     <ContainerStyle ref={ref}>
       {(setShowHiddenFiles && typeof showHiddenFiles !== 'undefined') &&
-        <Spacing mb={1} mx={2}>
+        <Spacing mx={2} my={1}>
           <FlexContainer alignItems="center" justifyContent="right">
             <ToggleSwitch
               checked={showHiddenFiles}

--- a/mage_ai/frontend/components/FileBrowser/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/index.tsx
@@ -1,5 +1,7 @@
 import * as osPath from 'path';
 import React, {
+  Dispatch,
+  SetStateAction,
   useCallback,
   useContext,
   useEffect,
@@ -12,14 +14,17 @@ import { useMutation } from 'react-query';
 
 import BlockType, { BlockRequestPayloadType, BlockTypeEnum } from '@interfaces/BlockType';
 import FileType from '@interfaces/FileType';
-import FlyoutMenu, { DEFAULT_MENU_ITEM_HEIGHT } from '@oracle/components/FlyoutMenu';
+import FlexContainer from '@oracle/components/FlexContainer';
+import FlyoutMenu from '@oracle/components/FlyoutMenu';
 import Folder, { FolderSharedProps } from './Folder';
 import GradientLogoIcon from '@oracle/icons/GradientLogo';
 import NewFile from './NewFile';
 import NewFolder from './NewFolder';
 import PipelineType, { PipelineTypeEnum } from '@interfaces/PipelineType';
 import PopupMenu from '@oracle/components/PopupMenu';
+import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
+import ToggleSwitch from '@oracle/elements/Inputs/ToggleSwitch';
 import UploadFiles from './UploadFiles';
 import api from '@api';
 import useProject from '@utils/models/project/useProject';
@@ -63,6 +68,8 @@ type FileBrowserProps = {
     response: any;
   }) => void;
   setSelectedBlock?: (block: BlockType) => void;
+  setShowHiddenFiles?: Dispatch<SetStateAction<boolean>>;
+  showHiddenFiles?: boolean;
   uuid?: string;
   widgets?: BlockType[];
 } & FolderSharedProps & ContextAreaProps;
@@ -92,6 +99,8 @@ function FileBrowser({
   pipeline,
   showError,
   setSelectedBlock,
+  setShowHiddenFiles,
+  showHiddenFiles,
   uuid,
   widgets = [],
 }: FileBrowserProps, ref) {
@@ -705,6 +714,22 @@ function FileBrowser({
 
   return (
     <ContainerStyle ref={ref}>
+      {(setShowHiddenFiles && typeof showHiddenFiles !== 'undefined') &&
+        <Spacing mb={1} mx={2}>
+          <FlexContainer alignItems="center" justifyContent="right">
+            <ToggleSwitch
+              checked={showHiddenFiles}
+              compact
+              onCheck={() => setShowHiddenFiles(prevState => !prevState)}
+            />
+            <Spacing pl={1} />
+            <Text muted>
+              Show hidden files
+            </Text>
+          </FlexContainer>
+        </Spacing>
+      }
+
       {filesMemo}
 
       {(selectedBlock || selectedFile || selectedFolder) && menuMemo}

--- a/mage_ai/frontend/components/FileBrowser/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/index.tsx
@@ -62,7 +62,6 @@ type FileBrowserProps = {
   fetchFiles?: () => void;
   fetchPipeline?: () => void;
   files?: FileType[];
-  showHiddenFilesToggle?: boolean;
   pipeline?: PipelineType;
   showError?: (opts: {
     errors: any;
@@ -70,6 +69,7 @@ type FileBrowserProps = {
   }) => void;
   setSelectedBlock?: (block: BlockType) => void;
   setShowHiddenFiles?: Dispatch<SetStateAction<boolean>>;
+  showHiddenFilesSetting?: boolean;
   showHiddenFiles?: boolean;
   uuid?: string;
   widgets?: BlockType[];
@@ -92,7 +92,6 @@ function FileBrowser({
   fetchFiles: fetchFileTree,
   fetchPipeline,
   files,
-  showHiddenFilesToggle,
   onClickFile,
   onClickFolder,
   onSelectBlockFile,
@@ -103,6 +102,7 @@ function FileBrowser({
   setSelectedBlock,
   setShowHiddenFiles,
   showHiddenFiles,
+  showHiddenFilesSetting,
   uuid,
   widgets = [],
 }: FileBrowserProps, ref) {
@@ -716,7 +716,7 @@ function FileBrowser({
 
   return (
     <ContainerStyle ref={ref}>
-      {(showHiddenFilesToggle && setShowHiddenFiles && typeof showHiddenFiles !== 'undefined') &&
+      {(showHiddenFilesSetting && setShowHiddenFiles && typeof showHiddenFiles !== 'undefined') &&
         <Spacing mx={2} my={1}>
           <FlexContainer alignItems="center" justifyContent="right">
             <ToggleSwitch

--- a/mage_ai/frontend/components/FileBrowser/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/index.tsx
@@ -62,6 +62,7 @@ type FileBrowserProps = {
   fetchFiles?: () => void;
   fetchPipeline?: () => void;
   files?: FileType[];
+  showHiddenFilesToggle?: boolean;
   pipeline?: PipelineType;
   showError?: (opts: {
     errors: any;
@@ -91,6 +92,7 @@ function FileBrowser({
   fetchFiles: fetchFileTree,
   fetchPipeline,
   files,
+  showHiddenFilesToggle,
   onClickFile,
   onClickFolder,
   onSelectBlockFile,
@@ -714,7 +716,7 @@ function FileBrowser({
 
   return (
     <ContainerStyle ref={ref}>
-      {(setShowHiddenFiles && typeof showHiddenFiles !== 'undefined') &&
+      {(showHiddenFilesToggle && setShowHiddenFiles && typeof showHiddenFiles !== 'undefined') &&
         <Spacing mx={2} my={1}>
           <FlexContainer alignItems="center" justifyContent="right">
             <ToggleSwitch

--- a/mage_ai/frontend/components/FileBrowser/utils.ts
+++ b/mage_ai/frontend/components/FileBrowser/utils.ts
@@ -55,7 +55,7 @@ export function getFullPathWithoutRootFolder(
 }
 
 export function getFileExtension(filename: string): FileExtensionEnum {
-  const match = filename?.match(ALL_SUPPORTED_FILE_EXTENSIONS_REGEX)
+  const match = filename?.match(ALL_SUPPORTED_FILE_EXTENSIONS_REGEX);
   return match?.length >= 1
     ? match[0].replace('.', '') as FileExtensionEnum
     : null;
@@ -71,7 +71,7 @@ export function validBlockFileExtension(filename: string): string {
   ].join('|');
   const extensionRegex = new RegExp(`${extensions}$`);
 
-  const match = filename.match(extensionRegex)
+  const match = filename.match(extensionRegex);
 
   return match?.length >= 1 ? match[0].replace('.', '') : null;
 }
@@ -97,13 +97,13 @@ export function getBlockFromFile(
 ) {
   // parts example:
   // ['default_repo', 'data_loaders', 'team', 'foo.py']
-  let parts = getFullPath(file, currentPathInit).split(osPath.sep);
+  const parts = getFullPath(file, currentPathInit).split(osPath.sep);
 
   if (!parts) {
     return null;
   }
 
-  let blockType = getBlockType(parts);
+  const blockType = getBlockType(parts);
 
   if (!parts) {
     return null;

--- a/mage_ai/frontend/components/FileEditor/Header/index.tsx
+++ b/mage_ai/frontend/components/FileEditor/Header/index.tsx
@@ -15,7 +15,6 @@ import {
   KEY_CODE_ARROW_LEFT,
   KEY_CODE_ARROW_RIGHT,
 } from '@utils/hooks/keyboardShortcuts/constants';
-import { LinkStyle } from '@components/PipelineDetail/FileHeaderMenu/index.style';
 import { isMac } from '@utils/os';
 import { useKeyboardContext } from '@context/Keyboard';
 

--- a/mage_ai/frontend/components/FileEditor/Header/index.tsx
+++ b/mage_ai/frontend/components/FileEditor/Header/index.tsx
@@ -15,6 +15,7 @@ import {
   KEY_CODE_ARROW_LEFT,
   KEY_CODE_ARROW_RIGHT,
 } from '@utils/hooks/keyboardShortcuts/constants';
+import { SHARED_FILE_HEADER_BUTTON_PROPS } from '@components/PipelineDetail/FileHeaderMenu/constants';
 import { isMac } from '@utils/os';
 import { useKeyboardContext } from '@context/Keyboard';
 
@@ -103,11 +104,8 @@ function FileHeaderMenu({
       <FlexContainer alignItems="center" fullHeight fullWidth>
         <div style={{ position: 'relative' }}>
           <Button
-            compact
+            {...SHARED_FILE_HEADER_BUTTON_PROPS}
             noBackground={highlightedIndex !== 0}
-            noBorder
-            highlightOnHoverAlt
-            padding="4px 12px"
             onClick={() => setHighlightedIndex(val => val === 0 ? null : 0)}
             onMouseEnter={() => setHighlightedIndex(val => val !== null ? 0 : null)}
             ref={refFile}
@@ -128,11 +126,8 @@ function FileHeaderMenu({
 
         <div style={{ position: 'relative' }}>
           <Button
-            compact
+            {...SHARED_FILE_HEADER_BUTTON_PROPS}
             noBackground={highlightedIndex !== 1}
-            noBorder
-            highlightOnHoverAlt
-            padding="4px 12px"
             onClick={() => setHighlightedIndex(val => val === 1 ? null : 1)}
             onMouseEnter={() => setHighlightedIndex(val => val !== null ? 1 : null)}
             ref={refRun}
@@ -153,12 +148,9 @@ function FileHeaderMenu({
 
         <div style={{ position: 'relative' }}>
           <Button
+            {...SHARED_FILE_HEADER_BUTTON_PROPS}
             beforeIcon={<FileIcon muted={!fileVersionsVisible} />}
-            compact
             noBackground={!fileVersionsVisible}
-            noBorder
-            highlightOnHoverAlt
-            padding="4px 12px"
             onClick={() => setFilesVersionsVisible(!fileVersionsVisible)}
           >
             <Text>

--- a/mage_ai/frontend/components/Files/index.tsx
+++ b/mage_ai/frontend/components/Files/index.tsx
@@ -9,13 +9,6 @@ import useFileComponents from '@components/Files/useFileComponents';
 import FileTabsScroller from '@components/FileTabsScroller';
 import { HEADER_HEIGHT } from '@components/shared/Header/index.style';
 
-import {
-  HeaderStyle,
-  MAIN_CONTENT_TOP_OFFSET,
-  MenuStyle,
-  TabsStyle,
-} from './index.style';
-
 function FilesPageComponent() {
   const refHeader = useRef(null);
   const [headerOffset, setHeaderOffset] = useState(null);
@@ -42,29 +35,27 @@ function FilesPageComponent() {
       before={browser}
       contained
       headerOffset={headerOffset + HEADER_HEIGHT}
-      mainContainerHeader={({ widthOffset }) => {
-        return (
-          <div
-            ref={refHeader}
-            style={{
-              position: 'relative',
-              zIndex: 3,
-            }}
-          >
-            <Spacing p={1}>
-              <FlexContainer alignItems="center">
-                {menu}
-              </FlexContainer>
-            </Spacing>
+      mainContainerHeader={({ widthOffset }) => (
+        <div
+          ref={refHeader}
+          style={{
+            position: 'relative',
+            zIndex: 3,
+          }}
+        >
+          <Spacing p={1}>
+            <FlexContainer alignItems="center">
+              {menu}
+            </FlexContainer>
+          </Spacing>
 
-            <Divider light />
+          <Divider light />
 
-            <FileTabsScroller widthOffset={widthOffset}>
-              {tabs}
-            </FileTabsScroller>
-          </div>
-        );
-      }}
+          <FileTabsScroller widthOffset={widthOffset}>
+            {tabs}
+          </FileTabsScroller>
+        </div>
+      )}
       title="Files"
       uuid="Files/index"
     >

--- a/mage_ai/frontend/components/Files/index.tsx
+++ b/mage_ai/frontend/components/Files/index.tsx
@@ -29,7 +29,7 @@ function FilesPageComponent() {
     tabs,
     versions,
     versionsVisible,
-  } = useFileComponents();
+  } = useFileComponents({ showHiddenFilesToggle: true });
 
   useEffect(() => {
     setTimeout(() => setHeaderOffset(refHeader?.current?.getBoundingClientRect()?.height || 0), 1);

--- a/mage_ai/frontend/components/Files/index.tsx
+++ b/mage_ai/frontend/components/Files/index.tsx
@@ -29,7 +29,7 @@ function FilesPageComponent() {
     tabs,
     versions,
     versionsVisible,
-  } = useFileComponents({ showHiddenFilesToggle: true });
+  } = useFileComponents({ showHiddenFilesSetting: true });
 
   useEffect(() => {
     setTimeout(() => setHeaderOffset(refHeader?.current?.getBoundingClientRect()?.height || 0), 1);

--- a/mage_ai/frontend/components/Files/useFileComponents.tsx
+++ b/mage_ai/frontend/components/Files/useFileComponents.tsx
@@ -54,6 +54,7 @@ type UseFileComponentsProps = {
   fetchAutocompleteItems?: () => void;
   fetchPipeline?: () => void;
   fetchVariables?: () => void;
+  showHiddenFilesToggle?: boolean;
   onOpenFile?: (filePath: string, isFolder: boolean) => void;
   onSelectBlockFile?: (
     blockUUID: string,
@@ -94,6 +95,7 @@ function useFileComponents({
   fetchAutocompleteItems,
   fetchPipeline,
   fetchVariables,
+  showHiddenFilesToggle,
   onOpenFile,
   onSelectBlockFile,
   onSelectFile,
@@ -213,10 +215,10 @@ function useFileComponents({
   }, [showHiddenFiles]);
 
   const { data: filesData, mutate: fetchFiles } = api.files.list(
-    showHiddenFiles
+    (showHiddenFilesToggle && showHiddenFiles)
       ? {
         ...FILES_QUERY_INCLUDE_HIDDEN_FILES,
-        ...query
+        ...query,
       } : query,
   );
   const files = useMemo(() => filesData?.files || [], [filesData]);
@@ -317,6 +319,7 @@ function useFileComponents({
       fetchFiles={fetchFiles}
       fetchPipeline={fetchPipeline}
       files={files}
+      showHiddenFilesToggle={showHiddenFilesToggle}
       onClickFile={(path: string) => openFile(path)}
       onClickFolder={(path: string) => openFile(path, true)}
       onSelectBlockFile={onSelectBlockFile}
@@ -340,6 +343,7 @@ function useFileComponents({
     fetchPipeline,
     fileTreeRef,
     files,
+    showHiddenFilesToggle,
     onSelectBlockFile,
     openFile,
     openSidekickView,

--- a/mage_ai/frontend/components/Files/useFileComponents.tsx
+++ b/mage_ai/frontend/components/Files/useFileComponents.tsx
@@ -54,7 +54,6 @@ type UseFileComponentsProps = {
   fetchAutocompleteItems?: () => void;
   fetchPipeline?: () => void;
   fetchVariables?: () => void;
-  showHiddenFilesToggle?: boolean;
   onOpenFile?: (filePath: string, isFolder: boolean) => void;
   onSelectBlockFile?: (
     blockUUID: string,
@@ -83,6 +82,7 @@ type UseFileComponentsProps = {
   sendTerminalMessage?: (message: string, keep?: boolean) => void;
   setDisableShortcuts?: (disableShortcuts: boolean) => void;
   setSelectedBlock?: (value: BlockType) => void;
+  showHiddenFilesSetting?: boolean;
   uuid?: string;
   widgets?: BlockType[];
 };
@@ -95,7 +95,6 @@ function useFileComponents({
   fetchAutocompleteItems,
   fetchPipeline,
   fetchVariables,
-  showHiddenFilesToggle,
   onOpenFile,
   onSelectBlockFile,
   onSelectFile,
@@ -107,6 +106,7 @@ function useFileComponents({
   sendTerminalMessage,
   setDisableShortcuts,
   setSelectedBlock,
+  showHiddenFilesSetting,
   uuid,
   widgets,
 }: UseFileComponentsProps = {}) {
@@ -215,7 +215,7 @@ function useFileComponents({
   }, [showHiddenFiles]);
 
   const { data: filesData, mutate: fetchFiles } = api.files.list(
-    (showHiddenFilesToggle && showHiddenFiles)
+    (showHiddenFilesSetting && showHiddenFiles)
       ? {
         ...FILES_QUERY_INCLUDE_HIDDEN_FILES,
         ...query,
@@ -319,7 +319,7 @@ function useFileComponents({
       fetchFiles={fetchFiles}
       fetchPipeline={fetchPipeline}
       files={files}
-      showHiddenFilesToggle={showHiddenFilesToggle}
+      showHiddenFilesSetting={showHiddenFilesSetting}
       onClickFile={(path: string) => openFile(path)}
       onClickFolder={(path: string) => openFile(path, true)}
       onSelectBlockFile={onSelectBlockFile}
@@ -343,7 +343,7 @@ function useFileComponents({
     fetchPipeline,
     fileTreeRef,
     files,
-    showHiddenFilesToggle,
+    showHiddenFilesSetting,
     onSelectBlockFile,
     openFile,
     openSidekickView,

--- a/mage_ai/frontend/components/Files/useFileComponents.tsx
+++ b/mage_ai/frontend/components/Files/useFileComponents.tsx
@@ -9,7 +9,9 @@ import Dashboard from '@components/Dashboard';
 import FileBrowser from '@components/FileBrowser';
 import FileEditorHeader from '@components/FileEditor/Header';
 import FileTabs from '@components/PipelineDetail/FileTabs';
-import FileType from '@interfaces/FileType';
+import FileType, {
+  FILES_QUERY_INCLUDE_HIDDEN_FILES,
+} from '@interfaces/FileType';
 import FileVersions from '@components/FileVersions';
 import PipelineType from '@interfaces/PipelineType';
 import api from '@api';
@@ -25,11 +27,13 @@ import {
 } from '@utils/hooks/keyboardShortcuts/constants';
 import { ViewKeyEnum } from '@components/Sidekick/constants';
 import {
+  LOCAL_STORAGE_KEY_SHOW_HIDDEN_FILES,
   addOpenFilePath as addOpenFilePathLocalStorage,
   getOpenFilePaths,
   removeOpenFilePath as removeOpenFilePathLocalStorage,
   setOpenFilePaths as setOpenFilePathsLocalStorage,
 } from '@storage/files';
+import { get, set } from '@storage/localStorage';
 import { getFilenameFromFilePath } from './utils';
 import { onSuccess } from '@api/utils/response';
 import { onlyKeysPresent } from '@utils/hooks/keyboardShortcuts/utils';
@@ -108,6 +112,9 @@ function useFileComponents({
   const [showError] = useError(null, {}, [], {
     uuid: `useFileComponents/${uuid}`,
   });
+  const [showHiddenFiles, setShowHiddenFiles] = useState<boolean>(
+    get(LOCAL_STORAGE_KEY_SHOW_HIDDEN_FILES, false),
+  );
 
   const fileTreeRef = useRef(null);
   const contentByFilePath = useRef(null);
@@ -199,7 +206,19 @@ function useFileComponents({
     setOpenFilePaths,
   ]);
 
-  const { data: filesData, mutate: fetchFiles } = api.files.list(query);
+  const toggleShowHiddenFiles = useCallback(() => {
+    const updatedShowHiddenFiles = !showHiddenFiles;
+    setShowHiddenFiles(updatedShowHiddenFiles);
+    set(LOCAL_STORAGE_KEY_SHOW_HIDDEN_FILES, updatedShowHiddenFiles);
+  }, [showHiddenFiles]);
+
+  const { data: filesData, mutate: fetchFiles } = api.files.list(
+    showHiddenFiles
+      ? {
+        ...FILES_QUERY_INCLUDE_HIDDEN_FILES,
+        ...query
+      } : query,
+  );
   const files = useMemo(() => filesData?.files || [], [filesData]);
 
   const uuidKeyboard = 'Files/index';
@@ -306,6 +325,8 @@ function useFileComponents({
       ref={fileTreeRef}
       showError={showError}
       setSelectedBlock={setSelectedBlock}
+      setShowHiddenFiles={toggleShowHiddenFiles}
+      showHiddenFiles={showHiddenFiles}
       uuid={uuid}
       widgets={widgets}
     />
@@ -325,6 +346,8 @@ function useFileComponents({
     pipeline,
     setSelectedBlock,
     showError,
+    showHiddenFiles,
+    toggleShowHiddenFiles,
     uuid,
     widgets,
   ]);

--- a/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/constants.ts
+++ b/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/constants.ts
@@ -1,0 +1,6 @@
+export const SHARED_FILE_HEADER_BUTTON_PROPS = {
+  compact: true,
+  highlightOnHoverAlt: true,
+  noBorder: true,
+  padding: '4px 12px',
+};

--- a/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/index.tsx
@@ -30,7 +30,7 @@ import {
   KEY_CODE_ARROW_LEFT,
   KEY_CODE_ARROW_RIGHT,
 } from '@utils/hooks/keyboardShortcuts/constants';
-import { LinkStyle } from './index.style';
+import { SHARED_FILE_HEADER_BUTTON_PROPS } from './constants';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { ViewKeyEnum } from '@components/Sidekick/constants';
 import { isMac } from '@utils/os';
@@ -367,11 +367,8 @@ function FileHeaderMenu({
       <FlexContainer>
         <div style={{ position: 'relative' }}>
           <Button
-            compact
+            {...SHARED_FILE_HEADER_BUTTON_PROPS}
             noBackground={highlightedIndex !== 0}
-            noBorder
-            highlightOnHoverAlt
-            padding="4px 12px"
             onClick={() => setHighlightedIndex(val => val === 0 ? null : 0)}
             onMouseEnter={() => setHighlightedIndex(val => val !== null ? 0 : null)}
             ref={refFile}
@@ -392,11 +389,8 @@ function FileHeaderMenu({
 
         <div style={{ position: 'relative' }}>
           <Button
-            compact
+            {...SHARED_FILE_HEADER_BUTTON_PROPS}
             noBackground={highlightedIndex !== 2}
-            noBorder
-            highlightOnHoverAlt
-            padding="4px 12px"
             onClick={() => setHighlightedIndex(val => val === 2 ? null : 2)}
             onMouseEnter={() => setHighlightedIndex(val => val !== null ? 2 : null)}
             ref={refEdit}
@@ -417,11 +411,8 @@ function FileHeaderMenu({
 
         <div style={{ position: 'relative' }}>
           <Button
-            compact
+            {...SHARED_FILE_HEADER_BUTTON_PROPS}
             noBackground={highlightedIndex !== 1}
-            noBorder
-            highlightOnHoverAlt
-            padding="4px 12px"
             onClick={() => setHighlightedIndex(val => val === 1 ? null : 1)}
             onMouseEnter={() => setHighlightedIndex(val => val !== null ? 1 : null)}
             ref={refRun}
@@ -445,11 +436,8 @@ function FileHeaderMenu({
           && (
           <div style={{ position: 'relative' }}>
             <Button
-              compact
+              {...SHARED_FILE_HEADER_BUTTON_PROPS}
               noBackground={highlightedIndex !== 3}
-              noBorder
-              highlightOnHoverAlt
-              padding="4px 12px"
               onClick={() => setHighlightedIndex(val => val === 3 ? null : 3)}
               onMouseEnter={() => setHighlightedIndex(val => val !== null ? 3 : null)}
               ref={refView}
@@ -472,11 +460,8 @@ function FileHeaderMenu({
         {featureEnabled?.(featureUUIDs.COMPUTE_MANAGEMENT) && (
           <div style={{ position: 'relative' }}>
             <Button
-              compact
+              {...SHARED_FILE_HEADER_BUTTON_PROPS}
               noBackground={highlightedIndex !== INDEX_COMPUTE}
-              noBorder
-              highlightOnHoverAlt
-              padding="4px 12px"
               onClick={() => setHighlightedIndex(val => val === INDEX_COMPUTE ? null : INDEX_COMPUTE)}
               onMouseEnter={() => setHighlightedIndex(val => val !== null ? INDEX_COMPUTE : null)}
               ref={refCompute}

--- a/mage_ai/frontend/interfaces/FileType.ts
+++ b/mage_ai/frontend/interfaces/FileType.ts
@@ -23,6 +23,20 @@ export enum SpecialFileEnum {
   REQS_TXT = 'requirements.txt',
 }
 
+export enum FileQueryEnum {
+  EXCLUDE_DIR_PATTERN = 'exclude_dir_pattern',
+  EXCLUDE_PATTERN = 'exclude_pattern',
+  PATTERN = 'pattern',
+}
+
+// This is regex for matching nothing (to include all files, including hidden ones)
+export const FILE_PATTERN_NO_MATCHES = 'a^';
+// We exclude no files (e.g. hidden files) by matching no file patterns.
+export const FILES_QUERY_INCLUDE_HIDDEN_FILES = {
+  [FileQueryEnum.EXCLUDE_PATTERN]: FILE_PATTERN_NO_MATCHES,
+  [FileQueryEnum.EXCLUDE_DIR_PATTERN]: FILE_PATTERN_NO_MATCHES,
+};
+
 export const CODE_BLOCK_FILE_EXTENSIONS = [
   FileExtensionEnum.PY,
   FileExtensionEnum.SQL,

--- a/mage_ai/frontend/pages/manage/files/index.tsx
+++ b/mage_ai/frontend/pages/manage/files/index.tsx
@@ -9,21 +9,15 @@ import PrivateRoute from '@components/shared/PrivateRoute';
 import Spacing from '@oracle/elements/Spacing';
 import WorkspacesDashboard from '@components/workspaces/Dashboard';
 import api from '@api';
-import { FILES_QUERY_INCLUDE_HIDDEN_FILES } from '@interfaces/FileType';
-import { LOCAL_STORAGE_KEY_SHOW_HIDDEN_FILES } from '@storage/files';
-import { PipelineHeaderStyle } from '@components/PipelineDetail/index.style';
-import { WorkspacesPageNameEnum } from '@components/workspaces/Dashboard/constants';
 import { equals } from '@utils/array';
-import { get, set } from '@storage/localStorage';
 import { goToWithQuery } from '@utils/routing';
 import { queryFromUrl } from '@utils/url';
+import { PipelineHeaderStyle } from '@components/PipelineDetail/index.style';
+import { WorkspacesPageNameEnum } from '@components/workspaces/Dashboard/constants';
 
 
 function FilesPage() {
   const [errors, setErrors] = useState<ErrorsType>(null);
-  const [showHiddenFiles, setShowHiddenFiles] = useState<boolean>(
-    get(LOCAL_STORAGE_KEY_SHOW_HIDDEN_FILES, false),
-  );
 
   const qUrl = queryFromUrl();
   const {
@@ -54,15 +48,7 @@ function FilesPage() {
     });
   }, []);
 
-  const toggleShowHiddenFiles = useCallback(() => {
-    const updatedShowHiddenFiles = !showHiddenFiles;
-    setShowHiddenFiles(updatedShowHiddenFiles);
-    set(LOCAL_STORAGE_KEY_SHOW_HIDDEN_FILES, updatedShowHiddenFiles);
-  }, [showHiddenFiles]);
-
-  const { data: filesData, mutate: fetchFileTree } = api.files.list(
-    showHiddenFiles ? FILES_QUERY_INCLUDE_HIDDEN_FILES : {},
-  );
+  const { data: filesData, mutate: fetchFileTree } = api.files.list();
   const files = useMemo(() => filesData?.files || [], [filesData]);
   const fileTreeRef = useRef(null);
   const [selectedFilePath, setSelectedFilePath] = useState<string>(null);
@@ -78,9 +64,7 @@ function FilesPage() {
         files={files}
         openFile={openFile}
         ref={fileTreeRef}
-        setErrors={setErrors}
-        setShowHiddenFiles={toggleShowHiddenFiles}
-        showHiddenFiles={showHiddenFiles}
+        showError={setErrors}
       />
     </Spacing>
   ), [
@@ -88,8 +72,6 @@ function FilesPage() {
     files,
     openFile,
     setErrors,
-    showHiddenFiles,
-    toggleShowHiddenFiles,
   ]);
 
   useEffect(() => {

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1026,6 +1026,7 @@ function PipelineDetailPage({
     sendTerminalMessage,
     setDisableShortcuts,
     setSelectedBlock,
+    showHiddenFilesToggle: true,
     uuid: pipelineUUID,
     widgets,
   });

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -37,6 +37,7 @@ import FileHeaderMenu from '@components/PipelineDetail/FileHeaderMenu';
 import FileTabsScroller from '@components/FileTabsScroller';
 import FileType, {
   FILE_EXTENSION_TO_LANGUAGE_MAPPING_REVERSE,
+  FileQueryEnum,
   SpecialFileEnum,
 } from '@interfaces/FileType';
 import FlexContainer from '@oracle/components/FlexContainer';

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1026,7 +1026,7 @@ function PipelineDetailPage({
     sendTerminalMessage,
     setDisableShortcuts,
     setSelectedBlock,
-    showHiddenFilesToggle: true,
+    showHiddenFilesSetting: true,
     uuid: pipelineUUID,
     widgets,
   });

--- a/mage_ai/frontend/storage/files.ts
+++ b/mage_ai/frontend/storage/files.ts
@@ -1,6 +1,7 @@
 import { get, set } from './localStorage';
 import { remove } from '@utils/array';
 
+export const LOCAL_STORAGE_KEY_SHOW_HIDDEN_FILES = 'show_hidden_files';
 const OPEN_FILES = 'open_files';
 
 export function getOpenFilePaths(): string[] {


### PR DESCRIPTION
# Description
- Add file header menu to FileBrowser component to view of hide hidden files/folders.

# How Has This Been Tested?
<img width="255" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/2e696741-f7e7-4cdd-ac27-c030cd3c537b">

![view hidden files](https://github.com/mage-ai/mage-ai/assets/78053898/785dcc7f-688f-44b6-a8a1-d7f5475f0fc5)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:

