### PR TITLE
[dy] Create and view workspaces in different namespaces

### DIFF
--- a/mage_ai/api/policies/WorkspacePolicy.py
+++ b/mage_ai/api/policies/WorkspacePolicy.py
@@ -62,12 +62,21 @@ WorkspacePolicy.allow_write([
 ], condition=lambda policy: policy.is_owner())
 
 WorkspacePolicy.allow_query([
+    'namespace[]',
+    'cluster_type',
+    'user_id',
+], scopes=[
+    OauthScope.CLIENT_PRIVATE,
+], on_action=[
+    constants.LIST,
+], condition=lambda policy: policy.has_at_least_viewer_role())
+
+WorkspacePolicy.allow_query([
     'cluster_type',
     'user_id',
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,
 ], on_action=[
     constants.DETAIL,
-    constants.LIST,
     constants.UPDATE,
 ], condition=lambda policy: policy.has_at_least_viewer_role())

--- a/mage_ai/cluster_manager/manage.py
+++ b/mage_ai/cluster_manager/manage.py
@@ -15,15 +15,18 @@ from mage_ai.data_preparation.repo_manager import ProjectType, get_project_type
 from mage_ai.settings.repo import get_repo_path
 
 
-def get_instances(cluster_type: str) -> List[Dict]:
+def get_instances(cluster_type: str, **kwargs) -> List[Dict]:
     instances = []
     if cluster_type == ClusterType.K8S:
         from mage_ai.cluster_manager.kubernetes.workload_manager import WorkloadManager
+        namespaces = kwargs.get('namespaces') or []
+        if '__all__' in namespaces:
+            instances = WorkloadManager.list_all_workloads()
+        else:
+            namespace = namespaces[0] if namespaces else os.getenv(KUBE_NAMESPACE)
+            workload_manager = WorkloadManager(namespace)
 
-        namespace = os.getenv(KUBE_NAMESPACE)
-        workload_manager = WorkloadManager(namespace)
-
-        instances = workload_manager.list_workloads()
+            instances = workload_manager.list_workloads()
     elif cluster_type == ClusterType.ECS:
         from mage_ai.cluster_manager.aws.ecs_task_manager import EcsTaskManager
 
@@ -47,7 +50,7 @@ def get_instances(cluster_type: str) -> List[Dict]:
     return instances
 
 
-def get_workspaces(cluster_type: ClusterType) -> List[Workspace]:
+def get_workspaces(cluster_type: ClusterType, **kwargs) -> List[Workspace]:
     """
     Retrieve a list of workspaces based on the cluster type and project type.
 
@@ -73,7 +76,7 @@ def get_workspaces(cluster_type: ClusterType) -> List[Workspace]:
             if not f.is_dir() and f.name.endswith('.yaml')
         ]
     else:
-        instances = get_instances(cluster_type)
+        instances = get_instances(cluster_type, **kwargs)
         projects = [instance.get('name') for instance in instances]
 
     workspaces = []

--- a/mage_ai/cluster_manager/workspace/kubernetes.py
+++ b/mage_ai/cluster_manager/workspace/kubernetes.py
@@ -17,9 +17,8 @@ class KubernetesWorkspace(Workspace):
     def __init__(self, name: str):
         super().__init__(name)
         self.cluster_type = ClusterType.K8S
-        self.workload_manager = WorkloadManager(
-            self.config.namespace or os.getenv(KUBE_NAMESPACE)
-        )
+        self.namespace = self.config.namespace or os.getenv(KUBE_NAMESPACE)
+        self.workload_manager = WorkloadManager(self.namespace)
 
     @classmethod
     def initialize(

--- a/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
@@ -47,6 +47,7 @@ type ToolbarProps = {
     Icon: any;
     confirmationDescription?: string;
     confirmationMessage?: string;
+    disabled?: boolean;
     isLoading?: boolean;
     label?: string;
     onClick: () => void;
@@ -139,6 +140,7 @@ function Toolbar({
     Icon: extraActionIcon,
     confirmationDescription: extraActionConfirmDescription,
     confirmationMessage: extraActionConfirmMessage,
+    disabled: disabledExtraAction = disabledActions,
     isLoading: isLoadingExtraAction,
     label: extraActionLabel,
     onClick: onExtraActionClick,
@@ -391,7 +393,7 @@ function Toolbar({
             <KeyboardShortcutButton
               Icon={!isLoadingExtraAction && extraActionIcon}
               bold
-              disabled={disabledActions}
+              disabled={disabledExtraAction}
               greyBorder
               loading={isLoadingExtraAction}
               onClick={openExtraActionConfirmDialogue

--- a/mage_ai/frontend/components/workspaces/ConfigureWorkspace/constants.ts
+++ b/mage_ai/frontend/components/workspaces/ConfigureWorkspace/constants.ts
@@ -24,6 +24,11 @@ export const WORKSPACE_FIELDS = [
 
 export const GENERAL_K8S_FIELDS = [
   {
+    label: 'Namespace',
+    labelDescription: 'The namespace where the workspace resources will be deployed. Defaults to the value of the KUBE_NAMESPACE environment variable.',
+    uuid: 'namespace',
+  },
+  {
     label: 'Service account name',
     placeholder: 'default',
     uuid: 'service_account_name',

--- a/mage_ai/frontend/interfaces/WorkspaceType.ts
+++ b/mage_ai/frontend/interfaces/WorkspaceType.ts
@@ -6,6 +6,11 @@ export interface InstanceType {
   task_arn?: string;
 }
 
+export enum WorkspaceQueryEnum {
+  ALL = '__all__',
+  NAMESPACE = 'namespace[]',
+}
+
 export default interface WorkspaceType {
   access?: number;
   cluster_type?: string;

--- a/mage_ai/frontend/pages/manage/index.tsx
+++ b/mage_ai/frontend/pages/manage/index.tsx
@@ -1,248 +1,44 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { useMutation } from 'react-query';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import Button from '@oracle/elements/Button';
-import ClickOutside from '@oracle/components/ClickOutside';
 import ConfigureWorkspace from '@components/workspaces/ConfigureWorkspace';
 import ErrorsType from '@interfaces/ErrorsType';
-import FlexContainer from '@oracle/components/FlexContainer';
-import FlyoutMenu from '@oracle/components/FlyoutMenu';
-import KeyboardShortcutButton from '@oracle/elements/Button/KeyboardShortcutButton';
 import Panel from '@oracle/components/Panel';
 import PrivateRoute from '@components/shared/PrivateRoute';
 import ProjectType from '@interfaces/ProjectType';
-import Spacing from '@oracle/elements/Spacing';
 import Table from '@components/shared/Table';
 import Text from '@oracle/elements/Text';
 import WorkspacesDashboard from '@components/workspaces/Dashboard';
 import WorkspaceDetail from '@components/workspaces/Detail';
-import WorkspaceType, { InstanceType } from '@interfaces/WorkspaceType';
+import WorkspaceType, { WorkspaceQueryEnum } from '@interfaces/WorkspaceType';
 import api from '@api';
-import { Add, Ellipsis, Expand } from '@oracle/icons';
 import { BORDER_RADIUS_XXXLARGE } from '@oracle/styles/units/borders';
-import { BUTTON_GRADIENT } from '@oracle/styles/colors/gradients';
-import { PopupContainerStyle } from '@components/PipelineDetail/Runs/Table.style';
+import { Expand, Refresh } from '@oracle/icons';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { WorkspacesPageNameEnum } from '@components/workspaces/Dashboard/constants';
 import { capitalizeRemoveUnderscoreLower } from '@utils/string';
-import { onSuccess } from '@api/utils/response';
 import { useModal } from '@context/Modal';
-
-function MoreActions({
-  clusterType,
-  fetchWorkspaces,
-  instance,
-  setErrors,
-}: {
-  clusterType: string;
-  fetchWorkspaces: any;
-  instance: InstanceType;
-  setErrors: (errors: ErrorsType) => void;
-}) {
-  const refMoreActions = useRef(null);
-  const [showMoreActions, setShowMoreActions] = useState<boolean>();
-  const [confirmDelete, setConfirmDelete] = useState<boolean>();
-
-  const {
-    name,
-    task_arn,
-  } = instance;
-
-  const query = {
-    cluster_type: clusterType,
-  };
-
-  const [updateWorkspace] = useMutation(
-    api.workspaces.useUpdate(name, query),
-    {
-      onSuccess: (response: any) => onSuccess(
-        response, {
-          callback: () => {
-            fetchWorkspaces();
-            setShowMoreActions(false);
-          },
-          onErrorCallback: (response, errors) => setErrors({
-            errors,
-            response,
-          }),
-        },
-      ),
-    },
-  );
-
-  const [deleteWorkspace] = useMutation(
-    api.workspaces.useDelete(name, query),
-    {
-      onSuccess: (response: any) => onSuccess(
-        response, {
-          callback: () => {
-            fetchWorkspaces();
-            setShowMoreActions(false);
-          },
-          onErrorCallback: (response, errors) => setErrors({
-            errors,
-            response,
-          }),
-        },
-      ),
-    },
-  );
-
-  const actions = useMemo(() => {
-    const {
-      status,
-    } = instance;
-
-    const items = [
-      {
-        label: () => <Text>Delete workspace</Text>,
-        onClick: () => setConfirmDelete(true),
-        uuid: 'delete_workspace',
-      },
-    ];
-    
-    if (clusterType === 'ecs') {
-      if (status === 'STOPPED') {
-        items.unshift({
-          label: () => <Text>Resume instance</Text>,
-          // @ts-ignore
-          onClick: () => updateWorkspace({
-            workspace: {
-              action: 'resume',
-              cluster_type: clusterType,
-              name: instance.name,
-              task_arn: instance.task_arn,
-            },
-          }),
-          uuid: 'resume_instance',
-        });
-      } else if (status === 'RUNNING') {
-        items.unshift({
-          label: () => <Text>Stop instance</Text>,
-          // @ts-ignore
-          onClick: () => updateWorkspace({
-            workspace: {
-              action: 'stop',
-              cluster_type: clusterType,
-              name: instance.name,
-              task_arn: instance.task_arn,
-            },
-          }),
-          uuid: 'stop_instance',
-        });
-      }
-    }
-
-    if (clusterType === 'k8s') {
-      if (status === 'STOPPED') {
-        items.unshift({
-          label: () => <Text>Resume instance</Text>,
-          // @ts-ignore
-          onClick: () => updateWorkspace({
-            workspace: {
-              action: 'resume',
-              cluster_type: clusterType,
-              name: instance.name,
-            },
-          }),
-          uuid: 'resume_instance',
-        });
-      } else if (status === 'RUNNING') {
-        items.unshift({
-          label: () => <Text>Stop instance</Text>,
-          // @ts-ignore
-          onClick: () => updateWorkspace({
-            workspace: {
-              action: 'stop',
-              cluster_type: clusterType,
-              name: instance.name,
-            },
-          }),
-          uuid: 'stop_instance',
-        });
-      }
-    }
-    
-    return items;
-  }, [clusterType, instance, updateWorkspace]);
-
-  return (
-    <>
-      {['ecs', 'k8s'].includes(clusterType) && (
-        <div
-          ref={refMoreActions}
-          style={{
-            position: 'relative',
-            zIndex: '1',
-          }}
-        >
-          <Button
-            iconOnly
-            onClick={() => setShowMoreActions(!showMoreActions)}
-          >
-            <Ellipsis size={2 * UNIT} />
-          </Button>
-          <ClickOutside
-            disableEscape
-            onClickOutside={() => {
-              setShowMoreActions(false);
-              setConfirmDelete(false);
-            }}
-            open={showMoreActions}
-          >
-            {confirmDelete ? (
-              <PopupContainerStyle
-                leftOffset={-UNIT * 30}
-                topOffset={-UNIT * 3}
-                width={UNIT * 30}
-              >
-                <Text>
-                  Are you sure you want to delete
-                </Text>
-                <Text>
-                  this instance? You may not be
-                </Text>
-                <Text>
-                  able to recover your data.
-                </Text>
-                <Spacing mt={1} />
-                <FlexContainer>
-                  <Button
-                    danger
-                    onClick={deleteWorkspace}
-                  >
-                    Confirm
-                  </Button>
-                  <Spacing ml={1} />
-                  <Button
-                    default
-                    onClick={() => setConfirmDelete(false)}
-                  >
-                    Cancel
-                  </Button>
-                </FlexContainer>
-              </PopupContainerStyle>
-            ) : (
-              <FlyoutMenu
-                items={actions}
-                left={-UNIT * 25}
-                open={showMoreActions}
-                parentRef={refMoreActions}
-                topOffset={-UNIT * 3}
-                uuid="workspaces/more_actions"
-                width={UNIT * 25}
-              />
-            )}
-          </ClickOutside>
-        </div>
-      )}
-    </>
-  );
-}
+import { getFilters, setFilters } from '@storage/workspaces';
+import { useRouter } from 'next/router';
+import Toolbar from '@components/shared/Table/Toolbar';
+import { filterQuery, queryFromUrl } from '@utils/url';
+import { META_QUERY_KEYS } from '@api/constants';
+import { ClusterTypeEnum } from '@components/workspaces/constants';
+import { isEmptyObject, selectEntriesWithValues } from '@utils/hash';
+import { goToWithQuery } from '@utils/routing';
 
 function WorkspacePage() {
+  const router = useRouter();
   const { data: dataStatus } = api.statuses.list();
   const [errors, setErrors] = useState<ErrorsType>(null);
+
+  const q = queryFromUrl();
+  const query = useMemo(() => ({
+    ...filterQuery(q, [
+      WorkspaceQueryEnum.NAMESPACE,
+    ]),
+  }), [q]);
+
   const clusterType = useMemo(
     () => dataStatus?.statuses?.[0]?.instance_type || 'ecs',
     [dataStatus],
@@ -254,10 +50,12 @@ function WorkspacePage() {
   const project: ProjectType = useMemo(() => data?.projects?.[0], [data]);
 
   const { data: dataWorkspaces, mutate: fetchWorkspaces } = api.workspaces.list(
-    { cluster_type: clusterType },
     {
-      refreshInterval: 10000,
-      revalidateOnFocus: true,
+      ...query,
+      cluster_type: clusterType,
+    },
+    {
+      revalidateOnFocus: false,
     },
   );
 
@@ -313,6 +111,131 @@ function WorkspacePage() {
     showDetailModal({ workspace });
   }, [showDetailModal, workspaces]);
 
+  useEffect(() => {
+    let queryFinal = {};
+
+    if (isEmptyObject(query)) {
+      const filtersQuery = {};
+      const f = getFilters();
+
+      if (f) {
+        Object.entries(f).forEach(([k, v]) => {
+          if (typeof v !== 'undefined' && v !== null) {
+            // @ts-ignore
+            if (META_QUERY_KEYS.includes(k)) {
+              filtersQuery[k] = v;
+            } else {
+              filtersQuery[k] = [];
+
+              Object.entries(v).forEach(([k2, v2]) => {
+                if (v2) {
+                  filtersQuery[k].push(k2);
+                }
+              });
+            }
+          }
+        });
+      }
+
+      if (!isEmptyObject(filtersQuery)) {
+        queryFinal = {};
+        Object.entries({
+          ...queryFinal,
+          ...filtersQuery,
+        } || {}).forEach(([k, v]) => {
+          if (typeof v !== 'undefined' && v !== null) {
+            queryFinal[k] = v;
+          }
+        });
+      }
+    } else {
+      const f = {};
+      Object.entries(query).forEach(([k, v]) => {
+        f[k] = {};
+
+        let v2 = v;
+
+        if (typeof v !== 'undefined' && v !== null) {
+          // @ts-ignore
+          if (META_QUERY_KEYS.includes(k)) {
+              f[k] = v2;
+          } else {
+            if (!Array.isArray(v2)) {
+              // @ts-ignore
+              v2 = [v2];
+            }
+
+            if (v2 && Array.isArray(v2)) {
+              v2?.forEach((v3) => {
+                f[k][v3] = true;
+              });
+            }
+          }
+        }
+      });
+
+      setFilters(selectEntriesWithValues(f));
+    }
+
+    if (!isEmptyObject(queryFinal)) {
+      goToWithQuery(selectEntriesWithValues(queryFinal), {
+        pushHistory: false,
+      });
+    }
+  }, [
+    query,
+  ]);
+
+  const toolbarEl = useMemo(() => {
+    let filterOptions = {};
+    let filterValueLabelMapping = {};
+    if (clusterType === ClusterTypeEnum.K8S) {
+      filterOptions = {
+        namespace: [WorkspaceQueryEnum.ALL],
+      };
+      filterValueLabelMapping = {
+        namespace: {
+          [WorkspaceQueryEnum.ALL]: 'All namespaces',
+        },
+      };
+    }
+
+    return (
+      <Toolbar
+        addButtonProps={{
+          label: 'Create new workspace',
+          onClick: showModal,
+        }}
+        extraActionButtonProps={{
+          Icon: Refresh,
+          disabled: false,
+          onClick: () => fetchWorkspaces(),
+          tooltip: 'Refresh workspaces',
+        }}
+        filterOptions={filterOptions}
+        filterValueLabelMapping={filterValueLabelMapping}
+        onClickFilterDefaults={() => {
+          setFilters({});
+          router.push('/manage');
+        }}
+        onFilterApply={(query, updatedQuery) => {
+          // @ts-ignore
+          if (Object.values(updatedQuery).every(arr => !arr?.length)) {
+            setFilters({});
+          }
+        }}
+        // @ts-ignore
+        query={query}
+      />
+    );
+  }, [
+    clusterType,
+    fetchWorkspaces,
+    query,
+    router,
+    showModal,
+  ]);
+
   return (
     <WorkspacesDashboard  
       breadcrumbs={[
@@ -324,18 +247,7 @@ function WorkspacePage() {
       errors={errors}
       pageName={WorkspacesPageNameEnum.WORKSPACES}
       setErrors={setErrors}
-      subheaderChildren={
-        <KeyboardShortcutButton
-          background={BUTTON_GRADIENT}
-          beforeElement={<Add size={2.5 * UNIT} />}
-          bold
-          inline
-          onClick={() => showModal()}
-          uuid="workspaces/new"
-        >
-          Create new workspace
-        </KeyboardShortcutButton>
-      }
+      subheaderChildren={toolbarEl}
     >
       <Table
         columnFlex={[2, 4, 2, 3, 1, null]}

--- a/mage_ai/frontend/storage/workspaces.ts
+++ b/mage_ai/frontend/storage/workspaces.ts
@@ -1,0 +1,19 @@
+import { get, set } from './localStorage';
+
+const LOCAL_STORAGE_KEY_WORKSPACE_LIST_FILTERS = 'workspace_list_filters';
+
+type FilterType = {
+  [filterKey: string]: {
+    [value: string]: boolean;
+  };
+};
+
+export function getFilters() {
+  return get(LOCAL_STORAGE_KEY_WORKSPACE_LIST_FILTERS, {});
+}
+
+export function setFilters(filters: FilterType) {
+  set(LOCAL_STORAGE_KEY_WORKSPACE_LIST_FILTERS, filters);
+
+  return filters;
+}

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -475,13 +475,13 @@ async def main(
                 entity_id=get_project_uuid(),
                 prefix=get_repo_name(),
             )
+            default_owner_role = Role.get_role(f'{get_repo_name()}_{Role.DefaultRole.OWNER}')
         else:
             Role.create_default_roles()
+            default_owner_role = Role.get_role(Role.DefaultRole.OWNER)
 
         # Fetch legacy owner user to check if we need to batch update the users with new roles.
         legacy_owner_user = User.query.filter(User._owner == True).first()  # noqa: E712
-
-        default_owner_role = Role.get_role(Role.DefaultRole.OWNER)
         owner_users = default_owner_role.users if default_owner_role else []
         if not legacy_owner_user and len(owner_users) == 0:
             logger.info('User with owner permission doesn’t exist, creating owner user.')


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Resolves https://github.com/mage-ai/mage-ai/issues/4451.

Added a filter on the workspaces dashboard to fetch workspaces in all namespaces. In the future, maybe we can add more granular filtering, but right now it's either the default namespace or all workspaces.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with workspaces in multiple namespaces
![Screenshot 2024-02-01 at 4 15 45 PM](https://github.com/mage-ai/mage-ai/assets/14357209/1a9609e1-d329-4d7e-95e6-3406c01444ae)


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
