### PR TITLE
[xy] Support overwriting column types in BigQuery.

### DIFF
--- a/docs/integrations/databases/BigQuery.mdx
+++ b/docs/integrations/databases/BigQuery.mdx
@@ -74,3 +74,50 @@ def load_data_from_big_query(**kwargs) -> DataFrame:
 ```
 
 5. Run the block.
+
+
+### Export a dataframe
+
+Here is an example code snippet to export a dataframe to BigQuery:
+
+```python
+from mage_ai.settings.repo import get_repo_path
+from mage_ai.io.bigquery import BigQuery
+from mage_ai.io.config import ConfigFileLoader
+from pandas import DataFrame
+from os import path
+
+if 'data_exporter' not in globals():
+    from mage_ai.data_preparation.decorators import data_exporter
+
+
+@data_exporter
+def export_data_to_big_query(df: DataFrame, **kwargs) -> None:
+    """
+    Template for exporting data to a BigQuery warehouse.
+    Specify your configuration settings in 'io_config.yaml'.
+
+    Docs: https://docs.mage.ai/design/data-loading#bigquery
+    """
+    table_id = 'your-project.your_dataset.your_table_name'
+    config_path = path.join(get_repo_path(), 'io_config.yaml')
+    config_profile = 'default'
+
+    BigQuery.with_config(ConfigFileLoader(config_path, config_profile)).export(
+        df,
+        table_id,
+        if_exists='replace',  # Specify resolution policy if table name already exists
+        overwrite_types=None, # Specify the column types to overwrite in a dictionary
+    )
+```
+
+To overwrite a column type when running a python export block, simply specify the column name and type in the `overwrite_types` dict in data exporter config.
+You can find the supported types in this [doc](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#TableFieldSchema.FIELDS.type). Here is the example code:
+```python
+    BigQuery.with_config(ConfigFileLoader(config_path, config_profile)).export(
+        df,
+        table_id,
+        if_exists='replace',  # Specify resolution policy if table name already exists
+        overwrite_types={'col_name': 'STRING'}, # Specify the column types to overwrite
+    )
+```


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Support overwriting column types in BigQuery.

`overwite_types` param is added to `export` method as an optional param.

Supported column types: https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#TableFieldSchema.FIELDS.type

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested exporting dataframe to BigQuery with overwrite_types
<img width="675" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/75870b08-9df7-42f4-9264-b0974c470ad3">
<img width="359" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/894ba425-db8b-4fff-90f0-ec78fd5345c8">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
