### PR TITLE
[xy] Wrap block run initialization logic with lock.

### DIFF
--- a/mage_ai/orchestration/pipeline_scheduler_original.py
+++ b/mage_ai/orchestration/pipeline_scheduler_original.py
@@ -132,7 +132,7 @@ class PipelineScheduler:
             return True
 
         lock_key = f'pipeline_run_{self.pipeline_run.id}'
-        if not lock.try_acquire_lock(lock_key, timeout=10):
+        if not lock.try_acquire_lock(lock_key):
             return
 
         tags = self.build_tags()

--- a/mage_ai/orchestration/pipeline_scheduler_original.py
+++ b/mage_ai/orchestration/pipeline_scheduler_original.py
@@ -131,6 +131,10 @@ class PipelineScheduler:
         if self.pipeline_run.status == PipelineRun.PipelineRunStatus.RUNNING:
             return True
 
+        lock_key = f'pipeline_run_{self.pipeline_run.id}'
+        if not lock.try_acquire_lock(lock_key, timeout=10):
+            return
+
         tags = self.build_tags()
 
         is_integration = PipelineType.INTEGRATION == self.pipeline.type
@@ -167,6 +171,8 @@ class PipelineScheduler:
                 error=error_msg,
             )
             return False
+        finally:
+            lock.release_lock(lock_key)
 
         self.pipeline_run.update(
             started_at=datetime.now(tz=pytz.UTC),

--- a/mage_ai/orchestration/pipeline_scheduler_project_platform.py
+++ b/mage_ai/orchestration/pipeline_scheduler_project_platform.py
@@ -140,7 +140,7 @@ class PipelineScheduler:
             return True
 
         lock_key = f'pipeline_run_{self.pipeline_run.id}'
-        if not lock.try_acquire_lock(lock_key, timeout=10):
+        if not lock.try_acquire_lock(lock_key):
             return
 
         tags = self.build_tags()

--- a/mage_ai/orchestration/pipeline_scheduler_project_platform.py
+++ b/mage_ai/orchestration/pipeline_scheduler_project_platform.py
@@ -139,6 +139,10 @@ class PipelineScheduler:
         if self.pipeline_run.status == PipelineRun.PipelineRunStatus.RUNNING:
             return True
 
+        lock_key = f'pipeline_run_{self.pipeline_run.id}'
+        if not lock.try_acquire_lock(lock_key, timeout=10):
+            return
+
         tags = self.build_tags()
 
         is_integration = PipelineType.INTEGRATION == self.pipeline.type
@@ -175,6 +179,8 @@ class PipelineScheduler:
                 error=error_msg,
             )
             return False
+        finally:
+            lock.release_lock(lock_key)
 
         self.pipeline_run.update(
             started_at=datetime.now(tz=pytz.UTC),


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Wrap block run initialization logic with lock so that no duplicate block runs are created for data integration pipeline when there're multiple servers running

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested in local k8s cluster with multiple replicas
Run a data integration pipeline, no duplicate block runs are created anymore
Original:
<img width="920" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/c2a2ce38-17bc-404d-b3d0-857d3b3d7393">


With the fix:
<img width="908" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/47dacab1-6f41-4655-8131-e52909f53457">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
