### PR TITLE
[td] Fix incremental sync bug with missing arg

### DIFF
--- a/mage_ai/data_preparation/models/block/data_integration/mixins.py
+++ b/mage_ai/data_preparation/models/block/data_integration/mixins.py
@@ -419,6 +419,7 @@ class DataIntegrationMixin:
         upstream_block_uuids: List[str] = None,
         all_catalogs: bool = False,
         all_streams: bool = False,
+        **kwargs,
     ) -> Tuple[List, List, List]:
         block_uuids_to_fetch = upstream_block_uuids or self.upstream_block_uuids_for_inputs
 


### PR DESCRIPTION
# Description
```
TypeError                                 Traceback (most recent call last)
/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/models/block/__init__.py in execute_block(self, block_run_outputs_cache, build_block_output_stdout, custom_code, execution_partition, from_notebook, global_vars, input_args, logger, logging_tags, input_from_output, runtime_arguments, dynamic_block_index, dynamic_block_indexes, dynamic_upstream_block_uuids, run_settings, data_integration_runtime_settings, execution_partition_previous, **kwargs)
   1270             if from_notebook and self.is_data_integration():
   1271                 input_vars, kwargs_vars, upstream_block_uuids = \
-> 1272                     self.fetch_input_variables_and_catalog(
   1273                         input_args,
   1274                         execution_partition,
TypeError: DataIntegrationMixin.fetch_input_variables_and_catalog() got an unexpected keyword argument 'dynamic_block_indexes'
```