### PR TITLE
[td] Show multiple outputs and fix downstream dynamic child block inputs and outputs

### DIFF
--- a/mage_ai/data_preparation/models/block/utils.py
+++ b/mage_ai/data_preparation/models/block/utils.py
@@ -735,13 +735,13 @@ def fetch_input_variables(
 
                 input_vars[idx] = final_value
 
-    # DX_PRINTER.debug(
-    #     'fetch_input_variables final',
-    #     input_vars=input_vars,
-    #     kwargs_vars=kwargs_vars,
-    #     upstream_block_uuids_final=upstream_block_uuids_final,
-    #     __uuid='output_variables'
-    # )
+    DX_PRINTER.debug(
+        'fetch_input_variables final',
+        input_vars=input_vars,
+        kwargs_vars=kwargs_vars,
+        upstream_block_uuids_final=upstream_block_uuids_final,
+        __uuid='output_variables'
+    )
 
     return input_vars, kwargs_vars, upstream_block_uuids_final
 

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -17,6 +17,10 @@ from mage_ai.data_preparation.models.block import Block, run_blocks, run_blocks_
 from mage_ai.data_preparation.models.block.data_integration.utils import (
     convert_outputs_to_data,
 )
+from mage_ai.data_preparation.models.block.dynamic.utils import (
+    is_dynamic_block,
+    is_dynamic_block_child,
+)
 from mage_ai.data_preparation.models.block.errors import HasDownstreamDependencies
 from mage_ai.data_preparation.models.constants import (
     DATA_INTEGRATION_CATALOG_FILE,
@@ -1090,10 +1094,11 @@ class Pipeline:
                             widget=widget,
                         )
                     if 'outputs' in block_data:
-                        await block.save_outputs_async(
-                            block_data['outputs'],
-                            override=True,
-                        )
+                        if not is_dynamic_block(block) and not is_dynamic_block_child(block):
+                            await block.save_outputs_async(
+                                block_data['outputs'],
+                                override=True,
+                            )
 
                     name = block_data.get('name')
 

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/MultiOutput.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/MultiOutput.tsx
@@ -16,7 +16,7 @@ type MultiOutputProps = {
 function MultiOutput({ outputs }: MultiOutputProps) {
   const outputsRef = useRef({});
 
-  const tabs = useMemo(() => outputs.map(({ uuid }) => ({ uuid }), [outputs]));
+  const tabs = useMemo(() => outputs.map(({ uuid }) => ({ uuid })), [outputs]);
 
   const [selectedTab, setSelectedTab] = useState<TabType>(tabs?.[0]);
 
@@ -49,16 +49,21 @@ function MultiOutput({ outputs }: MultiOutputProps) {
           setSelectedTab(tab);
 
           Object.entries(outputsRef?.current || {})?.forEach(([uuid, ref]) => {
+            // @ts-ignore
             if (ref?.current) {
               if (tab?.uuid === uuid) {
+                // @ts-ignore
                 ref.current.className = removeClassNames(
+                  // @ts-ignore
                   ref.current.className || '',
                   [
                     'inactive',
                   ],
                 );
               } else {
+                // @ts-ignore
                 ref.current.className = addClassNames(
+                  // @ts-ignore
                   ref.current.className || '',
                   [
                     'inactive',

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/MultiOutput.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/MultiOutput.tsx
@@ -1,0 +1,80 @@
+import { createRef, useMemo, useRef, useState } from 'react';
+
+import ButtonTabs, { TabType } from '@oracle/components/Tabs/ButtonTabs';
+import { MultiOutputStyle } from './index.style';
+import { addClassNames, removeClassNames } from '@utils/elements';
+
+type OutputType = {
+  render: () => JSX.Element;
+  uuid: string;
+};
+
+type MultiOutputProps = {
+  outputs: OutputType[];
+};
+
+function MultiOutput({ outputs }: MultiOutputProps) {
+  const outputsRef = useRef({});
+
+  const tabs = useMemo(() => outputs.map(({ uuid }) => ({ uuid }), [outputs]));
+
+  const [selectedTab, setSelectedTab] = useState<TabType>(tabs?.[0]);
+
+  const outputsMemo = useMemo(() => {
+    const arr = [];
+
+
+    outputs?.forEach(({
+      render,
+      uuid,
+    }, idx: number) => {
+      outputsRef.current[uuid] = outputsRef?.current?.[uuid] || createRef<HTMLDivElement>();
+      const ref = outputsRef?.current?.[uuid];
+
+      arr.push(
+        <div className={idx >= 1 ? 'inactive' : null} key={uuid} ref={ref}>
+          {render()}
+        </div>
+      );
+    });
+
+    return arr;
+  }, [outputs]);
+
+  return (
+    <MultiOutputStyle>
+      <ButtonTabs
+        selectedTabUUID={selectedTab?.uuid}
+        onClickTab={(tab) => {
+          setSelectedTab(tab);
+
+          Object.entries(outputsRef?.current || {})?.forEach(([uuid, ref]) => {
+            if (ref?.current) {
+              if (tab?.uuid === uuid) {
+                ref.current.className = removeClassNames(
+                  ref.current.className || '',
+                  [
+                    'inactive',
+                  ],
+                );
+              } else {
+                ref.current.className = addClassNames(
+                  ref.current.className || '',
+                  [
+                    'inactive',
+                  ],
+                );
+              }
+            }
+          });
+        }}
+        tabs={tabs}
+        underlineStyle
+      />
+
+      {outputsMemo}
+    </MultiOutputStyle>
+  );
+}
+
+export default MultiOutput;

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/index.style.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/index.style.tsx
@@ -125,3 +125,9 @@ export const ExtraInfoBorderStyle = styled.div`
     border-top: 1px solid ${(props.theme.borders || dark.borders).medium};
   `}
 `;
+
+export const MultiOutputStyle = styled.div`
+  .inactive {
+    display: none;
+  }
+`;

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
@@ -341,11 +341,16 @@ function CodeOutput({
         if (!!dataInit?.multi_output) {
           return (
             <MultiOutput
-              outputs={rows?.map(({
-                data,
-                type,
-              }, idx: number) => ({
+              outputs={rows?.map((row, idx: number) => ({
                 render: () => {
+                  if (!row) {
+                    return <div />;
+                  }
+
+                  const {
+                    data,
+                    type,
+                  } = row;
                   if (DataTypeEnum.TABLE === type) {
                     return createDataTableElement(data, {
                       borderTop,

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
@@ -22,6 +22,7 @@ import KernelOutputType, {
   DataTypeEnum,
   DATA_TYPE_TEXTLIKE,
 } from '@interfaces/KernelOutputType';
+import MultiOutput from './MultiOutput';
 import PipelineType, { PipelineTypeEnum } from '@interfaces/PipelineType';
 import ProgressBar from '@oracle/components/ProgressBar';
 import Spacing from '@oracle/elements/Spacing';
@@ -63,6 +64,7 @@ import { ViewKeyEnum } from '@components/Sidekick/constants';
 import { addDataOutputBlockUUID, openSaveFileDialog } from '@components/PipelineDetail/utils';
 import { isJsonString } from '@utils/string';
 import { onSuccess } from '@api/utils/response';
+import { isObject } from '@utils/hash';
 
 type CodeOutputProps = {
   alwaysShowExtraInfo?: boolean;
@@ -322,15 +324,44 @@ function CodeOutput({
     tableContent,
     testContent,
   } = useMemo(() => {
-    const createDataTableElement = ({
-      columns,
-      index,
-      rows,
-      shape,
-    }, {
+    const createDataTableElement = (output, {
       borderTop,
       selected: selectedProp,
-    }) => {
+    }, dataInit: {
+      multi_output?: boolean;
+    } = {}) => {
+      const {
+        columns,
+        index,
+        rows,
+        shape,
+      } = output;
+
+      if (dataInit && isObject(dataInit)) {
+        if (!!dataInit?.multi_output) {
+          return (
+            <MultiOutput
+              outputs={rows?.map(({
+                data,
+                type,
+              }, idx: number) => ({
+                render: () => {
+                  if (DataTypeEnum.TABLE === type) {
+                    return createDataTableElement(data, {
+                      borderTop,
+                      selected: selectedProp,
+                    });
+                  }
+
+                  return data;
+                },
+                uuid: columns?.[idx],
+              }))}
+            />
+          );
+        }
+      }
+
       if (shape) {
         setDataFrameShape(shape);
       }
@@ -347,7 +378,7 @@ function CodeOutput({
         );
       }
 
-      return rows.length >= 1 && (
+      return rows?.length >= 1 && (
         <DataTable
           columns={columns}
           disableScrolling={!selectedProp}
@@ -473,38 +504,40 @@ function CodeOutput({
           }
 
           if (isJsonString(rawString)) {
+            const data = JSON.parse(rawString);
             const {
               data: dataDisplay,
               type: typeDisplay,
-            } = JSON.parse(rawString);
+            } = data;
 
             if (DataTypeEnum.TABLE === typeDisplay) {
-              isTable = true;
+              if (dataDisplay) {
+                isTable = true;
+                const tableEl = createDataTableElement(dataDisplay, {
+                  borderTop,
+                  selected,
+                }, data);
+                tableContent.push(tableEl);
 
-              const tableEl = createDataTableElement(dataDisplay, {
-                borderTop,
-                selected,
-              });
-              tableContent.push(tableEl);
-
-              if (!isDBT) {
-                displayElement = tableEl;
+                if (!isDBT) {
+                  displayElement = tableEl;
+                }
               }
             }
           }
         } else if (dataType === DataTypeEnum.TABLE) {
-          isTable = true;
-          const tableEl = createDataTableElement(
-            isJsonString(data) ? JSON.parse(data) : data,
-            {
+          const dataDisplay = isJsonString(data) ? JSON.parse(data) : data;
+          if (dataDisplay) {
+            isTable = true;
+            const tableEl = createDataTableElement(dataDisplay, {
               borderTop,
               selected,
-            },
-          );
-          tableContent.push(tableEl);
+            }, output);
+            tableContent.push(tableEl);
 
-          if (!isDBT) {
-            displayElement = tableEl;
+            if (!isDBT) {
+              displayElement = tableEl;
+            }
           }
         } else if (DATA_TYPE_TEXTLIKE.includes(dataType)) {
           const textArr = data?.split('\\n');

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/useCodeOutput.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/useCodeOutput.tsx
@@ -392,7 +392,6 @@ export default function useCodeOutput({
             } = JSON.parse(rawString);
 
             if (DataTypeEnum.TABLE === typeDisplay) {
-
               const tableEl = createTableData(dataDisplay, {
                 borderTop,
                 selected,

--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/buildTableSidekick.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/buildTableSidekick.tsx
@@ -138,7 +138,7 @@ export default function({
             ? JSON.stringify(JSON.parse(textData), null, 2)
             : textData;
 
-          const blockOutputText = !!textData
+          const blockOutputText = (typeof textData !== 'undefined' && textData !== null)
             ? (
               <Spacing key={`output-text-${idx1}-${idx}`} ml={2}>
                 <Text monospace>

--- a/mage_ai/frontend/interfaces/BlockType.ts
+++ b/mage_ai/frontend/interfaces/BlockType.ts
@@ -158,6 +158,7 @@ export interface SampleDataType {
 }
 
 export interface OutputType {
+  multi_output?: boolean;
   sample_data: SampleDataType;
   shape: number[];
   text_data: string;

--- a/mage_ai/frontend/interfaces/KernelOutputType.ts
+++ b/mage_ai/frontend/interfaces/KernelOutputType.ts
@@ -35,6 +35,7 @@ export default interface KernelOutputType {
   metadata?: {
     [key: string]: string;
   };
+  multi_output?: boolean;
   msg_id?: string;
   msg_type?: MsgType;
   pipeline_uuid?: string;

--- a/mage_ai/server/websocket_server.py
+++ b/mage_ai/server/websocket_server.py
@@ -483,7 +483,7 @@ db_connection.start_session()
 """
                 client.execute(initialize_db_connection)
 
-            msg_id = client.execute(add_internal_output_info(code))
+            msg_id = client.execute(add_internal_output_info(block, code))
 
             WebSocketServer.running_executions_mapping[msg_id] = value
 

--- a/mage_ai/shared/custom_logger.py
+++ b/mage_ai/shared/custom_logger.py
@@ -47,9 +47,10 @@ def targets():
         # 'get_outputs',
         # 'get_variables_by_block',
         # 'fetch_input_variables',
-        'output_variables',
+        # 'output_variables',
         # 'uuid_for_output_variables',
         # 'dynamic_block_values_and_metadata',
+        'nothing',
     ]
 
 

--- a/mage_ai/shared/custom_logger.py
+++ b/mage_ai/shared/custom_logger.py
@@ -47,7 +47,7 @@ def targets():
         # 'get_outputs',
         # 'get_variables_by_block',
         # 'fetch_input_variables',
-        # 'output_variables',
+        'output_variables',
         # 'uuid_for_output_variables',
         # 'dynamic_block_values_and_metadata',
     ]


### PR DESCRIPTION
# Description
- Fix dynamic child blocks input and output data
- Show dynamic block outputs in notebook
- Show dynamic child block outputs in notebook

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

## Dynamic block
https://github.com/mage-ai/mage-ai/assets/1066980/d2328ae7-009c-4a5e-96ce-ebe38f4a338a

## Dynamic child block
https://github.com/mage-ai/mage-ai/assets/1066980/7be11881-6496-425f-94b6-59398c1ce6d9

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
