### PR TITLE
[xy] Fix interpolating mage secret in project metadata.yaml

### DIFF
--- a/mage_ai/data_preparation/models/project/__init__.py
+++ b/mage_ai/data_preparation/models/project/__init__.py
@@ -23,8 +23,7 @@ class Project():
         self.root_project = root_project
         self.repo_path = repo_path or get_repo_path(root_project=self.root_project)
 
-        parts = self.repo_path.split('/')
-        self.name = parts[-1]
+        self.name = os.path.basename(self.repo_path)
         self.settings = None
 
         if not root_project and project_platform_activated():
@@ -32,12 +31,9 @@ class Project():
             if self.settings and self.settings.get('uuid'):
                 self.name = self.settings.get('uuid')
 
-        self.repo_config = repo_config or get_repo_config(
-            repo_path=self.repo_path,
-            root_project=self.root_project,
-        )
         self.version = VERSION
         self._features = None
+        self._repo_config = repo_config
 
         self.__repo_config_root_project = None
 
@@ -46,6 +42,15 @@ class Project():
                 repo_path=get_repo_path(root_project=True),
                 root_project=True,
             )
+
+    @property
+    def repo_config(self):
+        if not self._repo_config:
+            self._repo_config = get_repo_config(
+                repo_path=self.repo_path,
+                root_project=self.root_project,
+            )
+        return self._repo_config
 
     @property
     def workspace_config_defaults(self) -> Dict:

--- a/mage_ai/settings/repo.py
+++ b/mage_ai/settings/repo.py
@@ -146,12 +146,13 @@ def get_variables_dir(
             metadata_path = get_metadata_path(root_project=root_project)
             if os.path.exists(metadata_path):
                 with open(metadata_path, 'r', encoding='utf-8') as f:
-                    config_file = Template(f.read()).render(
-                        **get_template_vars_no_db()
-                    )
-                    repo_config = yaml.full_load(config_file) or {}
+                    config_file_raw = f.read()
+                    repo_config = yaml.full_load(config_file_raw) or {}
                     if repo_config.get('variables_dir'):
                         variables_dir = repo_config.get('variables_dir')
+                        variables_dir = Template(variables_dir).render(
+                            **get_template_vars_no_db()
+                        )
         if variables_dir is None:
             variables_dir = DEFAULT_MAGE_DATA_DIR
         variables_dir = os.path.expanduser(variables_dir)

--- a/mage_ai/tests/data_preparation/models/test_project.py
+++ b/mage_ai/tests/data_preparation/models/test_project.py
@@ -32,6 +32,8 @@ class ProjectTest(ProjectPlatformMixin, AsyncDBTestCase):
                 self.assertEqual(project.version, VERSION)
                 self.assertFalse(project.root_project)
 
+                mock_get_repo_config.assert_not_called()
+                project.repo_config
                 mock_get_repo_config.assert_called_once_with(
                     repo_path=base_repo_path(),
                     root_project=False,
@@ -45,13 +47,14 @@ class ProjectTest(ProjectPlatformMixin, AsyncDBTestCase):
             'mage_ai.data_preparation.models.project.get_repo_config',
         ) as mock_get_repo_config:
             project = Project(root_project=True)
-
             self.assertEqual(project.name, 'test')
             self.assertEqual(project.repo_path, base_repo_path())
             self.assertEqual(project.settings, None)
             self.assertEqual(project.version, VERSION)
             self.assertTrue(project.root_project)
 
+            mock_get_repo_config.assert_not_called()
+            project.repo_config
             mock_get_repo_config.assert_called_once_with(
                 repo_path=base_repo_path(),
                 root_project=True,

--- a/mage_ai/tests/data_preparation/models/test_project.py
+++ b/mage_ai/tests/data_preparation/models/test_project.py
@@ -83,18 +83,19 @@ class ProjectTest(ProjectPlatformMixin, AsyncDBTestCase):
                         self.assertEqual(project.version, VERSION)
                         self.assertFalse(project.root_project)
 
+                        project.repo_config
                         self.assertEqual(
                             mock_get_repo_config.mock_calls[0],
                             call(
-                                repo_path=os.path.join(base_repo_path(), 'mage_platform'),
-                                root_project=False,
+                                repo_path=base_repo_path(),
+                                root_project=True,
                             ),
                         )
                         self.assertEqual(
                             mock_get_repo_config.mock_calls[1],
                             call(
-                                repo_path=base_repo_path(),
-                                root_project=True,
+                                repo_path=os.path.join(base_repo_path(), 'mage_platform'),
+                                root_project=False,
                             ),
                         )
 
@@ -109,6 +110,7 @@ class ProjectTest(ProjectPlatformMixin, AsyncDBTestCase):
                         self.assertEqual(project.version, VERSION)
                         self.assertTrue(project.root_project)
 
+                        project.repo_config
                         self.assertEqual(
                             mock_get_repo_config.mock_calls[0],
                             call(


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
When using `mage_secret_var` in project metadata.yaml and starting the Mage server, there's an infinite loop that prevents
the server from starting.

The infinite loop: get_secret_value calls Project(), Project() calls get_repo_config(), get_repo_config() calls get_secret_value.

To fix this issue, I change the `repo_config` to be lazy initialized in Project model.

There's another issue of calling `get_variables_dir`. This method throws undefined variable error. Thus, I change this method to only render the `variables_dir` value in the project metadata.yaml instead of rendering the whole file.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested setting `mage_secret_var` in project metadata.yaml and start the server. The server can start correctly.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
