### PR TITLE
[dy] Select status for pipeline runs that time out

### DIFF
--- a/mage_ai/data_preparation/models/triggers/__init__.py
+++ b/mage_ai/data_preparation/models/triggers/__init__.py
@@ -52,6 +52,7 @@ class SettingsConfig(BaseConfig):
     create_initial_pipeline_run: bool = False
     landing_time_enabled: bool = False
     timeout: int = None  # in seconds
+    timeout_status: str = None
 
 
 @dataclass

--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -77,6 +77,7 @@ import {
   UNITS_BETWEEN_SECTIONS,
 } from '@oracle/styles/units/spacing';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
+import { RunStatus } from '@interfaces/BlockRunType';
 import {
   SUBHEADER_TABS,
   SUBHEADER_TAB_CUSTOMIZE,
@@ -1538,23 +1539,51 @@ function Edit({
 
         <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
           {!isStreamingPipeline && (
-            <Spacing mb={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
-              <Text>
-                Set a timeout for each run of this trigger (optional)
-              </Text>
-              <Spacing mb={1} />
-              <TextInput
-                label="Timeout (in seconds)"
-                onChange={e => setSettings(prev => ({
-                  ...prev,
-                  timeout: e.target.value,
-                }))}
-                primary
-                setContentOnMount
-                type="number"
-                value={settings?.timeout}
-              />
-            </Spacing>
+            <>
+              <Spacing mb={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
+                <Text>
+                  Set a timeout for each run of this trigger (optional)
+                </Text>
+                <Spacing mb={1} />
+                <TextInput
+                  label="Timeout (in seconds)"
+                  onChange={e => setSettings(prev => ({
+                    ...prev,
+                    timeout: e.target.value,
+                  }))}
+                  primary
+                  setContentOnMount
+                  type="number"
+                  value={settings?.timeout}
+                />
+              </Spacing>
+              <Spacing mb={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
+                <Text>
+                  Status for runs that exceed the timeout (default: failed)
+                </Text>
+                <Spacing mb={1} />
+                <Select
+                  fullWidth
+                  monospace
+                  onChange={(e) => {
+                    e.preventDefault();
+                    setSettings(s => ({
+                      ...s,
+                      timeout_status: e.target.value,
+                    }));
+                  }}
+                  placeholder="Timeout status"
+                  value={settings?.timeout_status}
+                >
+                  <option value={RunStatus.FAILED}>
+                    Failed
+                  </option>
+                  <option value={RunStatus.CANCELLED}>
+                    Cancelled
+                  </option>
+                </Select>
+              </Spacing>
+            </>
           )}
           <FlexContainer alignItems="center">
             <Spacing mr={2}>

--- a/mage_ai/frontend/interfaces/PipelineScheduleType.ts
+++ b/mage_ai/frontend/interfaces/PipelineScheduleType.ts
@@ -63,6 +63,7 @@ export interface PipelineScheduleSettingsType {
   create_initial_pipeline_run?: boolean;
   skip_if_previous_running?: boolean;
   timeout?: number;
+  timeout_status?: string;
   invalid_schedule_interval?: boolean; // Used to detect triggers with invalid cron expressions
 }
 

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -202,6 +202,10 @@ class PipelineSchedule(PipelineScheduleProjectPlatformMixin, BaseModel):
     def timeout(self) -> int:
         return (self.settings or {}).get('timeout')
 
+    @property
+    def timeout_status(self) -> 'PipelineRun.PipelineRunStatus':
+        return (self.settings or {}).get('timeout_status')
+
     @validates('schedule_interval')
     def validate_schedule_interval(self, key, schedule_interval):
         if schedule_interval and schedule_interval not in \

--- a/mage_ai/orchestration/pipeline_scheduler_original.py
+++ b/mage_ai/orchestration/pipeline_scheduler_original.py
@@ -275,9 +275,15 @@ class PipelineScheduler:
                             schedule.schedule_interval == ScheduleInterval.ONCE:
 
                         schedule.update(status=ScheduleStatus.INACTIVE)
-            elif self.__check_pipeline_run_timeout() or \
-                    (self.pipeline_run.any_blocks_failed() and
-                     not self.allow_blocks_to_fail):
+            elif self.__check_pipeline_run_timeout():
+                status = (
+                    self.pipeline_schedule.timeout_status
+                    or PipelineRun.PipelineRunStatus.FAILED
+                )
+                self.pipeline_run.update(status=status)
+
+                self.on_pipeline_run_failure('Pipeline run timed out.')
+            elif self.pipeline_run.any_blocks_failed() and not self.allow_blocks_to_fail:
                 self.pipeline_run.update(
                     status=PipelineRun.PipelineRunStatus.FAILED)
 
@@ -295,21 +301,11 @@ class PipelineScheduler:
                             status=Backfill.Status.FAILED,
                         )
 
-                asyncio.run(UsageStatisticLogger().pipeline_run_ended(self.pipeline_run))
-
                 failed_block_runs = self.pipeline_run.failed_block_runs
-                if len(failed_block_runs) > 0:
-                    error_msg = 'Failed blocks: '\
-                                f'{", ".join([b.block_uuid for b in failed_block_runs])}.'
-                else:
-                    error_msg = 'Pipeline run timed out.'
-                self.notification_sender.send_pipeline_run_failure_message(
-                    pipeline=self.pipeline,
-                    pipeline_run=self.pipeline_run,
-                    error=error_msg,
-                )
-                # Cancel block runs that are still in progress for the pipeline run.
-                cancel_block_runs_and_jobs(self.pipeline_run, self.pipeline)
+                error_msg = 'Failed blocks: '\
+                            f'{", ".join([b.block_uuid for b in failed_block_runs])}.'
+
+                self.on_pipeline_run_failure(error_msg)
             elif PipelineType.INTEGRATION == self.pipeline.type:
                 self.__schedule_integration_streams(block_runs)
             elif self.pipeline.run_pipeline_in_one_process:
@@ -317,6 +313,17 @@ class PipelineScheduler:
             else:
                 if not self.__check_block_run_timeout():
                     self.__schedule_blocks(block_runs)
+
+    @safe_db_query
+    def on_pipeline_run_failure(self, error: str) -> None:
+        asyncio.run(UsageStatisticLogger().pipeline_run_ended(self.pipeline_run))
+        self.notification_sender.send_pipeline_run_failure_message(
+            pipeline=self.pipeline,
+            pipeline_run=self.pipeline_run,
+            error=error,
+        )
+        # Cancel block runs that are still in progress for the pipeline run.
+        cancel_block_runs_and_jobs(self.pipeline_run, self.pipeline)
 
     @safe_db_query
     def on_block_complete(
@@ -479,7 +486,7 @@ class PipelineScheduler:
             bool: True if the pipeline run has timed out, False otherwise.
         """
         try:
-            pipeline_run_timeout = self.pipeline_run.pipeline_schedule.timeout
+            pipeline_run_timeout = self.pipeline_schedule.timeout
 
             if self.pipeline_run.started_at and pipeline_run_timeout:
                 time_difference = datetime.now(tz=pytz.UTC).timestamp() - \


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Allow users to select what the time out status is for a pipeline schedule. By default, the runs will be set to status failed.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
