### PR TITLE
[xy] Fix global_vars context in pipeline executor.

### DIFF
--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -579,7 +579,7 @@ class BlockExecutor:
                     def __execute_with_retry():
                         # Update global_vars dictionary without copying it so that 'context' arg
                         # can be shared across blocks
-                        global_vars.update(self.retry_metadata)
+                        global_vars.update(dict(retry=self.retry_metadata))
 
                         return self._execute(
                             analyze_outputs=analyze_outputs,

--- a/mage_ai/data_preparation/executors/block_executor.py
+++ b/mage_ai/data_preparation/executors/block_executor.py
@@ -145,6 +145,8 @@ class BlockExecutor:
         Returns:
             The result of the block execution.
         """
+        if global_vars is None:
+            global_vars = {}
         block_run = None
 
         if Project.is_feature_enabled_in_root_or_active_project(

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -1496,15 +1496,6 @@ class Block(DataIntegrationMixin, SparkBlock, ProjectPlatformAccessible):
         if logging_tags is None:
             logging_tags = dict()
 
-        # Add pipeline uuid and block uuid to global_vars
-        global_vars = merge_dict(
-            global_vars or dict(),
-            dict(
-                pipeline_uuid=self.pipeline.uuid if self.pipeline else None,
-                block_uuid=self.uuid,
-            ),
-        )
-
         with self._redirect_streams(
             build_block_output_stdout=build_block_output_stdout,
             from_notebook=from_notebook,
@@ -3064,6 +3055,10 @@ df = get_variable('{self.pipeline.uuid}', '{self.uuid}', 'df')
         global_vars['configuration'] = self.configuration
         if 'context' not in global_vars:
             global_vars['context'] = dict()
+
+        # Add pipeline uuid and block uuid to global_vars
+        global_vars['pipeline_uuid'] = self.pipeline.uuid if self.pipeline else None
+        global_vars['block_uuid'] = self.uuid
 
         self.global_vars = global_vars
 

--- a/mage_ai/tests/data_preparation/executors/test_block_executor.py
+++ b/mage_ai/tests/data_preparation/executors/test_block_executor.py
@@ -13,7 +13,7 @@ from mage_ai.data_preparation.models.block.hook.block import HookBlock
 from mage_ai.data_preparation.models.constants import BlockType
 from mage_ai.data_preparation.models.project.constants import FeatureUUID
 from mage_ai.orchestration.db.models.schedules import BlockRun, PipelineRun
-from mage_ai.shared.hash import ignore_keys, merge_dict
+from mage_ai.shared.hash import merge_dict
 from mage_ai.tests.api.operations.test_base import BaseApiTestCase
 from mage_ai.tests.factory import create_pipeline_with_blocks
 from mage_ai.tests.shared.mixins import build_hooks
@@ -173,7 +173,7 @@ class BlockExecutorTest(BaseApiTestCase):
             callback_kwargs=dict(retry=dict(attempts=1)),
             dynamic_block_index=None,
             dynamic_upstream_block_uuids=None,
-            global_vars=ignore_keys(global_vars, ['retry']),
+            global_vars=global_vars,
             logging_tags={
                 'block_type': BlockType.DBT,
                 'block_uuid': self.block_uuid,

--- a/mage_ai/tests/data_preparation/executors/test_pipeline_executor.py
+++ b/mage_ai/tests/data_preparation/executors/test_pipeline_executor.py
@@ -26,6 +26,27 @@ class PipelineExecutorTest(DBTestCase):
             'test pipeline 2',
             self.repo_path,
         )
+        data_loader_block = pipeline.get_block('block1')
+        transformer_block = pipeline.get_block('block2')
+        with open(data_loader_block.file_path, 'w') as file:
+            file.write('''
+@data_loader
+def load_data(**kwargs):
+    kwargs['context']['a'] = 1
+    return 'ok1'
+            ''')
+        with open(transformer_block.file_path, 'w') as file:
+            file.write('''
+@transformer
+def transform(*args, **kwargs):
+    if args[0] != 'ok1':
+        raise Exception('upstream block output has wrong value.')
+    if kwargs['context'].get('a') != 1:
+        raise Exception('kwargs context has wrong value.')
+    if kwargs['attempts'] != 1:
+        raise Exception(f'retry attempts has wrong value.')
+    return 'ok2'
+            ''')
         execution_date = datetime.now()
         pipeline_run = create_pipeline_run_with_schedule(
             pipeline_uuid='test_pipeline_2',

--- a/mage_ai/tests/data_preparation/executors/test_pipeline_executor.py
+++ b/mage_ai/tests/data_preparation/executors/test_pipeline_executor.py
@@ -43,7 +43,7 @@ def transform(*args, **kwargs):
         raise Exception('upstream block output has wrong value.')
     if kwargs['context'].get('a') != 1:
         raise Exception('kwargs context has wrong value.')
-    if kwargs['attempts'] != 1:
+    if kwargs['retry']['attempts'] != 1:
         raise Exception(f'retry attempts has wrong value.')
     return 'ok2'
             ''')


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
There was a bug introduced in version 0.9.59 that the `global_vars['context']` is not passed across blocks because the `global_vars` is copied before execute method.
This PR fixes this issue.

Also comment out `asyncio.run(UsageStatisticLogger().block_run_ended(self.block_run))` in BlockExecutor since it throws error when running PipelineExecutor

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested run pipeline in one process, and the context arg is passed across blocks again.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
