### PR TITLE
[dy] Pass in query_vars as a dict

### DIFF
--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -364,3 +364,16 @@ COPY {full_table_name} ({insert_columns}) FROM STDIN (
     , FORCE_NULL({insert_columns})
 );
         """, buffer)
+
+    def execute(self, query_string: str, **query_vars) -> None:
+        """
+        Sends query to the connected database.
+
+        Args:
+            query_string (str): SQL query string to apply on the connected database.
+            query_vars: Variable values to fill in when using format strings in query.
+        """
+        with self.printer.print_msg(f'Executing query \'{query_string}\''):
+            query_string = self._clean_query(query_string)
+            with self.conn.cursor() as cur:
+                cur.execute(query_string, query_vars)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Resolves https://github.com/mage-ai/mage-ai/issues/3929. Like the issue suggests, psycopg2 does not accept keyword arguments in the `.execute` method, so this PR changes the postgres io class to pass in the query variables as a dictionary when they exist.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with psycopg2 and mage io postgres loader


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
