### PR TITLE
[td] Remove terminal colors because the commands freeze pip installed Mage

### DIFF
--- a/mage_ai/server/terminal_server.py
+++ b/mage_ai/server/terminal_server.py
@@ -11,7 +11,6 @@ from mage_ai.data_preparation.models.file import ensure_file_is_in_project
 from mage_ai.data_preparation.repo_manager import get_project_uuid
 from mage_ai.orchestration.constants import Entity
 from mage_ai.orchestration.db.models.oauth import Oauth2Application
-from mage_ai.server.websockets.terminal.utils import build_color_commands
 from mage_ai.settings import (
     DISABLE_TERMINAL,
     REQUIRE_USER_AUTHENTICATION,
@@ -154,8 +153,3 @@ class TerminalWebsocketServer(terminado.TermSocket):
         if self.term_command == 'bash':
             self.terminal.ptyproc.write(
                 "bind 'set enable-bracketed-paste off' # Mage terminal settings command\r")
-
-        for cmd in build_color_commands(uuid=term_name):
-            self.terminal.ptyproc.write(f'{cmd}\r')
-
-        self.terminal.read_buffer.clear()

--- a/mage_ai/server/websockets/terminal/server.py
+++ b/mage_ai/server/websockets/terminal/server.py
@@ -1,7 +1,0 @@
-from mage_ai.server.terminal_server import TerminalWebsocketServer
-from mage_ai.server.websockets.base import BaseHandler
-from mage_ai.server.websockets.constants import Channel
-
-
-class Terminal(TerminalWebsocketServer, BaseHandler):
-    channel = Channel.TERMINAL

--- a/mage_ai/server/websockets/terminal/utils.py
+++ b/mage_ai/server/websockets/terminal/utils.py
@@ -1,6 +1,7 @@
 from typing import List
 
 
+# RUNNING THESE COMMANDs will freeze the pip installed app.
 def build_color_commands(uuid: str = None) -> List[str]:
     """
     Enter this in your terminal to view available colors:


### PR DESCRIPTION
# Description
Remove extraneous terminal subclasses and the color commands because it freezes the apps installed via pip.

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
