### PR TITLE
Added Modin for `return` of a block

### DIFF
--- a/mage_ai/data_cleaner/shared/utils.py
+++ b/mage_ai/data_cleaner/shared/utils.py
@@ -83,6 +83,10 @@ def is_spark_dataframe(df):
     return type(df).__module__ == 'pyspark.sql.dataframe'
 
 
+def is_modin_dataframe(df):
+    return type(df).__module__ == 'modin.pandas.dataframe'
+
+
 def __parse_element(element: str) -> Any:
     if element == 'nan' or element == 'np.nan':
         return np.nan

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -17,6 +17,7 @@ from queue import Queue
 from typing import Any, Callable, Dict, Generator, List, Set, Tuple, Union
 
 import inflection
+import modin.pandas as mpd
 import pandas as pd
 import polars as pl
 import simplejson
@@ -2130,7 +2131,7 @@ class Block(DataIntegrationMixin, SparkBlock, ProjectPlatformAccessible):
                 outputs and non data product outputs are handled slightly differently.
         """
         variable_manager = self.pipeline.variable_manager
-        if isinstance(data, pd.DataFrame):
+        if isinstance(data, (pd.DataFrame, mpd.DataFrame)):
             if csv_lines_only:
                 data = dict(
                     table=data.to_csv(header=True, index=False).strip('\n').split('\n')
@@ -2771,7 +2772,7 @@ df = get_variable('{self.pipeline.uuid}', '{self.uuid}', 'df')
         if self.pipeline is None:
             return
         for uuid, data in variable_mapping.items():
-            if type(data) is pd.DataFrame:
+            if isinstance(data, (pd.DataFrame, mpd.DataFrame)):
                 if data.shape[1] > DATAFRAME_ANALYSIS_MAX_COLUMNS or shape_only:
                     self.pipeline.variable_manager.add_variable(
                         self.pipeline.uuid,

--- a/mage_ai/data_preparation/models/variable.py
+++ b/mage_ai/data_preparation/models/variable.py
@@ -156,7 +156,7 @@ class Variable:
         ):
             # If parquet file exists for given variable, set the variable type to DATAFRAME
             self.variable_type = VariableType.DATAFRAME
-        if self.variable_type == VariableType.DATAFRAME:
+        if self.variable_type in [VariableType.DATAFRAME, VariableType.MODIN_DATAFRAME]:
             self.__delete_parquet()
         elif self.variable_type == VariableType.DATAFRAME_ANALYSIS:
             return self.__delete_dataframe_analysis()
@@ -202,7 +202,7 @@ class Variable:
             return self.__read_geo_dataframe(sample=sample, sample_count=sample_count)
         elif self.variable_type == VariableType.DATAFRAME_ANALYSIS:
             return self.__read_dataframe_analysis(dataframe_analysis_keys=dataframe_analysis_keys)
-        elif self.variable_type == Variable.MODIN_DATAFRAME:
+        elif self.variable_type == VariableType.MODIN_DATAFRAME:
             return self.__read_modin_parquet(sample=sample, sample_count=sample_count)
 
         return self.__read_json(raise_exception=raise_exception, sample=sample)
@@ -239,8 +239,8 @@ class Variable:
             return await self.__read_dataframe_analysis_async(
                 dataframe_analysis_keys=dataframe_analysis_keys,
             )
-        elif self.variable_type == Variable.MODIN_DATAFRAME:
-            return await self.__read_modin_parquet(sample=sample, sample_count=sample_count)
+        elif self.variable_type == VariableType.MODIN_DATAFRAME:
+            return self.__read_modin_parquet(sample=sample, sample_count=sample_count)
 
         return await self.__read_json_async(sample=sample)
 
@@ -576,7 +576,7 @@ class Variable:
         sample: bool = False,
         sample_count: int = None,
         raise_exception: bool = False,
-    ) -> pd.DataFrame:
+    ) -> mpd.DataFrame:
         file_path = os.path.join(self.variable_path, DATAFRAME_PARQUET_FILE)
         sample_file_path = os.path.join(self.variable_path, DATAFRAME_PARQUET_SAMPLE_FILE)
 

--- a/mage_ai/data_preparation/storage/base_storage.py
+++ b/mage_ai/data_preparation/storage/base_storage.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import Dict, List
 
+import modin.pandas as mpd
 import pandas as pd
 import polars as pl
 
@@ -60,6 +61,13 @@ class BaseStorage(ABC):
     def read_polars_parquet(self, file_path: str, **kwargs) -> pl.DataFrame:
         """
         Read parquet from a file with file path and return a polars DataFrame.
+        """
+        pass
+
+    @abstractmethod
+    def read_modin_parquet(self, file_path: str, **kwargs) -> mpd.DataFrame:
+        """
+        Read parquet from a file with file path and return a modin pandas DataFrame.
         """
         pass
 

--- a/mage_ai/data_preparation/storage/gcs_storage.py
+++ b/mage_ai/data_preparation/storage/gcs_storage.py
@@ -3,6 +3,7 @@ import json
 from contextlib import contextmanager
 from typing import Dict, List
 
+import modin.pandas as mpd
 import pandas as pd
 import polars as pl
 import simplejson
@@ -110,6 +111,10 @@ class GCSStorage(BaseStorage):
     def read_polars_parquet(self, file_path: str, **kwargs) -> pl.DataFrame:
         buffer = io.BytesIO(self.bucket.blob(gcs_url_path(file_path)).download_as_bytes())
         return pl.read_parquet(buffer, **kwargs)
+
+    def read_modin_parquet(self, file_path: str, **kwargs) -> mpd.DataFrame:
+        buffer = io.BytesIO(self.bucket.blob(gcs_url_path(file_path)).download_as_bytes())
+        return mpd.read_parquet(buffer, **kwargs)
 
     def write_parquet(self, df: pd.DataFrame, file_path: str) -> None:
         buffer = io.BytesIO()

--- a/mage_ai/data_preparation/storage/local_storage.py
+++ b/mage_ai/data_preparation/storage/local_storage.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from typing import Dict, List
 
 import aiofiles
+import modin.pandas as mpd
 import pandas as pd
 import polars as pl
 import simplejson
@@ -98,6 +99,9 @@ class LocalStorage(BaseStorage):
 
     def read_polars_parquet(self, file_path: str, **kwargs) -> pl.DataFrame:
         return pl.read_parquet(file_path, use_pyarrow=True)
+
+    def read_modin_parquet(self, file_path: str, **kwargs) -> mpd.DataFrame:
+        return mpd.read_parquet(file_path, engine='pyarrow')
 
     def write_csv(self, df: pd.DataFrame, file_path: str) -> None:
         File.create_parent_directories(file_path)

--- a/mage_ai/data_preparation/storage/s3_storage.py
+++ b/mage_ai/data_preparation/storage/s3_storage.py
@@ -3,6 +3,7 @@ import json
 from contextlib import contextmanager
 from typing import Dict, List
 
+import modin.pandas as mpd
 import pandas as pd
 import polars as pl
 import simplejson
@@ -100,6 +101,10 @@ class S3Storage(BaseStorage):
     def read_polars_parquet(self, file_path: str, **kwargs) -> pl.DataFrame:
         buffer = io.BytesIO(self.client.get_object(s3_url_path(file_path)).read())
         return pl.read_parquet(buffer, **kwargs)
+
+    def read_modin_parquet(self, file_path: str, **kwargs) -> mpd.DataFrame:
+        buffer = io.BytesIO(self.client.get_object(s3_url_path(file_path)).read())
+        return mpd.read_parquet(buffer, **kwargs)
 
     def write_parquet(self, df: pd.DataFrame, file_path: str) -> None:
         buffer = io.BytesIO()

--- a/mage_ai/data_preparation/variable_manager.py
+++ b/mage_ai/data_preparation/variable_manager.py
@@ -4,7 +4,11 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from mage_ai.data_cleaner.shared.utils import is_geo_dataframe, is_spark_dataframe
+from mage_ai.data_cleaner.shared.utils import (
+    is_geo_dataframe,
+    is_modin_dataframe,
+    is_spark_dataframe,
+)
 from mage_ai.data_preparation.models.variable import (
     VARIABLE_DIR,
     Variable,
@@ -62,6 +66,9 @@ class VariableManager:
             variable_type = VariableType.SPARK_DATAFRAME
         elif is_geo_dataframe(data):
             variable_type = VariableType.GEO_DATAFRAME
+        elif is_modin_dataframe(data):
+            variable_type = VariableType.MODIN_DATAFRAME
+
         variable = Variable(
             clean_name(variable_uuid),
             self.__pipeline_path(pipeline_uuid),

--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -137,6 +137,7 @@ def __custom_output():
     from datetime import datetime
     from mage_ai.shared.parsers import encode_complex, sample_output
     import json
+    import modin.pandas as mpd
     import pandas as pd
     import polars as pl
     import simplejson
@@ -151,7 +152,7 @@ def __custom_output():
 
     _internal_output_return = {last_line}
 
-    if isinstance(_internal_output_return, pd.DataFrame) and (
+    if isinstance(_internal_output_return, (pd.DataFrame, mpd.DataFrame)) and (
         type(_internal_output_return).__module__ != 'geopandas.geodataframe'
     ):
         _sample = _internal_output_return.iloc[:{DATAFRAME_SAMPLE_COUNT_PREVIEW}]

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,10 +22,10 @@ jupyter-server-proxy==3.2.1
 jupyter-server==1.23.5
 jupyter_client==7.3.4
 ldap3==2.9.1
-modin[dask]==0.28.0
+modin[dask]==0.26.0
 newrelic==8.8.0
 numpy>=1.21.0
-pandas>=1.3.0
+pandas>=2.0.0
 polars>=0.18.0, <0.19.2
 protobuf~=4.21.12
 pyarrow-hotfix==0.5
@@ -54,7 +54,7 @@ boto3==1.26.60
 botocore==1.29.60
 chromadb>=0.4.17
 clickhouse-connect~=0.6.23
-db-dtypes==1.0.5
+db-dtypes==1.2.0
 duckdb==0.9.1
 google-api-core~=2.15.0
 google-api-python-client~=2.70.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ jupyter-server-proxy==3.2.1
 jupyter-server==1.23.5
 jupyter_client==7.3.4
 ldap3==2.9.1
+modin[dask]==0.28.0
 newrelic==8.8.0
 numpy>=1.21.0
 pandas>=1.3.0


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Added Modin pandas DataFrame as type for accepting in `return` of a block. This way a developer doesn't need to manually move it to a pandas DF and also allows them to load/write data in a distributed way.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [ ] Created unit tests in the `test_variable.py` that are passing.
- [ ] Tested through the UI


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
