### PR TITLE
[jk] Use utc date for trigger start date

### DIFF
--- a/mage_ai/frontend/components/Triggers/utils.ts
+++ b/mage_ai/frontend/components/Triggers/utils.ts
@@ -188,7 +188,10 @@ export function getDatetimeFromDateAndTime(
 ): string {
   let datetimeString;
 
-  const momentObj = moment(date);
+  let momentObj = moment.utc(date);
+  if (opts?.localTimezone) {
+    momentObj = moment(date);
+  }
   momentObj.set('hour', +time?.hour || 0);
   momentObj.set('minute', +time?.minute || 0);
   momentObj.set('second', 0);


### PR DESCRIPTION
# Description
- When UTC dates were being used in the app ("Display local timezone" setting NOT enabled), the "Start date and time" for a new trigger should default to the current datetime in UTC time, but the start date (YYYY-MM-DD) was defaulting to the current local date, so it could appear to be 1 day off depending on the timezone difference. This PR fixes that.

# How Has This Been Tested?
Before (Current datetime was `2024-01-03 18:42 PST` / `2024-01-04 02:42 UTC`, but UTC start time was defaulting to `2024-01-03` instead of `2024-01-04`):
![Before - Trigger start date](https://github.com/mage-ai/mage-ai/assets/78053898/ef550142-4b49-4cdd-99a6-cafae72916ac)

After (Current datetime was `2024-01-03 18:40 PST` / `2024-01-04 02:40 UTC`, and UTC start time correctly defaults to `2024-01-04`):
![After - Trigger start date](https://github.com/mage-ai/mage-ai/assets/78053898/1e155856-1c09-484f-a3b9-1986a1531c1f)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
