### PR TITLE
[xy] Fix creating widget.

### DIFF
--- a/mage_ai/api/resources/WidgetResource.py
+++ b/mage_ai/api/resources/WidgetResource.py
@@ -48,7 +48,7 @@ class WidgetResource(GenericResource):
         )
 
         if payload.get('content'):
-            await resource.write_async(payload['content'], widget=True)
+            await resource.update_content_async(payload['content'], widget=True)
 
         if payload.get('configuration'):
             resource.configuration = payload['configuration']


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fix exception when creating widget: `Widget object has no attribute 'write_async'`

Close: https://github.com/mage-ai/mage-ai/issues/4364

The bug was introduced in version 0.9.55 https://github.com/mage-ai/mage-ai/pull/4193

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested creating bar chart locally. The chart can be created after the fix.
<img width="457" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/47633099-fd76-4c08-ac55-64b486041ebc">


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
