### PR TITLE
Fix alter table column names cleaning (postgresql integration exporter)

### DIFF
--- a/mage_integrations/mage_integrations/destinations/postgresql/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/postgresql/__init__.py
@@ -76,7 +76,7 @@ SELECT
 FROM INFORMATION_SCHEMA.COLUMNS
 WHERE TABLE_NAME = '{table_name}' AND TABLE_SCHEMA = '{schema_name}'
         """)
-        current_columns = [r[0].lower() for r in results]
+        current_columns = [self.clean_column_name(r[0]) for r in results]
         schema_columns = schema['properties'].keys()
         new_columns = [c for c in schema_columns if self.clean_column_name(c)
                        not in current_columns]


### PR DESCRIPTION
# Description
Properly cleaning column names for existing columns when altering table in postgresql destination mage_integrations.


# How Has This Been Tested?
1. Create data_loader block that returns any uppercase column name DataFrame e.g. `[{"ID": 1,},]`
2. Create data_exporter integration destination block (PostgreSQL). Set option `lower_case: false`
3. Run pipeline. This will create a new table, columns and data. Correctly.
4. Run this pipeline again. As a result the following will happen:
- Without this PR, runner will raise exception: `Error while executing query: column "ID" of relation ... already exists ... Query string: ALTER TABLE "schemaname"."tablename" ADD COLUMN "ID" BIGINT ...`
- With this PR, repeated integration runs are performed correctly.


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

