### PR TITLE
[xy] Fix writing to Snowflake with mixed int and str types

### DIFF
--- a/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
@@ -440,7 +440,7 @@ WHERE TABLE_SCHEMA = '{schema_name}' AND TABLE_NAME = '{table_name}'
             self.logger.info(f'Columns: {df.columns}')
 
             # Clean dataframe column names and values
-            df = self._clean_df(df, stream)
+            df = self.clean_df(df, stream)
 
             database = self.config.get(self.DATABASE_CONFIG_KEY)
             schema = self.config.get(self.SCHEMA_CONFIG_KEY)
@@ -489,7 +489,7 @@ WHERE TABLE_SCHEMA = '{schema_name}' AND TABLE_NAME = '{table_name}'
 
             return results
 
-    def _clean_df(self, df: pd.DataFrame, stream: str):
+    def clean_df(self, df: pd.DataFrame, stream: str):
         # Clean column names in the dataframe
         col_mapping = {col: self.clean_column_name(col) for col in df.columns}
         df = df.rename(columns=col_mapping)

--- a/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
@@ -502,7 +502,7 @@ WHERE TABLE_SCHEMA = '{schema_name}' AND TABLE_NAME = '{table_name}'
                     default=encode_complex,
                     ignore_nan=True,
                 )
-            return val
+            return str(val)
 
         def remove_empty_dicts(val: Dict):
             # Remove empty dicts to avoid

--- a/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
@@ -516,7 +516,6 @@ WHERE TABLE_SCHEMA = '{schema_name}' AND TABLE_NAME = '{table_name}'
                 for key, value in val.items():
                     if isinstance(value, dict) and len(value) == 0:
                         val[key] = None
-                        return val
             return val
 
         mapping = column_type_mapping(


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix writing to Snowflake with mixed int and str types. 

```
, "  File \"/usr/local/lib/python3.10/site-packages/mage_integrations/destinations/sql/base.py\", line 383, in main

    destination.process(sys.stdin.buffer)

", "  File \"/usr/local/lib/python3.10/site-packages/mage_integrations/destinations/base.py\", line 364, in process

    errors=traceback.format_stack(),

"], "message": "Traceback (most recent call last):

  File \"/usr/local/lib/python3.10/site-packages/mage_integrations/destinations/base.py\", line 359, in process

    self._process(input_buffer)

  File \"/usr/local/lib/python3.10/site-packages/mage_integrations/destinations/base.py\", line 516, in _process

    self.__process_batch_set(

  File \"/usr/local/lib/python3.10/site-packages/mage_integrations/destinations/base.py\", line 585, in __process_batch_set

    raise err

  File \"/usr/local/lib/python3.10/site-packages/mage_integrations/destinations/base.py\", line 547, in __process_batch_set

    self.process_record_data(

  File \"/usr/local/lib/python3.10/site-packages/mage_integrations/destinations/base.py\", line 267, in process_record_data

    self.export_batch_data(

  File \"/usr/local/lib/python3.10/site-packages/mage_integrations/destinations/sql/base.py\", line 98, in export_batch_data

    data = self.process_queries(

  File \"/usr/local/lib/python3.10/site-packages/mage_integrations/destinations/snowflake/__init__.py\", line 487, in process_queries

    results += self.write_dataframe_to_table(df, database, schema, table)

  File \"/usr/local/lib/python3.10/site-packages/mage_integrations/destinations/snowflake/__init__.py\", line 370, in write_dataframe_to_table

    success, num_chunks, num_rows, output = write_pandas(

  File \"/usr/local/lib/python3.10/site-packages/snowflake/connector/pandas_tools.py\", line 298, in write_pandas

    chunk.to_parquet(chunk_path, compression=compression, **kwargs)

  File \"/usr/local/lib/python3.10/site-packages/pandas/util/_decorators.py\", line 211, in wrapper

    return func(*args, **kwargs)

  File \"/usr/local/lib/python3.10/site-packages/pandas/core/frame.py\", line 2976, in to_parquet

    return to_parquet(

  File \"/usr/local/lib/python3.10/site-packages/pandas/io/parquet.py\", line 430, in to_parquet

    impl.write(

  File \"/usr/local/lib/python3.10/site-packages/pandas/io/parquet.py\", line 174, in write

    table = self.api.Table.from_pandas(df, **from_pandas_kwargs)

  File \"pyarrow/table.pxi\", line 3475, in pyarrow.lib.Table.from_pandas

  File \"/usr/local/lib/python3.10/site-packages/pyarrow/pandas_compat.py\", line 611, in dataframe_to_arrays

    arrays = [convert_column(c, f)

  File \"/usr/local/lib/python3.10/site-packages/pyarrow/pandas_compat.py\", line 611, in <listcomp>

    arrays = [convert_column(c, f)

  File \"/usr/local/lib/python3.10/site-packages/pyarrow/pandas_compat.py\", line 598, in convert_column

    raise e

  File \"/usr/local/lib/python3.10/site-packages/pyarrow/pandas_compat.py\", line 592, in convert_column

    result = pa.array(col, type=type_, from_pandas=True, safe=safe)

  File \"pyarrow/array.pxi\", line 316, in pyarrow.lib.array

  File \"pyarrow/array.pxi\", line 83, in pyarrow.lib._ndarray_to_array

  File \"pyarrow/error.pxi\", line 100, in pyarrow.lib.check_status

pyarrow.lib.ArrowInvalid: (\"Could not convert '10a' with type str: tried to convert to int64\", 'Conversion failed for column CUSTOMER_ID with type object')
```

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested syncing from Google sheets to Snowflake

Google sheets content:
<img width="122" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/ae636216-b7dd-4d5d-abd8-e737188ad5aa">

Snowflake data:
<img width="1016" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/7536a5b0-9bf2-40c7-b9af-d4a62727c13b">




# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
