### PR TITLE
[dy] Only show files with correct prefix

### DIFF
--- a/mage_ai/frontend/components/Files/useFileComponents.tsx
+++ b/mage_ai/frontend/components/Files/useFileComponents.tsx
@@ -393,17 +393,20 @@ function useFileComponents({
         }
       }
 
+      const filtered = arr.filter((fp: string) =>
+        fp.startsWith(status.repo_path) || fp.startsWith(status.repo_path_relative_root));
+
       setSelectedFilePath((prev: string): string => {
         if (fp) {
           return fp;
-        } else if (!prev && arr?.length >= 1) {
-          return arr[0];
+        } else if (!prev && filtered?.length >= 1) {
+          return filtered[0];
         }
 
         return prev;
       });
 
-      setOpenFilePaths(arr);
+      setOpenFilePaths(filtered);
     }
   }, [
     status,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Only show open files that have the correct repo_path prefix. This should reduce the number of file not found errors that occur when opening the file viewer.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally after switching projects


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
