### PR TITLE
Fixed Oauth connection on Salesforce Source

### DIFF
--- a/mage_integrations/mage_integrations/sources/salesforce/README.md
+++ b/mage_integrations/mage_integrations/sources/salesforce/README.md
@@ -11,7 +11,7 @@ You must enter the following settings when configuring this source:
 | Key | Description | Sample value
 | --- | --- | --- |
 | `api_type` | The `api_type` is used to switch the behavior of the tap between using Salesforce's "REST" and "BULK" APIs. When new fields are discovered in Salesforce objects, the `select_fields_by_default` key describes whether or not the tap will select those fields by default. | `REST`, `BULK` |
-| `domain` | If `test`, then sandbox account configuration/endpoints will be used.  | `login`, `test` |
+| `domain` | Your Salesforce instance domain. Use 'login' (default) or 'test' (sandbox), or Salesforce My domain.| `test`, `login`|
 | `select_fields_by_default` | If `true`, the fields in a schema of a stream will all be selected by default when setting up a synchronization. | `true`, `false` |
 | `start_date` | The `start_date` is used by the tap as a bound on SOQL queries when searching for records.  This should be this exact format `YYYY-mm-ddTHH:MM:SSZ`. | `2022-11-30T21:31:20Z` |
 

--- a/mage_integrations/mage_integrations/sources/salesforce/__init__.py
+++ b/mage_integrations/mage_integrations/sources/salesforce/__init__.py
@@ -29,7 +29,7 @@ class Salesforce(Source):
             credentials=parse_credentials(self.config),
             quota_percent_total=self.config.get('quota_percent_total'),
             quota_percent_per_run=self.config.get('quota_percent_per_run'),
-            is_sandbox=self.config.get('domain'),
+            domain=self.config.get('domain'),
             select_fields_by_default=self.config.get('select_fields_by_default'),
             default_start_date=self.config.get('start_date'),
             api_type=self.config.get('api_type')

--- a/mage_integrations/mage_integrations/sources/salesforce/__init__.py
+++ b/mage_integrations/mage_integrations/sources/salesforce/__init__.py
@@ -53,21 +53,7 @@ class Salesforce(Source):
         catalog = Catalog(do_discover(self.client,
                                       streams=self.config.get('streams', None),
                                       logger=self.logger)['streams'])
-        self.__finally_clean_up()
         return catalog
-
-    def __finally_clean_up(self):
-        if self.client:
-            if self.client.rest_requests_attempted > 0:
-                self.logger.info(
-                    f"This job used {self.client.rest_requests_attempted} REST requests \
-                    towards the Salesforce quota.")
-            if self.client.jobs_completed > 0:
-                self.logger.info(
-                    f"Replication used {self.client.jobs_completed} Bulk API jobs \
-                    towards the Salesforce quota.")
-            if self.client.login_timer:
-                self.client.login_timer.cancel()
 
     def test_connection(self):
         try:

--- a/mage_integrations/mage_integrations/sources/salesforce/client/tap_salesforce/salesforce/__init__.py
+++ b/mage_integrations/mage_integrations/sources/salesforce/client/tap_salesforce/salesforce/__init__.py
@@ -210,7 +210,7 @@ class Salesforce():
                  token=None,
                  quota_percent_per_run=None,
                  quota_percent_total=None,
-                 is_sandbox=None,
+                 domain=None,
                  select_fields_by_default=None,
                  default_start_date=None,
                  api_type=None):
@@ -223,7 +223,7 @@ class Salesforce():
 
         self.quota_percent_per_run = float(quota_percent_per_run) if quota_percent_per_run is not None else 25 # noqa
         self.quota_percent_total = float(quota_percent_total) if quota_percent_total is not None else 80 # noqa
-        self.is_sandbox = is_sandbox
+        self.domain = domain
         self.select_fields_by_default = select_fields_by_default is True or (isinstance(
             select_fields_by_default, str) and select_fields_by_default.lower() == 'true')
         self.default_start_date = default_start_date
@@ -233,7 +233,7 @@ class Salesforce():
         self.pk_chunking = False
         self.login_timer = None
 
-        self.auth = SalesforceAuth.from_credentials(credentials, is_sandbox=self.is_sandbox)
+        self.auth = SalesforceAuth.from_credentials(credentials, domain=self.domain)
 
         # validate start_date
         singer_utils.strptime(default_start_date)

--- a/mage_integrations/mage_integrations/sources/salesforce/client/tap_salesforce/salesforce/credentials.py
+++ b/mage_integrations/mage_integrations/sources/salesforce/client/tap_salesforce/salesforce/credentials.py
@@ -31,8 +31,8 @@ def parse_credentials(config):
 
 
 class SalesforceAuth():
-    def __init__(self, credentials, is_sandbox='login'):
-        self.is_sandbox = is_sandbox
+    def __init__(self, credentials, domain='login'):
+        self.domain = domain
         self._credentials = credentials
         self._access_token = None
         self._instance_url = None
@@ -77,7 +77,7 @@ class SalesforceAuthOAuth(SalesforceAuth):
 
     @property
     def _login_url(self):
-        return f"https://{self.is_sandbox}.salesforce.com/services/oauth2/token"
+        return f"https://{self.domain}.salesforce.com/services/oauth2/token"
 
     def login(self):
         try:
@@ -103,7 +103,7 @@ class SalesforceAuthOAuth(SalesforceAuth):
 class SalesforceAuthPassword(SalesforceAuth):
     def login(self):
         login = SalesforceLogin(
-            domain=self.is_sandbox,
+            domain=self.domain,
             **self._credentials._asdict()
         )
 

--- a/mage_integrations/mage_integrations/sources/salesforce/client/tap_salesforce/salesforce/credentials.py
+++ b/mage_integrations/mage_integrations/sources/salesforce/client/tap_salesforce/salesforce/credentials.py
@@ -31,7 +31,7 @@ def parse_credentials(config):
 
 
 class SalesforceAuth():
-    def __init__(self, credentials, is_sandbox=False):
+    def __init__(self, credentials, is_sandbox='login'):
         self.is_sandbox = is_sandbox
         self._credentials = credentials
         self._access_token = None
@@ -77,12 +77,7 @@ class SalesforceAuthOAuth(SalesforceAuth):
 
     @property
     def _login_url(self):
-        login_url = 'https://login.salesforce.com/services/oauth2/token'
-
-        if self.is_sandbox:
-            login_url = 'https://test.salesforce.com/services/oauth2/token'
-
-        return login_url
+        return f"https://{self.is_sandbox}.salesforce.com/services/oauth2/token"
 
     def login(self):
         try:
@@ -103,10 +98,6 @@ class SalesforceAuthOAuth(SalesforceAuth):
             if resp:
                 error_message = error_message + ", Response from Salesforce: {}".format(resp.text)
             raise Exception(error_message) from e
-        finally:
-            LOGGER.info("Starting new login timer")
-            self.login_timer = threading.Timer(self.REFRESH_TOKEN_EXPIRATION_PERIOD, self.login)
-            self.login_timer.start()
 
 
 class SalesforceAuthPassword(SalesforceAuth):


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This PR fixes OAuth connection inside Salesforce Source

These problems originated by a timer set on the login method inside SalesforceOAuth connection. This timer would break the 10 seconds rule for Test Connection and block discover time.

Also, the Login URL was modified to match Salesforce Destination connection, and support specific domains instead of the usual login/test param.

Finally, the `__finally_clean_up()` method was removed from the discover phase. This method would only delivery such information outside of the main pipelines logs, and the standard logs from pipeline output already deliver the exact number of requests versus the max cap. This should allow for less discovery time.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
Tested using a Salesforce Source account and a PostgreSQL DB as destination.

## FULL TABLE Sync
![Screenshot from 2024-01-19 07-01-16](https://github.com/mage-ai/mage-ai/assets/14100959/a3af4a58-5e31-4eb7-9f63-4e9ea85fdff6)

## INCREMENTAL Sync
![Screenshot from 2024-01-19 07-01-32](https://github.com/mage-ai/mage-ai/assets/14100959/386d4af2-c971-49d2-83bc-570615216ad8)

## Data Example
( Account stream example )
![Screenshot from 2024-01-19 07-35-17](https://github.com/mage-ai/mage-ai/assets/14100959/5ba7bd8e-77dd-44b6-ac03-d0d800dd1dc1)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation


cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 