### PR TITLE
Added ability to customize default admin credentials on deployment

### DIFF
--- a/docs/api-reference/sessions/create-session.mdx
+++ b/docs/api-reference/sessions/create-session.mdx
@@ -12,7 +12,7 @@ curl --request POST \
   --header 'X-API-KEY: zkWlN0PkIKSN0C11CfUHUj84OT5XOJ6tDZ6bDRO2' \
   --data '{
   "session": {
-    "email": "admin@admin.com",
+    "email": "admin@example.com",
     "password": "admin"
   }
 }'

--- a/docs/production/authentication/overview.mdx
+++ b/docs/production/authentication/overview.mdx
@@ -78,7 +78,7 @@ Here are the default credentials for the owner user to sign in with:
 
 | Field | Value |
 | --- | --- |
-| Email | `admin@admin.com` |
+| Email | `admin@example.com` |
 | Password | `admin` |
 
 ## Sign in page

--- a/mage_ai/server/default_credential_initializer.py
+++ b/mage_ai/server/default_credential_initializer.py
@@ -1,0 +1,12 @@
+from mage_ai.authentication.passwords import create_bcrypt_hash, generate_salt
+from mage_ai.orchestration.db.models.oauth import User
+
+def get_default_credentials(default_role):
+    password_salt = generate_salt()
+    return User.create(
+        email='admin@example.com',
+        password_hash=create_bcrypt_hash('admin', password_salt),
+        password_salt=password_salt,
+        roles_new=[default_role],
+        username='admin',
+    )

--- a/mage_ai/server/default_credential_initializer.py
+++ b/mage_ai/server/default_credential_initializer.py
@@ -1,11 +1,12 @@
 from mage_ai.authentication.passwords import create_bcrypt_hash, generate_salt
 from mage_ai.orchestration.db.models.oauth import User
+from mage_ai.settings import DEFAULT_ADMIN_EMAIL, DEFAULT_ADMIN_PASSWORD
 
 def get_default_credentials(default_role):
     password_salt = generate_salt()
     return User.create(
-        email='admin@example.com',
-        password_hash=create_bcrypt_hash('admin', password_salt),
+        email=DEFAULT_ADMIN_EMAIL,
+        password_hash=create_bcrypt_hash(DEFAULT_ADMIN_PASSWORD, password_salt),
         password_salt=password_salt,
         roles_new=[default_role],
         username='admin',

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -491,7 +491,7 @@ async def main(
             else:
                 password_salt = generate_salt()
                 user = User.create(
-                    email='admin@admin.com',
+                    email='admin@example.com',
                     password_hash=create_bcrypt_hash('admin', password_salt),
                     password_salt=password_salt,
                     roles_new=[default_owner_role],

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -11,6 +11,7 @@ from time import sleep
 from typing import Optional, Union
 
 import pytz
+from mage_ai.server.default_credential_initializer import get_default_credentials
 import tornado.ioloop
 import tornado.web
 from tornado import autoreload
@@ -484,20 +485,12 @@ async def main(
         if not legacy_owner_user and len(owner_users) == 0:
             logger.info('User with owner permission doesn’t exist, creating owner user.')
             if AUTHENTICATION_MODE.lower() == 'ldap':
-                user = User.create(
+                owner_user = User.create(
                     roles_new=[default_owner_role],
                     username=LDAP_ADMIN_USERNAME,
                 )
             else:
-                password_salt = generate_salt()
-                user = User.create(
-                    email='admin@example.com',
-                    password_hash=create_bcrypt_hash('admin', password_salt),
-                    password_salt=password_salt,
-                    roles_new=[default_owner_role],
-                    username='admin',
-                )
-            owner_user = user
+                owner_user = get_default_credentials(default_owner_role)
         else:
             if legacy_owner_user and not legacy_owner_user.roles_new:
                 User.batch_update_user_roles()

--- a/mage_ai/settings/__init__.py
+++ b/mage_ai/settings/__init__.py
@@ -81,6 +81,13 @@ LDAP_DEFAULT_ACCESS = os.getenv('LDAP_DEFAULT_ACCESS', None)
 LDAP_GROUP_FIELD = os.getenv('LDAP_GROUP_FIELD', 'memberOf')
 LDAP_ROLES_MAPPING = os.getenv('LDAP_ROLES_MAPPING', None)
 
+DEFAULT_ADMIN_EMAIL = os.getenv('DEFAULT_ADMIN_EMAIL', 'admin@example.com')
+try:
+    DEFAULT_ADMIN_PASSWORD = os.getenv('DEFAULT_ADMIN_PASSWORD', None)
+except ValueError:
+    print('A default passowrd value is expected.')
+    exit(1)
+
 ACTIVE_DIRECTORY_DIRECTORY_ID = os.getenv('ACTIVE_DIRECTORY_DIRECTORY_ID', None)
 
 # ----------------------------------------------------------

--- a/mage_ai/tests/api/operations/test_syncs.py
+++ b/mage_ai/tests/api/operations/test_syncs.py
@@ -71,7 +71,7 @@ class SyncOperationTests(BaseApiTestCase):
                 branch='main',
                 auth_type='https',
                 username='username',
-                email='admin@admin.com',
+                email='admin@example.com',
                 access_token='abc123',
                 user_git_settings=dict(
                     username='another_username',

--- a/mage_ai/tests/api/test_utils.py
+++ b/mage_ai/tests/api/test_utils.py
@@ -43,7 +43,7 @@ class UtilsTest(DBTestCase):
     def test_get_user_access_for_user_with_no_permissions(self):
         password_salt = generate_salt()
         user = User.create(
-            email='no_access@admin.com',
+            email='no_access@example.com',
             password_hash=create_bcrypt_hash('admin', password_salt),
             password_salt=password_salt,
             username='no_access',
@@ -66,7 +66,7 @@ class UtilsTest(DBTestCase):
     def test_get_user_access_for_global_owner(self):
         password_salt = generate_salt()
         user = User.create(
-            email='admin@admin.com',
+            email='admin@example.com',
             password_hash=create_bcrypt_hash('admin', password_salt),
             password_salt=password_salt,
             roles_new=[Role.query.filter(Role.name == 'Owner').first()],


### PR DESCRIPTION
# Description
Added two new environment variables called `DEFAULT_ADMIN_EMAIL` and `DEFAULT_ADMIN_PASSWORD` that are used in creating the default owner user.  `DEFAULT_ADMIN_PASSWORD` is mandatory in case `REQUIRE_USER_AUTHENTICATION` is set to `True`.


# How Has This Been Tested?
Manually tested.

- [ ] Test A
- [ ] Test B


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
@adelcast 
