### PR TITLE
[xy] Fix executing data integration block with ecs executor

### DIFF
--- a/mage_ai/data_preparation/executors/ecs_block_executor.py
+++ b/mage_ai/data_preparation/executors/ecs_block_executor.py
@@ -25,4 +25,4 @@ class EcsBlockExecutor(BlockExecutor):
             global_vars=global_vars,
             **kwargs,
         )
-        ecs.run_task(' '.join(cmd), ecs_config=self.executor_config)
+        ecs.run_task(cmd, ecs_config=self.executor_config)

--- a/mage_ai/services/aws/ecs/config.py
+++ b/mage_ai/services/aws/ecs/config.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict, List, Union
 
 import boto3
 import requests
@@ -67,7 +67,7 @@ class EcsConfig(BaseConfig):
             container_name=container_name,
         )
 
-    def get_task_config(self, command: str = None) -> Dict:
+    def get_task_config(self, command: Union[str, Dict] = None) -> Dict:
         network_configuration = self.network_configuration
         if network_configuration is None:
             network_configuration = {
@@ -94,7 +94,7 @@ class EcsConfig(BaseConfig):
                 'containerOverrides': [
                     {
                         'name': self.container_name,
-                        'command': command.split(' '),
+                        'command': command.split(' ') if isinstance(command, str) else command,
                         'cpu': self.cpu,
                         'memory': self.memory,
                     },

--- a/mage_ai/services/aws/ecs/ecs.py
+++ b/mage_ai/services/aws/ecs/ecs.py
@@ -1,12 +1,12 @@
 import json
-from typing import Dict, List
+from typing import Dict, List, Union
 
 from mage_ai.services.aws import get_aws_boto3_client
 from mage_ai.services.aws.ecs.config import EcsConfig
 
 
 def run_task(
-    command: str,
+    command: Union[str, Dict],
     ecs_config: EcsConfig,
     wait_for_completion: bool = True,
 ) -> None:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
ECS executor command was split by empty space. When data integration block's command has parameter like `--template-runtime-configuration '{"destination_table": "table_name", "index": 0, "is_last_block_run": false, "selected_streams": ["stream_name"]}'`, it splits the json into multiple args, which causes the ECS task execution to fail.

<img width="465" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/d64cc668-feb3-43bb-9b04-11d522776a05">
<img width="537" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/8e00c1c9-1384-47b4-b236-0a614490a51d">

Thus, fix this issue by passing a list of args directly to ECS run_task method.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested on data integration pipeline with ECS executor on ECS cluster


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
