### PR TITLE
[xh]Enable hugging face client to use code generation specific model

### DIFF
--- a/docs/guides/ai/ai-client.mdx
+++ b/docs/guides/ai/ai-client.mdx
@@ -56,6 +56,29 @@ You are ready to go once the "ai_config" is setup. At this point,
 you can fully leverage Mage AI's capabilities, such as generating blocks 
 with text description, automatically write comments for your functions, etc.
 
+#### Use Dedicated Code Generation Model
+
+You can also utilize a dedicated code generation model to enhance the AI capabilities 
+for generating customized code. To achieve this, you will need to enable code generation
+(enable_code_gen: true) and include the code generation inference API within the 
+'ai_config' section of your project's metadata YAML configuration. That covers everything you need.
+
+Example configuration:
+
+```
+ai_config:
+  mode: 'hugging_face'
+  open_ai_config:
+    openai_api_key: key
+  hugging_face_config:
+    huggingface_api: api_url
+    huggingface_inference_api_token: api_token
+    enable_code_gen: true
+    code_gen_api: https://nyvss6tksvgn7mf3.us-east-1.aws.endpoints.huggingface.cloud
+```
+
+To reach a good performance, you can use `codellama/CodeLlama-34b-hf` or `codellama/CodeLlama-13b-hf`.
+
 ## How to add a new AI Client
 
 You may find it necessary to employ an AI client other than those offered by OpenAI and Hugging Face. 

--- a/mage_ai/ai/ai_client.py
+++ b/mage_ai/ai/ai_client.py
@@ -1,4 +1,11 @@
+from enum import Enum
 from typing import Dict
+
+
+class InferenceType(str, Enum):
+    DEFAULT = 'default'
+    # Handle case to generate customized code based on descriptionn
+    CODE_GENERATION = 'code_generation'
 
 
 class AIClient():
@@ -6,7 +13,8 @@ class AIClient():
             self,
             variable_values: Dict[str, str],
             prompt_template: str,
-            is_json_response: bool = True
+            is_json_response: bool = True,
+            inference_type: InferenceType = InferenceType.DEFAULT
     ):
         """
         Infers with Large Language Model with prompt and variables

--- a/mage_ai/ai/llm_pipeline_wizard.py
+++ b/mage_ai/ai/llm_pipeline_wizard.py
@@ -9,6 +9,7 @@ from jinja2.exceptions import TemplateNotFound
 from langchain.chains import LLMChain
 from langchain.prompts import PromptTemplate
 
+from mage_ai.ai.ai_client import InferenceType
 from mage_ai.ai.hugging_face_client import HuggingFaceClient
 from mage_ai.ai.openai_client import OpenAIClient
 from mage_ai.data_cleaner.transformer_actions.constants import ActionType
@@ -240,6 +241,7 @@ class LLMPipelineWizard:
         """
         variable_values = dict()
         variable_values['code_description'] = code_description
+        variable_values['code_language'] = block_language
         if block_language == BlockLanguage.PYTHON:
             customized_logic = await self.client.inference_with_prompt(
                 variable_values,
@@ -258,7 +260,8 @@ class LLMPipelineWizard:
         elif block_language == BlockLanguage.SQL:
             customized_logic = await self.client.inference_with_prompt(
                 variable_values,
-                PROMPT_FOR_CUSTOMIZED_CODE_IN_SQL
+                PROMPT_FOR_CUSTOMIZED_CODE_IN_SQL,
+                inference_type=InferenceType.CODE_GENERATION
             )
             if 'sql_code' in customized_logic.keys():
                 block_code = f'{block_code}\n{customized_logic.get("sql_code")}'
@@ -279,7 +282,8 @@ class LLMPipelineWizard:
         if is_default_transformer_template(config):
             customized_logic = await self.client.inference_with_prompt(
                 variable_values,
-                PROMPT_FOR_CUSTOMIZED_CODE_WITH_BASE_TEMPLATE
+                PROMPT_FOR_CUSTOMIZED_CODE_WITH_BASE_TEMPLATE,
+                inference_type=InferenceType.CODE_GENERATION,
             )
             if 'code' in customized_logic.keys():
                 config['existing_code'] = customized_logic.get('code')
@@ -306,7 +310,8 @@ class LLMPipelineWizard:
                 # ask LLM to fully generate the customized code.
                 customized_logic = await self.client.inference_with_prompt(
                     variable_values,
-                    PROMPT_FOR_CUSTOMIZED_CODE_WITH_BASE_TEMPLATE
+                    PROMPT_FOR_CUSTOMIZED_CODE_WITH_BASE_TEMPLATE,
+                    inference_type=InferenceType.CODE_GENERATION
                 )
                 if 'code' in customized_logic.keys():
                     block_code = fetch_transformer_default_template(

--- a/mage_ai/ai/openai_client.py
+++ b/mage_ai/ai/openai_client.py
@@ -7,7 +7,7 @@ from langchain.chains import LLMChain
 from langchain.llms import OpenAI
 from langchain.prompts import PromptTemplate
 
-from mage_ai.ai.ai_client import AIClient
+from mage_ai.ai.ai_client import AIClient, InferenceType
 from mage_ai.data_cleaner.transformer_actions.constants import ActionType, Axis
 from mage_ai.data_preparation.models.constants import (
     BlockLanguage,
@@ -83,7 +83,8 @@ class OpenAIClient(AIClient):
             self,
             variable_values: Dict[str, str],
             prompt_template: str,
-            is_json_response: bool = True
+            is_json_response: bool = True,
+            inference_type: InferenceType = InferenceType.DEFAULT
     ):
         """Generic function to call OpenAI LLM and return JSON response by default.
 

--- a/mage_ai/orchestration/ai/config.py
+++ b/mage_ai/orchestration/ai/config.py
@@ -13,6 +13,8 @@ class OpenAIConfig(BaseConfig):
 class HuggingFaceConfig(BaseConfig):
     huggingface_api: str = None
     huggingface_inference_api_token: str = None
+    enable_code_gen: bool = False
+    code_gen_api: str = None
 
 
 @dataclass


### PR DESCRIPTION
# Description
When use description to generate block code, one step may run into is to generated customized code based on description.
In existing hugging face client, it uses default language model to generate the customized code. However, there are `code generation` specific model which can perform better than general language model for that task. 

This PR enables this capability by using a code generation model for that specific task.
- It adds config to enable this feature and provides a code_gen_api
- In the inference function, it adds the inference type and for code generation type, it calls a specific function to call the `code_gen_api` to fulfill the task


# How Has This Been Tested?
Tested with local command and Mage UI
![2](https://github.com/mage-ai/mage-ai/assets/5386254/3f1b154b-59fa-49fa-a894-6abc4650ea04)



# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
@dy46 
