### PR TITLE
[td] Fix the way we store pipelines by type in the cache

### DIFF
--- a/mage_ai/cache/pipeline.py
+++ b/mage_ai/cache/pipeline.py
@@ -36,7 +36,7 @@ class PipelineCache(BaseCache):
         groups = group_models_by_keys(
             [model_dict.get('pipeline') for model_dict in value.values()],
             ['type'],
-            'uuid',
+            self.build_key
         )
 
         super().set(key, dict(

--- a/mage_ai/cache/tag.py
+++ b/mage_ai/cache/tag.py
@@ -92,17 +92,35 @@ class TagCache(BaseCache):
         pipelines_dict = mapping[key].get(KEY_FOR_PIPELINES, {})
 
         for pipeline in pipelines:
-            pipeline_uuid = pipeline.get('uuid') if type(pipeline) is dict else pipeline.uuid
-            pipelines_dict[pipeline_uuid] = build_pipeline_dict(
-                pipeline,
-                added_at=added_at,
-            )
+
+            if isinstance(pipeline, dict):
+                pipeline_uuid = pipeline.get('uuid')
+                repo_path = pipeline.get('repo_path')
+            else:
+                pipeline_uuid = pipeline.uuid
+                repo_path = pipeline.repo_path
+
+            if repo_path:
+                if pipeline_uuid not in pipelines_dict:
+                    pipelines_dict[pipeline_uuid] = {}
+                if repo_path not in pipelines_dict.get(pipeline_uuid):
+                    pipelines_dict[pipeline_uuid][repo_path] = {}
+                pipelines_dict[pipeline_uuid][repo_path] = build_pipeline_dict(
+                    pipeline,
+                    added_at=added_at,
+                    repo_path=repo_path,
+                )
+            else:
+                pipelines_dict[pipeline_uuid] = build_pipeline_dict(
+                    pipeline,
+                    added_at=added_at,
+                )
 
         mapping[key][KEY_FOR_PIPELINES] = pipelines_dict
 
         self.set(self.cache_key, mapping)
 
-    def remove_pipeline(self, tag_uuid: str, pipeline_uuid: str) -> None:
+    def remove_pipeline(self, tag_uuid: str, pipeline_uuid: str, repo_path: str = None) -> None:
         key = self.build_key(tag_uuid)
         if not key:
             return
@@ -115,7 +133,15 @@ class TagCache(BaseCache):
             mapping[key] = {}
 
         pipelines_dict = mapping[key].get(KEY_FOR_PIPELINES, {})
-        pipelines_dict.pop(pipeline_uuid, None)
+
+        if repo_path:
+            if pipeline_uuid in pipelines_dict and repo_path in pipelines_dict.get(pipeline_uuid):
+                pipelines_dict[pipeline_uuid].pop(repo_path, None)
+                if not pipelines_dict.get(pipeline_uuid):
+                    pipelines_dict.pop(pipeline_uuid, None)
+        else:
+            pipelines_dict.pop(pipeline_uuid, None)
+
         mapping[key][KEY_FOR_PIPELINES] = pipelines_dict
 
         self.set(self.cache_key, mapping)
@@ -123,16 +149,25 @@ class TagCache(BaseCache):
     async def initialize_cache_for_all_objects(self) -> None:
         from mage_ai.data_preparation.models.pipeline import Pipeline
 
-        pipeline_uuids = Pipeline.get_all_pipelines(self.repo_path)
+        pipeline_uuids_and_repo_path = Pipeline.get_all_pipelines_all_projects(
+            self.repo_path,
+            include_repo_path=True,
+        )
 
         pipeline_dicts = await asyncio.gather(
-            *[Pipeline.load_metadata(uuid, raise_exception=False) for uuid in pipeline_uuids],
+            *[Pipeline.load_metadata(
+                uuid,
+                raise_exception=False,
+                repo_path=repo_path,
+            ) for uuid, repo_path in pipeline_uuids_and_repo_path],
         )
         pipeline_dicts = [p for p in pipeline_dicts if p is not None]
 
         mapping = {}
 
         for pipeline_dict in pipeline_dicts:
+            repo_path = pipeline_dict.get('repo_path')
+
             for tag_uuid in pipeline_dict.get('tags', []):
                 key = self.build_key(tag_uuid)
                 if not key:
@@ -144,8 +179,14 @@ class TagCache(BaseCache):
                 if KEY_FOR_PIPELINES not in mapping[key]:
                     mapping[key][KEY_FOR_PIPELINES] = {}
 
-                mapping[key][KEY_FOR_PIPELINES][pipeline_dict.get('uuid')] = build_pipeline_dict(
+                key_pipeline = pipeline_dict.get('uuid')
+
+                if key_pipeline not in mapping[key][KEY_FOR_PIPELINES]:
+                    mapping[key][KEY_FOR_PIPELINES][key_pipeline] = {}
+
+                mapping[key][KEY_FOR_PIPELINES][key_pipeline][repo_path] = build_pipeline_dict(
                     pipeline_dict,
+                    repo_path=repo_path,
                 )
 
         self.set(self.cache_key, mapping)

--- a/mage_ai/cache/utils.py
+++ b/mage_ai/cache/utils.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, List, Union
+from typing import Callable, Dict, List, Union
 
 from mage_ai.shared.hash import extract, merge_dict
 
@@ -104,7 +104,11 @@ def build_pipeline_dict(
     )
 
 
-def group_models_by_keys(model_dicts: List[Dict], keys: List[str], uuid_key: str) -> Dict:
+def group_models_by_keys(
+    model_dicts: List[Dict],
+    keys: List[str],
+    get_uuid_key: Callable,
+) -> Dict:
     mapping = {key: {} for key in keys}
 
     for model_dict in model_dicts:
@@ -115,6 +119,6 @@ def group_models_by_keys(model_dicts: List[Dict], keys: List[str], uuid_key: str
             value = str(model_dict.get(key))
             if value not in mapping[key]:
                 mapping[key][value] = []
-            mapping[key][value].append(model_dict.get(uuid_key))
+            mapping[key][value].append(get_uuid_key(model_dict))
 
     return mapping

--- a/mage_ai/frontend/components/Dashboard/index.tsx
+++ b/mage_ai/frontend/components/Dashboard/index.tsx
@@ -91,6 +91,8 @@ function Dashboard({
   } = useWindowSize();
   const localStorageKeyAfter = `dashboard_after_width_${uuid}`;
   const localStorageKeyBefore = `dashboard_before_width_${uuid}`;
+  const afterWidthLocal = get(localStorageKeyAfter);
+  const beforeWidthLocal = get(localStorageKeyBefore);
 
   const mainContainerRef = useRef(null);
   const [afterMousedownActive, setAfterMousedownActive] = useState(false);
@@ -112,15 +114,14 @@ function Dashboard({
       setAfterWidthState(prev);
     }
 
-    set(localStorageKeyAfter, value);
+    set(localStorageKeyAfter, Math.max(value, 20  * UNIT));
 
     return value;
   }, [localStorageKeyAfter, setAfterWidthProp, setAfterWidthState]);
 
   useEffect(() => {
-    const value = get(localStorageKeyAfter);
-    if (after && value) {
-      setAfterWidth(Math.max(value, 40  * UNIT));
+    if (after) {
+      setAfterWidth(Math.max(afterWidthLocal, 20  * UNIT));
     }
   }, []);
 
@@ -141,16 +142,14 @@ function Dashboard({
       setBeforeWidthState(prev);
     }
 
-    // value = Math.max(value, UNIT * 13);
-    set(localStorageKeyBefore, value);
+    set(localStorageKeyBefore, Math.max(value, 20  * UNIT));
 
     return value;
   }, [localStorageKeyBefore, setBeforeWidthProp, setBeforeWidthState]);
 
   useEffect(() => {
-    const value = get(localStorageKeyBefore);
-    if (before && value) {
-      setBeforeWidth(Math.max(value, 40  * UNIT));
+    if (before) {
+      setBeforeWidth(Math.max(beforeWidthLocal, 20  * UNIT));
     }
   }, []);
 


### PR DESCRIPTION
# Description
Filtering by type was throwing an error because of how we stored pipelines in the cache. We now add the repo path to the key.

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
