### PR TITLE
[dy] Support serialize Polars dataframe

### DIFF
--- a/mage_ai/data_preparation/models/utils.py
+++ b/mage_ai/data_preparation/models/utils.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 import dask.dataframe as dd
 import numpy
 import pandas as pd
+import polars as pl
 import simplejson
 import yaml
 
@@ -23,6 +24,11 @@ CAST_TYPE_COLUMN_TYPES = set([
     'int64',
     'float64',
 ])
+
+POLARS_CAST_TYPE_COLUMN_TYPES = {
+    'Float64': pl.Float64,
+    'Int64': pl.Int64,
+}
 
 
 def serialize_columns(row: pd.Series, column_types: Dict) -> pd.Series:
@@ -49,6 +55,16 @@ def cast_column_types(df: pd.DataFrame, column_types: Dict):
         if column_type in CAST_TYPE_COLUMN_TYPES:
             try:
                 df[column] = df[column].astype(column_type)
+            except Exception:
+                traceback.print_exc()
+    return df
+
+
+def cast_column_types_polars(df: pl.DataFrame, column_types: Dict):
+    for column, column_type in column_types.items():
+        if column_type in POLARS_CAST_TYPE_COLUMN_TYPES:
+            try:
+                df = df.cast({column: POLARS_CAST_TYPE_COLUMN_TYPES.get(column_type)})
             except Exception:
                 traceback.print_exc()
     return df
@@ -82,6 +98,10 @@ def apply_transform(ddf: dd, apply_function) -> dd:
 
 
 def apply_transform_pandas(df: pd.DataFrame, apply_function) -> pd.DataFrame:
+    return df.apply(apply_function, axis=1)
+
+
+def apply_transform_polars(df: pl.DataFrame, apply_function) -> pl.DataFrame:
     return df.apply(apply_function, axis=1)
 
 

--- a/mage_ai/data_preparation/models/variable.py
+++ b/mage_ai/data_preparation/models/variable.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List
 import numpy as np
 import pandas as pd
 import polars as pl
+import yaml
 from pandas.api.types import is_object_dtype
 from pandas.core.indexes.range import RangeIndex
 
@@ -21,6 +22,7 @@ from mage_ai.data_preparation.models.utils import (  # dask_from_pandas,
     STRING_SERIALIZABLE_COLUMN_TYPES,
     apply_transform_pandas,
     cast_column_types,
+    cast_column_types_polars,
     deserialize_columns,
     serialize_columns,
     should_deserialize_pandas,
@@ -35,6 +37,8 @@ DATAFRAME_COLUMN_TYPES_FILE = 'data_column_types.json'
 DATAFRAME_PARQUET_FILE = 'data.parquet'
 DATAFRAME_PARQUET_SAMPLE_FILE = 'sample_data.parquet'
 DATAFRAME_CSV_FILE = 'data.csv'
+
+METADATA_FILE = 'metadata.yaml'
 
 JSON_FILE = 'data.json'
 JSON_SAMPLE_FILE = 'sample_data.json'
@@ -87,26 +91,43 @@ class Variable:
     def variable_path(self):
         return os.path.join(self.variable_dir_path, self.uuid or '')
 
+    @property
+    def metadata_path(self):
+        return os.path.join(self.variable_path, METADATA_FILE)
+
     @classmethod
     def dir_path(self, pipeline_path, block_uuid):
         return os.path.join(pipeline_path, VARIABLE_DIR, clean_name(block_uuid))
 
     def check_variable_type(self, spark=None):
         """
-        Infer variable type based on data in the storage.
+        If the variable has a metadata file, read the variable type from the metadata file.
+        Fallback to inferring variable type based on data in the storage.
         """
+        try:
+            if os.path.exists(self.metadata_path):
+                with open(self.metadata_path, 'r') as f:
+                    metadata = yaml.safe_load(f)
+                    self.variable_type = metadata.get('type')
+        except Exception:
+            traceback.print_exc()
+
         if self.variable_type is None and self.storage.path_exists(
             os.path.join(self.variable_path, DATAFRAME_PARQUET_FILE)
         ):
             # If parquet file exists for given variable, set the variable type to DATAFRAME
             self.variable_type = VariableType.DATAFRAME
-        elif ((self.variable_type == VariableType.DATAFRAME or self.variable_type is None)
-                and os.path.exists(
-                os.path.join(self.variable_dir_path, f'{self.uuid}', 'data.sh'))):
+        elif (
+            self.variable_type == VariableType.DATAFRAME or self.variable_type is None
+        ) and os.path.exists(
+            os.path.join(self.variable_path, f'{self.uuid}', 'data.sh')
+        ):
             self.variable_type = VariableType.GEO_DATAFRAME
-        elif self.variable_type is None and \
-                len(self.storage.listdir(self.variable_path, suffix='.parquet')) > 0 and \
-                spark is not None:
+        elif (
+            self.variable_type is None
+            and len(self.storage.listdir(self.variable_path, suffix='.parquet')) > 0
+            and spark is not None
+        ):
             self.variable_type = VariableType.SPARK_DATAFRAME
 
     def convert_parquet_to_csv(self):
@@ -160,6 +181,12 @@ class Variable:
         """
         if self.variable_type == VariableType.DATAFRAME:
             return self.__read_parquet(
+                raise_exception=raise_exception,
+                sample=sample,
+                sample_count=sample_count,
+            )
+        elif self.variable_type == VariableType.POLARS_DATAFRAME:
+            return self.__read_polars_parquet(
                 raise_exception=raise_exception,
                 sample=sample,
                 sample_count=sample_count,
@@ -244,6 +271,8 @@ class Variable:
         else:
             self.__write_json(data)
 
+        self.write_metadata()
+
     async def write_data_async(self, data: Any) -> None:
         """
         Write variable data to the persistent storage.
@@ -273,6 +302,20 @@ class Variable:
         else:
             await self.__write_json_async(data)
 
+        self.write_metadata()
+
+    def write_metadata(self) -> None:
+        """
+        Write metadata to the persistent storage.
+        """
+        metadata = dict(
+            type=self.variable_type.value
+            if isinstance(self.variable_type, VariableType)
+            else self.variable_type,
+        )
+        with self.open_to_write(self.metadata_path) as f:
+            yaml.safe_dump(metadata, f)
+
     def __delete_dataframe_analysis(self) -> None:
         for k in DATAFRAME_ANALYSIS_KEYS:
             file_path = os.path.join(self.variable_path, f'{k}.json')
@@ -300,7 +343,7 @@ class Variable:
         self,
         default_value: Dict = None,
         raise_exception: bool = False,
-        sample: bool = False
+        sample: bool = False,
     ) -> Dict:
         if default_value is None:
             default_value = {}
@@ -410,7 +453,7 @@ class Variable:
         read_sample_success = False
         if sample:
             try:
-                df = self.storage.read_parquet(sample_file_path, engine='pyarrow')
+                df = self.storage.read_parquet(sample_file_path)
                 read_sample_success = True
             except Exception as ex:
                 if raise_exception:
@@ -419,7 +462,7 @@ class Variable:
                     traceback.print_exc()
         if not read_sample_success:
             try:
-                df = self.storage.read_parquet(file_path, engine='pyarrow')
+                df = self.storage.read_parquet(file_path)
             except Exception as ex:
                 if raise_exception:
                     raise Exception(f'Failed to read parquet file: {file_path}') from ex
@@ -441,6 +484,51 @@ class Variable:
                     lambda row: deserialize_columns(row, column_types),
                 )
             df = cast_column_types(df, column_types)
+        return df
+
+    def __read_polars_parquet(
+        self,
+        sample: bool = False,
+        sample_count: int = None,
+        raise_exception: bool = False,
+    ) -> pl.DataFrame:
+        file_path = os.path.join(self.variable_path, DATAFRAME_PARQUET_FILE)
+        sample_file_path = os.path.join(
+            self.variable_path, DATAFRAME_PARQUET_SAMPLE_FILE
+        )
+
+        read_sample_success = False
+        if sample:
+            try:
+                df = self.storage.read_polars_parquet(sample_file_path)
+                read_sample_success = True
+            except Exception as ex:
+                if raise_exception:
+                    raise Exception(
+                        f'Failed to read parquet file: {sample_file_path}'
+                    ) from ex
+                else:
+                    traceback.print_exc()
+        if not read_sample_success:
+            try:
+                df = self.storage.read_polars_parquet(file_path)
+            except Exception as ex:
+                if raise_exception:
+                    raise Exception(f'Failed to read parquet file: {file_path}') from ex
+                else:
+                    traceback.print_exc()
+                df = pl.DataFrame()
+        if sample:
+            sample_count = sample_count or DATAFRAME_SAMPLE_COUNT
+            if df.shape[0] > sample_count:
+                df = df.head(sample_count)
+
+        column_types_filename = os.path.join(self.variable_path, DATAFRAME_COLUMN_TYPES_FILE)
+        if self.storage.path_exists(column_types_filename):
+            column_types = self.storage.read_json_file(column_types_filename)
+            # No Mage specific code to serialize columns for polars when writing a variable,
+            # so no need to deserialize columns here
+            df = cast_column_types_polars(df, column_types)
         return df
 
     def __read_spark_parquet(self, sample: bool = False, sample_count: int = None, spark=None):
@@ -514,7 +602,7 @@ class Variable:
                     pl_df = pl.from_pandas(df_output)
                     self.__write_polars_dataframe(pl_df)
                     # Test read dataframe from parquet
-                    self. __read_parquet(sample=True, raise_exception=True)
+                    self.__read_parquet(sample=True, raise_exception=True)
 
                     return
                 except Exception:
@@ -536,7 +624,7 @@ class Variable:
         try:
             df_sample_output = df_output_serialized.iloc[
                 :DATAFRAME_SAMPLE_COUNT,
-                :DATAFRAME_SAMPLE_MAX_COLUMNS
+                :DATAFRAME_SAMPLE_MAX_COLUMNS,
             ]
 
             self.storage.write_parquet(
@@ -616,7 +704,8 @@ class Variable:
             if dataframe_analysis_keys is not None and k not in dataframe_analysis_keys:
                 continue
             result[k] = await self.storage.read_json_file_async(
-                os.path.join(self.variable_path, f'{k}.json'))
+                os.path.join(self.variable_path, f'{k}.json')
+            )
         return result
 
     def __write_dataframe_analysis(self, data: Dict[str, Dict]) -> None:

--- a/mage_ai/data_preparation/storage/base_storage.py
+++ b/mage_ai/data_preparation/storage/base_storage.py
@@ -2,6 +2,9 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import Dict, List
 
+import pandas as pd
+import polars as pl
+
 
 class BaseStorage(ABC):
     @abstractmethod
@@ -43,6 +46,20 @@ class BaseStorage(ABC):
     def remove_dir(self, path: str) -> None:
         """
         Remove a directory with directory path.
+        """
+        pass
+
+    @abstractmethod
+    def read_parquet(self, file_path: str, **kwargs) -> pd.DataFrame:
+        """
+        Read parquet from a file with file path and return a pandas DataFrame.
+        """
+        pass
+
+    @abstractmethod
+    def read_polars_parquet(self, file_path: str, **kwargs) -> pl.DataFrame:
+        """
+        Read parquet from a file with file path and return a polars DataFrame.
         """
         pass
 

--- a/mage_ai/data_preparation/storage/gcs_storage.py
+++ b/mage_ai/data_preparation/storage/gcs_storage.py
@@ -107,6 +107,10 @@ class GCSStorage(BaseStorage):
         buffer = io.BytesIO(self.bucket.blob(gcs_url_path(file_path)).download_as_bytes())
         return pd.read_parquet(buffer, **kwargs)
 
+    def read_polars_parquet(self, file_path: str, **kwargs) -> pl.DataFrame:
+        buffer = io.BytesIO(self.bucket.blob(gcs_url_path(file_path)).download_as_bytes())
+        return pl.read_parquet(buffer, **kwargs)
+
     def write_parquet(self, df: pd.DataFrame, file_path: str) -> None:
         buffer = io.BytesIO()
         df.to_parquet(buffer)

--- a/mage_ai/data_preparation/storage/local_storage.py
+++ b/mage_ai/data_preparation/storage/local_storage.py
@@ -93,10 +93,10 @@ class LocalStorage(BaseStorage):
             )
             await file.write(fcontent)
 
-    def read_parquet(self, file_path: str) -> pd.DataFrame:
+    def read_parquet(self, file_path: str, **kwargs) -> pd.DataFrame:
         return pd.read_parquet(file_path, engine='pyarrow')
 
-    def read_polars_parquet(self, file_path: str) -> pl.DataFrame:
+    def read_polars_parquet(self, file_path: str, **kwargs) -> pl.DataFrame:
         return pl.read_parquet(file_path, use_pyarrow=True)
 
     def write_csv(self, df: pd.DataFrame, file_path: str) -> None:

--- a/mage_ai/data_preparation/storage/local_storage.py
+++ b/mage_ai/data_preparation/storage/local_storage.py
@@ -93,8 +93,11 @@ class LocalStorage(BaseStorage):
             )
             await file.write(fcontent)
 
-    def read_parquet(self, file_path: str, **kwargs) -> pd.DataFrame:
+    def read_parquet(self, file_path: str) -> pd.DataFrame:
         return pd.read_parquet(file_path, engine='pyarrow')
+
+    def read_polars_parquet(self, file_path: str) -> pl.DataFrame:
+        return pl.read_parquet(file_path, use_pyarrow=True)
 
     def write_csv(self, df: pd.DataFrame, file_path: str) -> None:
         File.create_parent_directories(file_path)

--- a/mage_ai/data_preparation/storage/s3_storage.py
+++ b/mage_ai/data_preparation/storage/s3_storage.py
@@ -97,6 +97,10 @@ class S3Storage(BaseStorage):
         buffer = io.BytesIO(self.client.get_object(s3_url_path(file_path)).read())
         return pd.read_parquet(buffer, **kwargs)
 
+    def read_polars_parquet(self, file_path: str, **kwargs) -> pl.DataFrame:
+        buffer = io.BytesIO(self.client.get_object(s3_url_path(file_path)).read())
+        return pl.read_parquet(buffer, **kwargs)
+
     def write_parquet(self, df: pd.DataFrame, file_path: str) -> None:
         buffer = io.BytesIO()
         df.to_parquet(buffer)

--- a/mage_ai/data_preparation/variable_manager.py
+++ b/mage_ai/data_preparation/variable_manager.py
@@ -71,6 +71,7 @@ class VariableManager:
             variable_type=variable_type,
             clean_block_uuid=clean_block_uuid,
         )
+
         # Delete data if it exists
         variable.delete()
         variable.variable_type = variable_type

--- a/mage_ai/tests/data_preparation/models/test_block.py
+++ b/mage_ai/tests/data_preparation/models/test_block.py
@@ -77,16 +77,14 @@ def remove_duplicate_rows(df):
             'output_0',
             variable_type='dataframe'
         )
-        analysis = variable_manager.get_variable(
-            pipeline.uuid,
-            block2.uuid,
-            'output_0',
-            variable_type='dataframe_analysis',
-        )
+        # analysis = variable_manager.get_variable(
+        #     pipeline.uuid,
+        #     block2.uuid,
+        #     'output_0',
+        #     variable_type='dataframe_analysis',
+        # )
         df_final = pd.DataFrame({'col1': [1, 1, 3], 'col2': [2, 2, 4]}).drop_duplicates()
         assert_frame_equal(data, df_final)
-
-        analysis
         # TODO (Xiaoyou Wang): uncomment this one serialization of block output is fixed.
         # self.assertEqual(
         #     analysis['metadata']['column_types'],

--- a/mage_ai/tests/data_preparation/models/test_variable.py
+++ b/mage_ai/tests/data_preparation/models/test_variable.py
@@ -1,11 +1,15 @@
+import os
+
+import numpy as np
+import pandas as pd
+import polars as pl
+from pandas.testing import assert_frame_equal
+from polars.testing import assert_frame_equal as assert_polars_frame_equal
+
 from mage_ai.data_preparation.models.block import Block
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.data_preparation.models.variable import Variable, VariableType
 from mage_ai.tests.base_test import DBTestCase
-from pandas.testing import assert_frame_equal
-import numpy as np
-import os
-import pandas as pd
 
 
 class VariableTest(DBTestCase):
@@ -120,6 +124,49 @@ class VariableTest(DBTestCase):
         self.assertEqual(variable.read_data(sample=True), dict(
             results=[100] * 20,
         ))
+
+    def test_write_and_read_polars_dataframe(self):
+        pipeline = self.__create_pipeline('test pipeline polars')
+        variable1 = Variable(
+            'polars1',
+            pipeline.dir_path,
+            'block1',
+        )
+        variable2 = Variable('polars2', pipeline.dir_path, 'block2')
+        df1 = pl.DataFrame(
+            [
+                [1, 'test'],
+                [2, 'test2'],
+            ],
+            schema=['col1', 'col2']
+        )
+        df2 = pl.DataFrame(
+            [
+                [1, 'test', 3.123, 41414123123124],
+                [2, 'test2', 4.321, 12111111],
+            ],
+            schema=['col1', 'col2', 'col3', 'col4']
+        )
+        df2 = df2.cast({'col4': pl.Int64})
+        variable1.write_data(df1)
+        variable2.write_data(df2)
+        variable_dir_path = os.path.join(pipeline.dir_path, '.variables')
+        self.assertTrue(os.path.exists(
+            os.path.join(variable_dir_path, 'block1', 'polars1', 'data.parquet'),
+        ))
+        self.assertTrue(os.path.exists(
+            os.path.join(variable_dir_path, 'block1', 'polars1', 'sample_data.parquet'),
+        ))
+        self.assertTrue(os.path.exists(
+            os.path.join(variable_dir_path, 'block2', 'polars2', 'data.parquet'),
+        ))
+        self.assertTrue(os.path.exists(
+            os.path.join(variable_dir_path, 'block2', 'polars2', 'sample_data.parquet'),
+        ))
+        assert_polars_frame_equal(variable1.read_data(), df1)
+        assert_polars_frame_equal(variable1.read_data(sample=True, sample_count=1), df1.head(1))
+        assert_polars_frame_equal(variable2.read_data(), df2)
+        assert_polars_frame_equal(variable2.read_data(sample=True, sample_count=1), df2.head(1))
 
     def __create_pipeline(self, name):
         pipeline = Pipeline.create(

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ ldap3==2.9.1
 newrelic==8.8.0
 numpy>=1.21.0
 pandas>=1.3.0
-polars<=0.19.2
+polars>=0.18.0, <0.19.2
 protobuf~=4.21.12
 pyarrow-hotfix==0.5
 pyarrow==10.0.1


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Resolves https://github.com/mage-ai/mage-ai/issues/4102.

In order to serialize a polars dataframe, we have to write some metadata about the output variable so that we can determine whether or not to use polars or pandas when serializing. This PR adds a `type.json` file to the variable directory that currently just stores the type of the variable which will be used when reading the output data. If there is no file, we will fallback to the previous logic.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with the example in the issue
![Screenshot 2024-01-03 at 5 33 36 PM](https://github.com/mage-ai/mage-ai/assets/14357209/ce7a2865-4194-4df4-b25d-9944db89847d)
![Screenshot 2024-01-03 at 5 33 32 PM](https://github.com/mage-ai/mage-ai/assets/14357209/6482bdb2-2799-4423-bf0c-627e3f8d6e4e)
- [x] Tested with S3 remote variable directory
- [x] Unit test


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
