### PR TITLE
[jk] Fix pipeline detail prop passed for fetching files

### DIFF
--- a/mage_ai/frontend/components/BlockSettings/index.tsx
+++ b/mage_ai/frontend/components/BlockSettings/index.tsx
@@ -246,7 +246,7 @@ function BlockSettings({
           callback: (resp) => {
             setBlockAttributesTouched(false);
 
-            fetchFileTree();
+            fetchFileTree?.();
             fetchPipeline();
 
             // Select the newly renamed block

--- a/mage_ai/frontend/components/DataIntegrationModal/constants.ts
+++ b/mage_ai/frontend/components/DataIntegrationModal/constants.ts
@@ -42,7 +42,7 @@ export type OpenDataIntegrationModalOptionsType = {
     pipeline?: PipelineType;
   }) => Promise<any>;
   setContent?: (content: string) => void;
-}
+};
 
 export type OpenDataIntegrationModalType = {
   showDataIntegrationModal?: (opts?: OpenDataIntegrationModalOptionsType) => void;

--- a/mage_ai/frontend/components/FileBrowser/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/index.tsx
@@ -313,7 +313,7 @@ function FileBrowser({
               ...draggingFile,
               path: getFullPath(draggingFile),
             },
-            status.repo_path,
+            status?.repo_path,
             pipeline,
           );
 

--- a/mage_ai/frontend/components/IntegrationPipeline/index.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/index.tsx
@@ -59,7 +59,7 @@ type IntegrationPipelineProps = {
   ) => Promise<any>;
   blocks: BlockType[];
   codeBlocks?: any;
-  fetchFileTree: () => void;
+  fetchFileTree?: () => void;
   fetchPipeline: () => void;
   fetchSampleData: () => void;
   globalVariables: PipelineVariableType[];
@@ -324,7 +324,7 @@ function IntegrationPipeline({
 
             savePipelineContent(payload).then(() => {
               fetchPipeline();
-              fetchFileTree();
+              fetchFileTree?.();
             });
           },
           onErrorCallback: (response, errors) => setErrors({

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -1041,12 +1041,12 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
           setHiddenBlocks={setHiddenBlocks}
           setMountedBlocks={setMountedBlocks}
           setOutputBlocks={setOutputBlocks}
+          setScrollTogether={setScrollTogether}
           setSelected={(value: boolean) => setSelectedBlock(value === true ? block : null)}
           setSelectedBlock={setSelectedBlock}
           setSelectedOutputBlock={setSelectedOutputBlock}
-          setTextareaFocused={setTextareaFocused}
-          setScrollTogether={setScrollTogether}
           setSideBySideEnabled={setSideBySideEnabled}
+          setTextareaFocused={setTextareaFocused}
           showBlockBrowserModal={showBlockBrowserModal}
           showBrowseTemplates={showBrowseTemplates}
           showConfigureProjectModal={showConfigureProjectModal}
@@ -1069,7 +1069,7 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
               {addNewBlocksMemo}
             </div>
           )}
-        </CodeBlock>
+        </CodeBlock>,
       );
     });
 

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -3058,7 +3058,7 @@ function PipelineDetailPage({
       dataProviders={dataProviders}
       deleteBlock={deleteBlock}
       disableShortcuts={disableShortcuts}
-      fetchFiles={fetchFiles}
+      fetchFileTree={fetchFiles}
       fetchPipeline={fetchPipeline}
       fetchSampleData={fetchSampleData}
       files={files}

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -2781,7 +2781,7 @@ function PipelineDetailPage({
       deleteWidget={deleteWidget}
       editingBlock={editingBlock}
       executePipeline={executePipeline}
-      fetchFiles={fetchFiles}
+      fetchFileTree={fetchFiles}
       fetchPipeline={fetchPipeline}
       fetchSecrets={fetchSecrets}
       fetchVariables={fetchVariables}


### PR DESCRIPTION
# Description
- Fix bug due to incorrectly named prop passed into `PipelineDetail` and `Sidekick` components for fetching files.

# How Has This Been Tested?
- Confirmed error no longer appears locally when clicking the `View and select streams` button in an integration pipeline and confirming a selected stream.

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
