### PR TITLE
[td] Fix dataframe validation

### DIFF
--- a/mage_ai/io/mongodb.py
+++ b/mage_ai/io/mongodb.py
@@ -80,7 +80,7 @@ class MongoDB(BaseIO):
             data (Union[DataFrame, List[Dict]): Data frame or List of Dictionary to export.
             collection (str): MongoDB collection name.
         """
-        if not data:
+        if data is None:
             return
         collection = collection or self.collection
         if collection is None:


### PR DESCRIPTION
# Description
Fixes:

```
File "/usr/local/lib/python3.10/site-packages/mage_ai/io/mongodb.py", line 83, in export
    if not data:
  File "/usr/local/lib/python3.10/site-packages/pandas/core/generic.py", line 1527, in __nonzero__
    raise ValueError(
ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```