### PR TITLE
[xy] Save statistics.json in correct execution partition folder.

### DIFF
--- a/mage_ai/api/resources/PipelineResource.py
+++ b/mage_ai/api/resources/PipelineResource.py
@@ -215,6 +215,17 @@ class PipelineResource(BaseResource):
                     print(err_message)
                     return None
 
+        def get_pipeline_with_config(uuid, config: Dict) -> Pipeline:
+            try:
+                return Pipeline(uuid, config=config)
+            except Exception as err:
+                err_message = f'Error loading pipeline sync {uuid}: {err}.'
+                if err.__class__.__name__ == 'OSError' and 'Too many open files' in err.strerror:
+                    raise Exception(err_message)
+                else:
+                    print(err_message)
+                    return None
+
         pipeline_uuids_miss = []
         pipelines = []
 
@@ -228,7 +239,9 @@ class PipelineResource(BaseResource):
             for uuid in pipeline_uuids:
                 pipeline_dict = cache.get_model(dict(uuid=uuid))
                 if pipeline_dict and pipeline_dict.get('pipeline'):
-                    pipelines.append(Pipeline(uuid, config=pipeline_dict['pipeline']))
+                    pipeline = get_pipeline_with_config(uuid, pipeline_dict['pipeline'])
+                    if pipeline:
+                        pipelines.append(pipeline)
                 else:
                     pipeline_uuids_miss.append(uuid)
 

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -1245,9 +1245,16 @@ class Block(DataIntegrationMixin, SparkBlock, ProjectPlatformAccessible):
 
             if BlockType.CHART != self.type:
                 if analyze_outputs:
-                    self.analyze_outputs(variable_mapping)
+                    self.analyze_outputs(
+                        variable_mapping,
+                        execution_partition=execution_partition,
+                    )
                 else:
-                    self.analyze_outputs(variable_mapping, shape_only=True)
+                    self.analyze_outputs(
+                        variable_mapping,
+                        execution_partition=execution_partition,
+                        shape_only=True,
+                    )
         except Exception as err:
             if update_status:
                 self.status = BlockStatus.FAILED
@@ -2597,7 +2604,12 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
                 logging_tags=logging_tags,
             )
 
-    def analyze_outputs(self, variable_mapping, shape_only: bool = False) -> None:
+    def analyze_outputs(
+        self,
+        variable_mapping,
+        execution_partition: str = None,
+        shape_only: bool = False,
+    ) -> None:
         if self.pipeline is None:
             return
         for uuid, data in variable_mapping.items():
@@ -2613,6 +2625,7 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
                                 original_column_count=data.shape[1],
                             ),
                         ),
+                        partition=execution_partition,
                         variable_type=VariableType.DATAFRAME_ANALYSIS,
                     )
                     continue
@@ -2640,6 +2653,7 @@ df = get_variable('{self.pipeline.uuid}', '{block_uuid}', 'df')
                             insights=analysis['insights'],
                             suggestions=analysis['suggestions'],
                         ),
+                        partition=execution_partition,
                         variable_type=VariableType.DATAFRAME_ANALYSIS,
                     )
                 except Exception:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This PR fixes two issues
* Catch pipeline initialization errors when loading pipeline list page
<img width="730" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/a29a1b6e-39a9-47b2-adb5-fe0940cf4083">

* Save block statistics.json in correct execution partition folder so that the file doesn't have conflicts when running multiple triggers.
<img width="452" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/9662f06f-9c37-4105-9813-96a71fe5cf8c">


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested loading pipeline list page with invalid pipeline metadata.yaml
- [x] Verified the statistics.json is now saved in the pipeline run partition folder with the fix


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
