### PR TITLE
[td] Speed up monitor stats and reduce calls on overview

### DIFF
--- a/mage_ai/api/policies/ProjectPolicy.py
+++ b/mage_ai/api/policies/ProjectPolicy.py
@@ -55,6 +55,7 @@ ProjectPolicy.allow_write([
 ], condition=lambda policy: policy.has_at_least_editor_role())
 
 ProjectPolicy.allow_write([
+    'deny_improve_mage',
     'help_improve_mage',
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,

--- a/mage_ai/api/resources/ProjectResource.py
+++ b/mage_ai/api/resources/ProjectResource.py
@@ -178,6 +178,11 @@ class ProjectResource(GenericResource):
 
             data['help_improve_mage'] = payload['help_improve_mage']
 
+        if 'deny_improve_mage' in payload:
+            await UsageStatisticLogger().project_deny_improve_mage(
+                repo_config.project_uuid or data.get('project_uuid'),
+            )
+
         if 'openai_api_key' in payload:
             openai_api_key = payload.get('openai_api_key')
             if repo_config.openai_api_key != openai_api_key:

--- a/mage_ai/command_center/applications/constants.py
+++ b/mage_ai/command_center/applications/constants.py
@@ -1,5 +1,6 @@
 from mage_ai.data_preparation.models.project.constants import FeatureUUID
 from mage_ai.settings import REQUIRE_USER_AUTHENTICATION, REQUIRE_USER_PERMISSIONS
+from mage_ai.settings.platform.constants import project_platform_activated
 
 ITEMS = [
     dict(
@@ -55,17 +56,17 @@ ITEMS = [
         path='/platform/global-hooks',
         condition=lambda opts: opts['project'].is_feature_enabled(
             FeatureUUID.GLOBAL_HOOKS,
-        ) and opts['project'].is_feature_enabled(FeatureUUID.PROJECT_PLATFORM),
+        ) and project_platform_activated(),
     ),
     dict(
         title='Platform preferences',
         path='/settings/platform/preferences',
-        condition=lambda opts: opts['project'].is_feature_enabled(FeatureUUID.PROJECT_PLATFORM),
+        condition=lambda _opts: project_platform_activated(),
     ),
     dict(
         title='Platform settings',
         path='/settings/platform/settings',
-        condition=lambda opts: opts['project'].is_feature_enabled(FeatureUUID.PROJECT_PLATFORM),
+        condition=lambda _opts: project_platform_activated(),
     ),
     dict(
         title='Project preferences',

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -119,21 +119,25 @@ class Pipeline:
         else:
             self.load_config(config, catalog=catalog)
 
-    @property
-    def config_path(self):
-        if project_platform_activated() and not self.use_repo_path:
+    @classmethod
+    def build_config_path(self, uuid: str, repo_path: str, use_repo_path: bool = False) -> str:
+        if project_platform_activated() and not use_repo_path:
             from mage_ai.settings.platform.utils import get_pipeline_config_path
 
-            config_path, _repo_path = get_pipeline_config_path(self.uuid)
+            config_path, _repo_path = get_pipeline_config_path(uuid)
             if config_path:
                 return config_path
 
         return os.path.join(
-            self.repo_path,
+            repo_path,
             PIPELINES_FOLDER,
-            self.uuid,
+            uuid,
             PIPELINE_CONFIG_FILE,
         )
+
+    @property
+    def config_path(self):
+        return self.build_config_path(self.uuid, self.repo_path, use_repo_path=self.use_repo_path)
 
     @property
     def catalog_config_path(self):

--- a/mage_ai/data_preparation/models/pipelines/seed.py
+++ b/mage_ai/data_preparation/models/pipelines/seed.py
@@ -1,0 +1,157 @@
+from datetime import datetime
+from typing import List
+
+from mage_ai.data_preparation.models.block import Block
+from mage_ai.data_preparation.models.constants import BlockType
+from mage_ai.data_preparation.models.pipeline import Pipeline
+from mage_ai.data_preparation.models.triggers import (
+    ScheduleInterval,
+    ScheduleStatus,
+    ScheduleType,
+)
+from mage_ai.orchestration.db import db_connection
+from mage_ai.orchestration.db.models.schedules import (
+    BlockRun,
+    PipelineRun,
+    PipelineSchedule,
+)
+from mage_ai.shared.hash import index_by
+
+
+def seed(
+    repo_path: str,
+    pipelines: int = None,
+    pipeline_schedules: int = None,
+    pipeline_runs: int = None,
+    block_runs: int = None,
+):
+    db_connection.start_session()
+
+    pipeline_models = [Pipeline.get(
+        uuid,
+        repo_path=repo_path,
+    ) for uuid in Pipeline.get_all_pipelines(repo_path=repo_path)]
+    for i1 in range(pipelines - len(pipeline_models)):
+        i = i1 + len(pipeline_models)
+        model = Pipeline.create(name=f'Pipeline {i}', repo_path=repo_path)
+        blocks = []
+        types = [BlockType.DATA_LOADER, BlockType.TRANSFORMER, BlockType.DATA_EXPORTER]
+        for i2 in range(3):
+            block = Block.create(
+                f'block_{i}_{i2}',
+                types[i2 % len(types)],
+                repo_path,
+            )
+            model.add_block(block, upstream_block_uuids=[b.uuid for b in blocks])
+            blocks.append(block)
+        pipeline_models.append(model)
+
+    try:
+        pipeline_schedules_models, pipeline_runs_models, block_runs_models = __process(
+            pipelines=pipeline_models,
+            pipeline_schedules=pipeline_schedules,
+            pipeline_runs=pipeline_runs,
+            block_runs=block_runs,
+        )
+        db_connection.session.commit()
+
+        print(f'Created {len(pipeline_models)} pipelines')
+        print(f'Created {len(pipeline_schedules_models)} pipeline schedules')
+        print(f'Created {len(pipeline_runs_models)} pipeline runs')
+        print(f'Created {len(block_runs_models)} block runs')
+    except Exception as err:
+        db_connection.session.rollback()
+        [p.delete() for p in pipeline_models]
+        raise err
+
+
+def __process(
+    pipelines: List[Pipeline],
+    pipeline_schedules: int = None,
+    pipeline_runs: int = None,
+    block_runs: int = None,
+):
+    pipelines_count = len(pipelines)
+
+    pipeline_schedules_models = []
+    if pipeline_schedules is None:
+        pipeline_schedules_models = PipelineSchedule.query.all()
+    else:
+        for i in range(pipeline_schedules):
+            pipeline = pipelines[i % pipelines_count]
+            model = PipelineSchedule(
+                name=f'Pipeline Schedule {i}',
+                pipeline_uuid=pipeline.uuid,
+                schedule_interval=ScheduleInterval.DAILY,
+                schedule_type=ScheduleType.TIME,
+                start_time=datetime.utcnow(),
+                status=ScheduleStatus.INACTIVE,
+            )
+            pipeline_schedules_models.append(model)
+
+        db_connection.session.bulk_save_objects(
+            pipeline_schedules_models,
+            return_defaults=True,
+        )
+
+    pipeline_runs_models = []
+    if pipeline_runs is None:
+        pipeline_runs_models = PipelineRun.query.all()
+    else:
+        statuses = [
+            PipelineRun.PipelineRunStatus.COMPLETED,
+            PipelineRun.PipelineRunStatus.FAILED,
+            PipelineRun.PipelineRunStatus.CANCELLED,
+        ]
+        pipeline_schedules_count = len(pipeline_schedules_models)
+        for i in range(pipeline_runs):
+            if (i + 1) % 100000 == 0:
+                print('Creating pipeline runs', i + 1)
+
+            pipeline_schedule = pipeline_schedules_models[i % pipeline_schedules_count]
+            model = PipelineRun(
+                completed_at=datetime.utcnow(),
+                execution_date=datetime.utcnow(),
+                pipeline_schedule_id=pipeline_schedule.id,
+                pipeline_uuid=pipeline_schedule.pipeline_uuid,
+                started_at=datetime.utcnow(),
+                status=statuses[i % len(statuses)],
+            )
+            pipeline_runs_models.append(model)
+
+        db_connection.session.bulk_save_objects(
+            pipeline_runs_models,
+            return_defaults=True,
+        )
+
+    pipelines_mapping = index_by(lambda x: x.uuid, pipelines)
+
+    block_runs_models = []
+    if block_runs is None:
+        block_runs_models = BlockRun.query.all()
+    else:
+        statuses = [v.value for v in BlockRun.BlockRunStatus]
+        pipeline_runs_count = len(pipeline_runs_models)
+        for i in range(block_runs):
+            if (i + 1) % 100000 == 0:
+                print('Creating block runs', i + 1)
+
+            pipeline_run = pipeline_runs_models[i % pipeline_runs_count]
+            pipeline = pipelines_mapping[pipeline_run.pipeline_uuid]
+            blocks = list(pipeline.blocks_by_uuid.values())
+
+            model = BlockRun(
+                block_uuid=blocks[i % len(blocks)].uuid,
+                completed_at=datetime.utcnow(),
+                pipeline_run_id=pipeline_run.id,
+                started_at=datetime.utcnow(),
+                status=statuses[i % len(statuses)],
+            )
+            block_runs_models.append(model)
+
+        db_connection.session.bulk_save_objects(
+            block_runs_models,
+            return_defaults=True,
+        )
+
+    return pipeline_schedules_models, pipeline_runs_models, block_runs_models

--- a/mage_ai/data_preparation/models/project/__init__.py
+++ b/mage_ai/data_preparation/models/project/__init__.py
@@ -113,11 +113,8 @@ class Project():
 
         for uuid in FeatureUUID:
             key = uuid.value
-            if FeatureUUID.PROJECT_PLATFORM == uuid:
-                data[key] = project_platform_activated()
-            else:
-                if features and key in features:
-                    data[key] = features.get(key)
+            if features and key in features:
+                data[key] = features.get(key)
 
         return data
 

--- a/mage_ai/data_preparation/models/project/constants.py
+++ b/mage_ai/data_preparation/models/project/constants.py
@@ -14,4 +14,3 @@ class FeatureUUID(str, Enum):
     LOCAL_TIMEZONE = 'display_local_timezone'
     NOTEBOOK_BLOCK_OUTPUT_SPLIT_VIEW = 'notebook_block_output_split_view'
     OPERATION_HISTORY = 'operation_history'
-    PROJECT_PLATFORM = 'project_platform'

--- a/mage_ai/frontend/components/FileBrowser/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/index.tsx
@@ -602,15 +602,13 @@ function FileBrowser({
         },
       ]);
 
-      if (featureEnabled?.(featureUUIDs?.PROJECT_PLATFORM)) {
-        items.push({
-          beforeIcon: <GradientLogoIcon width={UNIT * 1.5} />,
-          onClick: () => {
-            showModalNewFolder({ projectType: ProjectTypeEnum.STANDALONE });
-          },
-          uuid: 'New Mage project',
-        });
-      }
+      items.push({
+        beforeIcon: <GradientLogoIcon width={UNIT * 1.5} />,
+        onClick: () => {
+          showModalNewFolder({ projectType: ProjectTypeEnum.STANDALONE });
+        },
+        uuid: 'New Mage project',
+      });
 
       if (featureEnabled?.(featureUUIDs?.DBT_V2)) {
         items.push({

--- a/mage_ai/frontend/interfaces/ProjectType.ts
+++ b/mage_ai/frontend/interfaces/ProjectType.ts
@@ -14,7 +14,6 @@ export enum FeatureUUIDEnum {
   NOTEBOOK_BLOCK_OUTPUT_SPLIT_VIEW = 'notebook_block_output_split_view',
   LOCAL_TIMEZONE = 'display_local_timezone',
   OPERATION_HISTORY = 'operation_history',
-  PROJECT_PLATFORM = 'project_platform',
 }
 
 export enum ProjectTypeEnum {

--- a/mage_ai/frontend/pages/overview/index.tsx
+++ b/mage_ai/frontend/pages/overview/index.tsx
@@ -1,5 +1,5 @@
 import { MutateFunction, useMutation } from 'react-query';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import moment from 'moment';
 
@@ -95,32 +95,27 @@ const SHARED_FETCH_OPTIONS = {
   revalidateOnFocus: false,
 };
 
-function OverviewPage() {
+function OverviewPage({
+  tab,
+}: {
+  tab?: TimePeriodEnum;
+}) {
+  const abortRef = useRef(null);
+  const mountedRef = useRef(false);
   const refSubheader = useRef(null);
 
   const q = queryFromUrl();
   const router = useRouter();
   const newPipelineButtonMenuRef = useRef(null);
-  const [selectedTab, setSelectedTab] = useState<TabType>(TAB_TODAY);
+  const [selectedTab, setSelectedTabState] =
+    useState<TabType>(TIME_PERIOD_TABS.find(({ uuid }) => uuid === tab) || TAB_TODAY);
+
   const [addButtonMenuOpen, setAddButtonMenuOpen] = useState<boolean>(false);
   const [errors, setErrors] = useState<ErrorsType>(null);
 
   const timePeriod = selectedTab?.uuid;
 
   const allTabs = useMemo(() => TIME_PERIOD_TABS.concat(TAB_DASHBOARD), []);
-
-  const selectedTabPrev = usePrevious(selectedTab);
-  useEffect(() => {
-    const uuid = q[TAB_URL_PARAM];
-    if (uuid) {
-      setSelectedTab(allTabs.find(({ uuid: tabUUID }) => tabUUID === uuid));
-    }
-  }, [
-    allTabs,
-    q,
-    selectedTab,
-    selectedTabPrev,
-  ]);
 
   const startDateString = useMemo(() =>
     getStartDateStringFromPeriod(timePeriod, { isoString: true }),
@@ -130,15 +125,59 @@ function OverviewPage() {
     group_by_pipeline_type: 1,
     start_time: startDateString,
   }), [startDateString]);
-  const {
-    data: dataMonitor,
-    isValidating: isValidatingMonitorStats,
-    mutate: fetchMonitorStats,
-  } = api.monitor_stats.detail(
-    MonitorStatsEnum.PIPELINE_RUN_COUNT,
-    monitorStatsQueryParams,
-    { ...SHARED_FETCH_OPTIONS },
+
+  const [monitorStats, setMonitorStats] = useState();
+  const [fetchMonitorStats, { isLoading: isValidatingMonitorStats }] = useMutation(
+    () => api.monitor_stats?.detailAsync(
+      MonitorStatsEnum.PIPELINE_RUN_COUNT,
+      monitorStatsQueryParams,
+      {
+        signal: abortRef?.current?.signal,
+      },
+    ),
+    {
+      onSuccess: (response: any) => {
+        return onSuccess(
+          response,
+          {
+            callback: ({
+              monitor_stat: {
+                stats,
+              },
+            }) => {
+              setMonitorStats(stats);
+            },
+          },
+        );
+      },
+    },
   );
+
+  const setSelectedTab = useCallback((prev: TabType | ((tab: TabType) => TabType)) => {
+    if (abortRef?.current !== null) {
+      abortRef?.current?.abort();
+    }
+    abortRef.current = new AbortController();
+
+    setSelectedTabState((current: TabType) => {
+      const tab = typeof prev === 'function' ? prev(current) : prev;
+
+      if (current?.uuid !== tab?.uuid) {
+        goToWithQuery({ [TAB_URL_PARAM]: tab?.uuid }, { replaceParams: true });
+
+        fetchMonitorStats();
+      }
+
+      return tab;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!mountedRef?.current) {
+      mountedRef.current = true;
+      fetchMonitorStats();
+    }
+  }, []);
 
   const {
     data: dataPipelineRuns,
@@ -167,21 +206,14 @@ function OverviewPage() {
     streaming: streamingPipelineRuns = [],
   } = groupedPipelineRuns;
 
-  useEffect(() => {
-    if (selectedTabPrev && selectedTab?.uuid !== selectedTabPrev?.uuid) {
-      fetchMonitorStats();
-    }
-  }, [fetchMonitorStats, selectedTab, selectedTabPrev]);
-
   const dateRange = useMemo(() =>
     getDateRange(TIME_PERIOD_INTERVAL_MAPPING[timePeriod] + 1),
     [timePeriod],
     );
   const allPipelineRunData = useMemo(() => {
-    const monitorStats: RunCountStatsType = dataMonitor?.monitor_stat?.stats || {};
     return getAllPipelineRunDataGrouped(monitorStats, dateRange);
   }, [
-    dataMonitor?.monitor_stat?.stats,
+    monitorStats,
     dateRange,
   ]);
   const {
@@ -593,7 +625,7 @@ def d(df):
             </Spacing>
             <ButtonTabs
               onClickTab={({ uuid }) => {
-                goToWithQuery({ [TAB_URL_PARAM]: uuid }, { replaceParams: true });
+                setSelectedTab(() => TIME_PERIOD_TABS.find(t => uuid === t.uuid))
               }}
               regularSizeText
               selectedTabUUID={timePeriod}
@@ -704,6 +736,10 @@ def d(df):
   );
 }
 
-OverviewPage.getInitialProps = async () => ({});
+OverviewPage.getInitialProps = async (ctx) => {
+  return {
+    tab: (ctx?.query?.tab || TimePeriodEnum.TODAY) as TimePeriodEnum,
+  };
+};
 
 export default PrivateRoute(OverviewPage);

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -906,6 +906,7 @@ function PipelineListPage() {
     },
   );
   const updateProject = useCallback((payload: {
+    deny_improve_mage?: boolean;
     help_improve_mage?: boolean;
   }) => updateProjectBase({
     project: payload,

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -984,11 +984,13 @@ function PipelineListPage() {
                   'Are you sure you don’t want to help everyone in the community?',
                 )) {
                   updateProject({
+                    deny_improve_mage: true,
                     help_improve_mage: false,
                   }).then(() => hideHelpMageModal());
                 }
               } else {
                 updateProject({
+                  deny_improve_mage: true,
                   help_improve_mage: false,
                 }).then(() => hideHelpMageModal());
               }

--- a/mage_ai/frontend/utils/models/project/useProject.ts
+++ b/mage_ai/frontend/utils/models/project/useProject.ts
@@ -19,7 +19,6 @@ export type UseProjectType = {
     NOTEBOOK_BLOCK_OUTPUT_SPLIT_VIEW: FeatureUUIDEnum;
     LOCAL_TIMEZONE: FeatureUUIDEnum;
     OPERATION_HISTORY: FeatureUUIDEnum;
-    PROJECT_PLATFORM: FeatureUUIDEnum;
   };
   fetchProjects: () => any;
   project: ProjectType;

--- a/mage_ai/orchestration/db/constants.py
+++ b/mage_ai/orchestration/db/constants.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class DatabaseType(str, Enum):
+    POSTGRESQL = 'postgresql'
+    SQLITE = 'sqlite'

--- a/mage_ai/orchestration/db/functions.py
+++ b/mage_ai/orchestration/db/functions.py
@@ -1,0 +1,40 @@
+from typing import List
+
+from sqlalchemy.sql import func
+
+from mage_ai.orchestration.db import db_connection_url
+from mage_ai.orchestration.db.constants import DatabaseType
+
+
+def database_type() -> DatabaseType:
+    if db_connection_url.startswith('postgresql'):
+        return DatabaseType.POSTGRESQL
+    elif db_connection_url.startswith('sqlite'):
+        return DatabaseType.SQLITE
+
+
+def format_datetime(column, datetime_formats: List[str]):
+    datetime_format = []
+    for value in datetime_formats:
+        if 'year' == value:
+            if DatabaseType.POSTGRESQL == database_type():
+                datetime_format.append('YYYY')
+            else:
+                datetime_format.append('%Y')
+        elif 'month' == value:
+            if DatabaseType.POSTGRESQL == database_type():
+                datetime_format.append('MM')
+            else:
+                datetime_format.append('%m')
+        elif 'day' == value:
+            if DatabaseType.POSTGRESQL == database_type():
+                datetime_format.append('DD')
+            else:
+                datetime_format.append('%d')
+
+    datetime_format = '-'.join(datetime_format)
+
+    if DatabaseType.POSTGRESQL == database_type():
+        return func.to_char(column, datetime_format)
+
+    return func.strftime(datetime_format, column)

--- a/mage_ai/orchestration/monitor/monitor_stats.py
+++ b/mage_ai/orchestration/monitor/monitor_stats.py
@@ -7,6 +7,7 @@ import dateutil.parser
 from sqlalchemy.sql import func
 
 from mage_ai.data_preparation.models.pipeline import Pipeline
+from mage_ai.orchestration.db.functions import format_datetime
 from mage_ai.orchestration.db.models.schedules import (
     BlockRun,
     PipelineRun,
@@ -107,7 +108,11 @@ class MonitorStats:
                 PipelineRun.pipeline_uuid,
                 PipelineRun.status,
                 PipelineSchedule.name,
-                func.to_char(PipelineRun.created_at, 'YYYY-MM-DD').label('ds_created_at'),
+                format_datetime(PipelineRun.created_at, [
+                    'year',
+                    'month',
+                    'day',
+                ]).label('ds_created_at'),
             ).
             join(PipelineSchedule, PipelineRun.pipeline_schedule_id == PipelineSchedule.id)
         )
@@ -151,7 +156,7 @@ class MonitorStats:
                     name=pipeline_schedule_name,
                     data=dict(),
                 )
-            # created_at_formatted = p.created_at.strftime('YYYY-MM-DD')  # Over 1000 ms
+            # p.created_at.strftime >= 1000 ms
             # Loop: 0.5338
             created_at_formatted = p.ds_created_at  # Negligible time
             data = stats_by_schedule_id[pipeline_schedule_id]['data']
@@ -190,7 +195,11 @@ class MonitorStats:
         select = [
             PipelineRun.completed_at,
             PipelineRun.created_at,
-            func.to_char(PipelineRun.created_at, 'YYYY-MM-DD').label('ds_created_at'),
+            format_datetime(PipelineRun.created_at, [
+                'year',
+                'month',
+                'day',
+            ]).label('ds_created_at'),
         ]
 
         if pipeline_uuid:
@@ -240,7 +249,11 @@ class MonitorStats:
             BlockRun.block_uuid.label('name'),
             BlockRun.status,
             func.count(BlockRun.block_uuid).label('n_count'),
-            func.to_char(BlockRun.created_at, 'YYYY-MM-DD').label('ds_created_at'),
+            format_datetime(BlockRun.created_at, [
+                'year',
+                'month',
+                'day',
+            ]).label('ds_created_at'),
         ]
         filter_query = []
 

--- a/mage_ai/orchestration/monitor/monitor_stats.py
+++ b/mage_ai/orchestration/monitor/monitor_stats.py
@@ -1,11 +1,18 @@
 import enum
 from datetime import datetime, timedelta
+from functools import reduce
 from typing import Callable, Dict, List, Union
 
 import dateutil.parser
-from sqlalchemy.orm import joinedload
+from sqlalchemy.sql import func
 
-from mage_ai.orchestration.db.models.schedules import BlockRun, PipelineRun
+from mage_ai.data_preparation.models.pipeline import Pipeline
+from mage_ai.orchestration.db.models.schedules import (
+    BlockRun,
+    PipelineRun,
+    PipelineSchedule,
+)
+from mage_ai.settings.repo import get_repo_path
 from mage_ai.shared.hash import group_by, merge_dict
 
 NO_PIPELINE_SCHEDULE_ID = 'no_pipeline_schedule_id'
@@ -20,6 +27,10 @@ class MonitorStatsType(str, enum.Enum):
 
 
 class MonitorStats:
+    @property
+    def repo_path(self) -> str:
+        return get_repo_path(root_project=True)
+
     def get_stats(
         self,
         stats_type: MonitorStatsType,
@@ -50,45 +61,106 @@ class MonitorStats:
         elif stats_type == MonitorStatsType.BLOCK_RUN_TIME:
             return self.get_block_run_time(**new_kwargs)
 
+    def __filter(
+        self,
+        query,
+        end_time: datetime = None,
+        pipeline_schedule_id: int = None,
+        pipeline_uuid: str = None,
+        start_time: datetime = None,
+    ) -> List:
+        filter_statement = []
+
+        if pipeline_uuid is not None:
+            filter_statement.append(PipelineRun.pipeline_uuid == pipeline_uuid)
+
+        if start_time is not None:
+            filter_statement.append(PipelineRun.created_at >= start_time)
+
+        if end_time is not None:
+            filter_statement.append(PipelineRun.created_at <= end_time)
+
+        if pipeline_schedule_id is not None:
+            filter_statement.append(PipelineRun.pipeline_schedule_id == int(pipeline_schedule_id))
+
+        if filter_statement:
+            return query.filter(*filter_statement)
+
+        return query
+
     def get_pipeline_run_count(
         self,
         pipeline_uuid: str = None,
         start_time: datetime = None,
         end_time: datetime = None,
         group_by_pipeline_type: Union[str, bool] = False,
+        pipeline_schedule_id: int = None,
         **kwargs,
     ) -> Dict:
-        pipeline_runs = self.__filter_pipeline_runs(
+        now = datetime.utcnow().timestamp()
+
+        query = (
+            PipelineRun.
+            select(
+                PipelineRun.created_at,
+                PipelineRun.pipeline_schedule_id,
+                PipelineRun.pipeline_uuid,
+                PipelineRun.status,
+                PipelineSchedule.name,
+                func.to_char(PipelineRun.created_at, 'YYYY-MM-DD').label('ds_created_at'),
+            ).
+            join(PipelineSchedule, PipelineRun.pipeline_schedule_id == PipelineSchedule.id)
+        )
+
+        query = self.__filter(
+            query,
+            end_time=end_time,
+            pipeline_schedule_id=pipeline_schedule_id,
             pipeline_uuid=pipeline_uuid,
             start_time=start_time,
-            end_time=end_time,
-            **kwargs,
         )
-        pipeline_runs = pipeline_runs.all()
+
+        pipeline_runs = query.all()
+        # Query: 11.1094
+        # Query: 2.7102 (after optimization)
+        print(f'Query: {round((datetime.utcnow().timestamp() - now) * 10000) / 10000}')
+
+        now = datetime.utcnow().timestamp()
         stats_by_schedule_id = dict()
-        pipeline_type_by_pipeline_uuid = dict()
+        pipelines_mapping = {}
+        for pipeline in [Pipeline.get(
+            uuid,
+            check_if_exists=False,
+            repo_path=self.repo_path,
+            use_repo_path=True,
+        ) for uuid in set([p.pipeline_uuid for p in pipeline_runs])]:
+            pipelines_mapping[pipeline.uuid] = pipeline
+        # 0.2497
+        print(f'Mapping: {round((datetime.utcnow().timestamp() - now) * 10000) / 10000}')
+
+        now = datetime.utcnow().timestamp()
         for p in pipeline_runs:
-            if p.pipeline_schedule is None and not group_by_pipeline_type:
-                continue
             if p.pipeline_schedule_id is None:
                 pipeline_schedule_id = NO_PIPELINE_SCHEDULE_ID
                 pipeline_schedule_name = NO_PIPELINE_SCHEDULE_NAME
             else:
                 pipeline_schedule_id = p.pipeline_schedule_id
-                pipeline_schedule_name = p.pipeline_schedule_name
+                pipeline_schedule_name = p.name
             if pipeline_schedule_id not in stats_by_schedule_id:
                 stats_by_schedule_id[pipeline_schedule_id] = dict(
                     name=pipeline_schedule_name,
                     data=dict(),
                 )
-            created_at_formatted = p.created_at.strftime('%Y-%m-%d')
+            # created_at_formatted = p.created_at.strftime('YYYY-MM-DD')  # Over 1000 ms
+            # Loop: 0.5338
+            created_at_formatted = p.ds_created_at  # Negligible time
             data = stats_by_schedule_id[pipeline_schedule_id]['data']
             if created_at_formatted not in data:
                 data[created_at_formatted] = dict()
+
             if group_by_pipeline_type:
-                if p.pipeline_uuid not in pipeline_type_by_pipeline_uuid:
-                    pipeline_type_by_pipeline_uuid[p.pipeline_uuid] = p.pipeline_type
-                pipeline_type = pipeline_type_by_pipeline_uuid[p.pipeline_uuid]
+                # Loop: 0.734
+                pipeline_type = pipelines_mapping[p.pipeline_uuid].type
                 if pipeline_type not in data[created_at_formatted]:
                     data[created_at_formatted][pipeline_type] = dict()
                 if p.status not in data[created_at_formatted][pipeline_type]:
@@ -100,6 +172,10 @@ class MonitorStats:
                     data[created_at_formatted][p.status] = 1
                 else:
                     data[created_at_formatted][p.status] += 1
+        # Loop: 2.4017
+        # Loop: 1.0568 (optimized)
+        print(f'Loop: {round((datetime.utcnow().timestamp() - now) * 10000) / 10000}')
+
         return stats_by_schedule_id
 
     def get_pipeline_run_time(
@@ -109,14 +185,34 @@ class MonitorStats:
         end_time: datetime = None,
         **kwargs,
     ) -> Dict:
-        pipeline_runs = self.__filter_pipeline_runs(
+        now = datetime.utcnow().timestamp()
+
+        select = [
+            PipelineRun.completed_at,
+            PipelineRun.created_at,
+            func.to_char(PipelineRun.created_at, 'YYYY-MM-DD').label('ds_created_at'),
+        ]
+
+        if pipeline_uuid:
+            select.append(PipelineRun.pipeline_uuid)
+
+        if start_time or end_time:
+            select.append(PipelineRun.created_at)
+
+        query = self.__filter(
+            PipelineRun.select(*select),
+            end_time=end_time,
             pipeline_uuid=pipeline_uuid,
             start_time=start_time,
-            end_time=end_time,
-            **kwargs,
-        )
-        pipeline_runs = pipeline_runs.filter(PipelineRun.completed_at != None).all()  # noqa: E711
-        pipeline_run_by_date = group_by(lambda p: p.created_at.strftime('%Y-%m-%d'), pipeline_runs)
+        ).filter(PipelineRun.completed_at != None, PipelineRun.created_at != None)  # noqa: E711
+
+        pipeline_runs = query.all()
+        # v1: 11.4428
+        # v2: 2.2877
+        print(f'Query: {round((datetime.utcnow().timestamp() - now) * 10000) / 10000}')
+
+        now = datetime.utcnow().timestamp()
+        pipeline_run_by_date = group_by(lambda p: p.ds_created_at, pipeline_runs)
 
         def __mean_runtime(pipeline_runs):
             runtime_list = [(p.completed_at - p.created_at).total_seconds()
@@ -125,33 +221,79 @@ class MonitorStats:
                 return 0
             return sum(runtime_list) / len(runtime_list)
         pipeline_run_time_by_date = {k: __mean_runtime(v) for k, v in pipeline_run_by_date.items()}
+        # v1: 0.7857
+        print(f'Mapping: {round((datetime.utcnow().timestamp() - now) * 10000) / 10000}')
+
         return {pipeline_uuid: dict(name=pipeline_uuid, data=pipeline_run_time_by_date)}
 
     def get_block_run_count(
         self,
+        end_time: datetime = None,
+        pipeline_schedule_id: int = None,
         pipeline_uuid: str = None,
         start_time: datetime = None,
-        end_time: datetime = None,
         **kwargs,
     ) -> Dict:
-        block_runs = self.__filter_block_runs(
-            pipeline_uuid=pipeline_uuid,
-            start_time=start_time,
-            end_time=end_time,
-            **kwargs,
+        now = datetime.utcnow().timestamp()
+
+        select_query = [
+            BlockRun.block_uuid.label('name'),
+            BlockRun.status,
+            func.count(BlockRun.block_uuid).label('n_count'),
+            func.to_char(BlockRun.created_at, 'YYYY-MM-DD').label('ds_created_at'),
+        ]
+        filter_query = []
+
+        if end_time is not None or start_time is not None:
+            if start_time is not None:
+                filter_query.append(BlockRun.created_at >= start_time)
+            if end_time is not None:
+                filter_query.append(BlockRun.created_at <= end_time)
+
+        if pipeline_schedule_id is not None:
+            filter_query.append(PipelineRun.pipeline_schedule_id == int(pipeline_schedule_id))
+            select_query.append(PipelineRun.pipeline_schedule_id)
+
+        if pipeline_uuid is None:
+            query = BlockRun.select(*select_query)
+        else:
+            select_query += [BlockRun.pipeline_run_id, PipelineRun.pipeline_uuid]
+            query = (
+                BlockRun.
+                select(*select_query).
+                join(PipelineRun, PipelineRun.id == BlockRun.pipeline_run_id).
+                filter(PipelineRun.pipeline_uuid == pipeline_uuid)
+            )
+
+        if filter_query:
+            query = query.filter(*filter_query)
+
+        block_runs = (
+            query.
+            group_by('name', BlockRun.status, 'ds_created_at', *select_query[4:]).
+            all()
         )
-        block_runs = block_runs.all()
+        # v1: 21.6741
+        # v2: 1.24
+        print(f'Query: {round((datetime.utcnow().timestamp() - now) * 10000) / 10000}')
 
-        def __stats_func(block_runs):
-            count_by_status = dict()
-            for b in block_runs:
-                if b.status in count_by_status:
-                    count_by_status[b.status] += 1
-                else:
-                    count_by_status[b.status] = 1
-            return count_by_status
+        now = datetime.utcnow().timestamp()
 
-        return self.__cal_block_run_stats(block_runs, __stats_func)
+        def _reduce(obj, tup):
+            name, status, count, ds_created_at = tup[:4]
+            if name not in obj:
+                obj[name] = dict(data={}, name=name)
+            if ds_created_at not in obj[name]['data']:
+                obj[name]['data'][ds_created_at] = {}
+            obj[name]['data'][ds_created_at][status] = count
+            return obj
+        mapping = reduce(_reduce, block_runs, {})
+
+        # v1: <= 1
+        # v2: 0
+        print(f'Mapping: {round((datetime.utcnow().timestamp() - now) * 10000) / 10000}')
+
+        return mapping
 
     def get_block_run_time(
         self,
@@ -176,28 +318,6 @@ class MonitorStats:
             return sum(runtime_list) / len(runtime_list)
 
         return self.__cal_block_run_stats(block_runs, __stats_func)
-
-    def __filter_pipeline_runs(
-        self,
-        pipeline_uuid: str = None,
-        start_time: datetime = None,
-        end_time: datetime = None,
-        **kwargs
-    ) -> Dict:
-        pipeline_runs = PipelineRun.query.options(joinedload(PipelineRun.pipeline_schedule))
-        if pipeline_uuid is not None:
-            pipeline_runs = pipeline_runs.filter(PipelineRun.pipeline_uuid == pipeline_uuid)
-        if start_time is not None:
-            pipeline_runs = pipeline_runs.filter(PipelineRun.created_at >= start_time)
-        if end_time is not None:
-            pipeline_runs = pipeline_runs.filter(PipelineRun.created_at <= end_time)
-        pipeline_schedule_id = kwargs.get('pipeline_schedule_id')
-        if pipeline_schedule_id is not None:
-            pipeline_runs = pipeline_runs.filter(
-                PipelineRun.pipeline_schedule_id == int(pipeline_schedule_id)
-            )
-
-        return pipeline_runs
 
     def __filter_block_runs(
         self,

--- a/mage_ai/usage_statistics/constants.py
+++ b/mage_ai/usage_statistics/constants.py
@@ -10,6 +10,7 @@ class EventNameType(str, enum.Enum):
 
 class EventActionType(str, enum.Enum):
     CREATE = 'create'
+    DENY = 'deny'
     IMPRESSION = 'impression'
 
 


### PR DESCRIPTION
# Description
- Stop making multiple calls for a single endpoint (Overview page calls monitor stats twice or more)
- Don’t select all columns, only select the ones needed
- Perform as much formatting logic as possible in the database

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
