### PR TITLE
[dy] Only set the schema in the DB when the server is started

### DIFF
--- a/mage_ai/orchestration/db/__init__.py
+++ b/mage_ai/orchestration/db/__init__.py
@@ -106,9 +106,7 @@ def get_postgresql_schema(url):
     except ValueError:
         return None
     if parse_result.scheme == 'postgresql+psycopg2':
-        q = parse_qs(
-            parse_result.query.replace('%%', '%')
-        )
+        q = parse_qs(parse_result.query.replace('%%', '%'))
         options = q.get('options')
         if options and len(options) >= 1:
             params = options[0].replace('-c ', '').split(' ')
@@ -118,21 +116,29 @@ def get_postgresql_schema(url):
 
 db_connection = DBConnection()
 
-if db_connection_url.startswith('postgresql'):
-    db_schema = get_postgresql_schema(db_connection_url)
-    if db_schema:
-        db_connection.start_session()
-        db_connection.session.execute(f'CREATE SCHEMA IF NOT EXISTS {db_schema};')
-        # Get the current database name from the query fetchall() result, e.g., [('test_database',)]
-        db_current = db_connection.session.execute('SELECT current_database()').fetchall()[0][0]
-        username, _ = get_user_info_from_db_connection_url(db_connection_url)
-        if username:
-            db_connection.session.execute(
-                f'ALTER ROLE {username} IN DATABASE {db_current} SET search_path TO {db_schema}')
-            db_connection.session.commit()
-            db_connection.close_session()
-            print(f'Set the default PostgreSQL schema for role {username} ',
-                  f'in database {db_current} to {db_schema}')
+
+def set_db_schema():
+    if db_connection_url.startswith('postgresql'):
+        db_schema = get_postgresql_schema(db_connection_url)
+        if db_schema:
+            db_connection.start_session()
+            db_connection.session.execute(f'CREATE SCHEMA IF NOT EXISTS {db_schema};')
+            # Get the current database name from the query fetchall() result
+            # e.g., [('test_database',)]
+            db_current = db_connection.session.execute(
+                'SELECT current_database()'
+            ).fetchall()[0][0]
+            username, _ = get_user_info_from_db_connection_url(db_connection_url)
+            if username:
+                db_connection.session.execute(
+                    f'ALTER ROLE {username} IN DATABASE {db_current} SET search_path TO {db_schema}'
+                )
+                db_connection.session.commit()
+                db_connection.close_session()
+                print(
+                    f'Set the default PostgreSQL schema for role {username} ',
+                    f'in database {db_current} to {db_schema}',
+                )
 
 
 def safe_db_query(func):
@@ -150,6 +156,7 @@ def safe_db_query(func):
                 if retry_count >= DB_RETRY_COUNT:
                     raise e
                 retry_count += 1
+
     return func_with_rollback
 
 

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -42,7 +42,7 @@ from mage_ai.data_preparation.shared.constants import MANAGE_ENV_VAR
 from mage_ai.data_preparation.sync import GitConfig
 from mage_ai.data_preparation.sync.git_sync import GitSync
 from mage_ai.orchestration.constants import Entity
-from mage_ai.orchestration.db import db_connection
+from mage_ai.orchestration.db import db_connection, set_db_schema
 from mage_ai.orchestration.db.database_manager import database_manager
 from mage_ai.orchestration.db.models.oauth import Oauth2Application, Role, User
 from mage_ai.orchestration.utils.distributed_lock import DistributedLock
@@ -634,6 +634,7 @@ def start_server(
     if dbt_docs:
         run_docs_server()
     else:
+        set_db_schema()
         run_web_server = True
         project_type = get_project_type()
         if manage or project_type == ProjectType.MAIN:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Resolves https://github.com/mage-ai/mage-ai/issues/4217. We will only run the `ALTER ROLE ...` command when the web server is started, so that it isn't executing multiple times when multiple pipelines are started in executor pods/tasks.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
