### PR TITLE
[jk] Prevent error when searching for blocks

### DIFF
--- a/mage_ai/services/search/block_action_objects.py
+++ b/mage_ai/services/search/block_action_objects.py
@@ -25,8 +25,10 @@ async def search(query: str, ratio: float = None, limit: int = None) -> List:
     for object_type, mapping in cache.load_all_data().items():
         for uuid, block_action_object in mapping.items():
             text = get_searchable_text(object_type, block_action_object)
-            score = max([fuzz.token_sort_ratio(query, t) for t in text])
+            if not text:
+                continue
 
+            score = max([fuzz.token_sort_ratio(query, t) for t in text])
             if score >= (ratio / 2):
                 DX_PRINTER.info(
                     uuid,


### PR DESCRIPTION
# Description
- Prevent `max() arg is an empty sequence` error when searching for blocks.
- TODO (in separate PR): Include block files when searching for blocks, since they are currently not appearing in the search results.


# How Has This Been Tested?
Before:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/834909fc-22c5-434b-8d47-364bc23e5b16)

After:
<img width="814" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/2a04b65f-f15f-4da9-8cc9-4c7353e495e4">



# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
