### PR TITLE
fix: handle unprivileged user for postgres

### DIFF
--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -161,7 +161,7 @@ class Postgres(BaseSQL):
             self.ssh_tunnel = None
         if self.verbose and self.printer.exists_previous_message:
             print('')
-    
+
     def build_create_schema_command(
         self,
         schema_name: str
@@ -170,8 +170,8 @@ class Postgres(BaseSQL):
         DO $$
         BEGIN
             IF NOT EXISTS (
-                SELECT schema_name 
-                FROM information_schema.schemata 
+                SELECT schema_name
+                FROM information_schema.schemata
                 WHERE schema_name = '{schema_name}'
             ) THEN
                 EXECUTE 'CREATE SCHEMA {schema_name}';

--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -161,6 +161,24 @@ class Postgres(BaseSQL):
             self.ssh_tunnel = None
         if self.verbose and self.printer.exists_previous_message:
             print('')
+    
+    def build_create_schema_command(
+        self,
+        schema_name: str
+    ) -> str:
+        return f"""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT schema_name 
+                FROM information_schema.schemata 
+                WHERE schema_name = '{schema_name}'
+            ) THEN
+                EXECUTE 'CREATE SCHEMA {schema_name}';
+            END IF;
+        END
+        $$;
+        """
 
     def table_exists(self, schema_name: str, table_name: str) -> bool:
         with self.conn.cursor() as cur:


### PR DESCRIPTION
# Description

When a user doesn't have permission to create a schema, the CREATE SCHEMA IF NOT EXISTS... fails even if the schema already exists.

https://mageai.slack.com/archives/C03HTTWFEKE/p1705108869898959

I swapped out the `CREATE SCHEMA IF NOT EXISTS... ` statement for one that queries the schema catalog and only CREATES the schema if it doesn't exist.  


# How Has This Been Tested?
You can reproduce it by creating a new unprivileged user that only has INSERT on the target table.  

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
