### PR TITLE
MSSQL data integration source - add support for DATETIMEOFFSET type

### DIFF
--- a/mage_integrations/mage_integrations/connections/mssql/__init__.py
+++ b/mage_integrations/mage_integrations/connections/mssql/__init__.py
@@ -1,5 +1,8 @@
 import pyodbc
 
+from datetime import datetime, timedelta, timezone
+import struct
+
 from mage_integrations.connections.sql.base import Connection
 
 
@@ -32,4 +35,17 @@ class MSSQL(Connection):
             'ENCRYPT=yes;'
             'TrustServerCertificate=yes;'
         )
-        return pyodbc.connect(connection_string)
+
+        # https://github.com/mkleehammer/pyodbc/wiki/Using-an-Output-Converter-function
+        cnxn = pyodbc.connect(connection_string)
+
+        def handle_datetimeoffset(dto_value):
+            # ref: https://github.com/mkleehammer/pyodbc/issues/134#issuecomment-281739794
+            # now struct.unpack: e.g., (2017, 3, 16, 10, 35, 18, 500000000, -6, 0)
+            tup = struct.unpack("<6hI2h", dto_value)
+            return datetime(tup[0], tup[1], tup[2], tup[3], tup[4], tup[5], tup[6] // 1000,
+                            timezone(timedelta(hours=tup[7], minutes=tup[8])))
+
+        cnxn.add_output_converter(-155, handle_datetimeoffset)
+
+        return cnxn

--- a/mage_integrations/mage_integrations/connections/mssql/__init__.py
+++ b/mage_integrations/mage_integrations/connections/mssql/__init__.py
@@ -1,7 +1,7 @@
-import pyodbc
-
-from datetime import datetime, timedelta, timezone
 import struct
+from datetime import datetime, timedelta, timezone
+
+import pyodbc
 
 from mage_integrations.connections.sql.base import Connection
 


### PR DESCRIPTION
# Description
Implemented the code from here pyodbc wiki:
https://github.com/mkleehammer/pyodbc/wiki/Using-an-Output-Converter-function

**Note**: Similar patch is probably needed in `mage_ai/io/mssql.py`. I had not run into that yet, and had no time to fix that right now. Likely I will run into it soon, though.

# How Has This Been Tested?
Tested in local pipeline w/ mssql source.
Against:
- local postrgesql - ended up as timestamp_tz
- local mssql, ended up as text , this could be fixed by adding support for timestamp_tz in MSSQL as DATETIMEOFFSET

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
@wangxiaoyou1993 
