### PR TITLE
AWS S3 Destination: Added support for IAM role-based authentication.

### DIFF
--- a/mage_integrations/mage_integrations/destinations/amazon_s3/README.md
+++ b/mage_integrations/mage_integrations/destinations/amazon_s3/README.md
@@ -13,6 +13,7 @@ You must enter the following credentials when configuring this source:
 | `aws_access_key_id` | AWS access key ID. | `abc123` |
 | `aws_region` | Region where the bucket is located. | `us-west-2` (default value) |
 | `aws_secret_access_key` | AWS secret access key. | `xyz456` |
+| `role_arn` | (Optional) The ARN of the IAM role that can be assumed to get access to S3 bucket. | `arn:aws:iam::111111:role/example-role` |
 | `bucket` | Name of the AWS S3 bucket to save data in. | `user_generated_content` |
 | `file_type` | The type of S3 files. Supported file type values: `parquet`, `csv`. | `parquet` or `csv` |
 | `object_key_path` | The path of the location where you have files. Don’t include the `s3`, the bucket name, or the table name in this path value.  | `users/ds/20221225` |

--- a/mage_integrations/mage_integrations/destinations/amazon_s3/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/amazon_s3/__init__.py
@@ -42,6 +42,32 @@ class AmazonS3(Destination):
            },
         )
 
+        if (
+            not self.config.get('aws_access_key_id') and
+            not self.config.get('aws_secret_access_key') and
+            self.config.get('role_arn')
+        ):
+            # Assume IAM role and get credentials
+            role_session_name = self.config.get('role_session_name', 'mage-data-integration')
+            sts_session = boto3.Session()
+            sts_connection = sts_session.client('sts')
+            assume_role_object = sts_connection.assume_role(
+                RoleArn=self.config.get('role_arn'),
+                RoleSessionName=role_session_name,
+            )
+
+            session = boto3.Session(
+                aws_access_key_id=assume_role_object['Credentials']['AccessKeyId'],
+                aws_secret_access_key=assume_role_object['Credentials']['SecretAccessKey'],
+                aws_session_token=assume_role_object['Credentials']['SessionToken'],
+            )
+
+            return session.client(
+                's3',
+                config=config,
+                region_name=self.region,
+            )
+
         return boto3.client(
             's3',
             aws_access_key_id=self.config.get('aws_access_key_id'),


### PR DESCRIPTION
# Description
Added support for IAM role-based authentication for AWS S3 Destination integration by copying the implementation from AWS S3 Source integration.

Since both Source and Destination integrations share a lot of similar code, I would suggest minimising repetition by creating a base class that both integrations inherit from.

Related to #2516.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [ ] Test A
- [ ] Test B


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
