### PR TITLE
[jk] Fix unclickable vertical scrollbar and jumping before panel

### DIFF
--- a/mage_ai/frontend/components/ComputeManagement/index.tsx
+++ b/mage_ai/frontend/components/ComputeManagement/index.tsx
@@ -38,6 +38,7 @@ import {
   TabType,
   buildTabs,
 } from './constants';
+import { DEFAULT_BEFORE_RESIZE_OFFSET } from '@components/TripleLayout/useTripleLayout';
 import { HEADER_HEIGHT } from '@components/shared/Header/index.style';
 import {
   SparkApplicationType,
@@ -137,7 +138,8 @@ function ComputeManagement({
     UNIT * 20,
   ));
   const setBeforeWidth = useCallback((width: number) => {
-    setBeforeWidthState(width || UNIT * 20);
+    // If the DEFAULT_BEFORE_RESIZE_OFFSET is not subtracted, the before panel jumps forward a bit when resizing.
+    setBeforeWidthState((width || UNIT * 20) - DEFAULT_BEFORE_RESIZE_OFFSET);
     set(localStorageKeyBefore, width || UNIT * 20);
   }, [
     localStorageKeyBefore,

--- a/mage_ai/frontend/components/Dashboard/index.tsx
+++ b/mage_ai/frontend/components/Dashboard/index.tsx
@@ -92,6 +92,7 @@ function Dashboard({
     widthAfter,
     widthBefore,
   } = useTripleLayout(uuid, {
+    resizeOffset: 72,
     setWidthAfter: setAfterWidth,
     setWidthBefore: setBeforeWidth,
     widthAfter: afterWidth,

--- a/mage_ai/frontend/components/Dashboard/index.tsx
+++ b/mage_ai/frontend/components/Dashboard/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React from 'react';
 
 import ClickOutside from '@oracle/components/ClickOutside';
 import ErrorPopup from '@components/ErrorPopup';
@@ -9,7 +9,6 @@ import Header, { BreadcrumbType, MenuItemType } from '@components/shared/Header'
 import Subheader from './Subheader';
 import TripleLayout from '@components/TripleLayout';
 import VerticalNavigation, { VerticalNavigationProps } from './VerticalNavigation';
-import api from '@api';
 import useProject from '@utils/models/project/useProject';
 import {
   ContainerStyle,
@@ -17,8 +16,9 @@ import {
   VerticalNavigationStyle,
 } from './index.style';
 import { HEADER_HEIGHT } from '@components/shared/Header/index.style';
-import { UNIT } from '@oracle/styles/units/spacing';
-import useTripleLayout from '@components/TripleLayout/useTripleLayout';
+import useTripleLayout, {
+  DEFAULT_BEFORE_RESIZE_OFFSET,
+} from '@components/TripleLayout/useTripleLayout';
 
 export type DashboardSharedProps = {
   after?: any;
@@ -92,7 +92,7 @@ function Dashboard({
     widthAfter,
     widthBefore,
   } = useTripleLayout(uuid, {
-    resizeOffset: 72,
+    beforeResizeOffset: DEFAULT_BEFORE_RESIZE_OFFSET,
     setWidthAfter: setAfterWidth,
     setWidthBefore: setBeforeWidth,
     widthAfter: afterWidth,

--- a/mage_ai/frontend/components/Files/index.style.tsx
+++ b/mage_ai/frontend/components/Files/index.style.tsx
@@ -43,6 +43,7 @@ export const TabsStyle = styled.div`
 
 export const SearchContainerStyle = styled.div`
   margin: ${UNIT}px;
+  margin-right: 0;
   // position: fixed;
   // width: 100%;
 

--- a/mage_ai/frontend/components/PipelineLayout/index.tsx
+++ b/mage_ai/frontend/components/PipelineLayout/index.tsx
@@ -10,7 +10,6 @@ import Head from '@oracle/elements/Head';
 import Header, { BreadcrumbType } from '@components/shared/Header';
 import PipelineType from '@interfaces/PipelineType';
 import TripleLayout from '@components/TripleLayout';
-import api from '@api';
 import {
   AFTER_DEFAULT_WIDTH,
   BEFORE_DEFAULT_WIDTH,
@@ -39,6 +38,7 @@ type PipelineLayoutProps = {
   afterOverflow?: 'hidden';
   afterSubheader?: any;
   before?: any;
+  beforeDraggableTopOffset?: number;
   beforeHeader?: any;
   beforeHeightOffset?: number;
   beforeHidden?: boolean;
@@ -70,6 +70,7 @@ function PipelineLayout({
   afterOverflow,
   afterSubheader,
   before,
+  beforeDraggableTopOffset,
   beforeHeader,
   beforeHeightOffset,
   beforeHidden: beforeHiddenProp,
@@ -211,6 +212,7 @@ function PipelineLayout({
         afterSubheader={afterSubheader}
         afterWidth={afterWidth}
         before={before}
+        beforeDraggableTopOffset={beforeDraggableTopOffset}
         beforeHeader={beforeHeader}
         beforeHeightOffset={beforeHeightOffset}
         beforeHidden={beforeHidden}

--- a/mage_ai/frontend/components/ScheduleLayout/index.tsx
+++ b/mage_ai/frontend/components/ScheduleLayout/index.tsx
@@ -57,7 +57,7 @@ function ScheduleLayout({
     pipelineScheduleId,
     pipelineSchedules,
     pipelineUUID,
-  ])
+  ]);
 
   return (
     <PipelineLayout

--- a/mage_ai/frontend/components/TripleLayout/index.style.tsx
+++ b/mage_ai/frontend/components/TripleLayout/index.style.tsx
@@ -10,7 +10,7 @@ export const AFTER_DEFAULT_WIDTH = UNIT * 64;
 export const AFTER_MIN_WIDTH = UNIT * 30;
 export const BEFORE_MIN_WIDTH = UNIT * 21.25;
 export const BEFORE_DEFAULT_WIDTH = UNIT * 35;
-export const DRAGGABLE_WIDTH = UNIT * 2;
+export const DRAGGABLE_WIDTH = UNIT;
 export const MAIN_MIN_WIDTH = UNIT * 13;
 
 export const ASIDE_HEADER_HEIGHT = PADDING_UNITS * 3 * UNIT;
@@ -136,8 +136,10 @@ const ASIDE_INNER_STYLE = css<{
 
 const ASIDE_DRAGGABLE_STYLE = css<{
   active?: boolean;
+  left?: number;
   disabled?: boolean;
   top?: number;
+  topOffset?: number;
 }>`
   position: absolute;
   width: ${DRAGGABLE_WIDTH}px;
@@ -151,7 +153,7 @@ const ASIDE_DRAGGABLE_STYLE = css<{
 
   ${props => `
     height: calc(100% + ${props?.top || 0}px);
-    top: -${props?.top || 0}px;
+    top: ${-(props?.top || 0) + (props.topOffset || 0)}px;
   `}
 
   ${props => !props.disabled && `
@@ -306,6 +308,7 @@ export const DraggableStyle = styled.div<{
   left?: number;
   right?: number;
   top?: number;
+  topOffset?: number;
 }>`
   ${ASIDE_DRAGGABLE_STYLE}
 

--- a/mage_ai/frontend/components/TripleLayout/index.tsx
+++ b/mage_ai/frontend/components/TripleLayout/index.tsx
@@ -231,6 +231,8 @@ function TripleLayout({
         removeMousemove();
       };
     }
+  // getOffsetLeft intentionally left out of dependency array
+  // If it was included, the before panel would not resize correctly.
   }, [
     afterHidden,
     afterWidth,
@@ -671,14 +673,15 @@ function TripleLayout({
           inline={inline}
           style={{
             left: leftOffset,
+            paddingRight: DRAGGABLE_WIDTH,
             width: beforeWidthFinal,
           }}
         >
           {setBeforeWidth && (
             <DraggableStyle
               active={beforeMousedownActive}
-              disabled={beforeHidden}
               contrast={beforeDividerContrast}
+              disabled={beforeHidden}
               ref={refBeforeInnerDraggable}
               right={0}
               top={contained ? 0 : ASIDE_HEADER_HEIGHT}

--- a/mage_ai/frontend/components/TripleLayout/index.tsx
+++ b/mage_ai/frontend/components/TripleLayout/index.tsx
@@ -75,6 +75,7 @@ type TripleLayoutProps = {
   before?: any;
   beforeContentHeightOffset?: number;
   beforeDividerContrast?: boolean;
+  beforeDraggableTopOffset?: number;
   beforeFooter?: any;
   beforeHeader?: any;
   beforeHeaderOffset?: number;
@@ -127,6 +128,7 @@ function TripleLayout({
   before,
   beforeContentHeightOffset,
   beforeDividerContrast,
+  beforeDraggableTopOffset,
   beforeFooter,
   beforeHeader,
   beforeHeaderOffset,
@@ -667,62 +669,63 @@ function TripleLayout({
       )}
 
       {before && (
-        <BeforeStyle
-          autoLayout={autoLayout}
-          heightOffset={beforeHeightOffset}
-          inline={inline}
-          style={{
-            left: leftOffset,
-            paddingRight: DRAGGABLE_WIDTH,
-            width: beforeWidthFinal,
-          }}
-        >
+        <>
+          <BeforeStyle
+            autoLayout={autoLayout}
+            heightOffset={beforeHeightOffset}
+            inline={inline}
+            style={{
+              left: leftOffset,
+              width: beforeWidthFinal,
+            }}
+          >
+            {hasBeforeNavigationItems && (
+              <NavigationStyle>
+                {!beforeHidden && (
+                  <>
+                    <NavigationInnerStyle aligned="left">
+                      <VerticalNavigationStyle
+                        aligned="left"
+                        borderless
+                        showMore={navigationShowMore}
+                      >
+                        <VerticalNavigation
+                          aligned="left"
+                          navigationItems={beforeNavigationItems}
+                        />
+                      </VerticalNavigationStyle>
+                    </NavigationInnerStyle>
+
+                    <NavigationContainerStyle
+                      aligned="left"
+                      fullWidth
+                      heightOffset={beforeHeightOffset}
+                      // 1 for the border-left
+                      widthOffset={VERTICAL_NAVIGATION_WIDTH + 1}
+                    >
+                      {beforeContent}
+                    </NavigationContainerStyle>
+                  </>
+                )}
+
+                {beforeHidden && beforeContent}
+              </NavigationStyle>
+            )}
+
+            {!hasBeforeNavigationItems && beforeContent}
+          </BeforeStyle>
           {setBeforeWidth && (
             <DraggableStyle
               active={beforeMousedownActive}
               contrast={beforeDividerContrast}
               disabled={beforeHidden}
+              left={beforeWidthFinal + leftOffset}
               ref={refBeforeInnerDraggable}
-              right={0}
               top={contained ? 0 : ASIDE_HEADER_HEIGHT}
+              topOffset={beforeDraggableTopOffset}
             />
           )}
-
-          {hasBeforeNavigationItems && (
-            <NavigationStyle>
-              {!beforeHidden && (
-                <>
-                  <NavigationInnerStyle aligned="left">
-                    <VerticalNavigationStyle
-                      aligned="left"
-                      borderless
-                      showMore={navigationShowMore}
-                    >
-                      <VerticalNavigation
-                        aligned="left"
-                        navigationItems={beforeNavigationItems}
-                      />
-                    </VerticalNavigationStyle>
-                  </NavigationInnerStyle>
-
-                  <NavigationContainerStyle
-                    aligned="left"
-                    fullWidth
-                    heightOffset={beforeHeightOffset}
-                    // 1 for the border-left
-                    widthOffset={VERTICAL_NAVIGATION_WIDTH + 1}
-                  >
-                    {beforeContent}
-                  </NavigationContainerStyle>
-                </>
-              )}
-
-              {beforeHidden && beforeContent}
-            </NavigationStyle>
-          )}
-
-          {!hasBeforeNavigationItems && beforeContent}
-        </BeforeStyle>
+        </>
       )}
 
       {autoLayout && afterMemo}
@@ -778,15 +781,12 @@ function TripleLayout({
       {!autoLayout && afterMemo}
     </>
   ), [
-    after,
-    afterContent,
-    afterDividerContrast,
-    afterHeightOffset,
+    afterMemo,
     afterHidden,
     afterMousedownActive,
-    afterNavigationItems,
     afterWidthFinal,
     autoLayout,
+    before,
     beforeContent,
     beforeDividerContrast,
     beforeHeightOffset,
@@ -797,7 +797,6 @@ function TripleLayout({
     children,
     contained,
     footerOffset,
-    hasAfterNavigationItems,
     hasBeforeNavigationItems,
     header,
     headerOffset,
@@ -809,9 +808,7 @@ function TripleLayout({
     mainWidth,
     navigationShowMore,
     noBackground,
-    refAfterInnerDraggable,
     refBeforeInnerDraggable,
-    shouldHideAfterWrapper,
     setBeforeWidth,
   ]);
 

--- a/mage_ai/frontend/components/TripleLayout/useTripleLayout.ts
+++ b/mage_ai/frontend/components/TripleLayout/useTripleLayout.ts
@@ -96,7 +96,9 @@ function useAside(uuid, refData, {
         DEFAULT_ASIDE_WIDTH + MINIMUM_WIDTH_MAIN_CONTAINER + (refOther?.current?.disable ? 0 : DEFAULT_ASIDE_WIDTH),
       );
 
-      let value = prev;
+      // Need to add 72 to previous width so the mouse cursor
+      // doesn't jump when resizing before panel
+      let value = prev + 72;
       if (value < DEFAULT_ASIDE_WIDTH) {
         value = DEFAULT_ASIDE_WIDTH;
       } else if (value > maxWidth) {

--- a/mage_ai/frontend/components/TripleLayout/useTripleLayout.ts
+++ b/mage_ai/frontend/components/TripleLayout/useTripleLayout.ts
@@ -13,6 +13,7 @@ function useAside(uuid, refData, {
   hidden: hiddenProp,
   mainContainerWidth,
   refOther,
+  resizeOffset = 0,
   setWidth: setWidthProp,
   width: widthProp,
   widthOverride,
@@ -29,6 +30,7 @@ function useAside(uuid, refData, {
       widthProp?: number;
     };
   };
+  resizeOffset?: number;
   setWidth?: (value: number) => void;
   width?: number;
   widthOverride?: boolean;
@@ -96,9 +98,9 @@ function useAside(uuid, refData, {
         DEFAULT_ASIDE_WIDTH + MINIMUM_WIDTH_MAIN_CONTAINER + (refOther?.current?.disable ? 0 : DEFAULT_ASIDE_WIDTH),
       );
 
-      // Need to add 72 to previous width so the mouse cursor
-      // doesn't jump when resizing before panel
-      let value = prev + 72;
+      // May need to add a resize offset to previous width so the aside panel
+      // doesn't jump when resizing it. The panel might jump about 72px.
+      let value = prev + resizeOffset;
       if (value < DEFAULT_ASIDE_WIDTH) {
         value = DEFAULT_ASIDE_WIDTH;
       } else if (value > maxWidth) {
@@ -185,6 +187,7 @@ export type UseTripleLayoutProps = {
   hiddenAfter?: boolean;
   hiddenBefore?: boolean;
   mainContainerRef?: any;
+  resizeOffset?: number;
   setWidthAfter?: (value: number) => void;
   setWidthBefore?: (value: number) => void;
   widthAfter?: number;
@@ -199,6 +202,7 @@ export default function useTripleLayout(uuid: string, {
   hiddenAfter: hiddenAfterProp,
   hiddenBefore: hiddenBeforeProp,
   mainContainerRef: mainContainerRefProp,
+  resizeOffset,
   setWidthAfter: setWidthAfterProp,
   setWidthBefore: setWidthBeforeProp,
   widthAfter: widthAfterProp,
@@ -260,6 +264,7 @@ export default function useTripleLayout(uuid: string, {
     hidden: hiddenBeforeProp,
     mainContainerWidth,
     refOther: refAfter,
+    resizeOffset,
     setWidth: setWidthBeforeProp,
     width: widthBeforeProp,
     widthOverride: widthOverrideBeforeProp,

--- a/mage_ai/frontend/components/TripleLayout/useTripleLayout.ts
+++ b/mage_ai/frontend/components/TripleLayout/useTripleLayout.ts
@@ -7,6 +7,7 @@ import { useWindowSize } from '@utils/sizes';
 
 const DEFAULT_ASIDE_WIDTH = 25 * UNIT;
 const MINIMUM_WIDTH_MAIN_CONTAINER = DEFAULT_ASIDE_WIDTH * 2;
+export const DEFAULT_BEFORE_RESIZE_OFFSET = 72;
 
 function useAside(uuid, refData, {
   disable,
@@ -125,7 +126,9 @@ function useAside(uuid, refData, {
   }, [
     disable,
     key,
+    refData,
     refOther,
+    resizeOffset,
     setWidthProp,
     widthWindow,
   ]);
@@ -179,15 +182,15 @@ export type UseTripleLayoutType = {
   setWidthBefore: (value: number | ((value: number) => number)) => void;
   widthAfter: number;
   widthBefore: number;
-}
+};
 
 export type UseTripleLayoutProps = {
+  beforeResizeOffset?: number;
   disableAfter?: boolean;
   disableBefore?: boolean;
   hiddenAfter?: boolean;
   hiddenBefore?: boolean;
   mainContainerRef?: any;
-  resizeOffset?: number;
   setWidthAfter?: (value: number) => void;
   setWidthBefore?: (value: number) => void;
   widthAfter?: number;
@@ -197,12 +200,12 @@ export type UseTripleLayoutProps = {
 };
 
 export default function useTripleLayout(uuid: string, {
+  beforeResizeOffset,
   disableAfter,
   disableBefore,
   hiddenAfter: hiddenAfterProp,
   hiddenBefore: hiddenBeforeProp,
   mainContainerRef: mainContainerRefProp,
-  resizeOffset,
   setWidthAfter: setWidthAfterProp,
   setWidthBefore: setWidthBeforeProp,
   widthAfter: widthAfterProp,
@@ -264,7 +267,7 @@ export default function useTripleLayout(uuid: string, {
     hidden: hiddenBeforeProp,
     mainContainerWidth,
     refOther: refAfter,
-    resizeOffset,
+    resizeOffset: beforeResizeOffset,
     setWidth: setWidthBeforeProp,
     width: widthBeforeProp,
     widthOverride: widthOverrideBeforeProp,

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -83,6 +83,7 @@ import useProject from '@utils/models/project/useProject';
 import useStatus from '@utils/models/status/useStatus';
 import { ANIMATION_DURATION_CONTENT } from '@oracle/components/Accordion/AccordionPanel';
 import { ApplicationExpansionUUIDEnum } from '@interfaces/CommandCenterType';
+import { ASIDE_HEADER_HEIGHT } from '@components/TripleLayout/index.style';
 import {
   BLOCK_EXISTS_ERROR,
   CUSTOM_EVENT_BLOCK_OUTPUT_CHANGED,
@@ -3406,6 +3407,7 @@ function PipelineDetailPage({
           </FlexContainer>
         )}
         before={beforeToShow}
+        beforeDraggableTopOffset={HEADER_HEIGHT + ASIDE_HEADER_HEIGHT}
         beforeHeader={buttonTabs}
         beforeHeightOffset={HEADER_HEIGHT}
         beforeHidden={beforeHidden}


### PR DESCRIPTION
# Description
- Fix the following bugs:
1. The vertical scrollbar in the before panel (e.g. file browser or trigger detail panel) was not able to be clicked for vertical scrolling (though you could still scroll by using a laptop trackpad or mouse wheel).
2. The before panel width would jump to a smaller width when resizing initially.

# How Has This Been Tested?
Before (vertical scrollbar can't be clicked):
<img src="https://github.com/mage-ai/mage-ai/assets/78053898/ff29aeb2-b6db-47f5-bb58-d7544eeefcc2" width="300px" />
After (vertical scrollbar CAN be clicked):
<img src="https://github.com/mage-ai/mage-ai/assets/78053898/0a1528c9-40ce-42c0-b1cb-f9047b8eafd3" width="300px" />


Before (jumping before panel width):
<img src="https://github.com/mage-ai/mage-ai/assets/78053898/b4fca76d-e8bb-4b69-8b09-fdb40bd0b3fa" width="450px" />
After (Files page - before panel does not jump):
<img src="https://github.com/mage-ai/mage-ai/assets/78053898/52f673df-eacb-44a6-935a-9c917453017c" width="400px" />

- Also made sure before panel doesn't jump when resizing on Pipeline Editor, Trigger Detail, Backfill Detail, Pipeline Monitor, Version Control, and Compute Management pages.


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
