### PR TITLE
[jk] Make block type error more descriptive

### DIFF
--- a/mage_ai/api/resources/PipelineResource.py
+++ b/mage_ai/api/resources/PipelineResource.py
@@ -242,6 +242,12 @@ class PipelineResource(BaseResource):
                     pipeline = get_pipeline_with_config(uuid, pipeline_dict['pipeline'])
                     if pipeline:
                         pipelines.append(pipeline)
+                    else:
+                        # Add pipeline with type "invalid" so it can still be displayed in UI
+                        pipelines.append(Pipeline(
+                            pipeline_dict['pipeline']['uuid'],
+                            config=dict(type='invalid'),
+                        ))
                 else:
                     pipeline_uuids_miss.append(uuid)
 

--- a/mage_ai/api/resources/PipelineResource.py
+++ b/mage_ai/api/resources/PipelineResource.py
@@ -244,7 +244,7 @@ class PipelineResource(BaseResource):
                         pipelines.append(pipeline)
                     else:
                         # Add pipeline with type "invalid" so pipeline with invalid config
-                        # can still be displayed in UI
+                        # can still be displayed in UI and visible to user
                         pipelines.append(Pipeline(
                             uuid,
                             config=dict(type='invalid'),

--- a/mage_ai/api/resources/PipelineResource.py
+++ b/mage_ai/api/resources/PipelineResource.py
@@ -243,7 +243,8 @@ class PipelineResource(BaseResource):
                     if pipeline:
                         pipelines.append(pipeline)
                     else:
-                        # Add pipeline with type "invalid" so it can still be displayed in UI
+                        # Add pipeline with type "invalid" so pipeline with invalid config
+                        # can still be displayed in UI
                         pipelines.append(Pipeline(
                             uuid,
                             config=dict(type='invalid'),

--- a/mage_ai/api/resources/PipelineResource.py
+++ b/mage_ai/api/resources/PipelineResource.py
@@ -245,7 +245,7 @@ class PipelineResource(BaseResource):
                     else:
                         # Add pipeline with type "invalid" so it can still be displayed in UI
                         pipelines.append(Pipeline(
-                            pipeline_dict['pipeline']['uuid'],
+                            uuid,
                             config=dict(type='invalid'),
                         ))
                 else:

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -619,6 +619,12 @@ class Pipeline:
 
         def build_shared_args_kwargs(c):
             block_type = c.get('type')
+
+            if block_type not in [b.value for b in BlockType]:
+                raise Exception(
+                    f'Error loading pipeline ({self.uuid}): Invalid block type ({block_type})',
+                )
+
             language = c.get('language')
             return Block.block_class_from_type(block_type, language=language, pipeline=self)(
                 c.get('name'),

--- a/mage_ai/frontend/interfaces/PipelineType.ts
+++ b/mage_ai/frontend/interfaces/PipelineType.ts
@@ -14,6 +14,9 @@ export enum PipelineTypeEnum {
   STREAMING = 'streaming',
 }
 
+// Invalid pipeline type used for pipelines with invalid configuration
+export const PIPELINE_TYPE_INVALID = 'invalid';
+
 export const PIPELINE_TYPE_DISPLAY_NAME = {
   [PipelineTypeEnum.INTEGRATION]: 'Integration',
   [PipelineTypeEnum.PYTHON]: 'Python',
@@ -131,7 +134,7 @@ export default interface PipelineType {
   schedules?: PipelineScheduleType[];
   settings?: PipelineSettingsType;
   tags?: string[];
-  type?: PipelineTypeEnum;
+  type?: PipelineTypeEnum | string;
   updated_at?: string;
   uuid: string;
   variables?: { [keyof: string]: string };

--- a/mage_ai/frontend/interfaces/PipelineType.ts
+++ b/mage_ai/frontend/interfaces/PipelineType.ts
@@ -134,7 +134,7 @@ export default interface PipelineType {
   schedules?: PipelineScheduleType[];
   settings?: PipelineSettingsType;
   tags?: string[];
-  type?: PipelineTypeEnum | string;
+  type?: PipelineTypeEnum;
   updated_at?: string;
   uuid: string;
   variables?: { [keyof: string]: string };

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -1319,7 +1319,7 @@ function PipelineListPage() {
         const blocksCount = blocks.filter(({ type }) => BlockTypeEnum.SCRATCHPAD !== type).length;
         const schedulesCount = schedules.length;
         const isActive = schedules.find(({ status }) => ScheduleStatusEnum.ACTIVE === status);
-        const isInvalid = type === PIPELINE_TYPE_INVALID;
+        const isInvalid = type as string === PIPELINE_TYPE_INVALID;
 
         const tagsEl = (
           <div key={`pipeline_tags_${idx}`}>

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -23,6 +23,7 @@ import PipelineType, {
   PipelineQueryEnum,
   PipelineStatusEnum,
   PipelineTypeEnum,
+  PIPELINE_TYPE_INVALID,
   PIPELINE_TYPE_LABEL_MAPPING,
 } from '@interfaces/PipelineType';
 import Preferences from '@components/settings/workspace/Preferences';
@@ -1318,6 +1319,7 @@ function PipelineListPage() {
         const blocksCount = blocks.filter(({ type }) => BlockTypeEnum.SCRATCHPAD !== type).length;
         const schedulesCount = schedules.length;
         const isActive = schedules.find(({ status }) => ScheduleStatusEnum.ACTIVE === status);
+        const isInvalid = type === PIPELINE_TYPE_INVALID;
 
         const tagsEl = (
           <div key={`pipeline_tags_${idx}`}>
@@ -1388,9 +1390,11 @@ function PipelineListPage() {
             {description}
           </Text>,
           <Text
+            bold={isInvalid}
+            danger={isInvalid}
             key={`pipeline_type_${idx}`}
           >
-            {PIPELINE_TYPE_LABEL_MAPPING[type]}
+            {isInvalid ? capitalize(PIPELINE_TYPE_INVALID) : PIPELINE_TYPE_LABEL_MAPPING[type]}
           </Text>,
           <Text
             key={`pipeline_updated_at_${idx}`}


### PR DESCRIPTION
# Description
- The pipelines might not load on the Pipelines Dashboard if 1 of the pipelines has a block with an invalid block type, but the error (`'NoneType' object is not callable`) wasn't very explicit and could be difficult to troubleshoot not knowing which pipeline had the issue.
- The pipeline with an invalid configuration will still be displayed in the UI, but have an `invalid` pipeline type. When users click on that pipeline, they can see the error causing the pipeline to load. If it's due to an invalid block type error, the error will be more descriptive now.

# How Has This Been Tested?
![show invalid pipeline](https://github.com/mage-ai/mage-ai/assets/78053898/e55aa996-8f67-4714-b12f-2dc1d673e09f)


![image](https://github.com/mage-ai/mage-ai/assets/78053898/f8bac85a-8562-48b6-96b3-e002f7da8da7)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
