### PR TITLE
[td] Enable command center when user auth not required

### DIFF
--- a/mage_ai/frontend/pages/_app.tsx
+++ b/mage_ai/frontend/pages/_app.tsx
@@ -269,7 +269,7 @@ function MyApp(props: MyAppProps & AppProps) {
                     }}
                   />
                 )}
-                {AuthToken.isLoggedIn() && commandCenterEnabled && <CommandCenter />}
+                {(!requireUserAuthentication || AuthToken.isLoggedIn()) && commandCenterEnabled && <CommandCenter />}
               </ErrorProvider>
             </SheetProvider>
           </ModalProvider>


### PR DESCRIPTION
# Description
Don’t disable command center if user authentication is not required.