### PR TITLE
[jk] Fix cron expression conversion when using local midnight time

### DIFF
--- a/mage_ai/frontend/components/Triggers/utils.ts
+++ b/mage_ai/frontend/components/Triggers/utils.ts
@@ -271,9 +271,14 @@ function calculateCronValueWithOffset(
       }
     }
   }
+
+  const cronValueFinal = typeof range[currentIndex] === 'number'
+    ? range[currentIndex]
+    : timeUnitValue;
+
   return {
     additionalOffset: additionalOffsetForGreaterTimeUnit,
-    cronValue: String(range[currentIndex] || timeUnitValue),
+    cronValue: String(cronValueFinal),
   };
 }
 


### PR DESCRIPTION
# Description
- The cron expression wasn't being displayed properly in the UI when setting it to midnight local time (with `display_local_timezone` setting enabled). This PR fixes it.
- Addresses github issue https://github.com/mage-ai/mage-ai/issues/4266

# How Has This Been Tested?
Before: Setting the cron expression to 12 AM local time has the correct "Next run date", but the cron expression isn't displayed correctly.
![Before - Setting midnight cron expr](https://github.com/mage-ai/mage-ai/assets/78053898/4b02ac0a-5af9-4e10-8190-1e4c351007c0)

After - The cron expression displayed in the UI is consistent with what was entered.
![After - Setting midnight cron expr gif](https://github.com/mage-ai/mage-ai/assets/78053898/d252f0b5-0d87-408d-add1-04b8cde2d7a6)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
