### PR TITLE
Documentation/document create pipeline schedule api

### DIFF
--- a/docs/api-reference/pipeline-schedules/create-pipeline-schedule.mdx
+++ b/docs/api-reference/pipeline-schedules/create-pipeline-schedule.mdx
@@ -1,0 +1,93 @@
+---
+title: "Create pipeline schedule"
+api: "POST /api/pipelines/:pipeline_uuid/pipeline_schedules"
+---
+
+`POST /api/pipelines/:pipeline_uuid/pipeline_schedules`
+
+<ParamField path="pipeline_uuid" type="string" required>
+  Pipeline UUID that the pipeline schedule should all belong to.
+</ParamField>
+
+<ParamField body="pipeline_schedule" type="object" required>
+  <Expandable title="payload" defaultOpen="true">
+    <ParamField body="name" type="string" required>
+    </ParamField>
+    <ParamField body="description" type="string">
+    </ParamField>
+    <ParamField body="schedule_interval" type="string">
+    </ParamField>
+    <ParamField body="schedule_type" type="string">
+    </ParamField>
+    <ParamField body="settings" type="object">
+    </ParamField>
+    <ParamField body="sla" type="integer">
+    </ParamField>
+    <ParamField body="start_time" type="datetime">
+    </ParamField>
+    <ParamField body="status" type="string">
+    </ParamField>
+    <ParamField body="variables" type="object">
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<RequestExample>
+
+```bash Request
+  curl --request POST 
+  -H 'Content-Type: application/json' 
+  -H 'Cookie: oauth_token=some_really_long_string'
+  -H 'X-API-KEY: zkWlN0PkIKSN0C11CfUHUj84OT5XOJ6tDZ6bDRO2'
+  -d '{
+    "pipeline_schedule": {
+      "name": "Example Pipeline Schedule Name",
+      "schedule_type": "time",
+      "event_matchers": [],
+      "schedule_interval": "@once",
+      "start_time": "2023-03-06 04:53:00",
+      "variables": {
+        "env": "dev112222",
+        "test": 11111
+      },
+      "sla": 1000,
+      "settings": {
+        "skip_if_previous_running": true,
+        "allow_blocks_to_fail": true
+      }
+    }
+  }'
+  --url http://localhost:6789/api/pipelines/example_pipeline/pipeline_schedules
+```
+
+</RequestExample>
+<ResponseExample>
+
+```json Response
+{
+  "pipeline_schedule": {
+    "id": 55,
+    "created_at": "2023-03-08 04:52:54.268096+00:00",
+    "updated_at": "2023-04-01 00:52:11.753497+00:00",
+    "name": "Example Pipeline Schedule Name",
+    "pipeline_uuid": "example_pipeline",
+    "schedule_type": "time",
+    "start_time": "2023-03-06 04:53:00+00:00",
+    "schedule_interval": "@once",
+    "status": "inactive",
+    "variables": {
+      "env": "dev112222",
+      "test": 11111
+    },
+    "sla": 1000,
+    "token": "67d62ed3e66143839f58945bb7d16387",
+    "settings": {
+      "skip_if_previous_running": true,
+      "allow_blocks_to_fail": true
+    },
+    "event_matchers": []
+  }
+}
+```
+
+</ResponseExample>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -614,7 +614,8 @@
           "icon": "pipe-circle-check",
           "pages": [
             "api-reference/pipeline-schedules/overview",
-            "api-reference/pipeline-schedules/read-pipeline-schedules"
+            "api-reference/pipeline-schedules/read-pipeline-schedules",
+            "api-reference/pipeline-schedules/create-pipeline-schedule"
           ]
         },
         {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

1) Problem: There is currently no documentation for creating pipeline schedules via API
2) PR: Add `[POST] Create pipeline schedule` documentation page on mage
3) Notes:
- Ensured that documentation page format follows the other doc pages as much as possible
- Unsure if the body fields are exhaustive or accurate

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Locally ran `mintlify dev` and checked that new page is created as expected
- [x]  Ensured that the other pages under the API tab are not affected

https://github.com/mage-ai/mage-ai/assets/37792010/3ae2ee4d-78cd-4eab-8778-f4e2c96c7758


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->

@wangxiaoyou1993 I am unable to add reviewers, assignees or labels in PRs