### PR TITLE
[jk] Reset old block cache if it is older than 2 weeks

### DIFF
--- a/mage_ai/cache/base.py
+++ b/mage_ai/cache/base.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Union
 
 from mage_ai.cache.constants import (
@@ -79,6 +80,12 @@ class BaseCache():
         path = self.build_path(key or self.cache_key)
         if self.storage.path_exists(path):
             self.storage.remove(path)
+
+    def remove_old_cache(self, days_ago: int = 14) -> None:
+        # Remove cache older than specified # of days (default is 2 weeks) in order to reset it
+        days_ago = datetime.utcnow() - timedelta(days=days_ago)
+        if os.path.getctime(self.file_path) < days_ago.timestamp():
+            os.remove(self.file_path)
 
     @property
     def file_path(self) -> str:

--- a/mage_ai/cache/base.py
+++ b/mage_ai/cache/base.py
@@ -41,6 +41,9 @@ class BaseCache():
     def exists(self) -> bool:
         return self.get(self.cache_key) is not None
 
+    def cache_file_exists(self) -> bool:
+        return os.path.exists(self.file_path)
+
     def get(self, key: str = None, refresh: bool = False, **kwargs) -> Union[Dict, List]:
         if refresh or not self._temp_data:
             self._temp_data = self.storage.read_json_file(
@@ -84,9 +87,8 @@ class BaseCache():
     def remove_old_cache(self, days_ago: int = 14) -> None:
         # Remove cache older than specified # of days (default is 2 weeks) in order to reset it
         days_ago = datetime.utcnow() - timedelta(days=days_ago)
-        file_path = self.file_path
-        if os.path.exists(file_path) and os.path.getctime(file_path) < days_ago.timestamp():
-            os.remove(file_path)
+        if self.cache_file_exists() and os.path.getctime(self.file_path) < days_ago.timestamp():
+            os.remove(self.file_path)
 
     @property
     def file_path(self) -> str:

--- a/mage_ai/cache/base.py
+++ b/mage_ai/cache/base.py
@@ -84,8 +84,9 @@ class BaseCache():
     def remove_old_cache(self, days_ago: int = 14) -> None:
         # Remove cache older than specified # of days (default is 2 weeks) in order to reset it
         days_ago = datetime.utcnow() - timedelta(days=days_ago)
-        if self.exists() and os.path.getctime(self.file_path) < days_ago.timestamp():
-            os.remove(self.file_path)
+        file_path = self.file_path
+        if os.path.exists(file_path) and os.path.getctime(file_path) < days_ago.timestamp():
+            os.remove(file_path)
 
     @property
     def file_path(self) -> str:

--- a/mage_ai/cache/base.py
+++ b/mage_ai/cache/base.py
@@ -84,7 +84,7 @@ class BaseCache():
     def remove_old_cache(self, days_ago: int = 14) -> None:
         # Remove cache older than specified # of days (default is 2 weeks) in order to reset it
         days_ago = datetime.utcnow() - timedelta(days=days_ago)
-        if os.path.getctime(self.file_path) < days_ago.timestamp():
+        if self.exists() and os.path.getctime(self.file_path) < days_ago.timestamp():
             os.remove(self.file_path)
 
     @property

--- a/mage_ai/cache/block.py
+++ b/mage_ai/cache/block.py
@@ -31,9 +31,15 @@ class BlockCache(BaseCache):
         repo_path = repo_path or get_repo_path(root_project=root_project)
         cache = self(repo_path=repo_path)
 
+        # Replace the cache if it is older than 2 weeks (the default if days_ago not passed in).
         cache.remove_old_cache()
 
-        if replace or not cache.exists():
+        """
+        We also check if the cache file does not exist, and if it does not,
+        we create a new cache file, since it is possible for the cache to exist
+        (e.g. as an empty dictionary) but the cache file to not exist at the same time.
+        """
+        if replace or not cache.exists() or not cache.cache_file_exists():
             await cache.initialize_cache_for_all_pipelines(caches=caches, file_path=file_path)
 
         return cache

--- a/mage_ai/cache/block.py
+++ b/mage_ai/cache/block.py
@@ -30,6 +30,9 @@ class BlockCache(BaseCache):
     ) -> 'BlockCache':
         repo_path = repo_path or get_repo_path(root_project=root_project)
         cache = self(repo_path=repo_path)
+
+        cache.remove_old_cache()
+
         if replace or not cache.exists():
             await cache.initialize_cache_for_all_pipelines(caches=caches, file_path=file_path)
 

--- a/mage_ai/cache/block.py
+++ b/mage_ai/cache/block.py
@@ -40,7 +40,7 @@ class BlockCache(BaseCache):
         we create a new cache file, since it is possible for the cache to exist
         (e.g. as an empty dictionary) but the cache file to not exist at the same time.
         """
-        if not cache.exists() or not cache.cache_file_exists():
+        if replace or not cache.exists() or not cache.cache_file_exists():
             await cache.initialize_cache_for_all_pipelines(caches=caches, file_path=file_path)
 
         return cache

--- a/mage_ai/cache/block.py
+++ b/mage_ai/cache/block.py
@@ -35,13 +35,13 @@ class BlockCache(BaseCache):
             # Replace the cache if it is older than 2 weeks (the default if days_ago not passed in).
             cache.remove_old_cache()
 
-            """
-            We also check if the cache file does not exist, and if it does not,
-            we create a new cache file, since it is possible for the cache to exist
-            (e.g. as an empty dictionary) but the cache file to not exist at the same time.
-            """
-            if not cache.exists() or not cache.cache_file_exists():
-                await cache.initialize_cache_for_all_pipelines(caches=caches, file_path=file_path)
+        """
+        We also check if the cache file does not exist, and if it does not,
+        we create a new cache file, since it is possible for the cache to exist
+        (e.g. as an empty dictionary) but the cache file to not exist at the same time.
+        """
+        if not cache.exists() or not cache.cache_file_exists():
+            await cache.initialize_cache_for_all_pipelines(caches=caches, file_path=file_path)
 
         return cache
 

--- a/mage_ai/cache/block.py
+++ b/mage_ai/cache/block.py
@@ -31,16 +31,17 @@ class BlockCache(BaseCache):
         repo_path = repo_path or get_repo_path(root_project=root_project)
         cache = self(repo_path=repo_path)
 
-        # Replace the cache if it is older than 2 weeks (the default if days_ago not passed in).
-        cache.remove_old_cache()
+        if replace:
+            # Replace the cache if it is older than 2 weeks (the default if days_ago not passed in).
+            cache.remove_old_cache()
 
-        """
-        We also check if the cache file does not exist, and if it does not,
-        we create a new cache file, since it is possible for the cache to exist
-        (e.g. as an empty dictionary) but the cache file to not exist at the same time.
-        """
-        if replace or not cache.exists() or not cache.cache_file_exists():
-            await cache.initialize_cache_for_all_pipelines(caches=caches, file_path=file_path)
+            """
+            We also check if the cache file does not exist, and if it does not,
+            we create a new cache file, since it is possible for the cache to exist
+            (e.g. as an empty dictionary) but the cache file to not exist at the same time.
+            """
+            if not cache.exists() or not cache.cache_file_exists():
+                await cache.initialize_cache_for_all_pipelines(caches=caches, file_path=file_path)
 
         return cache
 


### PR DESCRIPTION
# Description
- We recently started including file extensions (e.g. `.py`) in the block cache keys to determine which pipelines are currently being used by a block. However, existing Mage projects might have a `blocks_to_pipeline_mapping` cache with existing pipelines and blocks that use the previous cache key convention of NOT including the file extensions.
- This could result in the pipelines using a block (i.e. "shared pipelines") not being displayed properly in the UI if these blocks were already in the existing pipeline before the file extension in cache keys update. For example, a block that is clearly in a pipeline might not even show the current pipeline under the "Pipelines using this block" section in the Block Settings:
<img width="1151" alt="missing shared pipeline" src="https://github.com/mage-ai/mage-ai/assets/78053898/587d559d-b76e-4c15-bba4-7137bbe0bab0">
- In order to prevent this issue from happening, this PR checks if the block cache file (e.g. `default_repo/.cache/blocks_to_pipeline_mapping`) is older than 2 weeks (by default, this value can be changed), and if it is, we remove the block cache file so it can be replaced with a new cache file that has the updated block cache keys.

# How Has This Been Tested?
- Tested locally:
1) Replaced a block's cache key with one formatted without the file extension so that no shared pipelines would appear in the UI for it
2) Reinitialized the block cache so the existing block cache would be deleted and replaced with a new one.
3) Confirmed that new block cache correctly showed shared pipelines using the block in both the file browser and block settings.

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
