### PR TITLE
[td] Disable sample query when using raw SQL

### DIFF
--- a/mage_ai/data_preparation/models/block/sql/__init__.py
+++ b/mage_ai/data_preparation/models/block/sql/__init__.py
@@ -89,6 +89,7 @@ def execute_sql_code(
     """
     configuration = configuration if configuration else block.configuration
     use_raw_sql = configuration.get('use_raw_sql')
+    disable_query_output = configuration.get('disable_query_output', False) or False
 
     if not config_file_loader:
         config_path = path.join(get_repo_path(), 'io_config.yaml')
@@ -106,7 +107,7 @@ def execute_sql_code(
     block.set_global_vars(global_vars)
 
     table_name = block.table_name
-    should_query = block.type in PREVIEWABLE_BLOCK_TYPES
+    should_query = block.type in PREVIEWABLE_BLOCK_TYPES and not disable_query_output
 
     limit = int(configuration.get('limit') or QUERY_ROW_LIMIT)
     # Limit rows when running the block in the pipeline run

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -127,6 +127,7 @@ import {
   CONFIG_KEY_LIMIT,
   CONFIG_KEY_UNIQUE_UPSTREAM_TABLE_NAME,
   CONFIG_KEY_USE_RAW_SQL,
+  CONFIG_KEY_DISABLE_QUERY_OUTPUT,
 } from '@interfaces/ChartBlockType';
 import { DataSourceTypeEnum } from '@interfaces/DataSourceType';
 import {
@@ -668,6 +669,7 @@ function CodeBlock({
     [CONFIG_KEY_LIMIT]: defaultLimitValue,
     [CONFIG_KEY_UNIQUE_UPSTREAM_TABLE_NAME]: blockConfiguration[CONFIG_KEY_UNIQUE_UPSTREAM_TABLE_NAME],
     [CONFIG_KEY_USE_RAW_SQL]: !!blockConfiguration[CONFIG_KEY_USE_RAW_SQL],
+    [CONFIG_KEY_DISABLE_QUERY_OUTPUT]: !!blockConfiguration[CONFIG_KEY_DISABLE_QUERY_OUTPUT],
   });
 
   const [errorMessages, setErrorMessages] = useState(null);
@@ -3114,6 +3116,52 @@ df = get_variable('${pipelineUUID}', '${blockUUID}', 'output_0')`;
                             </FlexContainer>
                           </Tooltip>
                         </FlexContainer>
+
+                        {dataProviderConfig?.[CONFIG_KEY_USE_RAW_SQL] && (
+                          <>
+                            <Spacing mr={1} />
+
+                            <FlexContainer alignItems="center">
+                              <Tooltip
+                                block
+                                description={
+                                  <Text default inline>
+                                    After successfully running this block
+                                    <br />
+                                    a <Text default inline monospace>
+                                      SELECT
+                                    </Text> query will be executed
+                                    <br />
+                                    to fetch sample output data.
+                                    <br />
+                                    Check this box to disable this behavior.
+                                  </Text>
+                                }
+                                size={null}
+                                widthFitContent
+                              >
+                                <FlexContainer alignItems="center">
+                                  <Checkbox
+                                    checked={dataProviderConfig?.[CONFIG_KEY_DISABLE_QUERY_OUTPUT]}
+                                    label={
+                                      <Text muted small>
+                                        Disable query output
+                                      </Text>
+                                    }
+                                    onClick={(e) => {
+                                      pauseEvent(e);
+                                      updateDataProviderConfig({
+                                        [CONFIG_KEY_DISABLE_QUERY_OUTPUT]: !dataProviderConfig?.[CONFIG_KEY_DISABLE_QUERY_OUTPUT],
+                                      });
+                                    }}
+                                  />
+                                  <span>&nbsp;</span>
+                                  <Info muted />
+                                </FlexContainer>
+                              </Tooltip>
+                            </FlexContainer>
+                          </>
+                        )}
 
                         {!dataProviderConfig[CONFIG_KEY_USE_RAW_SQL] && (
                           <>

--- a/mage_ai/frontend/interfaces/ChartBlockType.ts
+++ b/mage_ai/frontend/interfaces/ChartBlockType.ts
@@ -32,6 +32,7 @@ export const CONFIG_KEY_UNIQUE_UPSTREAM_TABLE_NAME = 'unique_upstream_table_name
 export const CONFIG_KEY_UPSTREAM_BLOCK_CONFIGURATION = 'upstream_block_configuration';
 export const CONFIG_KEY_UPSTREAM_BLOCK_CONFIGURATION_TABLE_NAME = 'table_name';
 export const CONFIG_KEY_USE_RAW_SQL = 'use_raw_sql';
+export const CONFIG_KEY_DISABLE_QUERY_OUTPUT = 'disable_query_output';
 
 export const CONFIG_KEY_DBT = 'dbt';
 export const CONFIG_KEY_DBT_COMMAND = 'command';


### PR DESCRIPTION
# Description
Optionally disable running a query at the end of executing raw SQL.

Some commands (e.g. `UNLOAD` in Redshift) don’t return data. Trying to fetch sample data after these commands will throw an error in Mage:

```python
None object is not iterable
```

# How Has This Been Tested?
![CleanShot 2023-12-26 at 03 17 24@2x](https://github.com/mage-ai/mage-ai/assets/1066980/523d7a60-5b9a-4ac3-8c7f-2c963589f68c)

![CleanShot 2023-12-26 at 03 17 34@2x](https://github.com/mage-ai/mage-ai/assets/1066980/a7c501d1-6ddc-4293-8e7c-2d2f04e5360c)


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
