### PR TITLE
Fix bug of rabbitmq consumer configuration (RabbitMQConfig.__init__() got an unexpected keyword argument 'exclusive')

### DIFF
--- a/mage_ai/streaming/sources/rabbitmq.py
+++ b/mage_ai/streaming/sources/rabbitmq.py
@@ -30,9 +30,12 @@ class RabbitMQConfig(BaseConfig):
 
     @classmethod
     def parse_config(self, config: Dict) -> Dict:
-        consume_config = config.get('consume_config')
-        if consume_config is not None and type(consume_config) is dict:
-            config['consume_config'] = ConsumeConfig(**consume_config)
+        consume_config = ConsumeConfig()
+        for key in consume_config.__dict__.keys():
+            if key in config.keys():
+                setattr(consume_config, key, config[key])
+                config.pop(key)
+        config['consume_config'] = consume_config
         return config
 
 


### PR DESCRIPTION
# Description
As shown in docs `docs/streaming/sources/rabbitmq.mdx`, mage.ai allows user to config some parameters of consumer (e.g. exclusive). However,  there was an error below when the user try to set the consumer configuration.

```
Pipeline streaming_image execution failed with error:
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/mage_ai/server/websocket_server.py", line 116, in run_pipeline
    pipeline.execute_sync(
  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/models/pipeline.py", line 538, in execute_sync
    StreamingPipelineExecutor(self).execute(
  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/executors/streaming_pipeline_executor.py", line 97, in execute
    raise e
  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/executors/streaming_pipeline_executor.py", line 87, in execute
    self.__execute_in_python(
  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/executors/streaming_pipeline_executor.py", line 114, in __execute_in_python
    source = SourceFactory.get_source(
  File "/usr/local/lib/python3.10/site-packages/mage_ai/streaming/sources/source_factory.py", line 43, in get_source
    return RabbitMQSource(config, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/mage_ai/streaming/sources/base.py", line 21, in __init__
    self.config = self.config_class.load(config=config)
  File "/usr/local/lib/python3.10/site-packages/mage_ai/shared/config.py", line 47, in load
    return self(**config)
TypeError: RabbitMQConfig.__init__() got an unexpected keyword argument 'exclusive'
```

I found that the bug was occurred due to mulfunction of `parse_config` in `RabbitMQConfig` which try to get `consume_config` that never been created before (and not mentioned in the docs). So, I fixed the function to create the `consume_config`.

Please note that, the configuration of `auto_ack`, `exclusive`, `inactivity_timeout` will be effective if and only if the `configure_consume` is `True`.


# How Has This Been Tested?
- [x] Configure the `configure_consume` to True, `exclusive` to True, and`auto_ack` to True. Then, check on rabbitmq console (the `Ack required` should not be filled and the `Exclusive` should be filled  as shown in image below)
```
configure_consume: True
auto_ack: True
exclusive: True
```
![image](https://github.com/mage-ai/mage-ai/assets/23212666/1151e081-bbd2-464a-8df1-c57bb4517f8f)
- [x] Configure the `configure_consume` to True, `exclusive` to False, and`auto_ack` to False. Then, check on rabbitmq console (the `Ack required` should be filled and the `Exclusive` should not be filled  as shown in image below)
```
configure_consume: True
auto_ack: False
exclusive: False
```
![image](https://github.com/mage-ai/mage-ai/assets/23212666/2d023af7-ae5b-4122-8e13-cf22b089a5fc)
- [x] Configure the `configure_consume` to False, `exclusive` to True, and`auto_ack` to True. Then, check on rabbitmq console (the `Ack required` should be filled and the `Exclusive` should not be filled as shown in image below) 
```
configure_consume: False
auto_ack: True
exclusive: True
```
![image](https://github.com/mage-ai/mage-ai/assets/23212666/35a53316-6f17-4e9e-8907-4cccf1bec1b6)



# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
