### PR TITLE
Removing Draft7 validation from Clickhouse destination

### DIFF
--- a/mage_integrations/mage_integrations/destinations/clickhouse/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/clickhouse/__init__.py
@@ -2,6 +2,7 @@ import argparse
 import sys
 
 from clickhouse_sqlalchemy import make_session
+from singer_sdk.helpers.capabilities import TargetLoadMethods
 from sqlalchemy import create_engine
 
 from mage_integrations.destinations.base import Destination
@@ -13,6 +14,7 @@ from mage_integrations.destinations.clickhouse.target_clickhouse.target import (
 class Clickhouse(Destination):
     def _process(self, input_buffer) -> None:
         self.config['state_path'] = self.state_file_path
+        self.config['load_method'] = TargetLoadMethods.APPEND_ONLY
         TargetClickhouse(config=self.config, logger=self.logger).listen_override(
             file_input=open(self.input_file_path, 'r'))
 

--- a/mage_integrations/mage_integrations/destinations/clickhouse/target_clickhouse/sinks.py
+++ b/mage_integrations/mage_integrations/destinations/clickhouse/target_clickhouse/sinks.py
@@ -183,3 +183,19 @@ class ClickhouseSink(SQLSink):
                     record[key] = json.dumps(value)
 
         return super().bulk_insert_records(full_table_name, schema, records)
+
+    def _validate_and_parse(self, record: dict) -> dict:
+        """Validate or repair the record, parsing to python-native types as needed.
+
+        Args:
+            record: Individual record in the stream.
+
+        Returns:
+            TODO
+        """
+        self._parse_timestamps_in_record(
+            record=record,
+            schema=self.schema,
+            treatment=self.datetime_error_treatment,
+        )
+        return record


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This PR removes Draft7 validation from Clickhouse destination.

## Issue
The issue seems to be caused by Draft7 expecting record datetime data to be valid RFC3339, but the Clickhouse engine not allowing the specified date-time string record to be inserted. ( preliminary tests seems to replicate the same behaviour on simple DateTime64 columns as well )

## Temporary solution
To quickly allow users to use MySQL -> Clickhouse Pipelines, this PR removes the Draft7 validation and guarantees datetime.datetime insertion on Clickhouse DB.

## Load Method
Also, when updating tables, the singer-sdk would point to a `load_method` variable that currently was not supported, the APPEND_ONLY method was selected as of now.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
Tested using MySQL -> Clickhouse DB

## FULL TABLE Sync

![Screenshot from 2024-01-22 16-37-59](https://github.com/mage-ai/mage-ai/assets/14100959/3cef9f88-ef6a-427f-af84-4939727f048e)

## Clickhouse Destination Example

![Screenshot from 2024-01-22 15-20-58](https://github.com/mage-ai/mage-ai/assets/14100959/0afc4193-1454-4f9c-91d8-6ab347f6cdec)



# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code


cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 