### PR TITLE
Fixed Stripe empty Metadata field

### DIFF
--- a/mage_integrations/mage_integrations/sources/stripe/__init__.py
+++ b/mage_integrations/mage_integrations/sources/stripe/__init__.py
@@ -930,7 +930,7 @@ def sync_sub_stream(sub_stream_name, parent_obj, updates=False):
 
             # If metadata is empty, set it as None
             if type(rec.get('metadata')) == dict and len(rec.get('metadata')) == 0:
-                        rec['metadata'] = None
+                rec['metadata'] = None
 
             if "id" in rec:
                 singer.write_record(sub_stream_name,
@@ -1094,7 +1094,7 @@ def sync_event_updates(stream_name, is_sub_stream):
                 rec = reduce_foreign_keys(rec, stream_name)
                 # If metadata is empty, set it as None
                 if type(rec.get('metadata')) == dict and len(rec.get('metadata')) == 0:
-                        rec['metadata'] = None
+                    rec['metadata'] = None
                 rec["updated"] = events_obj.created
                 rec["updated_by_event_type"] = events_obj.type
                 rec = transformer.transform(

--- a/mage_integrations/mage_integrations/sources/stripe/__init__.py
+++ b/mage_integrations/mage_integrations/sources/stripe/__init__.py
@@ -726,6 +726,9 @@ def sync_stream(stream_name, is_sub_stream=False, logger=None):
                     # any fields that aren't present in the whitelist.
                     if stream_field_whitelist:
                         rec = apply_whitelist(rec, stream_field_whitelist)
+                    # If metadata is empty, set it as None
+                    if type(rec.get('metadata')) == dict and len(rec.get('metadata')) == 0:
+                        rec['metadata'] = None
 
                     singer.write_record(stream_name,
                                         rec,
@@ -924,6 +927,11 @@ def sync_sub_stream(sub_stream_name, parent_obj, updates=False):
             ))
             # NB: Older structures (such as invoice_line_items) may not have had their ID present.
             #     Skip these if they don't match the structure we expect.
+
+            # If metadata is empty, set it as None
+            if type(rec.get('metadata')) == dict and len(rec.get('metadata')) == 0:
+                        rec['metadata'] = None
+
             if "id" in rec:
                 singer.write_record(sub_stream_name,
                                     rec,
@@ -1084,6 +1092,9 @@ def sync_event_updates(stream_name, is_sub_stream):
                 rec = recursive_to_dict(event_resource_obj)
                 rec = unwrap_data_objects(rec)
                 rec = reduce_foreign_keys(rec, stream_name)
+                # If metadata is empty, set it as None
+                if type(rec.get('metadata')) == dict and len(rec.get('metadata')) == 0:
+                        rec['metadata'] = None
                 rec["updated"] = events_obj.created
                 rec["updated_by_event_type"] = events_obj.type
                 rec = transformer.transform(


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fixed a issue where metadata fields from stripe contained only a empty dict, causing writing to snowflake fail.
Example:
![Screenshot from 2024-01-17 20-57-08](https://github.com/mage-ai/mage-ai/assets/14100959/5bd69653-1b1d-40c1-b614-ab0046450ee2)


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
Tested using a Stripe account and Snowflake destination

## FULL TABLE Sync
![Screenshot from 2024-01-17 21-15-42](https://github.com/mage-ai/mage-ai/assets/14100959/9ef04415-3474-4af4-ab0e-543bdfbe1747)


## INCREMENTAL Sync

![Screenshot from 2024-01-17 21-10-16](https://github.com/mage-ai/mage-ai/assets/14100959/4171a7ea-a61d-4ab2-af25-965d8acad73e)
![Screenshot from 2024-01-17 21-12-16](https://github.com/mage-ai/mage-ai/assets/14100959/585cc7c9-94c8-4fbf-88ac-11a18db1cbcf)

## Snoflake Data Result

![Screenshot from 2024-01-17 21-17-47](https://github.com/mage-ai/mage-ai/assets/14100959/b4e827cf-651c-4f50-910e-c24bc3179724)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas


cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 