### PR TITLE
[jk] Improve command center shortcut wording and example

### DIFF
--- a/mage_ai/frontend/components/CommandCenter/constants.tsx
+++ b/mage_ai/frontend/components/CommandCenter/constants.tsx
@@ -109,8 +109,8 @@ export function buildSettingsItemWithApplication(): {
 
               <Text inline muted small>
                 &nbsp;&nbsp;(<Text inline monospace muted small>
-                  metaKey
-                </Text> + <Text inline monospace muted small>period</Text>).
+                  Meta
+                </Text> + <Text inline monospace muted small>Period</Text>).
               </Text>
             </FlexContainer>
 
@@ -121,7 +121,7 @@ export function buildSettingsItemWithApplication(): {
             </Text>
           </>
         ),
-        placeholder: 'e.g. metaKey, 190',
+        placeholder: 'e.g. 91, 190',
         display_settings: {
           icon_uuid: 'Alphabet',
         },

--- a/mage_ai/frontend/components/CommandCenter/constants.tsx
+++ b/mage_ai/frontend/components/CommandCenter/constants.tsx
@@ -1,5 +1,6 @@
 import FlexContainer from '@oracle/components/FlexContainer';
 import KeyboardTextGroup from '@oracle/elements/KeyboardTextGroup';
+import Link from '@oracle/elements/Link';
 import Text from '@oracle/elements/Text';
 import {
   ButtonActionTypeEnum,
@@ -115,9 +116,15 @@ export function buildSettingsItemWithApplication(): {
             </FlexContainer>
 
             <Text muted small>
-              You can change this by entering
+              You can change this by entering the desired
               <br />
-              the desired key codes separated by commas.
+              <Link
+                href="https://www.toptal.com/developers/keycode"
+                openNewWindow
+                small
+              >
+                key codes
+              </Link> separated by commas.
             </Text>
           </>
         ),


### PR DESCRIPTION
# Description
- It was a bit confusing what exactly to enter when modifying the command center keyboard shortcut, so this PR improves the wording, provides a link to get key codes, and fixes the example shortcut.

# How Has This Been Tested?
<img width="586" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/7ea814a1-2b28-4c8e-9556-2f52af6be688">


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
