### PR TITLE
[xy] Fix pipeline run variable overwrite for sql block.

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -467,7 +467,8 @@ class Block(DataIntegrationMixin, SparkBlock, ProjectPlatformAccessible):
         **kwargs,
     ) -> str:
         variables = variables or {}
-        if self.pipeline and self.pipeline.variables:
+        if self.pipeline and self.pipeline.variables and not variables:
+            # If variables is an empty dictionary, set it with the pipeline variables
             variables.update(self.pipeline.variables)
 
         if upstream_block_uuids is None:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
When using `{{ var_name }}` syntax in SQL block, the pipeline run/trigger variable overwite doesn't work.
This PR fixes pipeline run variable overwrite for sql block.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with SQL block variable and pipeline run variable overwrite. The new value is appended to the table correctly.
Fix pipeline run variable overwrite for sql block.
<img width="626" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/ae8e299f-3ccb-47c1-9c93-f2011e59b4a0">
<img width="484" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/010dd335-6b8c-4427-8d7f-1add02092ead">
<img width="211" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/7b264a0e-1e1a-4e40-99df-833afd71857b">


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
