### PR TITLE
[td] Add retry info in callbacks and function that’s being retried

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
@@ -120,10 +120,14 @@ function BlockRunsTable({
   );
 
   const timezoneTooltipProps = displayLocalTimezone ? TIMEZONE_TOOLTIP_PROPS : {};
-  const columnFlex = [1, 2, 2, 1, 1, 1, null, null];
+  const columnFlex = [1, null, 2, 2, 1, 1, 1, null];
   const columns = [
     {
       uuid: 'Status',
+    },
+    {
+      center: true,
+      uuid: 'Logs',
     },
     {
       uuid: 'Block',
@@ -142,9 +146,6 @@ function BlockRunsTable({
     {
       ...timezoneTooltipProps,
       uuid: 'Completed at',
-    },
-    {
-      uuid: 'Logs',
     },
   ];
 
@@ -200,6 +201,17 @@ function BlockRunsTable({
           >
             {status}
           </Text>,
+          <Button
+            default
+            iconOnly
+            key={`${id}_logs`}
+            noBackground
+            onClick={() => Router.push(
+              `/pipelines/${pipelineUUID}/logs?block_run_id[]=${id}`,
+            )}
+          >
+            <Logs default size={2 * UNIT} />
+          </Button>,
           <NextLink
             as={`/pipelines/${pipelineUUID}/edit?block_uuid=${blockUUID}`}
             href={'/pipelines/[pipeline]/edit'}
@@ -287,17 +299,6 @@ function BlockRunsTable({
               )
             }
           </Text>,
-          <Button
-            default
-            iconOnly
-            key={`${id}_logs`}
-            noBackground
-            onClick={() => Router.push(
-              `/pipelines/${pipelineUUID}/logs?block_run_id[]=${id}`,
-            )}
-          >
-            <Logs default size={2 * UNIT} />
-          </Button>,
         ];
 
         if (isStandardPipeline) {

--- a/mage_ai/shared/retry.py
+++ b/mage_ai/shared/retry.py
@@ -9,6 +9,7 @@ def retry(
     exponential_backoff: bool = True,
     logger=None,
     logging_tags: Dict = None,
+    retry_metadata: Dict = None,
 ):
     """
     Create the decorator to retry a method
@@ -31,6 +32,9 @@ def retry(
             curr_delay = delay
             while attempt <= max_attempts:
                 try:
+                    if retry_metadata:
+                        retry_metadata['attempts'] = (retry_metadata.get('attempts', 0) or 0) + 1
+
                     return func(*args, **kwargs)
                 except Exception as e:
                     if logger is None:


### PR DESCRIPTION
# Description
Add retry attempts to kwargs for block function and callback functions.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
![CleanShot 2024-01-10 at 05 23 29@2x](https://github.com/mage-ai/mage-ai/assets/1066980/19b2ea6d-42b1-4323-aa85-d2d57b27192f)

![CleanShot 2024-01-10 at 05 24 49@2x](https://github.com/mage-ai/mage-ai/assets/1066980/ca3449f5-b104-431f-96ca-62bf357f1350)


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
