### PR TITLE
Added 'custom_fields' to freshdesk source

### DIFF
--- a/mage_integrations/mage_integrations/sources/freshdesk/tap_freshdesk/schemas/tickets.json
+++ b/mage_integrations/mage_integrations/sources/freshdesk/tap_freshdesk/schemas/tickets.json
@@ -1,6 +1,20 @@
 {
   "type": "object",
   "properties": {
+    "custom_fields": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "object"],
+        "properties": {
+          "name": {
+            "type": ["null", "string"]
+          },
+          "value": {
+            "type": ["null", "string"]
+          }
+        }
+      }
+    },
     "cc_emails": {
       "items": {
         "type": [


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
`custom_fields` was removed from freshdesk tickets.json schema in a latter PR
After inserting it back into the tickets.json file, no issue was found.
Since no issue was found, this PR adds `custom_fields` field back into tickets.json schema


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
Tested using a freshdesk test account, in a Freshdesk -> PostgreSQL pipeline 

# FULL TABLE sync
![Screenshot from 2024-01-12 17-34-46](https://github.com/mage-ai/mage-ai/assets/14100959/7d9a5fd0-bef8-475d-b79d-c174304b629a)

![Screenshot from 2024-01-12 17-35-33](https://github.com/mage-ai/mage-ai/assets/14100959/b0d24cd1-01b4-4422-92fa-91c11c181994)

# INCREMENTAL sync
State is not being handled correctly, rendering incremental sync inoperable as of now

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 
