### PR TITLE
[jk] Remove pipeline's updated_at attribute

### DIFF
--- a/mage_ai/api/presenters/PipelinePresenter.py
+++ b/mage_ai/api/presenters/PipelinePresenter.py
@@ -1,3 +1,6 @@
+import os
+from datetime import datetime, timezone
+
 from mage_ai.api.operations import constants
 from mage_ai.api.presenters.BasePresenter import BasePresenter
 from mage_ai.data_preparation.models.constants import (
@@ -95,6 +98,10 @@ class PipelinePresenter(BasePresenter):
 
         if include_schedules:
             data['schedules'] = self.model.schedules
+
+        updated_at_timestamp = os.path.getmtime(self.model.config_path)
+        updated_at = datetime.fromtimestamp(updated_at_timestamp, tz=timezone.utc)
+        data['updated_at'] = updated_at
 
         return data
 

--- a/mage_ai/api/presenters/PipelinePresenter.py
+++ b/mage_ai/api/presenters/PipelinePresenter.py
@@ -1,6 +1,3 @@
-import os
-from datetime import datetime, timezone
-
 from mage_ai.api.operations import constants
 from mage_ai.api.presenters.BasePresenter import BasePresenter
 from mage_ai.data_preparation.models.constants import (

--- a/mage_ai/api/presenters/PipelinePresenter.py
+++ b/mage_ai/api/presenters/PipelinePresenter.py
@@ -99,9 +99,7 @@ class PipelinePresenter(BasePresenter):
         if include_schedules:
             data['schedules'] = self.model.schedules
 
-        updated_at_timestamp = os.path.getmtime(self.model.config_path)
-        updated_at = datetime.fromtimestamp(updated_at_timestamp, tz=timezone.utc)
-        data['updated_at'] = updated_at
+        data['updated_at'] = self.model.updated_at
 
         return data
 

--- a/mage_ai/cache/utils.py
+++ b/mage_ai/cache/utils.py
@@ -9,7 +9,6 @@ PIPELINE_KEYS = [
     'name',
     'tags',
     'type',
-    'updated_at',
     'uuid',
 ]
 BLOCK_KEYS = [
@@ -65,7 +64,6 @@ def build_pipeline_dict(
         name=None,
         tags=None,
         type=None,
-        updated_at=None,
         uuid=None,
     )
 

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -6,7 +6,6 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 import aiofiles
-import dateutil.parser
 import pytz
 import yaml
 from jinja2 import Template

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -1,8 +1,8 @@
 import asyncio
-import datetime
 import json
 import os
 import shutil
+from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 import aiofiles
@@ -155,6 +155,10 @@ class Pipeline:
         )
 
     @property
+    def updated_at(self):
+        return datetime.fromtimestamp(os.path.getmtime(self.config_path), tz=timezone.utc)
+
+    @property
     def dir_path(self):
         return os.path.join(self.repo_path, PIPELINES_FOLDER, self.uuid)
 
@@ -215,7 +219,7 @@ class Pipeline:
         # Update metadata.yaml with pipeline config
         with open(os.path.join(pipeline_path, PIPELINE_CONFIG_FILE), 'w') as fp:
             yaml.dump(dict(
-                created_at=str(datetime.datetime.now(tz=pytz.UTC)),
+                created_at=str(datetime.now(tz=pytz.UTC)),
                 name=name,
                 uuid=uuid,
                 type=format_enum(pipeline_type or PipelineType.PYTHON),

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -156,7 +156,8 @@ class Pipeline:
 
     @property
     def updated_at(self):
-        return datetime.fromtimestamp(os.path.getmtime(self.config_path), tz=timezone.utc)
+        if os.path.exists(self.config_path):
+            return datetime.fromtimestamp(os.path.getmtime(self.config_path), tz=timezone.utc)
 
     @property
     def dir_path(self):

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -93,7 +93,6 @@ class Pipeline:
         self.settings = {}
         self.tags = []
         self.type = PipelineType.PYTHON
-        self.updated_at = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
         self.use_repo_path = use_repo_path
         self.uuid = uuid
         self.widget_configs = []
@@ -603,9 +602,6 @@ class Pipeline:
         except Exception:
             pass
         self.created_at = config.get('created_at')
-        self.updated_at = config.get('updated_at')
-        if self.updated_at and isinstance(self.updated_at, str):
-            self.updated_at = dateutil.parser.parse(self.updated_at).replace(tzinfo=pytz.UTC)
         self.type = config.get('type') or self.type
 
         self.block_configs = config.get('blocks') or []
@@ -738,10 +734,6 @@ class Pipeline:
         return blocks_by_uuid
 
     def to_dict_base(self, exclude_data_integration=False) -> Dict:
-        updated_at = self.updated_at
-        if updated_at and hasattr(updated_at, 'isoformat'):
-            updated_at = updated_at.isoformat()
-
         base = dict(
             cache_block_output_in_memory=self.cache_block_output_in_memory,
             concurrency_config=self.concurrency_config,
@@ -759,7 +751,6 @@ class Pipeline:
             settings=self.settings.to_dict() if self.settings else self.settings,
             tags=self.tags,
             type=self.type.value if type(self.type) is not str else self.type,
-            updated_at=updated_at,
             uuid=self.uuid,
             variables_dir=self.variables_dir,
         )
@@ -970,7 +961,6 @@ class Pipeline:
         for key in [
             'description',
             'type',
-            'updated_at',
         ]:
             if key in data and data.get(key) != getattr(self, key):
                 setattr(self, key, data.get(key))

--- a/mage_ai/frontend/components/PipelineDetail/utils.ts
+++ b/mage_ai/frontend/components/PipelineDetail/utils.ts
@@ -20,6 +20,7 @@ import {
 } from '@storage/localStorage';
 import { addUnderscores, isJsonString, randomNameGenerator, removeExtensionFromFilename } from '@utils/string';
 import {
+  dateFormatLong,
   dateFormatLongFromUnixTimestamp,
   datetimeInLocalTimezone,
   momentInLocalTimezone,
@@ -252,7 +253,7 @@ export function displayPipelineLastSaved(
   const displayLocalTimezone = shouldDisplayLocalTimezone();
   const isPipelineUpdating = opts?.isPipelineUpdating;
   const pipelineContentTouched = opts?.pipelineContentTouched;
-  const pipelineLastSaved = opts?.pipelineLastSaved
+  const pipelineLastSaved = opts?.pipelineLastSaved;
 
   let saveStatus;
   if (pipelineContentTouched) {
@@ -268,7 +269,10 @@ export function displayPipelineLastSaved(
       let lastSavedDate = dateFormatLongFromUnixTimestamp(pipelineLastSaved / 1000);
 
       if (pipeline?.updated_at) {
-        lastSavedDate = datetimeInLocalTimezone(pipeline?.updated_at, displayLocalTimezone);
+        lastSavedDate = datetimeInLocalTimezone(
+          dateFormatLong(pipeline?.updated_at, { includeSeconds: true, utcFormat: true }),
+          displayLocalTimezone,
+        );
       }
       saveStatus = `Last saved ${lastSavedDate}`;
     }

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -91,7 +91,7 @@ import {
   randomNameGenerator,
   removeUnderscore,
 } from '@utils/string';
-import { datetimeInLocalTimezone, utcStringToElapsedTime } from '@utils/date';
+import { dateFormatLong, datetimeInLocalTimezone, utcStringToElapsedTime } from '@utils/date';
 import { displayErrorFromReadResponse, onSuccess } from '@api/utils/response';
 import { filterQuery, queryFromUrl } from '@utils/url';
 import { get, set } from '@storage/localStorage';
@@ -1406,7 +1406,10 @@ function PipelineListPage() {
             title={updatedAt ? utcStringToElapsedTime(updatedAt) : null}
           >
             {updatedAt
-              ? datetimeInLocalTimezone(updatedAt, displayLocalTimezone)
+              ? datetimeInLocalTimezone(
+                dateFormatLong(updatedAt, { includeSeconds: true, utcFormat: true }),
+                displayLocalTimezone,
+              )
               : <>&#8212;</>}
           </Text>,
           <Text

--- a/mage_ai/tests/cache/example_pipeline.json
+++ b/mage_ai/tests/cache/example_pipeline.json
@@ -6,7 +6,6 @@
     "name": "example_pipeline",
     "tags": [],
     "type": "python",
-    "updated_at": "2023-09-22 22:59:13",
     "uuid": "example_pipeline",
     "blocks": [
       {

--- a/mage_ai/tests/cache/pipeline_details_mapping_template
+++ b/mage_ai/tests/cache/pipeline_details_mapping_template
@@ -1,1 +1,8489 @@
-{"groups": {"type": {"python": ["silent_frost", "cool_adfasddfgfasdfsdffgfdawn", "weathered_bush", "blue_fire", "dry_firefly", "icy_bush", "snowy_morning", "weathered_wave", "restless_surf", "dark_dust", "pipeline_with_variables", "data_integration_blocks_client", "cool_adfasddfgfgfdawn", "sparkling_river", "icy_dawn", "icy_darkness", "fragrant_grass", "little_dust", "morning_silence", "billowing_dream", "restless_morning", "snowy_silence", "green_wildflower", "pipeline_gdp", "winter_pond", "damp_butterfly", "dynamic_dynamic_child_upstream", "polished_fog", "icy_voice", "dynamic_reduce_all_levels", "withered_sunset", "billowing_bird", "twilight_water", "lively_wood", "long_darkness", "winter_shape", "twilight_grass", "cool_snosdfsdfwflake", "delicate_thunder", "using_ai_1", "quiet_firefly", "spring_dew", "dawn_meadow", "cool_adfasdfdawn_copy", "winter_cherry", "black_bird", "crystal_herald", "little_sea", "red_haze", "letter_22213144442312", "purple_sun", "ancient_water", "wild_rain", "interactions_testing_2", "snowflake", "delicate_glade", "snowy_snow", "dawn_frost", "white_river", "interactions_trigger", "autumn_sky", "cold_moon", "fragrant_mountain", "hidden_dew", "red_morning", "young_glitter", "shy_pond", "proud_pond", "asdfasdfasdff", "billowing_field", "purple_frost", "patient_wind", "crimson_surf", "restless_night", "proud_tree", "unified_pipeline", "falling_smoke", "dry_shape", "solitary_star", "old_shape", "ancient_rain", "holy_river", "ancient_sea", "icy_water", "di_client", "example_pipeline", "dbt_pipeline", "rough_water", "hidden_night", "fragrant_sound", "cool_adfasdfdawn", "wispy_field", "long_firefly", "pipeline_that_has_gdp_copy", "dynamic_pipeline_testing", "long_wave", "damp_silence", "winter_bird", "shy_bush", "polished_snow", "divine_butterfly", "dawn_flower", "throbbing_wave", "holy_grass", "white_cloud", "elden_glade", "dynamic_2", "unify_pipeline_destination", "rough_wind", "pipeline_that_has_gdp", "misty_morning", "proud_grass", "wispy_knight", "unify_destination_block_python", "white_feather", "billowing_waterfall", "lively_shadow", "purple_morning", "user_transactions", "crimson_water", "snowy_wind", "interactions_testing", "green_moon", "snowy_smoke", "unified_pipeline_demo", "withered_wave", "pipeline_hook", "destination_parallel", "di_client_2", "rough_violet", "throbbing_firefly", "withered_flower", "green_mountain", "summer_night", "withered_dawn", "with_attached_hook", "small_shapeasdasdadasd", "floral_star", "young_shape", "asdfasdfasdf111f", "test_interval_kwargs"], "streaming": ["red_snow", "young_wave", "rough_flower", "hidden_sea", "quiet_rain", "morning_rain", "ancient_forest", "aged_violet", "small_shape"], "integration": ["solitary_sky", "spring_smoke", "withered_leaf", "wild_wind", "floral_field", "delicate_forest", "holy_sound", "letter_2221314afsdfsdf4442312", "throbbing_hill", "patient_mountain", "withered_feather", "lingering_dew", "floral_night", "data_integration_pipeline_normal_test", "summer_resonance", "dry_rain", "lingering_voice", "late_wind", "twilight_frog", "frosty_night", "wandering_waterfall", "muddy_firefly", "dawn_thunder"], "pyspark": ["spark"]}}, "models": {"silent_frost": {"added_at": null, "pipeline": {"description": null, "name": "silent frost", "tags": [], "type": "python", "updated_at": "2023-12-06 11:41:09", "uuid": "silent_frost", "blocks": [{"downstream_blocks": ["misty_cherry"], "language": "python", "name": "dark pond", "type": "global_data_product", "upstream_blocks": [], "uuid": "dark_pond"}, {"downstream_blocks": [], "language": "python", "name": "misty cherry", "type": "transformer", "upstream_blocks": ["dark_pond"], "uuid": "misty_cherry"}]}, "updated_at": 1702284950.402959}, "red_snow": {"added_at": null, "pipeline": {"description": null, "name": "red snow", "tags": null, "type": "streaming", "updated_at": null, "uuid": "red_snow", "blocks": []}, "updated_at": 1702284950.402966}, "cool_adfasddfgfasdfsdffgfdawn": {"added_at": null, "pipeline": {"description": null, "name": "cool adfasddfgfasdfsdffgfdawn", "tags": [], "type": "python", "updated_at": null, "uuid": "cool_adfasddfgfasdfsdffgfdawn", "blocks": [{"downstream_blocks": [], "language": "python", "name": "1", "type": "data_loader", "upstream_blocks": [], "uuid": "letter_1"}, {"downstream_blocks": [], "language": "python", "name": "2", "type": "data_loader", "upstream_blocks": [], "uuid": "letter_2"}]}, "updated_at": 1702284950.402973}, "weathered_bush": {"added_at": null, "pipeline": {"description": null, "name": "weathered bush", "tags": [], "type": "python", "updated_at": "2023-09-30 04:25:26", "uuid": "weathered_bush", "blocks": [{"downstream_blocks": [], "language": "yaml", "name": "fragrant dust", "type": "data_loader", "upstream_blocks": [], "uuid": "fragrant_dust"}, {"downstream_blocks": [], "language": "python", "name": "proud dream", "type": "scratchpad", "upstream_blocks": [], "uuid": "proud_dream"}]}, "updated_at": 1702284950.40298}, "blue_fire": {"added_at": null, "pipeline": {"description": null, "name": "blue fire", "tags": [], "type": "python", "updated_at": "2023-08-10 06:35:41", "uuid": "blue_fire", "blocks": [{"downstream_blocks": ["autumn_dew"], "language": "python", "name": "load_data_from_internet", "type": "data_loader", "upstream_blocks": [], "uuid": "load_data_from_internet"}, {"downstream_blocks": ["autumn_dew"], "language": "sql", "name": "broken bush", "type": "data_loader", "upstream_blocks": [], "uuid": "broken_bush"}, {"downstream_blocks": [], "language": "python", "name": "autumn dew", "type": "transformer", "upstream_blocks": ["broken_bush", "load_data_from_internet"], "uuid": "autumn_dew"}]}, "updated_at": 1702284950.40299}, "dry_firefly": {"added_at": null, "pipeline": {"description": null, "name": "dry firefly", "tags": [], "type": "python", "updated_at": "2023-10-05 23:25:16", "uuid": "dry_firefly", "blocks": [{"downstream_blocks": ["cool_star"], "language": "python", "name": "summer breeze", "type": "data_loader", "upstream_blocks": [], "uuid": "summer_breeze"}, {"downstream_blocks": [], "language": "python", "name": "cool star", "type": "transformer", "upstream_blocks": ["summer_breeze"], "uuid": "cool_star"}]}, "updated_at": 1702284950.402997}, "young_wave": {"added_at": null, "pipeline": {"description": null, "name": "young wave", "tags": [], "type": "streaming", "updated_at": null, "uuid": "young_wave", "blocks": []}, "updated_at": 1702284950.403}, "rough_flower": {"added_at": null, "pipeline": {"description": null, "name": "rough flower", "tags": [], "type": "streaming", "updated_at": "2023-08-08 07:38:02", "uuid": "rough_flower", "blocks": [{"downstream_blocks": ["patient_cloud"], "language": "yaml", "name": "falling glitter", "type": "data_loader", "upstream_blocks": [], "uuid": "falling_glitter"}, {"downstream_blocks": ["crimson_breeze"], "language": "python", "name": "patient cloud", "type": "transformer", "upstream_blocks": ["falling_glitter"], "uuid": "patient_cloud"}, {"downstream_blocks": [], "language": "yaml", "name": "crimson breeze", "type": "data_exporter", "upstream_blocks": ["patient_cloud"], "uuid": "crimson_breeze"}]}, "updated_at": 1702284950.403009}, "icy_bush": {"added_at": null, "pipeline": {"description": null, "name": "icy bush", "tags": [], "type": "python", "updated_at": "2023-08-03 18:20:05", "uuid": "icy_bush", "blocks": [{"downstream_blocks": ["restless_lake"], "language": "python", "name": "load_data_from_internet", "type": "data_loader", "upstream_blocks": [], "uuid": "load_data_from_internet"}, {"downstream_blocks": ["restless_lake"], "language": "sql", "name": "cool bush", "type": "data_loader", "upstream_blocks": [], "uuid": "cool_bush"}, {"downstream_blocks": [], "language": "python", "name": "restless lake", "type": "transformer", "upstream_blocks": ["cool_bush", "load_data_from_internet"], "uuid": "restless_lake"}]}, "updated_at": 1702284950.403018}, "snowy_morning": {"added_at": null, "pipeline": {"description": null, "name": "snowy morning", "tags": [], "type": "python", "updated_at": "2023-07-25 03:04:17", "uuid": "snowy_morning", "blocks": [{"downstream_blocks": [], "language": "python", "name": "little dipper", "type": "data_loader", "upstream_blocks": [], "uuid": "little_dipper"}, {"downstream_blocks": [], "language": "python", "name": "proud grass", "type": "scratchpad", "upstream_blocks": [], "uuid": "proud_grass"}, {"downstream_blocks": [], "language": "sql", "name": "winter smoke", "type": "data_loader", "upstream_blocks": [], "uuid": "winter_smoke"}]}, "updated_at": 1702284950.403027}, "weathered_wave": {"added_at": null, "pipeline": {"description": null, "name": "weathered wave", "tags": null, "type": "python", "updated_at": null, "uuid": "weathered_wave", "blocks": []}, "updated_at": 1702284950.40303}, "restless_surf": {"added_at": null, "pipeline": {"description": null, "name": "example_pipeline", "tags": [], "type": "python", "updated_at": "2023-07-22 22:21:39", "uuid": "restless_surf", "blocks": [{"downstream_blocks": ["fill_in_missing_values", "summer_dew", "wandering_voice", "blue_haze", "solitary_moon", "spring_feather"], "language": "python", "name": "load_titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "load_titanic"}, {"downstream_blocks": [], "language": "markdown", "name": "spring feather", "type": "markdown", "upstream_blocks": ["load_titanic"], "uuid": "spring_feather"}, {"downstream_blocks": [], "language": "markdown", "name": "polished field", "type": "markdown", "upstream_blocks": [], "uuid": "polished_field"}, {"downstream_blocks": [], "language": "python", "name": "solitary moon", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "solitary_moon"}, {"downstream_blocks": ["autumn_sound"], "language": "python", "name": "blue haze", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "blue_haze"}, {"downstream_blocks": [], "language": "yaml", "name": "autumn sound", "type": "dbt", "upstream_blocks": ["blue_haze"], "uuid": "autumn_sound"}, {"downstream_blocks": [], "language": "python", "name": "wandering voice", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "wandering_voice"}, {"downstream_blocks": [], "language": "python", "name": "summer dew", "type": "data_exporter", "upstream_blocks": ["load_titanic"], "uuid": "summer_dew"}, {"downstream_blocks": ["export_titanic_clean"], "language": "python", "name": "fill_in_missing_values", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "fill_in_missing_values"}, {"downstream_blocks": ["hidden_wildflower"], "language": "python", "name": "export_titanic_clean", "type": "data_exporter", "upstream_blocks": ["fill_in_missing_values"], "uuid": "export_titanic_clean"}, {"downstream_blocks": ["empty_shadow"], "language": "python", "name": "hidden wildflower", "type": "data_loader", "upstream_blocks": ["export_titanic_clean"], "uuid": "hidden_wildflower"}, {"downstream_blocks": [], "language": "python", "name": "empty shadow", "type": "transformer", "upstream_blocks": ["hidden_wildflower"], "uuid": "empty_shadow"}, {"downstream_blocks": [], "language": "markdown", "name": "winter waterfall", "type": "markdown", "upstream_blocks": [], "uuid": "winter_waterfall"}]}, "updated_at": 1702284950.403057}, "dark_dust": {"added_at": null, "pipeline": {"description": null, "name": "dark dust", "tags": [], "type": "python", "updated_at": "2023-07-27 18:08:06", "uuid": "dark_dust", "blocks": [{"downstream_blocks": ["summer_wood"], "language": "python", "name": "quiet violet", "type": "data_loader", "upstream_blocks": [], "uuid": "quiet_violet"}, {"downstream_blocks": ["crimson_frog"], "language": "python", "name": "summer wood", "type": "transformer", "upstream_blocks": ["quiet_violet"], "uuid": "summer_wood"}, {"downstream_blocks": [], "language": "python", "name": "crimson frog", "type": "data_exporter", "upstream_blocks": ["summer_wood"], "uuid": "crimson_frog"}, {"downstream_blocks": [], "language": "python", "name": "purple dawn", "type": "scratchpad", "upstream_blocks": [], "uuid": "purple_dawn"}]}, "updated_at": 1702284950.403065}, "pipeline_with_variables": {"added_at": null, "pipeline": {"description": null, "name": "pipeline with variables", "tags": ["AWS", "Azure"], "type": "python", "updated_at": null, "uuid": "pipeline_with_variables", "blocks": [{"downstream_blocks": [], "language": "python", "name": "twilight paper", "type": "data_loader", "upstream_blocks": [], "uuid": "twilight_paper"}]}, "updated_at": 1702284950.40307}, "data_integration_blocks_client": {"added_at": null, "pipeline": {"description": null, "name": "data integration blocks client", "tags": [], "type": "python", "updated_at": "2023-09-28 00:47:57", "uuid": "data_integration_blocks_client", "blocks": [{"downstream_blocks": ["destination_pg_yaml", "source_pg_python"], "language": "yaml", "name": "source pg yaml", "type": "data_loader", "upstream_blocks": ["withered_smoke"], "uuid": "source_pg_yaml"}, {"downstream_blocks": ["destination_pg_yaml"], "language": "python", "name": "titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "titanic"}, {"downstream_blocks": [], "language": "yaml", "name": "destination pg yaml", "type": "data_exporter", "upstream_blocks": ["source_pg_yaml", "titanic"], "uuid": "destination_pg_yaml"}, {"downstream_blocks": ["destination_pg_python"], "language": "python", "name": "source pg python", "type": "data_loader", "upstream_blocks": ["withered_smoke", "withered_wildflower", "source_pg_yaml"], "uuid": "source_pg_python"}, {"downstream_blocks": [], "language": "python", "name": "destination pg python", "type": "data_exporter", "upstream_blocks": ["source_pg_python"], "uuid": "destination_pg_python"}, {"downstream_blocks": ["source_pg_python", "source_pg_yaml"], "language": "python", "name": "withered smoke", "type": "custom", "upstream_blocks": [], "uuid": "withered_smoke"}, {"downstream_blocks": ["source_pg_python"], "language": "python", "name": "withered wildflower", "type": "data_loader", "upstream_blocks": [], "uuid": "withered_wildflower"}]}, "updated_at": 1702284950.403086}, "hidden_sea": {"added_at": null, "pipeline": {"description": null, "name": "hidden sea", "tags": null, "type": "streaming", "updated_at": null, "uuid": "hidden_sea", "blocks": []}, "updated_at": 1702284950.403088}, "cool_adfasddfgfgfdawn": {"added_at": null, "pipeline": {"description": null, "name": "cool adfasddfgfgfdawn", "tags": [], "type": "python", "updated_at": null, "uuid": "cool_adfasddfgfgfdawn", "blocks": [{"downstream_blocks": [], "language": "python", "name": "2", "type": "data_loader", "upstream_blocks": [], "uuid": "letter_2"}, {"downstream_blocks": [], "language": "python", "name": "1", "type": "data_loader", "upstream_blocks": [], "uuid": "letter_1"}]}, "updated_at": 1702284950.403094}, "sparkling_river": {"added_at": null, "pipeline": {"description": null, "name": "sparkling river", "tags": [], "type": "python", "updated_at": "2023-08-28 05:17:17", "uuid": "sparkling_river", "blocks": [{"downstream_blocks": [], "language": "markdown", "name": "Documentation for solitary_butterfly", "type": "markdown", "upstream_blocks": [], "uuid": "documentation_for_solitary_butterfly"}, {"downstream_blocks": [], "language": "python", "name": "solitary butterfly", "type": "transformer", "upstream_blocks": [], "uuid": "solitary_butterfly"}, {"downstream_blocks": [], "language": "python", "name": "purple rain", "type": "data_loader", "upstream_blocks": [], "uuid": "purple_rain"}]}, "updated_at": 1702284950.403102}, "icy_dawn": {"added_at": null, "pipeline": {"description": null, "name": "icy dawn", "tags": [], "type": "python", "updated_at": "2023-07-26 06:49:56", "uuid": "icy_dawn", "blocks": [{"downstream_blocks": [], "language": "r", "name": "throbbing sun", "type": "data_loader", "upstream_blocks": [], "uuid": "throbbing_sun"}, {"downstream_blocks": [], "language": "sql", "name": "old waterfall", "type": "data_loader", "upstream_blocks": [], "uuid": "old_waterfall"}, {"downstream_blocks": ["solitary_rain"], "language": "r", "name": "empty feather", "type": "data_loader", "upstream_blocks": [], "uuid": "empty_feather"}, {"downstream_blocks": ["winter_sunset"], "language": "sql", "name": "solitary rain", "type": "transformer", "upstream_blocks": ["empty_feather"], "uuid": "solitary_rain"}, {"downstream_blocks": ["frosty_night"], "language": "r", "name": "winter sunset", "type": "transformer", "upstream_blocks": ["solitary_rain"], "uuid": "winter_sunset"}, {"downstream_blocks": ["shy_moon"], "language": "sql", "name": "frosty night", "type": "data_exporter", "upstream_blocks": ["winter_sunset"], "uuid": "frosty_night"}, {"downstream_blocks": ["icy_bird"], "language": "r", "name": "shy moon", "type": "data_exporter", "upstream_blocks": ["frosty_night"], "uuid": "shy_moon"}, {"downstream_blocks": ["icy_thunder"], "language": "python", "name": "icy bird", "type": "transformer", "upstream_blocks": ["shy_moon"], "uuid": "icy_bird"}, {"downstream_blocks": ["restless_glitter"], "language": "python", "name": "icy thunder", "type": "transformer", "upstream_blocks": ["icy_bird"], "uuid": "icy_thunder"}, {"downstream_blocks": ["withered_wood"], "language": "python", "name": "restless glitter", "type": "transformer", "upstream_blocks": ["icy_thunder"], "uuid": "restless_glitter"}, {"downstream_blocks": [], "language": "python", "name": "withered wood", "type": "transformer", "upstream_blocks": ["restless_glitter"], "uuid": "withered_wood"}]}, "updated_at": 1702284950.403125}, "icy_darkness": {"added_at": null, "pipeline": {"description": null, "name": "icy darkness", "tags": [], "type": "python", "updated_at": null, "uuid": "icy_darkness", "blocks": [{"downstream_blocks": ["dawn_water"], "language": "python", "name": "morning darkness", "type": "data_loader", "upstream_blocks": [], "uuid": "morning_darkness"}, {"downstream_blocks": [], "language": "python", "name": "dawn water", "type": "transformer", "upstream_blocks": ["morning_darkness"], "uuid": "dawn_water"}]}, "updated_at": 1702284950.403132}, "fragrant_grass": {"added_at": null, "pipeline": {"description": null, "name": "pipeline with variables", "tags": ["demo"], "type": "python", "updated_at": "2023-08-28 06:28:37", "uuid": "fragrant_grass", "blocks": [{"downstream_blocks": [], "language": "python", "name": "twilight paper", "type": "data_loader", "upstream_blocks": [], "uuid": "twilight_paper"}]}, "updated_at": 1702284950.403137}, "little_dust": {"added_at": null, "pipeline": {"description": null, "name": "little dust", "tags": [], "type": "python", "updated_at": "2023-07-29 05:51:40", "uuid": "little_dust", "blocks": [{"downstream_blocks": [], "language": "python", "name": "restless voice", "type": "scratchpad", "upstream_blocks": [], "uuid": "restless_voice"}]}, "updated_at": 1702284950.403142}, "solitary_sky": {"added_at": null, "pipeline": {"description": null, "name": "solitary sky", "tags": [], "type": "integration", "updated_at": "2023-07-26 21:22:27", "uuid": "solitary_sky", "blocks": [{"downstream_blocks": [], "language": "yaml", "name": "green voice", "type": "data_loader", "upstream_blocks": [], "uuid": "green_voice"}]}, "updated_at": 1702284950.403146}, "morning_silence": {"added_at": null, "pipeline": {"description": null, "name": "morning silence", "tags": [], "type": "python", "updated_at": "2023-07-27 05:17:45", "uuid": "morning_silence", "blocks": [{"downstream_blocks": [], "language": "markdown", "name": "Documentation for late_sun", "type": "markdown", "upstream_blocks": [], "uuid": "documentation_for_late_sun"}, {"downstream_blocks": [], "language": "python", "name": "late sun", "type": "data_loader", "upstream_blocks": [], "uuid": "late_sun"}]}, "updated_at": 1702284950.403151}, "billowing_dream": {"added_at": null, "pipeline": {"description": null, "name": "billowing dream", "tags": [], "type": "python", "updated_at": "2023-08-08 00:16:34", "uuid": "billowing_dream", "blocks": [{"downstream_blocks": ["small_frost"], "language": "python", "name": "lively violet", "type": "data_loader", "upstream_blocks": [], "uuid": "lively_violet"}, {"downstream_blocks": [], "language": "python", "name": "small frost", "type": "global_data_product", "upstream_blocks": ["lively_violet"], "uuid": "small_frost"}]}, "updated_at": 1702284950.403157}, "spring_smoke": {"added_at": null, "pipeline": {"description": null, "name": "spring smoke", "tags": [], "type": "integration", "updated_at": "2023-08-24 06:09:55", "uuid": "spring_smoke", "blocks": [{"downstream_blocks": [], "language": "yaml", "name": "quiet sea", "type": "data_loader", "upstream_blocks": [], "uuid": "quiet_sea"}]}, "updated_at": 1702284950.403161}, "restless_morning": {"added_at": null, "pipeline": {"description": null, "name": "restless morning", "tags": [], "type": "python", "updated_at": "2023-08-04 06:58:16", "uuid": "restless_morning", "blocks": [{"downstream_blocks": ["black_tree"], "language": "python", "name": "still shape", "type": "global_data_product", "upstream_blocks": [], "uuid": "still_shape"}, {"downstream_blocks": [], "language": "python", "name": "black tree", "type": "data_exporter", "upstream_blocks": ["still_shape"], "uuid": "black_tree"}]}, "updated_at": 1702284950.403167}, "snowy_silence": {"added_at": null, "pipeline": {"description": null, "name": "snowy silence", "tags": [], "type": "python", "updated_at": "2023-08-24 06:09:35", "uuid": "snowy_silence", "blocks": [{"downstream_blocks": [], "language": "python", "name": "old flower", "type": "data_loader", "upstream_blocks": [], "uuid": "old_flower"}, {"downstream_blocks": [], "language": "sql", "name": "late morning", "type": "data_loader", "upstream_blocks": [], "uuid": "late_morning"}]}, "updated_at": 1702284950.403173}, "green_wildflower": {"added_at": null, "pipeline": {"description": null, "name": "green wildflower", "tags": [], "type": "python", "updated_at": "2023-08-11 15:46:34", "uuid": "green_wildflower", "blocks": [{"downstream_blocks": ["wild_leaf"], "language": "python", "name": "load_data_from_internet", "type": "data_loader", "upstream_blocks": [], "uuid": "load_data_from_internet"}, {"downstream_blocks": ["wild_leaf"], "language": "sql", "name": "icy star", "type": "data_loader", "upstream_blocks": [], "uuid": "icy_star"}, {"downstream_blocks": [], "language": "python", "name": "wild leaf", "type": "transformer", "upstream_blocks": ["icy_star", "load_data_from_internet"], "uuid": "wild_leaf"}]}, "updated_at": 1702284950.403181}, "pipeline_gdp": {"added_at": null, "pipeline": {"description": null, "name": "pipeline gdp", "tags": [], "type": "python", "updated_at": "2023-09-07 01:34:43", "uuid": "pipeline_gdp", "blocks": [{"downstream_blocks": ["histogram_for_restaurant_user_transactions_1693978385426", "line_chart_for_restaurant_user_transactions_1693979438332", "table_for_restaurant_user_transactions_1693979819546", "time_series_line_chart_for_restaurant_user_transactions_1693981628999"], "language": "python", "name": "restaurant_user_transactions", "type": "data_loader", "upstream_blocks": [], "uuid": "restaurant_user_transactions"}, {"downstream_blocks": [], "language": "python", "name": "polished brook", "type": "scratchpad", "upstream_blocks": [], "uuid": "polished_brook"}, {"downstream_blocks": ["time_series_bar_chart_for_product_purchases_1693981396696"], "language": "python", "name": "product_purchases", "type": "data_loader", "upstream_blocks": [], "uuid": "product_purchases"}]}, "updated_at": 1702284950.403198}, "withered_leaf": {"added_at": null, "pipeline": {"description": null, "name": "withered leaf", "tags": [], "type": "integration", "updated_at": "2023-08-02 18:29:33", "uuid": "withered_leaf", "blocks": [{"downstream_blocks": ["polished_pine"], "language": "yaml", "name": "throbbing grass", "type": "data_loader", "upstream_blocks": [], "uuid": "throbbing_grass"}, {"downstream_blocks": ["broken_dust"], "language": "python", "name": "polished pine", "type": "transformer", "upstream_blocks": ["throbbing_grass"], "uuid": "polished_pine"}, {"downstream_blocks": [], "language": "yaml", "name": "broken dust", "type": "data_exporter", "upstream_blocks": ["polished_pine"], "uuid": "broken_dust"}]}, "updated_at": 1702284950.403205}, "winter_pond": {"added_at": null, "pipeline": {"description": null, "name": "winter pond", "tags": [], "type": "python", "updated_at": "2023-10-11 03:50:32", "uuid": "winter_pond", "blocks": [{"downstream_blocks": [], "language": "python", "name": "broken dawn", "type": "data_loader", "upstream_blocks": [], "uuid": "broken_dawn"}]}, "updated_at": 1702284950.403209}, "damp_butterfly": {"added_at": null, "pipeline": {"description": null, "name": "damp butterfly", "tags": [], "type": "python", "updated_at": "2023-10-15 01:26:43", "uuid": "damp_butterfly", "blocks": [{"downstream_blocks": [], "language": "python", "name": "damp pond", "type": "data_loader", "upstream_blocks": [], "uuid": "damp_pond"}]}, "updated_at": 1702284950.403213}, "dynamic_dynamic_child_upstream": {"added_at": null, "pipeline": {"description": null, "name": "dynamic dynamic child upstream", "tags": ["dynamic"], "type": "python", "updated_at": "2023-12-10 15:57:57", "uuid": "dynamic_dynamic_child_upstream", "blocks": [{"downstream_blocks": ["dynamic_child_a", "dynamic_child_child_a", "upstream_reduce_output_multiple"], "language": "python", "name": "dynamic_parent_b", "type": "data_loader", "upstream_blocks": [], "uuid": "dynamic_parent_b"}, {"downstream_blocks": ["dynamic_child_child_a", "dynamic_child_child_b"], "language": "python", "name": "dynamic_child_a", "type": "transformer", "upstream_blocks": ["dynamic_parent_b"], "uuid": "dynamic_child_a"}, {"downstream_blocks": ["upstream_reduce_output_multiple"], "language": "python", "name": "dynamic_child_child_a", "type": "data_exporter", "upstream_blocks": ["dynamic_parent_b", "dynamic_child_a"], "uuid": "dynamic_child_child_a"}, {"downstream_blocks": ["upstream_reduce_output_multiple"], "language": "python", "name": "dynamic_child_child_b", "type": "data_exporter", "upstream_blocks": ["dynamic_child_a"], "uuid": "dynamic_child_child_b"}, {"downstream_blocks": ["upstream_reduce_output"], "language": "python", "name": "upstream reduce output multiple", "type": "custom", "upstream_blocks": ["dynamic_child_child_a", "dynamic_child_child_b", "dynamic_parent_b"], "uuid": "upstream_reduce_output_multiple"}, {"downstream_blocks": [], "language": "python", "name": "upstream_reduce_output", "type": "custom", "upstream_blocks": ["upstream_reduce_output_multiple"], "uuid": "upstream_reduce_output"}]}, "updated_at": 1702284950.403226}, "polished_fog": {"added_at": null, "pipeline": {"description": null, "name": "polished fog", "tags": [], "type": "python", "updated_at": "2023-08-15 18:58:44", "uuid": "polished_fog", "blocks": [{"downstream_blocks": ["cool_shadow"], "language": "python", "name": "withered sun", "type": "data_loader", "upstream_blocks": [], "uuid": "withered_sun"}, {"downstream_blocks": ["cool_shadow"], "language": "sql", "name": "winter moon", "type": "data_loader", "upstream_blocks": [], "uuid": "winter_moon"}, {"downstream_blocks": [], "language": "python", "name": "cool shadow", "type": "transformer", "upstream_blocks": ["winter_moon", "withered_sun"], "uuid": "cool_shadow"}]}, "updated_at": 1702284950.403234}, "wild_wind": {"added_at": null, "pipeline": {"description": null, "name": "wild wind", "tags": [], "type": "integration", "updated_at": "2023-08-02 18:15:12", "uuid": "wild_wind", "blocks": [{"downstream_blocks": ["small_mountain"], "language": "yaml", "name": "cold shape", "type": "data_loader", "upstream_blocks": [], "uuid": "cold_shape"}, {"downstream_blocks": ["dry_breeze"], "language": "python", "name": "small mountain", "type": "transformer", "upstream_blocks": ["cold_shape"], "uuid": "small_mountain"}, {"downstream_blocks": [], "language": "yaml", "name": "dry breeze", "type": "data_exporter", "upstream_blocks": ["small_mountain"], "uuid": "dry_breeze"}]}, "updated_at": 1702284950.403241}, "icy_voice": {"added_at": null, "pipeline": {"description": null, "name": "icy voice", "tags": null, "type": "python", "updated_at": null, "uuid": "icy_voice", "blocks": []}, "updated_at": 1702284950.403243}, "dynamic_reduce_all_levels": {"added_at": null, "pipeline": {"description": null, "name": "dynamic reduce all levels", "tags": ["dynamic"], "type": "python", "updated_at": "2023-10-01 05:38:06", "uuid": "dynamic_reduce_all_levels", "blocks": [{"downstream_blocks": ["child_a_30"], "language": "python", "name": "parent 30", "type": "data_loader", "upstream_blocks": [], "uuid": "parent_30"}, {"downstream_blocks": ["child_b_30", "broken_shadow"], "language": "python", "name": "child a 30", "type": "transformer", "upstream_blocks": ["parent_30"], "uuid": "child_a_30"}, {"downstream_blocks": ["child_c_30"], "language": "python", "name": "child b 30", "type": "custom", "upstream_blocks": ["child_a_30"], "uuid": "child_b_30"}, {"downstream_blocks": ["child_d_30"], "language": "python", "name": "child c 30", "type": "custom", "upstream_blocks": ["child_b_30"], "uuid": "child_c_30"}, {"downstream_blocks": ["final_30", "purple_lake"], "language": "python", "name": "child d 30", "type": "custom", "upstream_blocks": ["child_c_30"], "uuid": "child_d_30"}, {"downstream_blocks": [], "language": "python", "name": "final 30", "type": "data_exporter", "upstream_blocks": ["child_d_30"], "uuid": "final_30"}, {"downstream_blocks": ["broken_shadow", "purple_lake"], "language": "python", "name": "load_titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "load_titanic"}, {"downstream_blocks": [], "language": "python", "name": "broken shadow", "type": "transformer", "upstream_blocks": ["load_titanic", "child_a_30"], "uuid": "broken_shadow"}, {"downstream_blocks": [], "language": "python", "name": "purple lake", "type": "data_exporter", "upstream_blocks": ["load_titanic", "child_d_30"], "uuid": "purple_lake"}]}, "updated_at": 1702284950.40326}, "withered_sunset": {"added_at": null, "pipeline": {"description": null, "name": "example_pipeline", "tags": [], "type": "python", "updated_at": "2023-07-22 22:21:39", "uuid": "withered_sunset", "blocks": [{"downstream_blocks": ["fill_in_missing_values", "summer_dew", "wandering_voice", "blue_haze", "solitary_moon", "spring_feather"], "language": "python", "name": "load_titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "load_titanic"}, {"downstream_blocks": [], "language": "markdown", "name": "spring feather", "type": "markdown", "upstream_blocks": ["load_titanic"], "uuid": "spring_feather"}, {"downstream_blocks": [], "language": "markdown", "name": "polished field", "type": "markdown", "upstream_blocks": [], "uuid": "polished_field"}, {"downstream_blocks": [], "language": "python", "name": "solitary moon", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "solitary_moon"}, {"downstream_blocks": ["autumn_sound"], "language": "python", "name": "blue haze", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "blue_haze"}, {"downstream_blocks": [], "language": "yaml", "name": "autumn sound", "type": "dbt", "upstream_blocks": ["blue_haze"], "uuid": "autumn_sound"}, {"downstream_blocks": [], "language": "python", "name": "wandering voice", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "wandering_voice"}, {"downstream_blocks": [], "language": "python", "name": "summer dew", "type": "data_exporter", "upstream_blocks": ["load_titanic"], "uuid": "summer_dew"}, {"downstream_blocks": ["export_titanic_clean"], "language": "python", "name": "fill_in_missing_values", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "fill_in_missing_values"}, {"downstream_blocks": ["hidden_wildflower"], "language": "python", "name": "export_titanic_clean", "type": "data_exporter", "upstream_blocks": ["fill_in_missing_values"], "uuid": "export_titanic_clean"}, {"downstream_blocks": ["empty_shadow"], "language": "python", "name": "hidden wildflower", "type": "data_loader", "upstream_blocks": ["export_titanic_clean"], "uuid": "hidden_wildflower"}, {"downstream_blocks": [], "language": "python", "name": "empty shadow", "type": "transformer", "upstream_blocks": ["hidden_wildflower"], "uuid": "empty_shadow"}, {"downstream_blocks": [], "language": "markdown", "name": "winter waterfall", "type": "markdown", "upstream_blocks": [], "uuid": "winter_waterfall"}]}, "updated_at": 1702284950.40329}, "billowing_bird": {"added_at": null, "pipeline": {"description": null, "name": "billowing bird", "tags": [], "type": "python", "updated_at": "2023-10-11 03:12:58", "uuid": "billowing_bird", "blocks": [{"downstream_blocks": ["throbbing_dawn"], "language": "python", "name": "titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "titanic"}, {"downstream_blocks": ["throbbing_dawn"], "language": "sql", "name": "shy waterfall", "type": "data_loader", "upstream_blocks": [], "uuid": "shy_waterfall"}, {"downstream_blocks": ["young_dew"], "language": "python", "name": "throbbing dawn", "type": "transformer", "upstream_blocks": ["titanic", "shy_waterfall"], "uuid": "throbbing_dawn"}, {"downstream_blocks": [], "language": "python", "name": "young dew", "type": "data_exporter", "upstream_blocks": ["throbbing_dawn"], "uuid": "young_dew"}]}, "updated_at": 1702284950.403299}, "twilight_water": {"added_at": null, "pipeline": {"description": null, "name": "twilight water", "tags": [], "type": "python", "updated_at": "2023-08-02 19:34:24", "uuid": "twilight_water", "blocks": [{"downstream_blocks": ["summer_grass"], "language": "python", "name": "still frost", "type": "data_loader", "upstream_blocks": [], "uuid": "still_frost"}, {"downstream_blocks": ["cold_bird"], "language": "python", "name": "summer grass", "type": "transformer", "upstream_blocks": ["still_frost"], "uuid": "summer_grass"}, {"downstream_blocks": [], "language": "python", "name": "cold bird", "type": "data_exporter", "upstream_blocks": ["summer_grass", "load_data_from_internet"], "uuid": "cold_bird"}, {"downstream_blocks": ["cold_bird"], "language": "python", "name": "load_data_from_internet", "type": "data_loader", "upstream_blocks": [], "uuid": "load_data_from_internet"}]}, "updated_at": 1702284950.403307}, "lively_wood": {"added_at": null, "pipeline": {"description": null, "name": "lively wood", "tags": [], "type": "python", "updated_at": "2023-08-03 20:42:07", "uuid": "lively_wood", "blocks": [{"downstream_blocks": ["demo/models/example/my_second_dbt_model"], "language": "python", "name": "nameless dawn", "type": "sensor", "upstream_blocks": [], "uuid": "nameless_dawn"}, {"downstream_blocks": ["demo/models/example/my_second_dbt_model"], "language": "sql", "name": "demo/models/example/my_first_dbt_model", "type": "dbt", "upstream_blocks": ["aged_bush"], "uuid": "demo/models/example/my_first_dbt_model"}, {"downstream_blocks": ["demo/models/example/my_first_dbt_model"], "language": "python", "name": "aged bush", "type": "data_loader", "upstream_blocks": [], "uuid": "aged_bush"}, {"downstream_blocks": [], "language": "sql", "name": "demo/models/example/my_second_dbt_model", "type": "dbt", "upstream_blocks": ["nameless_dawn", "demo/models/example/my_first_dbt_model"], "uuid": "demo/models/example/my_second_dbt_model"}]}, "updated_at": 1702284950.403316}, "long_darkness": {"added_at": null, "pipeline": {"description": null, "name": "long darkness", "tags": null, "type": "python", "updated_at": null, "uuid": "long_darkness", "blocks": []}, "updated_at": 1702284950.403319}, "floral_field": {"added_at": null, "pipeline": {"description": null, "name": "floral field", "tags": [], "type": "integration", "updated_at": "2023-08-24 06:06:14", "uuid": "floral_field", "blocks": [{"downstream_blocks": ["wandering_cherry"], "language": "yaml", "name": "damp shape", "type": "data_loader", "upstream_blocks": [], "uuid": "damp_shape"}, {"downstream_blocks": ["fragrant_mountain"], "language": "python", "name": "wandering cherry", "type": "transformer", "upstream_blocks": ["damp_shape"], "uuid": "wandering_cherry"}, {"downstream_blocks": [], "language": "yaml", "name": "fragrant mountain", "type": "data_exporter", "upstream_blocks": ["wandering_cherry"], "uuid": "fragrant_mountain"}]}, "updated_at": 1702284950.403377}, "winter_shape": {"added_at": null, "pipeline": {"description": null, "name": "winter shape", "tags": [], "type": "python", "updated_at": "2023-10-11 04:16:31", "uuid": "winter_shape", "blocks": [{"downstream_blocks": ["proud_meadow"], "language": "sql", "name": "little field", "type": "data_loader", "upstream_blocks": [], "uuid": "little_field"}, {"downstream_blocks": [], "language": "sql", "name": "proud meadow", "type": "data_loader", "upstream_blocks": ["little_field"], "uuid": "proud_meadow"}, {"downstream_blocks": [], "language": "sql", "name": "empty cherry", "type": "data_loader", "upstream_blocks": [], "uuid": "empty_cherry"}]}, "updated_at": 1702284950.403385}, "quiet_rain": {"added_at": null, "pipeline": {"description": null, "name": "quiet rain", "tags": null, "type": "streaming", "updated_at": null, "uuid": "quiet_rain", "blocks": []}, "updated_at": 1702284950.403387}, "twilight_grass": {"added_at": null, "pipeline": {"description": null, "name": "twilight grass", "tags": [], "type": "python", "updated_at": null, "uuid": "twilight_grass", "blocks": [{"downstream_blocks": [], "language": "sql", "name": "late fire", "type": "data_loader", "upstream_blocks": [], "uuid": "late_fire"}]}, "updated_at": 1702284950.403391}, "cool_snosdfsdfwflake": {"added_at": null, "pipeline": {"description": null, "name": "cool snosdfsdfwflake", "tags": [], "type": "python", "updated_at": null, "uuid": "cool_snosdfsdfwflake", "blocks": [{"downstream_blocks": [], "language": "python", "name": "cool_snosdfsdfwflake_block_3", "type": "transformer", "upstream_blocks": ["cool_snosdfsdfwflake_block_1", "cool_snosdfsdfwflake_block_2"], "uuid": "cool_snosdfsdfwflake_block_3"}, {"downstream_blocks": ["cool_snosdfsdfwflake_block_3"], "language": "python", "name": "cool_snosdfsdfwflake_block_2", "type": "data_loader", "upstream_blocks": [], "uuid": "cool_snosdfsdfwflake_block_2"}, {"downstream_blocks": ["cool_snosdfsdfwflake_block_3"], "language": "python", "name": "cool_snosdfsdfwflake_block_1", "type": "data_loader", "upstream_blocks": [], "uuid": "cool_snosdfsdfwflake_block_1"}]}, "updated_at": 1702284950.4034}, "delicate_thunder": {"added_at": null, "pipeline": {"description": null, "name": "delicate thunder", "tags": null, "type": "python", "updated_at": null, "uuid": "delicate_thunder", "blocks": []}, "updated_at": 1702284950.403402}, "using_ai_1": {"added_at": null, "pipeline": {"description": null, "name": "using ai 1", "tags": [], "type": "python", "updated_at": "2023-08-29 22:42:11", "uuid": "using_ai_1", "blocks": [{"downstream_blocks": [], "language": "python", "name": "snowy frost", "type": "scratchpad", "upstream_blocks": [], "uuid": "snowy_frost"}]}, "updated_at": 1702284950.403406}, "quiet_firefly": {"added_at": null, "pipeline": {"description": null, "name": "quiet firefly", "tags": [], "type": "python", "updated_at": "2023-08-17 05:58:09", "uuid": "quiet_firefly", "blocks": [{"downstream_blocks": [], "language": "python", "name": "lively water", "type": "data_loader", "upstream_blocks": [], "uuid": "lively_water"}]}, "updated_at": 1702284950.40341}, "morning_rain": {"added_at": null, "pipeline": {"description": null, "name": "morning rain", "tags": [], "type": "streaming", "updated_at": null, "uuid": "morning_rain", "blocks": [{"downstream_blocks": ["restless_bush"], "language": "yaml", "name": "falling meadow", "type": "data_loader", "upstream_blocks": [], "uuid": "falling_meadow"}, {"downstream_blocks": ["wandering_bush"], "language": "python", "name": "restless bush", "type": "transformer", "upstream_blocks": ["falling_meadow"], "uuid": "restless_bush"}, {"downstream_blocks": [], "language": "yaml", "name": "wandering bush", "type": "data_exporter", "upstream_blocks": ["restless_bush"], "uuid": "wandering_bush"}]}, "updated_at": 1702284950.403417}, "delicate_forest": {"added_at": null, "pipeline": {"description": null, "name": "delicate forest", "tags": [], "type": "integration", "updated_at": "2023-09-15 07:03:50", "uuid": "delicate_forest", "blocks": [{"downstream_blocks": ["cool_feather"], "language": "yaml", "name": "silent brook", "type": "data_loader", "upstream_blocks": [], "uuid": "silent_brook"}, {"downstream_blocks": ["small_sea"], "language": "python", "name": "cool feather", "type": "transformer", "upstream_blocks": ["silent_brook"], "uuid": "cool_feather"}, {"downstream_blocks": [], "language": "yaml", "name": "small sea", "type": "data_exporter", "upstream_blocks": ["cool_feather"], "uuid": "small_sea"}]}, "updated_at": 1702284950.403424}, "spring_dew": {"added_at": null, "pipeline": {"description": null, "name": "spring dew", "tags": [], "type": "python", "updated_at": "2023-09-29 23:07:47", "uuid": "spring_dew", "blocks": [{"downstream_blocks": ["withered_wind"], "language": "python", "name": "twilight meadow", "type": "custom", "upstream_blocks": [], "uuid": "twilight_meadow"}, {"downstream_blocks": ["withered_wind", "twilight_pond"], "language": "python", "name": "lively darkness", "type": "custom", "upstream_blocks": [], "uuid": "lively_darkness"}, {"downstream_blocks": ["twilight_pond"], "language": "python", "name": "withered wind", "type": "data_loader", "upstream_blocks": ["lively_darkness", "twilight_meadow"], "uuid": "withered_wind"}, {"downstream_blocks": [], "language": "yaml", "name": "twilight pond", "type": "data_exporter", "upstream_blocks": ["withered_wind", "lively_darkness"], "uuid": "twilight_pond"}]}, "updated_at": 1702284950.403432}, "dawn_meadow": {"added_at": null, "pipeline": {"description": null, "name": "dawn meadow", "tags": [], "type": "python", "updated_at": "2023-08-02 18:12:16", "uuid": "dawn_meadow", "blocks": [{"downstream_blocks": ["proud_snow"], "language": "python", "name": "load_data_from_internet", "type": "data_loader", "upstream_blocks": [], "uuid": "load_data_from_internet"}, {"downstream_blocks": ["proud_snow"], "language": "sql", "name": "spring firefly", "type": "data_loader", "upstream_blocks": [], "uuid": "spring_firefly"}, {"downstream_blocks": ["polished_sea"], "language": "python", "name": "proud snow", "type": "transformer", "upstream_blocks": ["spring_firefly", "load_data_from_internet"], "uuid": "proud_snow"}, {"downstream_blocks": [], "language": "python", "name": "polished sea", "type": "data_exporter", "upstream_blocks": ["proud_snow"], "uuid": "polished_sea"}]}, "updated_at": 1702284950.403442}, "cool_adfasdfdawn_copy": {"added_at": null, "pipeline": {"description": null, "name": "cool_adfasdfdawn_copy", "tags": [], "type": "python", "updated_at": "2023-09-15 22:09:48", "uuid": "cool_adfasdfdawn_copy", "blocks": [{"downstream_blocks": [], "language": "python", "name": "2", "type": "data_loader", "upstream_blocks": [], "uuid": "letter_2"}, {"downstream_blocks": [], "language": "python", "name": "3", "type": "transformer", "upstream_blocks": [], "uuid": "letter_3"}, {"downstream_blocks": [], "language": "python", "name": "1", "type": "data_loader", "upstream_blocks": [], "uuid": "letter_1"}, {"downstream_blocks": [], "language": "python", "name": "holy water", "type": "scratchpad", "upstream_blocks": [], "uuid": "holy_water"}, {"downstream_blocks": [], "language": "python", "name": "wild darkness", "type": "scratchpad", "upstream_blocks": [], "uuid": "wild_darkness"}]}, "updated_at": 1702284950.403453}, "winter_cherry": {"added_at": null, "pipeline": {"description": null, "name": "winter cherry", "tags": [], "type": "python", "updated_at": "2023-07-25 02:31:54", "uuid": "winter_cherry", "blocks": [{"downstream_blocks": ["extra_sales_from_tesla"], "language": "python", "name": "tesla", "type": "data_loader", "upstream_blocks": [], "uuid": "tesla"}, {"downstream_blocks": ["upload_sales_info_to_tesla"], "language": "python", "name": "extra sales from tesla", "type": "transformer", "upstream_blocks": ["tesla"], "uuid": "extra_sales_from_tesla"}, {"downstream_blocks": [], "language": "python", "name": "upload sales info to tesla", "type": "data_exporter", "upstream_blocks": ["extra_sales_from_tesla"], "uuid": "upload_sales_info_to_tesla"}]}, "updated_at": 1702284950.403459}, "black_bird": {"added_at": null, "pipeline": {"description": null, "name": "black bird", "tags": [], "type": "python", "updated_at": "2023-09-30 05:49:32", "uuid": "black_bird", "blocks": [{"downstream_blocks": [], "language": "python", "name": "ancient star", "type": "scratchpad", "upstream_blocks": [], "uuid": "ancient_star"}]}, "updated_at": 1702284950.403465}, "crystal_herald": {"added_at": null, "pipeline": {"description": null, "name": "crystal herald", "tags": [], "type": "python", "updated_at": "2023-12-11 01:34:48", "uuid": "crystal_herald", "blocks": [{"downstream_blocks": ["dynamic_child_generic_command", "demo/models/example/my_first_dbt_model"], "language": "python", "name": "dynamic_parent_a", "type": "data_loader", "upstream_blocks": [], "uuid": "dynamic_parent_a"}, {"downstream_blocks": [], "language": "yaml", "name": "dynamic child generic command", "type": "dbt", "upstream_blocks": ["dynamic_parent_a"], "uuid": "dynamic_child_generic_command"}, {"downstream_blocks": [], "language": "sql", "name": "demo/models/example/my_first_dbt_model", "type": "dbt", "upstream_blocks": ["dynamic_parent_a"], "uuid": "demo/models/example/my_first_dbt_model"}]}, "updated_at": 1702284950.403475}, "little_sea": {"added_at": null, "pipeline": {"description": null, "name": "little sea", "tags": [], "type": "python", "updated_at": "2023-10-11 03:32:00", "uuid": "little_sea", "blocks": [{"downstream_blocks": ["lively_haze"], "language": "python", "name": "nameless sea", "type": "data_loader", "upstream_blocks": [], "uuid": "nameless_sea"}, {"downstream_blocks": ["delicate_snowflake"], "language": "python", "name": "lively haze", "type": "transformer", "upstream_blocks": ["nameless_sea"], "uuid": "lively_haze"}, {"downstream_blocks": [], "language": "python", "name": "delicate snowflake", "type": "data_exporter", "upstream_blocks": ["lively_haze"], "uuid": "delicate_snowflake"}]}, "updated_at": 1702284950.403481}, "ancient_forest": {"added_at": null, "pipeline": {"description": null, "name": "ancient forest", "tags": ["identity", "postgres", "s3"], "type": "streaming", "updated_at": null, "uuid": "ancient_forest", "blocks": [{"downstream_blocks": ["hidden_cherry"], "language": "yaml", "name": "cold fire", "type": "data_loader", "upstream_blocks": [], "uuid": "cold_fire"}, {"downstream_blocks": [], "language": "yaml", "name": "hidden cherry", "type": "data_exporter", "upstream_blocks": ["cold_fire"], "uuid": "hidden_cherry"}]}, "updated_at": 1702284950.403487}, "holy_sound": {"added_at": null, "pipeline": {"description": null, "name": "holy sound", "tags": [], "type": "integration", "updated_at": "2023-08-24 06:07:36", "uuid": "holy_sound", "blocks": [{"downstream_blocks": ["damp_sea"], "language": "yaml", "name": "bold voice", "type": "data_loader", "upstream_blocks": [], "uuid": "bold_voice"}, {"downstream_blocks": [], "language": "yaml", "name": "damp sea", "type": "data_exporter", "upstream_blocks": ["bold_voice"], "uuid": "damp_sea"}]}, "updated_at": 1702284950.403493}, "red_haze": {"added_at": null, "pipeline": {"description": null, "name": "red haze", "tags": [], "type": "python", "updated_at": "2023-08-03 20:34:40", "uuid": "red_haze", "blocks": [{"downstream_blocks": ["frosty_mountain"], "language": "python", "name": "load_data_from_internet", "type": "data_loader", "upstream_blocks": ["holy_cloud"], "uuid": "load_data_from_internet"}, {"downstream_blocks": ["load_data_from_internet"], "language": "python", "name": "holy cloud", "type": "sensor", "upstream_blocks": [], "uuid": "holy_cloud"}, {"downstream_blocks": ["frosty_mountain"], "language": "sql", "name": "weathered cloud", "type": "data_loader", "upstream_blocks": [], "uuid": "weathered_cloud"}, {"downstream_blocks": ["wandering_darkness"], "language": "python", "name": "frosty mountain", "type": "transformer", "upstream_blocks": ["weathered_cloud", "load_data_from_internet"], "uuid": "frosty_mountain"}, {"downstream_blocks": [], "language": "python", "name": "wandering darkness", "type": "data_exporter", "upstream_blocks": ["frosty_mountain"], "uuid": "wandering_darkness"}]}, "updated_at": 1702284950.403507}, "letter_22213144442312": {"added_at": null, "pipeline": {"description": null, "name": "22213144442312", "tags": null, "type": "python", "updated_at": null, "uuid": "letter_22213144442312", "blocks": []}, "updated_at": 1702284950.40351}, "letter_2221314afsdfsdf4442312": {"added_at": null, "pipeline": {"description": null, "name": "2221314afsdfsdf4442312", "tags": ["identity", "postgres", "s3"], "type": "integration", "updated_at": "2023-08-15 06:12:42", "uuid": "letter_2221314afsdfsdf4442312", "blocks": [{"downstream_blocks": ["winter_sunset"], "language": "python", "name": "frosty firefly", "type": "global_data_product", "upstream_blocks": [], "uuid": "frosty_firefly"}, {"downstream_blocks": [], "language": "python", "name": "winter sunset", "type": "data_exporter", "upstream_blocks": ["frosty_firefly"], "uuid": "winter_sunset"}, {"downstream_blocks": [], "language": "sql", "name": "polished sky", "type": "data_loader", "upstream_blocks": [], "uuid": "polished_sky"}, {"downstream_blocks": [], "language": "python", "name": "late flower", "type": "data_loader", "upstream_blocks": [], "uuid": "late_flower"}, {"downstream_blocks": [], "language": "python", "name": "load_data_from_internet", "type": "data_loader", "upstream_blocks": [], "uuid": "load_data_from_internet"}, {"downstream_blocks": ["billowing_forest"], "language": "python", "name": "aged_bush", "type": "data_loader", "upstream_blocks": [], "uuid": "aged_bush"}, {"downstream_blocks": [], "language": "yaml", "name": "billowing forest", "type": "data_exporter", "upstream_blocks": ["aged_bush"], "uuid": "billowing_forest"}]}, "updated_at": 1702284950.403525}, "throbbing_hill": {"added_at": null, "pipeline": {"description": null, "name": "throbbing hill", "tags": [], "type": "integration", "updated_at": "2023-08-04 18:13:31", "uuid": "throbbing_hill", "blocks": [{"downstream_blocks": ["dry_fog"], "language": "yaml", "name": "sparkling sea", "type": "data_loader", "upstream_blocks": [], "uuid": "sparkling_sea"}, {"downstream_blocks": [], "language": "yaml", "name": "dry fog", "type": "data_exporter", "upstream_blocks": ["sparkling_sea"], "uuid": "dry_fog"}]}, "updated_at": 1702284950.403531}, "purple_sun": {"added_at": null, "pipeline": {"description": null, "name": "purple sun", "tags": null, "type": "python", "updated_at": null, "uuid": "purple_sun", "blocks": []}, "updated_at": 1702284950.403533}, "ancient_water": {"added_at": null, "pipeline": {"description": null, "name": "ancient water", "tags": ["dbt", "partnerstack"], "type": "python", "updated_at": "2023-08-31 23:34:45", "uuid": "ancient_water", "blocks": [{"downstream_blocks": ["holy_dawn"], "language": "python", "name": "polished sun", "type": "global_data_product", "upstream_blocks": [], "uuid": "polished_sun"}, {"downstream_blocks": [], "language": "python", "name": "holy dawn", "type": "data_exporter", "upstream_blocks": ["polished_sun"], "uuid": "holy_dawn"}, {"downstream_blocks": [], "language": "python", "name": "empty resonance", "type": "scratchpad", "upstream_blocks": [], "uuid": "empty_resonance"}, {"downstream_blocks": [], "language": "python", "name": "holy forest", "type": "data_loader", "upstream_blocks": [], "uuid": "holy_forest"}]}, "updated_at": 1702284950.403543}, "wild_rain": {"added_at": null, "pipeline": {"description": null, "name": "wild rain", "tags": [], "type": "python", "updated_at": "2023-10-15 03:05:34", "uuid": "wild_rain", "blocks": [{"downstream_blocks": [], "language": "python", "name": "load_titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "load_titanic"}]}, "updated_at": 1702284950.403547}, "interactions_testing_2": {"added_at": null, "pipeline": {"description": null, "name": "interactions testing 2", "tags": [], "type": "python", "updated_at": "2023-10-04 00:23:05", "uuid": "interactions_testing_2", "blocks": [{"downstream_blocks": [], "language": "python", "name": "falling butterfly", "type": "data_loader", "upstream_blocks": [], "uuid": "falling_butterfly"}, {"downstream_blocks": [], "language": "python", "name": "cold glitter", "type": "scratchpad", "upstream_blocks": [], "uuid": "cold_glitter"}, {"downstream_blocks": [], "language": "python", "name": "white snow", "type": "data_loader", "upstream_blocks": [], "uuid": "white_snow"}]}, "updated_at": 1702284950.403554}, "patient_mountain": {"added_at": null, "pipeline": {"description": null, "name": "patient mountain", "tags": [], "type": "integration", "updated_at": "2023-09-28 11:20:34", "uuid": "patient_mountain", "blocks": [{"downstream_blocks": ["bitter_morning"], "language": "yaml", "name": "patient sky", "type": "data_loader", "upstream_blocks": [], "uuid": "patient_sky"}, {"downstream_blocks": [], "language": "yaml", "name": "bitter morning", "type": "data_exporter", "upstream_blocks": ["patient_sky"], "uuid": "bitter_morning"}]}, "updated_at": 1702284950.403561}, "aged_violet": {"added_at": null, "pipeline": {"description": null, "name": "aged violet", "tags": [], "type": "streaming", "updated_at": null, "uuid": "aged_violet", "blocks": [{"downstream_blocks": ["dry_flower"], "language": "yaml", "name": "lively bush", "type": "data_loader", "upstream_blocks": [], "uuid": "lively_bush"}, {"downstream_blocks": ["white_pine"], "language": "python", "name": "dry flower", "type": "transformer", "upstream_blocks": ["lively_bush"], "uuid": "dry_flower"}, {"downstream_blocks": [], "language": "yaml", "name": "white pine", "type": "data_exporter", "upstream_blocks": ["dry_flower"], "uuid": "white_pine"}]}, "updated_at": 1702284950.403569}, "snowflake": {"added_at": null, "pipeline": {"description": null, "name": "snowflake", "tags": [], "type": "python", "updated_at": "2023-08-09 05:38:52", "uuid": "snowflake", "blocks": [{"downstream_blocks": [], "language": "sql", "name": "still sun", "type": "data_loader", "upstream_blocks": [], "uuid": "still_sun"}, {"downstream_blocks": ["demo/models/example/my_first_dbt_model"], "language": "python", "name": "wandering sun", "type": "data_loader", "upstream_blocks": [], "uuid": "wandering_sun"}, {"downstream_blocks": [], "language": "sql", "name": "demo/models/example/my_first_dbt_model", "type": "dbt", "upstream_blocks": ["wandering_sun"], "uuid": "demo/models/example/my_first_dbt_model"}]}, "updated_at": 1702284950.403576}, "delicate_glade": {"added_at": null, "pipeline": {"description": null, "name": "delicate glade", "tags": [], "type": "python", "updated_at": "2023-10-11 03:30:47", "uuid": "delicate_glade", "blocks": [{"downstream_blocks": [], "language": "python", "name": "rough silence", "type": "data_loader", "upstream_blocks": [], "uuid": "rough_silence"}]}, "updated_at": 1702284950.40358}, "snowy_snow": {"added_at": null, "pipeline": {"description": null, "name": "pipeline with variables", "tags": ["Spark", "PySpark"], "type": "python", "updated_at": "2023-07-26 00:51:10", "uuid": "snowy_snow", "blocks": [{"downstream_blocks": [], "language": "python", "name": "twilight paper", "type": "data_loader", "upstream_blocks": [], "uuid": "twilight_paper"}, {"downstream_blocks": ["misty_mountain"], "language": "python", "name": "floral_hill1111111111", "type": "data_loader", "upstream_blocks": [], "uuid": "floral_hill1111111111"}, {"downstream_blocks": ["lingering_rain"], "language": "python", "name": "misty mountain", "type": "data_loader", "upstream_blocks": ["floral_hill1111111111"], "uuid": "misty_mountain"}, {"downstream_blocks": [], "language": "python", "name": "lingering rain", "type": "transformer", "upstream_blocks": ["misty_mountain"], "uuid": "lingering_rain"}]}, "updated_at": 1702284950.403588}, "dawn_frost": {"added_at": null, "pipeline": {"description": null, "name": "dawn frost", "tags": [], "type": "python", "updated_at": "2023-07-26 00:23:57", "uuid": "dawn_frost", "blocks": [{"downstream_blocks": ["broken_meadow"], "language": "python", "name": "red feather", "type": "data_loader", "upstream_blocks": [], "uuid": "red_feather"}, {"downstream_blocks": ["spring_river"], "language": "python", "name": "broken meadow", "type": "transformer", "upstream_blocks": ["red_feather"], "uuid": "broken_meadow"}, {"downstream_blocks": [], "language": "python", "name": "spring river", "type": "custom", "upstream_blocks": ["broken_meadow"], "uuid": "spring_river"}, {"downstream_blocks": [], "language": "markdown", "name": "damp shape", "type": "markdown", "upstream_blocks": [], "uuid": "damp_shape"}, {"downstream_blocks": [], "language": "python", "name": "autumn wind", "type": "scratchpad", "upstream_blocks": [], "uuid": "autumn_wind"}, {"downstream_blocks": ["rough_haze"], "language": "python", "name": "holy sky", "type": "data_exporter", "upstream_blocks": [], "uuid": "holy_sky"}, {"downstream_blocks": [], "language": "python", "name": "rough haze", "type": "data_loader", "upstream_blocks": ["holy_sky"], "uuid": "rough_haze"}]}, "updated_at": 1702284950.403602}, "white_river": {"added_at": null, "pipeline": {"description": null, "name": "white river", "tags": [], "type": "python", "updated_at": "2023-10-11 02:32:59", "uuid": "white_river", "blocks": [{"downstream_blocks": ["wandering_frost"], "language": "python", "name": "cool meadow", "type": "data_loader", "upstream_blocks": [], "uuid": "cool_meadow"}, {"downstream_blocks": [], "language": "python", "name": "wandering wildflower", "type": "data_loader", "upstream_blocks": [], "uuid": "wandering_wildflower"}, {"downstream_blocks": [], "language": "python", "name": "wandering frost", "type": "transformer", "upstream_blocks": ["cool_meadow"], "uuid": "wandering_frost"}]}, "updated_at": 1702284950.40361}, "interactions_trigger": {"added_at": null, "pipeline": {"description": null, "name": "interactions trigger", "tags": ["interactions", "testing"], "type": "python", "updated_at": "2023-10-09 08:38:43", "uuid": "interactions_trigger", "blocks": [{"downstream_blocks": ["show_country_and_age"], "language": "python", "name": "fetch country", "type": "data_loader", "upstream_blocks": [], "uuid": "fetch_country"}, {"downstream_blocks": [], "language": "python", "name": "show country and age", "type": "transformer", "upstream_blocks": ["fetch_country"], "uuid": "show_country_and_age"}, {"downstream_blocks": [], "language": "python", "name": "hidden wood", "type": "data_loader", "upstream_blocks": [], "uuid": "hidden_wood"}]}, "updated_at": 1702284950.403617}, "autumn_sky": {"added_at": null, "pipeline": {"description": null, "name": "autumn sky", "tags": null, "type": "python", "updated_at": null, "uuid": "autumn_sky", "blocks": []}, "updated_at": 1702284950.403619}, "cold_moon": {"added_at": null, "pipeline": {"description": null, "name": "cold moon", "tags": [], "type": "python", "updated_at": "2023-08-22 22:52:54", "uuid": "cold_moon", "blocks": [{"downstream_blocks": ["demo/models/example/my_second_dbt_model"], "language": "sql", "name": "demo/models/example/my_first_dbt_model", "type": "dbt", "upstream_blocks": [], "uuid": "demo/models/example/my_first_dbt_model"}, {"downstream_blocks": [], "language": "sql", "name": "demo/models/example/my_second_dbt_model", "type": "dbt", "upstream_blocks": ["demo/models/example/my_first_dbt_model"], "uuid": "demo/models/example/my_second_dbt_model"}]}, "updated_at": 1702284950.403625}, "fragrant_mountain": {"added_at": null, "pipeline": {"description": null, "name": "fragrant mountain", "tags": [], "type": "python", "updated_at": "2023-10-10 03:20:01", "uuid": "fragrant_mountain", "blocks": [{"downstream_blocks": ["proud_dew"], "language": "python", "name": "little voice", "type": "data_loader", "upstream_blocks": [], "uuid": "little_voice"}, {"downstream_blocks": [], "language": "python", "name": "proud dew", "type": "data_exporter", "upstream_blocks": ["little_voice"], "uuid": "proud_dew"}]}, "updated_at": 1702284950.40363}, "hidden_dew": {"added_at": null, "pipeline": {"description": null, "name": "hidden dew", "tags": [], "type": "python", "updated_at": "2023-08-02 17:53:45", "uuid": "hidden_dew", "blocks": [{"downstream_blocks": ["late_wave"], "language": "python", "name": "purple paper", "type": "data_loader", "upstream_blocks": [], "uuid": "purple_paper"}, {"downstream_blocks": ["late_wave"], "language": "sql", "name": "cool tree", "type": "data_loader", "upstream_blocks": [], "uuid": "cool_tree"}, {"downstream_blocks": ["muddy_wind"], "language": "python", "name": "late wave", "type": "transformer", "upstream_blocks": ["cool_tree", "purple_paper"], "uuid": "late_wave"}, {"downstream_blocks": [], "language": "python", "name": "muddy wind", "type": "data_exporter", "upstream_blocks": ["late_wave"], "uuid": "muddy_wind"}]}, "updated_at": 1702284950.403639}, "red_morning": {"added_at": null, "pipeline": {"description": null, "name": "red morning", "tags": null, "type": "python", "updated_at": null, "uuid": "red_morning", "blocks": []}, "updated_at": 1702284950.403641}, "young_glitter": {"added_at": null, "pipeline": {"description": null, "name": "young glitter", "tags": null, "type": "python", "updated_at": null, "uuid": "young_glitter", "blocks": []}, "updated_at": 1702284950.403644}, "shy_pond": {"added_at": null, "pipeline": {"description": null, "name": "shy pond", "tags": [], "type": "python", "updated_at": "2023-10-04 01:38:00", "uuid": "shy_pond", "blocks": [{"downstream_blocks": ["bitter_silence"], "language": "python", "name": "divine wave", "type": "data_loader", "upstream_blocks": [], "uuid": "divine_wave"}, {"downstream_blocks": [], "language": "python", "name": "bitter silence", "type": "transformer", "upstream_blocks": ["divine_wave"], "uuid": "bitter_silence"}]}, "updated_at": 1702284950.40365}, "withered_feather": {"added_at": null, "pipeline": {"description": null, "name": "withered feather", "tags": null, "type": "integration", "updated_at": null, "uuid": "withered_feather", "blocks": []}, "updated_at": 1702284950.403653}, "proud_pond": {"added_at": null, "pipeline": {"description": null, "name": "proud pond", "tags": [], "type": "python", "updated_at": "2023-09-15 06:54:16", "uuid": "proud_pond", "blocks": [{"downstream_blocks": ["billowing_morning"], "language": "python", "name": "lively_dust", "type": "data_loader", "upstream_blocks": [], "uuid": "lively_dust"}, {"downstream_blocks": ["billowing_morning"], "language": "sql", "name": "purple waterfall", "type": "data_loader", "upstream_blocks": [], "uuid": "purple_waterfall"}, {"downstream_blocks": [], "language": "sql", "name": "misty hill", "type": "transformer", "upstream_blocks": [], "uuid": "misty_hill"}, {"downstream_blocks": ["billowing_morning"], "language": "python", "name": "ancient frog", "type": "data_loader", "upstream_blocks": [], "uuid": "ancient_frog"}, {"downstream_blocks": ["red_sunset"], "language": "python", "name": "billowing morning", "type": "transformer", "upstream_blocks": ["ancient_frog", "lively_dust", "purple_waterfall"], "uuid": "billowing_morning"}, {"downstream_blocks": [], "language": "python", "name": "red sunset", "type": "data_exporter", "upstream_blocks": ["billowing_morning"], "uuid": "red_sunset"}]}, "updated_at": 1702284950.403667}, "asdfasdfasdff": {"added_at": null, "pipeline": {"description": null, "name": "asdfasdfasdff", "tags": [], "type": "python", "updated_at": "2023-09-11 03:36:22", "uuid": "asdfasdfasdff", "blocks": [{"downstream_blocks": ["bar_chart_for_billowing_dust_1693440411008", "dawn_dew"], "language": "python", "name": "billowing dust", "type": "data_loader", "upstream_blocks": [], "uuid": "billowing_dust"}, {"downstream_blocks": [], "language": "python", "name": "dawn dew", "type": "custom", "upstream_blocks": ["billowing_dust"], "uuid": "dawn_dew"}]}, "updated_at": 1702284950.403674}, "billowing_field": {"added_at": null, "pipeline": {"description": null, "name": "billowing field", "tags": [], "type": "python", "updated_at": "2023-08-03 18:26:04", "uuid": "billowing_field", "blocks": [{"downstream_blocks": ["bold_dawn"], "language": "python", "name": "test/growth/dronewtf", "type": "data_loader", "upstream_blocks": ["bitter_wave"], "uuid": "test/growth/dronewtf"}, {"downstream_blocks": ["test/growth/dronewtf"], "language": "python", "name": "bitter wave", "type": "sensor", "upstream_blocks": [], "uuid": "bitter_wave"}, {"downstream_blocks": [], "language": "python", "name": "bold dawn", "type": "markdown", "upstream_blocks": ["test/growth/dronewtf"], "uuid": "bold_dawn"}, {"downstream_blocks": [], "language": "yaml", "name": "autumn_sound", "type": "dbt", "upstream_blocks": [], "uuid": "autumn_sound"}]}, "updated_at": 1702284950.403685}, "purple_frost": {"added_at": null, "pipeline": {"description": null, "name": "purple frost", "tags": [], "type": "python", "updated_at": "2023-09-21 05:02:06", "uuid": "purple_frost", "blocks": [{"downstream_blocks": [], "language": "python", "name": "morning rain", "type": "scratchpad", "upstream_blocks": [], "uuid": "morning_rain"}]}, "updated_at": 1702284950.40369}, "patient_wind": {"added_at": null, "pipeline": {"description": null, "name": "patient wind", "tags": [], "type": "python", "updated_at": "2023-10-11 03:46:39", "uuid": "patient_wind", "blocks": [{"downstream_blocks": ["still_morning"], "language": "sql", "name": "autumn resonance", "type": "data_loader", "upstream_blocks": [], "uuid": "autumn_resonance"}, {"downstream_blocks": ["still_morning"], "language": "python", "name": "divine wood", "type": "data_loader", "upstream_blocks": [], "uuid": "divine_wood"}, {"downstream_blocks": ["still_shadow"], "language": "sql", "name": "still morning", "type": "transformer", "upstream_blocks": ["autumn_resonance", "divine_wood"], "uuid": "still_morning"}, {"downstream_blocks": [], "language": "python", "name": "still shadow", "type": "data_exporter", "upstream_blocks": ["still_morning"], "uuid": "still_shadow"}, {"downstream_blocks": [], "language": "python", "name": "load_titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "load_titanic"}]}, "updated_at": 1702284950.403704}, "lingering_dew": {"added_at": null, "pipeline": {"description": "asdasdsd", "name": "lingering dew", "tags": [], "type": "integration", "updated_at": "2023-07-25 10:51:24", "uuid": "lingering_dew", "blocks": [{"downstream_blocks": [], "language": "python", "name": "green fire", "type": "scratchpad", "upstream_blocks": [], "uuid": "green_fire"}, {"downstream_blocks": ["still_shadow", "drone_more_please"], "language": "python", "name": "snowy thunder", "type": "data_exporter", "upstream_blocks": [], "uuid": "snowy_thunder"}, {"downstream_blocks": ["misty_sea"], "language": "python", "name": "drone_more_please", "type": "data_loader", "upstream_blocks": ["snowy_thunder"], "uuid": "drone_more_please"}, {"downstream_blocks": [], "language": "python", "name": "misty sea", "type": "data_loader", "upstream_blocks": ["drone_more_please"], "uuid": "misty_sea"}, {"downstream_blocks": ["test/growth/dronewtf"], "language": "python", "name": "still shadow", "type": "data_loader", "upstream_blocks": ["snowy_thunder"], "uuid": "still_shadow"}, {"downstream_blocks": [], "language": "python", "name": "test/growth/dronewtf", "type": "data_loader", "upstream_blocks": ["still_shadow"], "uuid": "test/growth/dronewtf"}]}, "updated_at": 1702284950.403717}, "crimson_surf": {"added_at": null, "pipeline": {"description": null, "name": "crimson surf", "tags": [], "type": "python", "updated_at": null, "uuid": "crimson_surf", "blocks": [{"downstream_blocks": [], "language": "python", "name": "2", "type": "data_loader", "upstream_blocks": [], "uuid": "letter_2"}, {"downstream_blocks": [], "language": "python", "name": "1", "type": "data_loader", "upstream_blocks": [], "uuid": "letter_1"}, {"downstream_blocks": [], "language": "python", "name": "3", "type": "transformer", "upstream_blocks": [], "uuid": "letter_3"}]}, "updated_at": 1702284950.403725}, "restless_night": {"added_at": null, "pipeline": {"description": null, "name": "restless night", "tags": [], "type": "python", "updated_at": "2023-09-18 09:31:29", "uuid": "restless_night", "blocks": [{"downstream_blocks": ["spring_dawn"], "language": "sql", "name": "heroku_cherre_person", "type": "data_loader", "upstream_blocks": [], "uuid": "heroku_cherre_person"}, {"downstream_blocks": ["spring_dawn"], "language": "sql", "name": "heroku_dbusa_person", "type": "data_loader", "upstream_blocks": [], "uuid": "heroku_dbusa_person"}, {"downstream_blocks": [], "language": "sql", "name": "spring_dawn", "type": "transformer", "upstream_blocks": ["heroku_cherre_person", "heroku_dbusa_person"], "uuid": "spring_dawn"}, {"downstream_blocks": [], "language": "python", "name": "withered pond", "type": "scratchpad", "upstream_blocks": [], "uuid": "withered_pond"}]}, "updated_at": 1702284950.403736}, "proud_tree": {"added_at": null, "pipeline": {"description": null, "name": "proud tree", "tags": [], "type": "python", "updated_at": "2023-08-04 18:10:01", "uuid": "proud_tree", "blocks": [{"downstream_blocks": ["lively_resonance"], "language": "python", "name": "load_data_from_internet", "type": "data_loader", "upstream_blocks": [], "uuid": "load_data_from_internet"}, {"downstream_blocks": ["lively_resonance"], "language": "sql", "name": "lively fire", "type": "data_loader", "upstream_blocks": [], "uuid": "lively_fire"}, {"downstream_blocks": [], "language": "python", "name": "lively resonance", "type": "transformer", "upstream_blocks": ["lively_fire", "load_data_from_internet"], "uuid": "lively_resonance"}]}, "updated_at": 1702284950.403744}, "unified_pipeline": {"added_at": null, "pipeline": {"description": null, "name": "unified pipeline", "tags": ["testing"], "type": "python", "updated_at": "2023-09-21 21:31:07", "uuid": "unified_pipeline", "blocks": [{"downstream_blocks": ["lingering_leaf"], "language": "yaml", "name": "source_postgresql_normal", "type": "data_loader", "upstream_blocks": [], "uuid": "source_postgresql_normal"}, {"downstream_blocks": ["red_morning"], "language": "python", "name": "lingering leaf", "type": "transformer", "upstream_blocks": ["source_postgresql_normal"], "uuid": "lingering_leaf"}, {"downstream_blocks": [], "language": "python", "name": "red morning", "type": "data_exporter", "upstream_blocks": ["lingering_leaf"], "uuid": "red_morning"}, {"downstream_blocks": ["source_postgresql_python"], "language": "python", "name": "old fog", "type": "custom", "upstream_blocks": [], "uuid": "old_fog"}, {"downstream_blocks": ["source_postgresql_python"], "language": "python", "name": "dawn sound", "type": "custom", "upstream_blocks": [], "uuid": "dawn_sound"}, {"downstream_blocks": ["divine_thunder"], "language": "python", "name": "source_postgresql_python", "type": "data_loader", "upstream_blocks": ["old_fog", "dawn_sound"], "uuid": "source_postgresql_python"}, {"downstream_blocks": ["dry_cherry"], "language": "python", "name": "divine thunder", "type": "transformer", "upstream_blocks": ["source_postgresql_python"], "uuid": "divine_thunder"}, {"downstream_blocks": [], "language": "python", "name": "dry cherry", "type": "data_exporter", "upstream_blocks": ["divine_thunder"], "uuid": "dry_cherry"}]}, "updated_at": 1702284950.403764}, "falling_smoke": {"added_at": null, "pipeline": {"description": null, "name": "falling smoke", "tags": [], "type": "python", "updated_at": "2023-08-02 19:25:02", "uuid": "falling_smoke", "blocks": [{"downstream_blocks": ["purple_sun"], "language": "python", "name": "load_data_from_internet", "type": "data_loader", "upstream_blocks": ["old_glitter"], "uuid": "load_data_from_internet"}, {"downstream_blocks": ["load_data_from_internet"], "language": "python", "name": "old glitter", "type": "sensor", "upstream_blocks": [], "uuid": "old_glitter"}, {"downstream_blocks": ["purple_sun"], "language": "sql", "name": "holy leaf", "type": "data_loader", "upstream_blocks": [], "uuid": "holy_leaf"}, {"downstream_blocks": ["floral_glitter"], "language": "python", "name": "purple sun", "type": "transformer", "upstream_blocks": ["holy_leaf", "load_data_from_internet"], "uuid": "purple_sun"}, {"downstream_blocks": [], "language": "python", "name": "floral glitter", "type": "data_exporter", "upstream_blocks": ["purple_sun"], "uuid": "floral_glitter"}]}, "updated_at": 1702284950.403776}, "dry_shape": {"added_at": null, "pipeline": {"description": null, "name": "dry shape", "tags": [], "type": "python", "updated_at": "2023-08-17 02:29:20", "uuid": "dry_shape", "blocks": [{"downstream_blocks": ["sparkling_fog"], "language": "python", "name": "old sun", "type": "data_loader", "upstream_blocks": [], "uuid": "old_sun"}, {"downstream_blocks": [], "language": "python", "name": "sparkling fog", "type": "transformer", "upstream_blocks": ["old_sun"], "uuid": "sparkling_fog"}, {"downstream_blocks": [], "language": "python", "name": "winter paper", "type": "scratchpad", "upstream_blocks": [], "uuid": "winter_paper"}, {"downstream_blocks": [], "language": "python", "name": "cold dew", "type": "global_data_product", "upstream_blocks": [], "uuid": "cold_dew"}]}, "updated_at": 1702284950.403785}, "solitary_star": {"added_at": null, "pipeline": {"description": null, "name": "solitary star", "tags": [], "type": "python", "updated_at": "2023-08-24 06:05:28", "uuid": "solitary_star", "blocks": [{"downstream_blocks": ["lively_frog"], "language": "python", "name": "misty wind", "type": "data_loader", "upstream_blocks": [], "uuid": "misty_wind"}, {"downstream_blocks": ["lively_frog"], "language": "sql", "name": "patient voice", "type": "data_loader", "upstream_blocks": [], "uuid": "patient_voice"}, {"downstream_blocks": [], "language": "python", "name": "lively frog", "type": "transformer", "upstream_blocks": ["patient_voice", "misty_wind"], "uuid": "lively_frog"}]}, "updated_at": 1702284950.403792}, "old_shape": {"added_at": null, "pipeline": {"description": null, "name": "old shape", "tags": [], "type": "python", "updated_at": "2023-08-17 02:30:38", "uuid": "old_shape", "blocks": [{"downstream_blocks": ["restless_feather"], "language": "python", "name": "old sun", "type": "global_data_product", "upstream_blocks": [], "uuid": "old_sun"}, {"downstream_blocks": [], "language": "python", "name": "restless feather", "type": "data_exporter", "upstream_blocks": ["old_sun"], "uuid": "restless_feather"}]}, "updated_at": 1702284950.403798}, "floral_night": {"added_at": null, "pipeline": {"description": null, "name": "floral night", "tags": [], "type": "integration", "updated_at": "2023-09-22 22:20:59", "uuid": "floral_night", "blocks": [{"downstream_blocks": ["delicate_dust"], "language": "python", "name": "little paper", "type": "transformer", "upstream_blocks": ["blue_wildflower"], "uuid": "little_paper"}, {"downstream_blocks": [], "language": "yaml", "name": "delicate dust", "type": "data_exporter", "upstream_blocks": ["little_paper"], "uuid": "delicate_dust"}, {"downstream_blocks": ["little_paper"], "language": "yaml", "name": "blue wildflower", "type": "data_loader", "upstream_blocks": [], "uuid": "blue_wildflower"}]}, "updated_at": 1702284950.403805}, "ancient_rain": {"added_at": null, "pipeline": {"description": null, "name": "ancient rain", "tags": [], "type": "python", "updated_at": "2023-10-04 10:29:27", "uuid": "ancient_rain", "blocks": [{"downstream_blocks": [], "language": "sql", "name": "cold grass", "type": "data_loader", "upstream_blocks": [], "uuid": "cold_grass"}]}, "updated_at": 1702284950.40381}, "holy_river": {"added_at": null, "pipeline": {"description": null, "name": "holy river", "tags": [], "type": "python", "updated_at": "2023-08-04 06:58:05", "uuid": "holy_river", "blocks": [{"downstream_blocks": ["damp_paper"], "language": "python", "name": "still shape", "type": "global_data_product", "upstream_blocks": [], "uuid": "still_shape"}, {"downstream_blocks": [], "language": "python", "name": "damp_paper", "type": "data_exporter", "upstream_blocks": ["still_shape"], "uuid": "damp_paper"}]}, "updated_at": 1702284950.403815}, "data_integration_pipeline_normal_test": {"added_at": null, "pipeline": {"description": null, "name": "data integration pipeline normal test", "tags": ["testing"], "type": "integration", "updated_at": "2023-09-27 09:52:01", "uuid": "data_integration_pipeline_normal_test", "blocks": [{"downstream_blocks": ["spring_brook"], "language": "yaml", "name": "source_postgresql_normal", "type": "data_loader", "upstream_blocks": [], "uuid": "source_postgresql_normal"}, {"downstream_blocks": [], "language": "yaml", "name": "spring brook", "type": "data_exporter", "upstream_blocks": ["source_postgresql_normal"], "uuid": "spring_brook"}]}, "updated_at": 1702284950.403821}, "ancient_sea": {"added_at": null, "pipeline": {"description": null, "name": "ancient sea", "tags": null, "type": "python", "updated_at": null, "uuid": "ancient_sea", "blocks": []}, "updated_at": 1702284950.403823}, "icy_water": {"added_at": null, "pipeline": {"description": null, "name": "icy water", "tags": null, "type": "python", "updated_at": null, "uuid": "icy_water", "blocks": []}, "updated_at": 1702284950.403825}, "di_client": {"added_at": null, "pipeline": {"description": null, "name": "di client", "tags": [], "type": "python", "updated_at": "2023-09-29 08:48:31", "uuid": "di_client", "blocks": [{"downstream_blocks": ["pgdestination", "divine_cherry"], "language": "yaml", "name": "pgsource", "type": "data_loader", "upstream_blocks": [], "uuid": "pgsource"}, {"downstream_blocks": [], "language": "python", "name": "divine cherry", "type": "custom", "upstream_blocks": ["pgsource"], "uuid": "divine_cherry"}, {"downstream_blocks": ["late_bush"], "language": "yaml", "name": "pgdestination", "type": "data_exporter", "upstream_blocks": ["pgsource"], "uuid": "pgdestination"}, {"downstream_blocks": [], "language": "python", "name": "late bush", "type": "custom", "upstream_blocks": ["pgdestination"], "uuid": "late_bush"}, {"downstream_blocks": ["pgsource_python", "pgdestination_python"], "language": "python", "name": "data integration uuid", "type": "custom", "upstream_blocks": [], "uuid": "data_integration_uuid"}, {"downstream_blocks": ["pgsource_python", "pgdestination_python"], "language": "python", "name": "data integration config", "type": "custom", "upstream_blocks": [], "uuid": "data_integration_config"}, {"downstream_blocks": ["pgdestination_python"], "language": "python", "name": "pgsource python", "type": "data_loader", "upstream_blocks": ["data_integration_uuid", "data_integration_config"], "uuid": "pgsource_python"}, {"downstream_blocks": [], "language": "python", "name": "pgdestination python", "type": "data_exporter", "upstream_blocks": ["pgsource_python", "data_integration_uuid", "data_integration_config"], "uuid": "pgdestination_python"}]}, "updated_at": 1702284950.403874}, "example_pipeline": {"added_at": null, "pipeline": {"created_at": "2023-09-01 12:00:00", "description": null, "name": "example_pipeline", "tags": [], "type": "python", "updated_at": "2023-09-22 22:59:13", "uuid": "example_pipeline", "blocks": [{"downstream_blocks": ["fill_in_missing_values", "summer_dew", "wandering_voice", "blue_haze", "solitary_moon", "spring_feather", "bar_chart_for_load_titanic_1695423547036"], "language": "python", "name": "load_titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "load_titanic"}, {"downstream_blocks": [], "language": "markdown", "name": "spring feather", "type": "markdown", "upstream_blocks": ["load_titanic"], "uuid": "spring_feather"}, {"downstream_blocks": [], "language": "markdown", "name": "polished field", "type": "markdown", "upstream_blocks": [], "uuid": "polished_field"}, {"downstream_blocks": [], "language": "python", "name": "solitary moon", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "solitary_moon"}, {"downstream_blocks": ["autumn_sound"], "language": "python", "name": "blue haze", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "blue_haze"}, {"downstream_blocks": [], "language": "yaml", "name": "autumn sound", "type": "dbt", "upstream_blocks": ["blue_haze"], "uuid": "autumn_sound"}, {"downstream_blocks": [], "language": "python", "name": "wandering voice", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "wandering_voice"}, {"downstream_blocks": [], "language": "python", "name": "summer dew", "type": "data_exporter", "upstream_blocks": ["load_titanic"], "uuid": "summer_dew"}, {"downstream_blocks": ["export_titanic_clean"], "language": "python", "name": "fill_in_missing_values", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "fill_in_missing_values"}, {"downstream_blocks": ["hidden_wildflower"], "language": "python", "name": "export_titanic_clean", "type": "data_exporter", "upstream_blocks": ["fill_in_missing_values"], "uuid": "export_titanic_clean"}, {"downstream_blocks": ["empty_shadow"], "language": "python", "name": "hidden wildflower", "type": "data_loader", "upstream_blocks": ["export_titanic_clean"], "uuid": "hidden_wildflower"}, {"downstream_blocks": ["aged_cloud"], "language": "python", "name": "empty shadow", "type": "transformer", "upstream_blocks": ["hidden_wildflower"], "uuid": "empty_shadow"}, {"downstream_blocks": [], "language": "python", "name": "aged cloud", "type": "data_exporter", "upstream_blocks": ["empty_shadow"], "uuid": "aged_cloud"}, {"downstream_blocks": [], "language": "markdown", "name": "winter waterfall", "type": "markdown", "upstream_blocks": [], "uuid": "winter_waterfall"}, {"downstream_blocks": [], "language": "python", "name": "growth/test", "type": "transformer", "upstream_blocks": [], "uuid": "growth/test"}]}, "updated_at": 1702284950.403907}, "summer_resonance": {"added_at": null, "pipeline": {"description": null, "name": "summer resonance", "tags": [], "type": "integration", "updated_at": "2023-08-02 19:20:53", "uuid": "summer_resonance", "blocks": [{"downstream_blocks": ["sparkling_sunset"], "language": "yaml", "name": "little smoke", "type": "data_loader", "upstream_blocks": [], "uuid": "little_smoke"}, {"downstream_blocks": ["patient_snowflake"], "language": "python", "name": "sparkling sunset", "type": "transformer", "upstream_blocks": ["little_smoke"], "uuid": "sparkling_sunset"}, {"downstream_blocks": [], "language": "yaml", "name": "patient snowflake", "type": "data_exporter", "upstream_blocks": ["sparkling_sunset"], "uuid": "patient_snowflake"}]}, "updated_at": 1702284950.403917}, "dbt_pipeline": {"added_at": null, "pipeline": {"description": null, "name": "dbt pipeline", "tags": ["testing"], "type": "python", "updated_at": "2023-09-23 04:54:24", "uuid": "dbt_pipeline", "blocks": [{"downstream_blocks": ["nameless_violet"], "language": "sql", "name": "bitter water", "type": "data_loader", "upstream_blocks": ["demo/models/example/my_second_dbt_model"], "uuid": "bitter_water"}, {"downstream_blocks": [], "language": "yaml", "name": "nameless violet", "type": "dbt", "upstream_blocks": ["bitter_water"], "uuid": "nameless_violet"}, {"downstream_blocks": ["demo/models/example/my_second_dbt_model"], "language": "sql", "name": "demo/models/example/my_first_dbt_model", "type": "dbt", "upstream_blocks": [], "uuid": "demo/models/example/my_first_dbt_model"}, {"downstream_blocks": ["bitter_water"], "language": "sql", "name": "demo/models/example/my_second_dbt_model", "type": "dbt", "upstream_blocks": ["demo/models/example/my_first_dbt_model"], "uuid": "demo/models/example/my_second_dbt_model"}]}, "updated_at": 1702284950.403926}, "dry_rain": {"added_at": null, "pipeline": {"description": null, "name": "dry rain", "tags": [], "type": "integration", "updated_at": "2023-08-10 06:37:29", "uuid": "dry_rain", "blocks": [{"downstream_blocks": ["lively_grass"], "language": "yaml", "name": "young water", "type": "data_loader", "upstream_blocks": [], "uuid": "young_water"}, {"downstream_blocks": ["icy_morning"], "language": "python", "name": "lively grass", "type": "transformer", "upstream_blocks": ["young_water"], "uuid": "lively_grass"}, {"downstream_blocks": [], "language": "yaml", "name": "icy morning", "type": "data_exporter", "upstream_blocks": ["lively_grass"], "uuid": "icy_morning"}]}, "updated_at": 1702284950.403935}, "rough_water": {"added_at": null, "pipeline": {"description": null, "name": "rough water", "tags": [], "type": "python", "updated_at": "2023-08-02 07:00:55", "uuid": "rough_water", "blocks": [{"downstream_blocks": [], "language": "python", "name": "weathered frog", "type": "data_loader", "upstream_blocks": [], "uuid": "weathered_frog"}]}, "updated_at": 1702284950.40394}, "hidden_night": {"added_at": null, "pipeline": {"description": null, "name": "hidden night", "tags": [], "type": "python", "updated_at": "2023-08-22 23:14:59", "uuid": "hidden_night", "blocks": [{"downstream_blocks": [], "language": "sql", "name": "solitary forest", "type": "data_loader", "upstream_blocks": [], "uuid": "solitary_forest"}, {"downstream_blocks": [], "language": "sql", "name": "delicate grass", "type": "data_loader", "upstream_blocks": [], "uuid": "delicate_grass"}]}, "updated_at": 1702284950.403945}, "fragrant_sound": {"added_at": null, "pipeline": {"description": null, "name": "fragrant sound", "tags": [], "type": "python", "updated_at": "2023-09-22 22:14:56", "uuid": "fragrant_sound", "blocks": [{"downstream_blocks": ["morning_dew"], "language": "python", "name": "load_titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "load_titanic"}, {"downstream_blocks": ["morning_dew"], "language": "sql", "name": "blue sunset", "type": "data_loader", "upstream_blocks": [], "uuid": "blue_sunset"}, {"downstream_blocks": [], "language": "python", "name": "morning dew", "type": "transformer", "upstream_blocks": ["blue_sunset", "load_titanic"], "uuid": "morning_dew"}]}, "updated_at": 1702284950.403953}, "lingering_voice": {"added_at": null, "pipeline": {"description": null, "name": "lingering voice", "tags": null, "type": "integration", "updated_at": null, "uuid": "lingering_voice", "blocks": []}, "updated_at": 1702284950.403955}, "cool_adfasdfdawn": {"added_at": null, "pipeline": {"description": null, "name": "cool adfasdfdawn", "tags": [], "type": "python", "updated_at": "2023-09-15 22:09:48", "uuid": "cool_adfasdfdawn", "blocks": [{"downstream_blocks": [], "language": "python", "name": "2", "type": "data_loader", "upstream_blocks": [], "uuid": "letter_2"}, {"downstream_blocks": [], "language": "python", "name": "3", "type": "transformer", "upstream_blocks": [], "uuid": "letter_3"}, {"downstream_blocks": [], "language": "python", "name": "1", "type": "data_loader", "upstream_blocks": [], "uuid": "letter_1"}, {"downstream_blocks": [], "language": "python", "name": "holy water", "type": "scratchpad", "upstream_blocks": [], "uuid": "holy_water"}, {"downstream_blocks": [], "language": "python", "name": "wild darkness", "type": "scratchpad", "upstream_blocks": [], "uuid": "wild_darkness"}]}, "updated_at": 1702284950.403967}, "wispy_field": {"added_at": null, "pipeline": {"description": null, "name": "wispy field", "tags": [], "type": "python", "updated_at": "2023-08-28 19:46:13", "uuid": "wispy_field", "blocks": [{"downstream_blocks": [], "language": "markdown", "name": "Documentation for wispy_field_block_3", "type": "markdown", "upstream_blocks": [], "uuid": "documentation_for_wispy_field_block_3"}, {"downstream_blocks": [], "language": "python", "name": "wispy_field_block_3", "type": "transformer", "upstream_blocks": ["wispy_field_block_1", "wispy_field_block_2"], "uuid": "wispy_field_block_3"}, {"downstream_blocks": ["wispy_field_block_3"], "language": "python", "name": "wispy_field_block_2", "type": "data_loader", "upstream_blocks": [], "uuid": "wispy_field_block_2"}, {"downstream_blocks": ["wispy_field_block_3"], "language": "python", "name": "wispy_field_block_1", "type": "data_loader", "upstream_blocks": [], "uuid": "wispy_field_block_1"}]}, "updated_at": 1702284950.403976}, "small_shape": {"added_at": null, "pipeline": {"description": null, "name": "small shape", "tags": null, "type": "streaming", "updated_at": null, "uuid": "small_shape", "blocks": []}, "updated_at": 1702284950.403978}, "long_firefly": {"added_at": null, "pipeline": {"description": null, "name": "long firefly", "tags": [], "type": "python", "updated_at": null, "uuid": "long_firefly", "blocks": [{"downstream_blocks": [], "language": "python", "name": "long_firefly_block_3", "type": "transformer", "upstream_blocks": ["long_firefly_block_1", "long_firefly_block_2"], "uuid": "long_firefly_block_3"}, {"downstream_blocks": ["long_firefly_block_3"], "language": "python", "name": "long_firefly_block_2", "type": "data_loader", "upstream_blocks": [], "uuid": "long_firefly_block_2"}, {"downstream_blocks": ["long_firefly_block_3"], "language": "python", "name": "long_firefly_block_1", "type": "data_loader", "upstream_blocks": [], "uuid": "long_firefly_block_1"}]}, "updated_at": 1702284950.403986}, "pipeline_that_has_gdp_copy": {"added_at": null, "pipeline": {"description": null, "name": "pipeline_that_has_gdp_copy", "tags": [], "type": "python", "updated_at": "2023-08-02 18:38:46", "uuid": "pipeline_that_has_gdp_copy", "blocks": [{"downstream_blocks": [], "language": "markdown", "name": "red_rain1", "type": "markdown", "upstream_blocks": [], "uuid": "red_rain1"}, {"downstream_blocks": ["morning_darkness"], "language": "python", "name": "gdp1", "type": "global_data_product", "upstream_blocks": [], "uuid": "gdp1"}, {"downstream_blocks": [], "language": "python", "name": "morning darkness", "type": "data_exporter", "upstream_blocks": ["gdp1"], "uuid": "morning_darkness"}]}, "updated_at": 1702284950.403994}, "dynamic_pipeline_testing": {"added_at": null, "pipeline": {"description": null, "name": "dynamic pipeline testing", "tags": ["dynamic"], "type": "python", "updated_at": "2023-09-21 21:40:19", "uuid": "dynamic_pipeline_testing", "blocks": [{"downstream_blocks": ["dawn_glitter", "billowing_bush"], "language": "python", "name": "silent dream", "type": "custom", "upstream_blocks": [], "uuid": "silent_dream"}, {"downstream_blocks": ["divine_bush"], "language": "python", "name": "dawn glitter", "type": "transformer", "upstream_blocks": ["silent_dream"], "uuid": "dawn_glitter"}, {"downstream_blocks": [], "language": "python", "name": "divine bush", "type": "data_exporter", "upstream_blocks": ["dawn_glitter"], "uuid": "divine_bush"}, {"downstream_blocks": ["crimson_sound"], "language": "python", "name": "billowing bush", "type": "custom", "upstream_blocks": ["silent_dream"], "uuid": "billowing_bush"}, {"downstream_blocks": [], "language": "python", "name": "crimson sound", "type": "data_exporter", "upstream_blocks": ["billowing_bush"], "uuid": "crimson_sound"}]}, "updated_at": 1702284950.404005}, "long_wave": {"added_at": null, "pipeline": {"description": "This python script provides a template for a custom transformation. The function transform_custom takes two parameters: data and *args, **kwargs. It returns the value of 1 + 1. The output of the function is tested using the test_output function which checks if the output is not None.", "name": "long wave", "tags": [], "type": "python", "updated_at": "2023-09-15 07:02:55", "uuid": "long_wave", "blocks": [{"downstream_blocks": [], "language": "markdown", "name": "Documentation for long_wave", "type": "markdown", "upstream_blocks": [], "uuid": "documentation_for_long_wave"}, {"downstream_blocks": [], "language": "markdown", "name": "Documentation for long_wave_block_3", "type": "markdown", "upstream_blocks": [], "uuid": "documentation_for_long_wave_block_3"}, {"downstream_blocks": [], "language": "python", "name": "long_wave_block_3", "type": "data_exporter", "upstream_blocks": ["long_wave_block_2"], "uuid": "long_wave_block_3"}, {"downstream_blocks": [], "language": "markdown", "name": "Documentation for long_wave_block_2", "type": "markdown", "upstream_blocks": [], "uuid": "documentation_for_long_wave_block_2"}, {"downstream_blocks": ["long_wave_block_3"], "language": "python", "name": "long_wave_block_2", "type": "transformer", "upstream_blocks": ["long_wave_block_1"], "uuid": "long_wave_block_2"}, {"downstream_blocks": [], "language": "markdown", "name": "Documentation for long_wave_block_1", "type": "markdown", "upstream_blocks": [], "uuid": "documentation_for_long_wave_block_1"}, {"downstream_blocks": ["long_wave_block_2", "silent_sunset"], "language": "python", "name": "long_wave_block_1", "type": "data_loader", "upstream_blocks": [], "uuid": "long_wave_block_1"}, {"downstream_blocks": [], "language": "markdown", "name": "Documentation for silent_sunset", "type": "markdown", "upstream_blocks": [], "uuid": "documentation_for_silent_sunset"}, {"downstream_blocks": ["weathered_glade"], "language": "python", "name": "silent sunset", "type": "data_loader", "upstream_blocks": ["long_wave_block_1"], "uuid": "silent_sunset"}, {"downstream_blocks": [], "language": "markdown", "name": "Documentation for documentation_for_weathered_glade", "type": "markdown", "upstream_blocks": [], "uuid": "documentation_for_documentation_for_weathered_glade"}, {"downstream_blocks": [], "language": "markdown", "name": "Documentation for weathered_glade", "type": "markdown", "upstream_blocks": [], "uuid": "documentation_for_weathered_glade"}, {"downstream_blocks": [], "language": "python", "name": "weathered glade", "type": "custom", "upstream_blocks": ["silent_sunset"], "uuid": "weathered_glade"}]}, "updated_at": 1702284950.404031}, "late_wind": {"added_at": null, "pipeline": {"description": null, "name": "late wind", "tags": [], "type": "integration", "updated_at": "2023-08-02 19:27:01", "uuid": "late_wind", "blocks": [{"downstream_blocks": [], "language": "yaml", "name": "small sun", "type": "data_loader", "upstream_blocks": [], "uuid": "small_sun"}]}, "updated_at": 1702284950.404035}, "damp_silence": {"added_at": null, "pipeline": {"description": null, "name": "damp silence", "tags": null, "type": "python", "updated_at": null, "uuid": "damp_silence", "blocks": []}, "updated_at": 1702284950.404038}, "winter_bird": {"added_at": null, "pipeline": {"description": null, "name": "winter bird", "tags": [], "type": "python", "updated_at": "2023-09-22 22:54:16", "uuid": "winter_bird", "blocks": [{"downstream_blocks": ["green_star"], "language": "python", "name": "load_titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "load_titanic"}, {"downstream_blocks": ["polished_sky"], "language": "sql", "name": "green star", "type": "data_loader", "upstream_blocks": ["load_titanic"], "uuid": "green_star"}, {"downstream_blocks": [], "language": "python", "name": "polished sky", "type": "transformer", "upstream_blocks": ["green_star"], "uuid": "polished_sky"}]}, "updated_at": 1702284950.404046}, "shy_bush": {"added_at": null, "pipeline": {"description": null, "name": "shy bush", "tags": [], "type": "python", "updated_at": null, "uuid": "shy_bush", "blocks": [{"downstream_blocks": [], "language": "python", "name": "1", "type": "data_loader", "upstream_blocks": [], "uuid": "letter_1"}, {"downstream_blocks": [], "language": "python", "name": "2", "type": "data_loader", "upstream_blocks": [], "uuid": "letter_2"}]}, "updated_at": 1702284950.404052}, "polished_snow": {"added_at": null, "pipeline": {"description": null, "name": "pipeline with variables", "tags": ["gcp"], "type": "python", "updated_at": null, "uuid": "polished_snow", "blocks": [{"downstream_blocks": [], "language": "python", "name": "twilight paper", "type": "data_loader", "upstream_blocks": [], "uuid": "twilight_paper"}]}, "updated_at": 1702284950.404056}, "divine_butterfly": {"added_at": null, "pipeline": {"description": null, "name": "divine butterfly", "tags": [], "type": "python", "updated_at": "2023-10-11 12:47:09", "uuid": "divine_butterfly", "blocks": [{"downstream_blocks": ["weathered_darkness"], "language": "python", "name": "throbbing pine", "type": "data_loader", "upstream_blocks": [], "uuid": "throbbing_pine"}, {"downstream_blocks": [], "language": "python", "name": "weathered darkness", "type": "transformer", "upstream_blocks": ["throbbing_pine"], "uuid": "weathered_darkness"}]}, "updated_at": 1702284950.404062}, "dawn_flower": {"added_at": null, "pipeline": {"description": null, "name": "dawn flower", "tags": [], "type": "python", "updated_at": "2023-10-06 04:57:36", "uuid": "dawn_flower", "blocks": [{"downstream_blocks": ["broken_hill"], "language": "python", "name": "load_titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "load_titanic"}, {"downstream_blocks": [], "language": "sql", "name": "broken hill", "type": "data_exporter", "upstream_blocks": ["load_titanic"], "uuid": "broken_hill"}]}, "updated_at": 1702284950.404069}, "throbbing_wave": {"added_at": null, "pipeline": {"description": null, "name": "throbbing wave", "tags": [], "type": "python", "updated_at": "2023-07-26 08:58:42", "uuid": "throbbing_wave", "blocks": [{"downstream_blocks": ["shy_hill"], "language": "python", "name": "dark violet", "type": "transformer", "upstream_blocks": [], "uuid": "dark_violet"}, {"downstream_blocks": ["wispy_tree"], "language": "python", "name": "shy hill", "type": "transformer", "upstream_blocks": ["dark_violet"], "uuid": "shy_hill"}, {"downstream_blocks": ["divine_haze"], "language": "python", "name": "wispy tree", "type": "transformer", "upstream_blocks": ["shy_hill"], "uuid": "wispy_tree"}, {"downstream_blocks": ["misty_flower"], "language": "python", "name": "divine haze", "type": "transformer", "upstream_blocks": ["wispy_tree"], "uuid": "divine_haze"}, {"downstream_blocks": ["little_wood"], "language": "yaml", "name": "misty flower", "type": "dbt", "upstream_blocks": ["divine_haze"], "uuid": "misty_flower"}, {"downstream_blocks": ["autumn_sound"], "language": "yaml", "name": "little_wood", "type": "data_loader", "upstream_blocks": ["misty_flower"], "uuid": "little_wood"}, {"downstream_blocks": ["drone_more_please"], "language": "yaml", "name": "autumn_sound", "type": "dbt", "upstream_blocks": ["little_wood"], "uuid": "autumn_sound"}, {"downstream_blocks": ["nameless_frog"], "language": "python", "name": "drone_more_please", "type": "data_loader", "upstream_blocks": ["autumn_sound"], "uuid": "drone_more_please"}, {"downstream_blocks": ["winter_glade"], "language": "python", "name": "nameless frog", "type": "data_exporter", "upstream_blocks": ["drone_more_please"], "uuid": "nameless_frog"}, {"downstream_blocks": ["aged_glitter"], "language": "python", "name": "winter glade", "type": "data_exporter", "upstream_blocks": ["nameless_frog"], "uuid": "winter_glade"}, {"downstream_blocks": ["empty_feather"], "language": "python", "name": "aged glitter", "type": "transformer", "upstream_blocks": ["winter_glade"], "uuid": "aged_glitter"}, {"downstream_blocks": ["test/growth/dronewtf"], "language": "r", "name": "empty_feather", "type": "data_loader", "upstream_blocks": ["aged_glitter"], "uuid": "empty_feather"}, {"downstream_blocks": [], "language": "python", "name": "test/growth/dronewtf", "type": "data_loader", "upstream_blocks": ["empty_feather"], "uuid": "test/growth/dronewtf"}]}, "updated_at": 1702284950.404096}, "holy_grass": {"added_at": null, "pipeline": {"description": null, "name": "holy grass", "tags": [], "type": "python", "updated_at": "2023-08-28 20:39:40", "uuid": "holy_grass", "blocks": [{"downstream_blocks": ["holy_grass_block_2"], "language": "python", "name": "holy_grass_block_1", "type": "data_loader", "upstream_blocks": [], "uuid": "holy_grass_block_1"}, {"downstream_blocks": [], "language": "python", "name": "holy_grass_block_3", "type": "data_exporter", "upstream_blocks": ["holy_grass_block_2"], "uuid": "holy_grass_block_3"}, {"downstream_blocks": ["holy_grass_block_3"], "language": "python", "name": "holy_grass_block_2", "type": "transformer", "upstream_blocks": ["holy_grass_block_1"], "uuid": "holy_grass_block_2"}]}, "updated_at": 1702284950.404104}, "white_cloud": {"added_at": null, "pipeline": {"description": null, "name": "white cloud", "tags": [], "type": "python", "updated_at": "2023-07-26 23:26:53", "uuid": "white_cloud", "blocks": [{"downstream_blocks": ["green_wildflower"], "language": "python", "name": "dry cloud", "type": "data_exporter", "upstream_blocks": [], "uuid": "dry_cloud"}, {"downstream_blocks": ["hidden_firefly"], "language": "python", "name": "green wildflower", "type": "data_exporter", "upstream_blocks": ["dry_cloud"], "uuid": "green_wildflower"}, {"downstream_blocks": ["young_bush"], "language": "python", "name": "hidden firefly", "type": "data_loader", "upstream_blocks": ["green_wildflower"], "uuid": "hidden_firefly"}, {"downstream_blocks": ["damp_paper"], "language": "python", "name": "young bush", "type": "data_loader", "upstream_blocks": ["hidden_firefly"], "uuid": "young_bush"}, {"downstream_blocks": ["frosty_frost"], "language": "python", "name": "damp paper", "type": "data_exporter", "upstream_blocks": ["young_bush"], "uuid": "damp_paper"}, {"downstream_blocks": [], "language": "python", "name": "frosty frost", "type": "data_loader", "upstream_blocks": ["damp_paper"], "uuid": "frosty_frost"}]}, "updated_at": 1702284950.404116}, "elden_glade": {"added_at": null, "pipeline": {"description": null, "name": "elden glade", "tags": [], "type": "python", "updated_at": "2023-12-09 00:45:26", "uuid": "elden_glade", "blocks": [{"downstream_blocks": ["rough_dew"], "language": "python", "name": "outstanding monk", "type": "custom", "upstream_blocks": [], "uuid": "outstanding_monk"}, {"downstream_blocks": ["rough_dew", "gracious_bonsai"], "language": "python", "name": "illusory elm", "type": "data_loader", "upstream_blocks": [], "uuid": "illusory_elm"}, {"downstream_blocks": ["floral_artificer", "holy_elm"], "language": "python", "name": "rough dew", "type": "transformer", "upstream_blocks": ["outstanding_monk", "illusory_elm"], "uuid": "rough_dew"}, {"downstream_blocks": ["kinetic_mana", "royal_elm"], "language": "python", "name": "floral artificer", "type": "transformer", "upstream_blocks": ["rough_dew"], "uuid": "floral_artificer"}, {"downstream_blocks": ["sincere_artifact"], "language": "python", "name": "kinetic mana", "type": "data_exporter", "upstream_blocks": ["floral_artificer"], "uuid": "kinetic_mana"}, {"downstream_blocks": [], "language": "python", "name": "sincere artifact", "type": "custom", "upstream_blocks": ["royal_elm", "kinetic_mana"], "uuid": "sincere_artifact"}, {"downstream_blocks": ["sincere_artifact"], "language": "python", "name": "royal elm", "type": "custom", "upstream_blocks": ["floral_artificer"], "uuid": "royal_elm"}, {"downstream_blocks": [], "language": "python", "name": "gracious bonsai", "type": "custom", "upstream_blocks": ["illusory_elm"], "uuid": "gracious_bonsai"}, {"downstream_blocks": [], "language": "python", "name": "holy elm", "type": "custom", "upstream_blocks": ["rough_dew"], "uuid": "holy_elm"}]}, "updated_at": 1702284950.404135}, "dynamic_2": {"added_at": null, "pipeline": {"description": null, "name": "dynamic 2", "tags": ["dynamic"], "type": "python", "updated_at": "2023-12-11T01:28:27+00:00", "uuid": "dynamic_2", "blocks": [{"downstream_blocks": ["dynamic_child_a"], "language": "python", "name": "dynamic parent A", "type": "data_loader", "upstream_blocks": [], "uuid": "dynamic_parent_a"}, {"downstream_blocks": ["dynamic_child_a", "upstream_reduce_output", "dynamic_child_child_a"], "language": "python", "name": "dynamic parent B", "type": "data_loader", "upstream_blocks": [], "uuid": "dynamic_parent_b"}, {"downstream_blocks": ["dynamic_child_a"], "language": "python", "name": "regular parent A", "type": "data_loader", "upstream_blocks": [], "uuid": "regular_parent_a"}, {"downstream_blocks": ["dynamic_child_child_a", "dynamic_child_child_b"], "language": "python", "name": "dynamic child A", "type": "transformer", "upstream_blocks": ["dynamic_parent_a", "regular_parent_a", "dynamic_parent_b"], "uuid": "dynamic_child_a"}, {"downstream_blocks": [], "language": "python", "name": "dynamic_child_child_a", "type": "data_exporter", "upstream_blocks": ["dynamic_child_a", "dynamic_parent_b"], "uuid": "dynamic_child_child_a"}, {"downstream_blocks": ["upstream_reduce_output"], "language": "python", "name": "dynamic child child B", "type": "data_exporter", "upstream_blocks": ["dynamic_child_a"], "uuid": "dynamic_child_child_b"}, {"downstream_blocks": ["upstream_reduce_output"], "language": "python", "name": "regular parent B", "type": "data_loader", "upstream_blocks": [], "uuid": "regular_parent_b"}, {"downstream_blocks": [], "language": "python", "name": "upstream reduce output", "type": "custom", "upstream_blocks": ["dynamic_child_child_b", "regular_parent_b", "dynamic_parent_b"], "uuid": "upstream_reduce_output"}]}, "updated_at": 1702284950.404152}, "unify_pipeline_destination": {"added_at": null, "pipeline": {"description": null, "name": "unify pipeline destination", "tags": ["testing"], "type": "python", "updated_at": "2023-09-24 09:44:06", "uuid": "unify_pipeline_destination", "blocks": [{"downstream_blocks": ["destination_postgresql"], "language": "python", "name": "api data", "type": "custom", "upstream_blocks": [], "uuid": "api_data"}, {"downstream_blocks": ["destination_postgresql"], "language": "python", "name": "titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "titanic"}, {"downstream_blocks": ["destination_postgresql"], "language": "python", "name": "input only", "type": "custom", "upstream_blocks": [], "uuid": "input_only"}, {"downstream_blocks": ["destination_postgresql"], "language": "yaml", "name": "source_postgresql_normal", "type": "data_loader", "upstream_blocks": [], "uuid": "source_postgresql_normal"}, {"downstream_blocks": [], "language": "yaml", "name": "destination_postgresql", "type": "data_exporter", "upstream_blocks": ["source_postgresql_normal", "api_data", "titanic", "input_only"], "uuid": "destination_postgresql"}]}, "updated_at": 1702284950.404163}, "rough_wind": {"added_at": null, "pipeline": {"description": null, "name": "rough wind", "tags": [], "type": "python", "updated_at": "2023-07-27 17:25:39", "uuid": "rough_wind", "blocks": [{"downstream_blocks": ["black_brook"], "language": "python", "name": "delicate shadow", "type": "data_loader", "upstream_blocks": [], "uuid": "delicate_shadow"}, {"downstream_blocks": ["silent_darkness"], "language": "python", "name": "black brook", "type": "data_loader", "upstream_blocks": ["delicate_shadow"], "uuid": "black_brook"}, {"downstream_blocks": [], "language": "markdown", "name": "Documentation for silent_darkness", "type": "markdown", "upstream_blocks": [], "uuid": "documentation_for_silent_darkness"}, {"downstream_blocks": [], "language": "python", "name": "silent darkness", "type": "data_loader", "upstream_blocks": ["black_brook"], "uuid": "silent_darkness"}]}, "updated_at": 1702284950.404173}, "pipeline_that_has_gdp": {"added_at": null, "pipeline": {"description": null, "name": "pipeline that has gdp", "tags": [], "type": "python", "updated_at": "2023-08-10 17:31:57", "uuid": "pipeline_that_has_gdp", "blocks": [{"downstream_blocks": [], "language": "markdown", "name": "red_rain1", "type": "markdown", "upstream_blocks": [], "uuid": "red_rain1"}, {"downstream_blocks": ["morning_darkness"], "language": "python", "name": "gdp1111", "type": "global_data_product", "upstream_blocks": [], "uuid": "gdp1111"}, {"downstream_blocks": [], "language": "python", "name": "morning darkness", "type": "data_exporter", "upstream_blocks": ["gdp1111"], "uuid": "morning_darkness"}]}, "updated_at": 1702284950.404181}, "misty_morning": {"added_at": null, "pipeline": {"description": null, "name": "example_pipeline", "tags": [], "type": "python", "updated_at": "2023-07-24 05:37:55", "uuid": "misty_morning", "blocks": [{"downstream_blocks": ["fill_in_missing_values", "summer_dew", "wandering_voice", "blue_haze", "solitary_moon", "spring_feather"], "language": "python", "name": "load_titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "load_titanic"}, {"downstream_blocks": [], "language": "markdown", "name": "spring feather", "type": "markdown", "upstream_blocks": ["load_titanic"], "uuid": "spring_feather"}, {"downstream_blocks": [], "language": "markdown", "name": "polished field", "type": "markdown", "upstream_blocks": [], "uuid": "polished_field"}, {"downstream_blocks": [], "language": "python", "name": "solitary moon", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "solitary_moon"}, {"downstream_blocks": ["autumn_sound"], "language": "python", "name": "blue haze", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "blue_haze"}, {"downstream_blocks": [], "language": "yaml", "name": "autumn sound", "type": "dbt", "upstream_blocks": ["blue_haze"], "uuid": "autumn_sound"}, {"downstream_blocks": [], "language": "python", "name": "wandering voice", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "wandering_voice"}, {"downstream_blocks": [], "language": "python", "name": "summer dew", "type": "data_exporter", "upstream_blocks": ["load_titanic"], "uuid": "summer_dew"}, {"downstream_blocks": ["export_titanic_clean"], "language": "python", "name": "fill_in_missing_values", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "fill_in_missing_values"}, {"downstream_blocks": ["hidden_wildflower"], "language": "python", "name": "export_titanic_clean", "type": "data_exporter", "upstream_blocks": ["fill_in_missing_values"], "uuid": "export_titanic_clean"}, {"downstream_blocks": ["empty_shadow"], "language": "python", "name": "hidden wildflower", "type": "data_loader", "upstream_blocks": ["export_titanic_clean"], "uuid": "hidden_wildflower"}, {"downstream_blocks": ["aged_cloud"], "language": "python", "name": "empty shadow", "type": "transformer", "upstream_blocks": ["hidden_wildflower"], "uuid": "empty_shadow"}, {"downstream_blocks": [], "language": "python", "name": "aged cloud", "type": "data_exporter", "upstream_blocks": ["empty_shadow"], "uuid": "aged_cloud"}, {"downstream_blocks": [], "language": "markdown", "name": "winter waterfall", "type": "markdown", "upstream_blocks": [], "uuid": "winter_waterfall"}, {"downstream_blocks": [], "language": "python", "name": "growth/test", "type": "transformer", "upstream_blocks": [], "uuid": "growth/test"}]}, "updated_at": 1702284950.40422}, "proud_grass": {"added_at": null, "pipeline": {"description": null, "name": "proud grass", "tags": ["testing"], "type": "python", "updated_at": "2023-09-19 00:54:50", "uuid": "proud_grass", "blocks": [{"downstream_blocks": [], "language": "python", "name": "restless tree", "type": "data_loader", "upstream_blocks": [], "uuid": "restless_tree"}]}, "updated_at": 1702284950.404224}, "wispy_knight": {"added_at": null, "pipeline": {"description": null, "name": "wispy knight", "tags": [], "type": "python", "updated_at": "2023-12-08 22:34:16", "uuid": "wispy_knight", "blocks": [{"downstream_blocks": ["charismatic_sword", "holy_sorcerer"], "language": "python", "name": "load_titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "load_titanic"}, {"downstream_blocks": ["charismatic_sword"], "language": "sql", "name": "holy sorcerer", "type": "data_exporter", "upstream_blocks": ["load_titanic"], "uuid": "holy_sorcerer"}, {"downstream_blocks": ["crystal_quest"], "language": "python", "name": "charismatic sword", "type": "data_exporter", "upstream_blocks": ["load_titanic", "holy_sorcerer"], "uuid": "charismatic_sword"}, {"downstream_blocks": [], "language": "sql", "name": "crystal quest", "type": "data_exporter", "upstream_blocks": ["charismatic_sword"], "uuid": "crystal_quest"}]}, "updated_at": 1702284950.404233}, "unify_destination_block_python": {"added_at": null, "pipeline": {"description": null, "name": "unify destination block python", "tags": ["testing"], "type": "python", "updated_at": "2023-09-24 05:07:18", "uuid": "unify_destination_block_python", "blocks": [{"downstream_blocks": ["destination_postgresql_python"], "language": "python", "name": "input_only", "type": "custom", "upstream_blocks": [], "uuid": "input_only"}, {"downstream_blocks": ["destination_postgresql_python"], "language": "python", "name": "api_data", "type": "custom", "upstream_blocks": [], "uuid": "api_data"}, {"downstream_blocks": ["destination_postgresql_python"], "language": "python", "name": "titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "titanic"}, {"downstream_blocks": ["destination_postgresql_python"], "language": "yaml", "name": "source_postgresql_normal", "type": "data_loader", "upstream_blocks": [], "uuid": "source_postgresql_normal"}, {"downstream_blocks": [], "language": "python", "name": "destination postgresql python", "type": "data_exporter", "upstream_blocks": ["input_only", "api_data", "titanic", "source_postgresql_normal"], "uuid": "destination_postgresql_python"}]}, "updated_at": 1702284950.404245}, "white_feather": {"added_at": null, "pipeline": {"description": null, "name": "example_pipeline", "tags": [], "type": "python", "updated_at": "2023-09-28 01:08:19", "uuid": "white_feather", "blocks": [{"downstream_blocks": ["fill_in_missing_values", "summer_dew", "wandering_voice", "blue_haze", "solitary_moon", "spring_feather", "histogram_for_load_titanic_1695862064031"], "language": "python", "name": "load_titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "load_titanic"}, {"downstream_blocks": [], "language": "markdown", "name": "spring feather", "type": "markdown", "upstream_blocks": ["load_titanic"], "uuid": "spring_feather"}, {"downstream_blocks": [], "language": "markdown", "name": "polished field", "type": "markdown", "upstream_blocks": [], "uuid": "polished_field"}, {"downstream_blocks": [], "language": "python", "name": "solitary moon", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "solitary_moon"}, {"downstream_blocks": ["autumn_sound"], "language": "python", "name": "blue haze", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "blue_haze"}, {"downstream_blocks": [], "language": "yaml", "name": "autumn sound", "type": "dbt", "upstream_blocks": ["blue_haze"], "uuid": "autumn_sound"}, {"downstream_blocks": [], "language": "python", "name": "wandering voice", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "wandering_voice"}, {"downstream_blocks": [], "language": "python", "name": "summer dew", "type": "data_exporter", "upstream_blocks": ["load_titanic"], "uuid": "summer_dew"}, {"downstream_blocks": ["export_titanic_clean"], "language": "python", "name": "fill_in_missing_values", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "fill_in_missing_values"}, {"downstream_blocks": ["hidden_wildflower"], "language": "python", "name": "export_titanic_clean", "type": "data_exporter", "upstream_blocks": ["fill_in_missing_values"], "uuid": "export_titanic_clean"}, {"downstream_blocks": ["empty_shadow"], "language": "python", "name": "hidden wildflower", "type": "data_loader", "upstream_blocks": ["export_titanic_clean"], "uuid": "hidden_wildflower"}, {"downstream_blocks": ["aged_cloud"], "language": "python", "name": "empty shadow", "type": "transformer", "upstream_blocks": ["hidden_wildflower"], "uuid": "empty_shadow"}, {"downstream_blocks": [], "language": "python", "name": "aged cloud", "type": "data_exporter", "upstream_blocks": ["empty_shadow"], "uuid": "aged_cloud"}, {"downstream_blocks": [], "language": "markdown", "name": "winter waterfall", "type": "markdown", "upstream_blocks": [], "uuid": "winter_waterfall"}, {"downstream_blocks": [], "language": "python", "name": "growth/test", "type": "transformer", "upstream_blocks": [], "uuid": "growth/test"}]}, "updated_at": 1702284950.404273}, "billowing_waterfall": {"added_at": null, "pipeline": {"description": null, "name": "example_pipeline", "tags": [], "type": "python", "updated_at": "2023-08-03 20:50:08", "uuid": "billowing_waterfall", "blocks": [{"downstream_blocks": ["fill_in_missing_values", "summer_dew", "wandering_voice", "blue_haze", "solitary_moon", "spring_feather", "histogram_for_load_titanic_1691095789740", "bar_chart_for_load_titanic_1691095796425"], "language": "python", "name": "load_titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "load_titanic"}, {"downstream_blocks": [], "language": "markdown", "name": "spring feather", "type": "markdown", "upstream_blocks": ["load_titanic"], "uuid": "spring_feather"}, {"downstream_blocks": [], "language": "markdown", "name": "polished field", "type": "markdown", "upstream_blocks": [], "uuid": "polished_field"}, {"downstream_blocks": [], "language": "python", "name": "solitary moon", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "solitary_moon"}, {"downstream_blocks": [], "language": "markdown", "name": "Documentation for blue_haze", "type": "markdown", "upstream_blocks": [], "uuid": "documentation_for_blue_haze"}, {"downstream_blocks": ["autumn_sound"], "language": "python", "name": "blue haze", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "blue_haze"}, {"downstream_blocks": [], "language": "yaml", "name": "autumn sound", "type": "dbt", "upstream_blocks": ["blue_haze"], "uuid": "autumn_sound"}, {"downstream_blocks": [], "language": "python", "name": "wandering voice", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "wandering_voice"}, {"downstream_blocks": [], "language": "python", "name": "summer dew", "type": "data_exporter", "upstream_blocks": ["load_titanic"], "uuid": "summer_dew"}, {"downstream_blocks": ["export_titanic_clean"], "language": "python", "name": "fill_in_missing_values", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "fill_in_missing_values"}, {"downstream_blocks": ["hidden_wildflower"], "language": "python", "name": "export_titanic_clean", "type": "data_exporter", "upstream_blocks": ["fill_in_missing_values"], "uuid": "export_titanic_clean"}, {"downstream_blocks": ["empty_shadow"], "language": "python", "name": "hidden wildflower", "type": "data_loader", "upstream_blocks": ["export_titanic_clean"], "uuid": "hidden_wildflower"}, {"downstream_blocks": [], "language": "python", "name": "empty shadow", "type": "transformer", "upstream_blocks": ["hidden_wildflower"], "uuid": "empty_shadow"}, {"downstream_blocks": [], "language": "markdown", "name": "winter waterfall", "type": "markdown", "upstream_blocks": [], "uuid": "winter_waterfall"}]}, "updated_at": 1702284950.404299}, "lively_shadow": {"added_at": null, "pipeline": {"description": null, "name": "lively shadow", "tags": [], "type": "python", "updated_at": null, "uuid": "lively_shadow", "blocks": [{"downstream_blocks": [], "language": "python", "name": "wandering waterfall", "type": "data_exporter", "upstream_blocks": [], "uuid": "wandering_waterfall"}]}, "updated_at": 1702284950.404303}, "purple_morning": {"added_at": null, "pipeline": {"description": null, "name": "purple morning", "tags": null, "type": "python", "updated_at": null, "uuid": "purple_morning", "blocks": []}, "updated_at": 1702284950.404305}, "user_transactions": {"added_at": null, "pipeline": {"description": null, "name": "user transactions", "tags": [], "type": "python", "updated_at": "2023-08-17 02:29:08", "uuid": "user_transactions", "blocks": [{"downstream_blocks": [], "language": "python", "name": "product_purchases", "type": "data_loader", "upstream_blocks": [], "uuid": "product_purchases"}]}, "updated_at": 1702284950.404309}, "twilight_frog": {"added_at": null, "pipeline": {"description": null, "name": "twilight frog", "tags": [], "type": "integration", "updated_at": "2023-09-24 01:34:04", "uuid": "twilight_frog", "blocks": [{"downstream_blocks": ["destination_postgresql"], "language": "yaml", "name": "source_postgresql_normal", "type": "data_loader", "upstream_blocks": [], "uuid": "source_postgresql_normal"}, {"downstream_blocks": [], "language": "yaml", "name": "destination postgresql", "type": "data_exporter", "upstream_blocks": ["source_postgresql_normal"], "uuid": "destination_postgresql"}]}, "updated_at": 1702284950.404316}, "crimson_water": {"added_at": null, "pipeline": {"description": null, "name": "example_pipeline", "tags": [], "type": "python", "updated_at": "2023-07-24 05:37:55", "uuid": "crimson_water", "blocks": [{"downstream_blocks": ["fill_in_missing_values", "summer_dew", "wandering_voice", "blue_haze", "solitary_moon", "spring_feather"], "language": "python", "name": "load_titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "load_titanic"}, {"downstream_blocks": [], "language": "markdown", "name": "spring feather", "type": "markdown", "upstream_blocks": ["load_titanic"], "uuid": "spring_feather"}, {"downstream_blocks": [], "language": "markdown", "name": "polished field", "type": "markdown", "upstream_blocks": [], "uuid": "polished_field"}, {"downstream_blocks": [], "language": "python", "name": "solitary moon", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "solitary_moon"}, {"downstream_blocks": ["autumn_sound"], "language": "python", "name": "blue haze", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "blue_haze"}, {"downstream_blocks": [], "language": "yaml", "name": "autumn sound", "type": "dbt", "upstream_blocks": ["blue_haze"], "uuid": "autumn_sound"}, {"downstream_blocks": [], "language": "python", "name": "wandering voice", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "wandering_voice"}, {"downstream_blocks": [], "language": "python", "name": "summer dew", "type": "data_exporter", "upstream_blocks": ["load_titanic"], "uuid": "summer_dew"}, {"downstream_blocks": ["export_titanic_clean"], "language": "python", "name": "fill_in_missing_values", "type": "transformer", "upstream_blocks": ["load_titanic"], "uuid": "fill_in_missing_values"}, {"downstream_blocks": ["hidden_wildflower"], "language": "python", "name": "export_titanic_clean", "type": "data_exporter", "upstream_blocks": ["fill_in_missing_values"], "uuid": "export_titanic_clean"}, {"downstream_blocks": ["empty_shadow"], "language": "python", "name": "hidden wildflower", "type": "data_loader", "upstream_blocks": ["export_titanic_clean"], "uuid": "hidden_wildflower"}, {"downstream_blocks": ["aged_cloud"], "language": "python", "name": "empty shadow", "type": "transformer", "upstream_blocks": ["hidden_wildflower"], "uuid": "empty_shadow"}, {"downstream_blocks": [], "language": "python", "name": "aged cloud", "type": "data_exporter", "upstream_blocks": ["empty_shadow"], "uuid": "aged_cloud"}, {"downstream_blocks": [], "language": "markdown", "name": "winter waterfall", "type": "markdown", "upstream_blocks": [], "uuid": "winter_waterfall"}, {"downstream_blocks": [], "language": "python", "name": "growth/test", "type": "transformer", "upstream_blocks": [], "uuid": "growth/test"}]}, "updated_at": 1702284950.404585}, "snowy_wind": {"added_at": null, "pipeline": {"description": null, "name": "snowy wind", "tags": [], "type": "python", "updated_at": "2023-09-29 22:42:53", "uuid": "snowy_wind", "blocks": [{"downstream_blocks": ["summer_fog", "empty_sun"], "language": "yaml", "name": "muddy glitter", "type": "data_loader", "upstream_blocks": [], "uuid": "muddy_glitter"}, {"downstream_blocks": ["empty_sun"], "language": "python", "name": "summer fog", "type": "transformer", "upstream_blocks": ["muddy_glitter"], "uuid": "summer_fog"}, {"downstream_blocks": [], "language": "yaml", "name": "empty sun", "type": "data_exporter", "upstream_blocks": ["summer_fog", "muddy_glitter"], "uuid": "empty_sun"}]}, "updated_at": 1702284950.404593}, "interactions_testing": {"added_at": null, "pipeline": {"description": null, "name": "interactions testing", "tags": ["interactions", "testing"], "type": "python", "updated_at": "2023-10-01 13:15:03", "uuid": "interactions_testing", "blocks": [{"downstream_blocks": ["check_age"], "language": "python", "name": "load country", "type": "custom", "upstream_blocks": [], "uuid": "load_country"}, {"downstream_blocks": ["wispy_smoke"], "language": "python", "name": "check age", "type": "custom", "upstream_blocks": ["load_country"], "uuid": "check_age"}, {"downstream_blocks": [], "language": "python", "name": "wispy smoke", "type": "custom", "upstream_blocks": ["check_age"], "uuid": "wispy_smoke"}]}, "updated_at": 1702284950.404601}, "green_moon": {"added_at": null, "pipeline": {"description": null, "name": "green moon", "tags": [], "type": "python", "updated_at": null, "uuid": "green_moon", "blocks": [{"downstream_blocks": [], "language": "python", "name": "2", "type": "data_loader", "upstream_blocks": [], "uuid": "letter_2"}, {"downstream_blocks": [], "language": "python", "name": "1", "type": "data_loader", "upstream_blocks": [], "uuid": "letter_1"}]}, "updated_at": 1702284950.404606}, "snowy_smoke": {"added_at": null, "pipeline": {"description": null, "name": "snowy smoke", "tags": null, "type": "python", "updated_at": null, "uuid": "snowy_smoke", "blocks": []}, "updated_at": 1702284950.404608}, "unified_pipeline_demo": {"added_at": null, "pipeline": {"description": null, "name": "unified pipeline demo", "tags": ["parallel", "testing"], "type": "python", "updated_at": "2023-09-24 05:13:00", "uuid": "unified_pipeline_demo", "blocks": [{"downstream_blocks": ["source_postgresql"], "language": "python", "name": "divine glitter", "type": "custom", "upstream_blocks": [], "uuid": "divine_glitter"}, {"downstream_blocks": ["source_postgresql"], "language": "python", "name": "nothing2", "type": "custom", "upstream_blocks": [], "uuid": "nothing2"}, {"downstream_blocks": ["falling_shadow"], "language": "yaml", "name": "source_postgresql", "type": "data_loader", "upstream_blocks": ["divine_glitter", "nothing2"], "uuid": "source_postgresql"}, {"downstream_blocks": [], "language": "python", "name": "falling shadow", "type": "data_exporter", "upstream_blocks": ["source_postgresql"], "uuid": "falling_shadow"}]}, "updated_at": 1702284950.40462}, "withered_wave": {"added_at": null, "pipeline": {"description": null, "name": "withered wave", "tags": [], "type": "python", "updated_at": null, "uuid": "withered_wave", "blocks": [{"downstream_blocks": [], "language": "python", "name": "withered_wave_block_3", "type": "transformer", "upstream_blocks": ["withered_wave_block_1", "withered_wave_block_2"], "uuid": "withered_wave_block_3"}, {"downstream_blocks": ["withered_wave_block_3"], "language": "python", "name": "withered_wave_block_2", "type": "data_loader", "upstream_blocks": [], "uuid": "withered_wave_block_2"}, {"downstream_blocks": ["withered_wave_block_3"], "language": "python", "name": "withered_wave_block_1", "type": "data_loader", "upstream_blocks": [], "uuid": "withered_wave_block_1"}]}, "updated_at": 1702284950.404628}, "pipeline_hook": {"added_at": null, "pipeline": {"description": null, "name": "pipeline hook", "tags": [], "type": "python", "updated_at": "2023-12-08T20:51:37+00:00", "uuid": "pipeline_hook", "blocks": [{"downstream_blocks": [], "language": "python", "name": "great fire", "type": "custom", "upstream_blocks": [], "uuid": "great_fire"}]}, "updated_at": 1702284950.404632}, "destination_parallel": {"added_at": null, "pipeline": {"description": null, "name": "destination parallel", "tags": ["testing"], "type": "python", "updated_at": "2023-09-24 05:46:41", "uuid": "destination_parallel", "blocks": [{"downstream_blocks": ["wandering_bush"], "language": "python", "name": "api_data", "type": "custom", "upstream_blocks": [], "uuid": "api_data"}, {"downstream_blocks": ["wandering_bush"], "language": "python", "name": "titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "titanic"}, {"downstream_blocks": [], "language": "yaml", "name": "wandering_bush", "type": "data_exporter", "upstream_blocks": ["api_data", "titanic"], "uuid": "wandering_bush"}]}, "updated_at": 1702284950.40464}, "frosty_night": {"added_at": null, "pipeline": {"description": null, "name": "frosty night", "tags": [], "type": "integration", "updated_at": "2023-08-03 20:35:27", "uuid": "frosty_night", "blocks": [{"downstream_blocks": [], "language": "yaml", "name": "little morning", "type": "data_loader", "upstream_blocks": [], "uuid": "little_morning"}]}, "updated_at": 1702284950.404643}, "wandering_waterfall": {"added_at": null, "pipeline": {"description": null, "name": "wandering waterfall", "tags": [], "type": "integration", "updated_at": "2023-09-22 22:55:09", "uuid": "wandering_waterfall", "blocks": [{"downstream_blocks": ["morning_brook"], "language": "yaml", "name": "still dust", "type": "data_loader", "upstream_blocks": [], "uuid": "still_dust"}, {"downstream_blocks": [], "language": "yaml", "name": "morning brook", "type": "data_exporter", "upstream_blocks": ["still_dust"], "uuid": "morning_brook"}]}, "updated_at": 1702284950.40465}, "di_client_2": {"added_at": null, "pipeline": {"description": null, "name": "di client 2", "tags": [], "type": "python", "updated_at": "2023-09-29 09:46:24", "uuid": "di_client_2", "blocks": [{"downstream_blocks": ["pgclient_destination"], "language": "python", "name": "pgclient", "type": "data_loader", "upstream_blocks": [], "uuid": "pgclient"}, {"downstream_blocks": [], "language": "python", "name": "pgclient destination", "type": "data_exporter", "upstream_blocks": ["pgclient"], "uuid": "pgclient_destination"}]}, "updated_at": 1702284950.404656}, "rough_violet": {"added_at": null, "pipeline": {"description": null, "name": "rough violet", "tags": [], "type": "python", "updated_at": null, "uuid": "rough_violet", "blocks": [{"downstream_blocks": [], "language": "python", "name": "lively river", "type": "global_data_product", "upstream_blocks": [], "uuid": "lively_river"}]}, "updated_at": 1702284950.404659}, "throbbing_firefly": {"added_at": null, "pipeline": {"description": null, "name": "throbbing firefly", "tags": [], "type": "python", "updated_at": "2023-09-29 03:48:27", "uuid": "throbbing_firefly", "blocks": [{"downstream_blocks": ["muddy_moon"], "language": "python", "name": "hidden star", "type": "custom", "upstream_blocks": [], "uuid": "hidden_star"}, {"downstream_blocks": [], "language": "python", "name": "muddy moon", "type": "custom", "upstream_blocks": ["hidden_star"], "uuid": "muddy_moon"}]}, "updated_at": 1702284950.404666}, "withered_flower": {"added_at": null, "pipeline": {"description": null, "name": "withered flower", "tags": [], "type": "python", "updated_at": "2023-12-09 09:32:33", "uuid": "withered_flower", "blocks": [{"downstream_blocks": ["wild_forest"], "language": "python", "name": "delicate grass", "type": "data_loader", "upstream_blocks": [], "uuid": "delicate_grass"}, {"downstream_blocks": ["aged_snowflake"], "language": "python", "name": "wild forest", "type": "data_exporter", "upstream_blocks": ["delicate_grass"], "uuid": "wild_forest"}, {"downstream_blocks": ["illusory_elm"], "language": "python", "name": "aged snowflake", "type": "data_exporter", "upstream_blocks": ["wild_forest"], "uuid": "aged_snowflake"}, {"downstream_blocks": ["elemental_ronin"], "language": "python", "name": "illusory_elm", "type": "data_loader", "upstream_blocks": ["aged_snowflake"], "uuid": "illusory_elm"}, {"downstream_blocks": [], "language": "python", "name": "elemental ronin", "type": "transformer", "upstream_blocks": ["illusory_elm"], "uuid": "elemental_ronin"}]}, "updated_at": 1702284950.404676}, "green_mountain": {"added_at": null, "pipeline": {"description": null, "name": "green mountain", "tags": null, "type": "python", "updated_at": null, "uuid": "green_mountain", "blocks": []}, "updated_at": 1702284950.404678}, "summer_night": {"added_at": null, "pipeline": {"description": null, "name": "summer night", "tags": [], "type": "python", "updated_at": null, "uuid": "summer_night", "blocks": [{"downstream_blocks": [], "language": "python", "name": "summer_night_block_3", "type": "transformer", "upstream_blocks": ["summer_night_block_1", "summer_night_block_2"], "uuid": "summer_night_block_3"}, {"downstream_blocks": ["summer_night_block_3"], "language": "python", "name": "summer_night_block_2", "type": "data_loader", "upstream_blocks": [], "uuid": "summer_night_block_2"}, {"downstream_blocks": ["summer_night_block_3"], "language": "python", "name": "summer_night_block_1", "type": "data_loader", "upstream_blocks": [], "uuid": "summer_night_block_1"}]}, "updated_at": 1702284950.404685}, "withered_dawn": {"added_at": null, "pipeline": {"description": "This data pipeline is used to export data from a DataFrame object to a Redshift cluster.", "name": "withered dawn", "tags": [], "type": "python", "updated_at": "2023-07-27 01:58:53", "uuid": "withered_dawn", "blocks": [{"downstream_blocks": [], "language": "markdown", "name": "Documentation for withered_dawn", "type": "markdown", "upstream_blocks": [], "uuid": "documentation_for_withered_dawn"}, {"downstream_blocks": [], "language": "markdown", "name": "Documentation for holy_bird", "type": "markdown", "upstream_blocks": [], "uuid": "documentation_for_holy_bird"}, {"downstream_blocks": [], "language": "python", "name": "holy bird", "type": "data_exporter", "upstream_blocks": [], "uuid": "holy_bird"}, {"downstream_blocks": [], "language": "markdown", "name": "Documentation for morning_waterfall", "type": "markdown", "upstream_blocks": [], "uuid": "documentation_for_morning_waterfall"}, {"downstream_blocks": ["misty_violet"], "language": "python", "name": "morning waterfall", "type": "data_exporter", "upstream_blocks": [], "uuid": "morning_waterfall"}, {"downstream_blocks": [], "language": "markdown", "name": "Documentation for misty_violet", "type": "markdown", "upstream_blocks": [], "uuid": "documentation_for_misty_violet"}, {"downstream_blocks": [], "language": "python", "name": "misty violet", "type": "data_exporter", "upstream_blocks": ["morning_waterfall"], "uuid": "misty_violet"}]}, "updated_at": 1702284950.404698}, "with_attached_hook": {"added_at": null, "pipeline": {"description": null, "name": "with_attached_hook", "tags": [], "type": "python", "updated_at": null, "uuid": "with_attached_hook", "blocks": [{"downstream_blocks": [], "language": "python", "name": "fancy paper", "type": "data_loader", "upstream_blocks": [], "uuid": "fancy_paper"}]}, "updated_at": 1702284950.404702}, "small_shapeasdasdadasd": {"added_at": null, "pipeline": {"description": null, "name": "small shapeasdasdadasd", "tags": [], "type": "python", "updated_at": "2023-09-18 03:43:52", "uuid": "small_shapeasdasdadasd", "blocks": [{"downstream_blocks": [], "language": "python", "name": "small_shapeasdasdadasd_block_1", "type": "data_loader", "upstream_blocks": [], "uuid": "small_shapeasdasdadasd_block_1"}, {"downstream_blocks": [], "language": "sql", "name": "frosty_night", "type": "data_exporter", "upstream_blocks": [], "uuid": "frosty_night"}, {"downstream_blocks": [], "language": "sql", "name": "fragrant_wildflower", "type": "data_exporter", "upstream_blocks": [], "uuid": "fragrant_wildflower"}, {"downstream_blocks": ["load_titanic"], "language": "python", "name": "holy_grass_block_3", "type": "data_exporter", "upstream_blocks": [], "uuid": "holy_grass_block_3"}, {"downstream_blocks": ["blue_paper"], "language": "python", "name": "load_titanic", "type": "data_loader", "upstream_blocks": ["holy_grass_block_3"], "uuid": "load_titanic"}, {"downstream_blocks": ["autumn_snow"], "language": "python", "name": "blue paper", "type": "global_data_product", "upstream_blocks": ["load_titanic"], "uuid": "blue_paper"}, {"downstream_blocks": ["weathered_shape"], "language": "python", "name": "autumn snow", "type": "data_exporter", "upstream_blocks": ["blue_paper"], "uuid": "autumn_snow"}, {"downstream_blocks": [], "language": "python", "name": "weathered shape", "type": "transformer", "upstream_blocks": ["autumn_snow"], "uuid": "weathered_shape"}, {"downstream_blocks": ["restless_morning"], "language": "python", "name": "cold meadow", "type": "transformer", "upstream_blocks": [], "uuid": "cold_meadow"}, {"downstream_blocks": [], "language": "python", "name": "restless morning", "type": "transformer", "upstream_blocks": ["cold_meadow"], "uuid": "restless_morning"}, {"downstream_blocks": [], "language": "python", "name": "wild lake", "type": "data_loader", "upstream_blocks": [], "uuid": "wild_lake"}, {"downstream_blocks": ["old_cherry"], "language": "python", "name": "old sunset", "type": "data_loader", "upstream_blocks": [], "uuid": "old_sunset"}, {"downstream_blocks": [], "language": "python", "name": "old cherry", "type": "data_loader", "upstream_blocks": ["old_sunset"], "uuid": "old_cherry"}, {"downstream_blocks": ["lively_sunset"], "language": "python", "name": "shy wood", "type": "data_loader", "upstream_blocks": [], "uuid": "shy_wood"}, {"downstream_blocks": ["still_fire"], "language": "python", "name": "lively sunset", "type": "data_loader", "upstream_blocks": ["shy_wood"], "uuid": "lively_sunset"}, {"downstream_blocks": ["twilight_water"], "language": "sql", "name": "still fire", "type": "custom", "upstream_blocks": ["lively_sunset"], "uuid": "still_fire"}, {"downstream_blocks": ["misty_pine"], "language": "python", "name": "twilight water", "type": "transformer", "upstream_blocks": ["still_fire"], "uuid": "twilight_water"}, {"downstream_blocks": ["export_titanic_clean"], "language": "python", "name": "misty pine", "type": "transformer", "upstream_blocks": ["twilight_water"], "uuid": "misty_pine"}, {"downstream_blocks": [], "language": "python", "name": "export_titanic_clean", "type": "data_exporter", "upstream_blocks": ["misty_pine"], "uuid": "export_titanic_clean"}]}, "updated_at": 1702284950.404732}, "muddy_firefly": {"added_at": null, "pipeline": {"description": null, "name": "muddy firefly", "tags": [], "type": "integration", "updated_at": "2023-08-03 18:30:45", "uuid": "muddy_firefly", "blocks": [{"downstream_blocks": ["cold_surf"], "language": "yaml", "name": "misty fire", "type": "data_loader", "upstream_blocks": [], "uuid": "misty_fire"}, {"downstream_blocks": ["restless_night"], "language": "python", "name": "cold surf", "type": "transformer", "upstream_blocks": ["misty_fire"], "uuid": "cold_surf"}, {"downstream_blocks": [], "language": "yaml", "name": "restless night", "type": "data_exporter", "upstream_blocks": ["cold_surf"], "uuid": "restless_night"}]}, "updated_at": 1702284950.404738}, "spark": {"added_at": null, "pipeline": {"description": null, "name": "spark", "tags": ["Spark", "PySpark"], "type": "pyspark", "updated_at": "2023-10-15 09:01:50", "uuid": "spark", "blocks": [{"downstream_blocks": [], "language": "python", "name": "quiet fire", "type": "data_loader", "upstream_blocks": [], "uuid": "quiet_fire"}]}, "updated_at": 1702284950.404742}, "floral_star": {"added_at": null, "pipeline": {"description": null, "name": "floral star", "tags": [], "type": "python", "updated_at": "2023-08-23 22:01:03", "uuid": "floral_star", "blocks": [{"downstream_blocks": [], "language": "python", "name": "lively night", "type": "data_loader", "upstream_blocks": [], "uuid": "lively_night"}]}, "updated_at": 1702284950.404746}, "dawn_thunder": {"added_at": null, "pipeline": {"description": null, "name": "dawn thunder", "tags": [], "type": "integration", "updated_at": "2023-08-03 20:27:42", "uuid": "dawn_thunder", "blocks": [{"downstream_blocks": ["autumn_grass"], "language": "yaml", "name": "green water", "type": "data_loader", "upstream_blocks": [], "uuid": "green_water"}, {"downstream_blocks": ["silent_dew"], "language": "python", "name": "autumn grass", "type": "transformer", "upstream_blocks": ["green_water"], "uuid": "autumn_grass"}, {"downstream_blocks": [], "language": "yaml", "name": "silent dew", "type": "data_exporter", "upstream_blocks": ["autumn_grass"], "uuid": "silent_dew"}]}, "updated_at": 1702284950.404754}, "young_shape": {"added_at": null, "pipeline": {"description": null, "name": "young shape", "tags": [], "type": "python", "updated_at": "2023-08-30 02:06:17", "uuid": "young_shape", "blocks": [{"downstream_blocks": ["young_shape_block_3"], "language": "python", "name": "young_shape_block_2", "type": "data_loader", "upstream_blocks": [], "uuid": "young_shape_block_2"}, {"downstream_blocks": ["young_shape_block_3"], "language": "python", "name": "young_shape_block_1", "type": "data_loader", "upstream_blocks": [], "uuid": "young_shape_block_1"}, {"downstream_blocks": [], "language": "python", "name": "young_shape_block_3", "type": "transformer", "upstream_blocks": ["young_shape_block_1", "young_shape_block_2"], "uuid": "young_shape_block_3"}, {"downstream_blocks": ["bar_chart_for_load_titanic_1693292685024", "histogram_for_load_titanic_1693348918007"], "language": "python", "name": "load_titanic", "type": "data_loader", "upstream_blocks": [], "uuid": "load_titanic"}, {"downstream_blocks": [], "language": "python", "name": "aged morning", "type": "data_loader", "upstream_blocks": [], "uuid": "aged_morning"}]}, "updated_at": 1702284950.404763}, "asdfasdfasdf111f": {"added_at": null, "pipeline": {"description": null, "name": "asdfasdfasdf111f", "tags": [], "type": "python", "updated_at": null, "uuid": "asdfasdfasdf111f", "blocks": [{"downstream_blocks": [], "language": "python", "name": "1", "type": "data_loader", "upstream_blocks": [], "uuid": "letter_1"}, {"downstream_blocks": [], "language": "python", "name": "2", "type": "data_loader", "upstream_blocks": [], "uuid": "letter_2"}, {"downstream_blocks": [], "language": "python", "name": "3", "type": "transformer", "upstream_blocks": [], "uuid": "letter_3"}]}, "updated_at": 1702284950.404769}, "test_interval_kwargs": {"added_at": null, "pipeline": {"description": null, "name": "test interval kwargs", "tags": [], "type": "python", "updated_at": "2023-07-24 06:33:18", "uuid": "test_interval_kwargs", "blocks": [{"downstream_blocks": [], "language": "python", "name": "little_glitter", "type": "data_loader", "upstream_blocks": [], "uuid": "little_glitter"}]}, "updated_at": 1702284950.404773}}}
+{
+  "groups": {
+    "type": {
+      "python": [
+        "silent_frost",
+        "cool_adfasddfgfasdfsdffgfdawn",
+        "weathered_bush",
+        "blue_fire",
+        "dry_firefly",
+        "icy_bush",
+        "snowy_morning",
+        "weathered_wave",
+        "restless_surf",
+        "dark_dust",
+        "pipeline_with_variables",
+        "data_integration_blocks_client",
+        "cool_adfasddfgfgfdawn",
+        "sparkling_river",
+        "icy_dawn",
+        "icy_darkness",
+        "fragrant_grass",
+        "little_dust",
+        "morning_silence",
+        "billowing_dream",
+        "restless_morning",
+        "snowy_silence",
+        "green_wildflower",
+        "pipeline_gdp",
+        "winter_pond",
+        "damp_butterfly",
+        "dynamic_dynamic_child_upstream",
+        "polished_fog",
+        "icy_voice",
+        "dynamic_reduce_all_levels",
+        "withered_sunset",
+        "billowing_bird",
+        "twilight_water",
+        "lively_wood",
+        "long_darkness",
+        "winter_shape",
+        "twilight_grass",
+        "cool_snosdfsdfwflake",
+        "delicate_thunder",
+        "using_ai_1",
+        "quiet_firefly",
+        "spring_dew",
+        "dawn_meadow",
+        "cool_adfasdfdawn_copy",
+        "winter_cherry",
+        "black_bird",
+        "crystal_herald",
+        "little_sea",
+        "red_haze",
+        "letter_22213144442312",
+        "purple_sun",
+        "ancient_water",
+        "wild_rain",
+        "interactions_testing_2",
+        "snowflake",
+        "delicate_glade",
+        "snowy_snow",
+        "dawn_frost",
+        "white_river",
+        "interactions_trigger",
+        "autumn_sky",
+        "cold_moon",
+        "fragrant_mountain",
+        "hidden_dew",
+        "red_morning",
+        "young_glitter",
+        "shy_pond",
+        "proud_pond",
+        "asdfasdfasdff",
+        "billowing_field",
+        "purple_frost",
+        "patient_wind",
+        "crimson_surf",
+        "restless_night",
+        "proud_tree",
+        "unified_pipeline",
+        "falling_smoke",
+        "dry_shape",
+        "solitary_star",
+        "old_shape",
+        "ancient_rain",
+        "holy_river",
+        "ancient_sea",
+        "icy_water",
+        "di_client",
+        "example_pipeline",
+        "dbt_pipeline",
+        "rough_water",
+        "hidden_night",
+        "fragrant_sound",
+        "cool_adfasdfdawn",
+        "wispy_field",
+        "long_firefly",
+        "pipeline_that_has_gdp_copy",
+        "dynamic_pipeline_testing",
+        "long_wave",
+        "damp_silence",
+        "winter_bird",
+        "shy_bush",
+        "polished_snow",
+        "divine_butterfly",
+        "dawn_flower",
+        "throbbing_wave",
+        "holy_grass",
+        "white_cloud",
+        "elden_glade",
+        "dynamic_2",
+        "unify_pipeline_destination",
+        "rough_wind",
+        "pipeline_that_has_gdp",
+        "misty_morning",
+        "proud_grass",
+        "wispy_knight",
+        "unify_destination_block_python",
+        "white_feather",
+        "billowing_waterfall",
+        "lively_shadow",
+        "purple_morning",
+        "user_transactions",
+        "crimson_water",
+        "snowy_wind",
+        "interactions_testing",
+        "green_moon",
+        "snowy_smoke",
+        "unified_pipeline_demo",
+        "withered_wave",
+        "pipeline_hook",
+        "destination_parallel",
+        "di_client_2",
+        "rough_violet",
+        "throbbing_firefly",
+        "withered_flower",
+        "green_mountain",
+        "summer_night",
+        "withered_dawn",
+        "with_attached_hook",
+        "small_shapeasdasdadasd",
+        "floral_star",
+        "young_shape",
+        "asdfasdfasdf111f",
+        "test_interval_kwargs"
+      ],
+      "streaming": [
+        "red_snow",
+        "young_wave",
+        "rough_flower",
+        "hidden_sea",
+        "quiet_rain",
+        "morning_rain",
+        "ancient_forest",
+        "aged_violet",
+        "small_shape"
+      ],
+      "integration": [
+        "solitary_sky",
+        "spring_smoke",
+        "withered_leaf",
+        "wild_wind",
+        "floral_field",
+        "delicate_forest",
+        "holy_sound",
+        "letter_2221314afsdfsdf4442312",
+        "throbbing_hill",
+        "patient_mountain",
+        "withered_feather",
+        "lingering_dew",
+        "floral_night",
+        "data_integration_pipeline_normal_test",
+        "summer_resonance",
+        "dry_rain",
+        "lingering_voice",
+        "late_wind",
+        "twilight_frog",
+        "frosty_night",
+        "wandering_waterfall",
+        "muddy_firefly",
+        "dawn_thunder"
+      ],
+      "pyspark": [
+        "spark"
+      ]
+    }
+  },
+  "models": {
+    "silent_frost": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "silent frost",
+        "tags": [],
+        "type": "python",
+        "uuid": "silent_frost",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "misty_cherry"
+            ],
+            "language": "python",
+            "name": "dark pond",
+            "type": "global_data_product",
+            "upstream_blocks": [],
+            "uuid": "dark_pond"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "misty cherry",
+            "type": "transformer",
+            "upstream_blocks": [
+              "dark_pond"
+            ],
+            "uuid": "misty_cherry"
+          }
+        ]
+      },
+      "updated_at": 1702284950.402959
+    },
+    "red_snow": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "red snow",
+        "tags": null,
+        "type": "streaming",
+        "updated_at": null,
+        "uuid": "red_snow",
+        "blocks": []
+      },
+      "updated_at": 1702284950.402966
+    },
+    "cool_adfasddfgfasdfsdffgfdawn": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "cool adfasddfgfasdfsdffgfdawn",
+        "tags": [],
+        "type": "python",
+        "updated_at": null,
+        "uuid": "cool_adfasddfgfasdfsdffgfdawn",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "1",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "letter_1"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "2",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "letter_2"
+          }
+        ]
+      },
+      "updated_at": 1702284950.402973
+    },
+    "weathered_bush": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "weathered bush",
+        "tags": [],
+        "type": "python",
+        "uuid": "weathered_bush",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "fragrant dust",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "fragrant_dust"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "proud dream",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "proud_dream"
+          }
+        ]
+      },
+      "updated_at": 1702284950.40298
+    },
+    "blue_fire": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "blue fire",
+        "tags": [],
+        "type": "python",
+        "uuid": "blue_fire",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "autumn_dew"
+            ],
+            "language": "python",
+            "name": "load_data_from_internet",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_data_from_internet"
+          },
+          {
+            "downstream_blocks": [
+              "autumn_dew"
+            ],
+            "language": "sql",
+            "name": "broken bush",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "broken_bush"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "autumn dew",
+            "type": "transformer",
+            "upstream_blocks": [
+              "broken_bush",
+              "load_data_from_internet"
+            ],
+            "uuid": "autumn_dew"
+          }
+        ]
+      },
+      "updated_at": 1702284950.40299
+    },
+    "dry_firefly": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "dry firefly",
+        "tags": [],
+        "type": "python",
+        "uuid": "dry_firefly",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "cool_star"
+            ],
+            "language": "python",
+            "name": "summer breeze",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "summer_breeze"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "cool star",
+            "type": "transformer",
+            "upstream_blocks": [
+              "summer_breeze"
+            ],
+            "uuid": "cool_star"
+          }
+        ]
+      },
+      "updated_at": 1702284950.402997
+    },
+    "young_wave": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "young wave",
+        "tags": [],
+        "type": "streaming",
+        "updated_at": null,
+        "uuid": "young_wave",
+        "blocks": []
+      },
+      "updated_at": 1702284950.403
+    },
+    "rough_flower": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "rough flower",
+        "tags": [],
+        "type": "streaming",
+        "uuid": "rough_flower",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "patient_cloud"
+            ],
+            "language": "yaml",
+            "name": "falling glitter",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "falling_glitter"
+          },
+          {
+            "downstream_blocks": [
+              "crimson_breeze"
+            ],
+            "language": "python",
+            "name": "patient cloud",
+            "type": "transformer",
+            "upstream_blocks": [
+              "falling_glitter"
+            ],
+            "uuid": "patient_cloud"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "crimson breeze",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "patient_cloud"
+            ],
+            "uuid": "crimson_breeze"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403009
+    },
+    "icy_bush": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "icy bush",
+        "tags": [],
+        "type": "python",
+        "uuid": "icy_bush",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "restless_lake"
+            ],
+            "language": "python",
+            "name": "load_data_from_internet",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_data_from_internet"
+          },
+          {
+            "downstream_blocks": [
+              "restless_lake"
+            ],
+            "language": "sql",
+            "name": "cool bush",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "cool_bush"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "restless lake",
+            "type": "transformer",
+            "upstream_blocks": [
+              "cool_bush",
+              "load_data_from_internet"
+            ],
+            "uuid": "restless_lake"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403018
+    },
+    "snowy_morning": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "snowy morning",
+        "tags": [],
+        "type": "python",
+        "uuid": "snowy_morning",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "little dipper",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "little_dipper"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "proud grass",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "proud_grass"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "winter smoke",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "winter_smoke"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403027
+    },
+    "weathered_wave": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "weathered wave",
+        "tags": null,
+        "type": "python",
+        "updated_at": null,
+        "uuid": "weathered_wave",
+        "blocks": []
+      },
+      "updated_at": 1702284950.40303
+    },
+    "restless_surf": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "example_pipeline",
+        "tags": [],
+        "type": "python",
+        "uuid": "restless_surf",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "fill_in_missing_values",
+              "summer_dew",
+              "wandering_voice",
+              "blue_haze",
+              "solitary_moon",
+              "spring_feather"
+            ],
+            "language": "python",
+            "name": "load_titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_titanic"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "spring feather",
+            "type": "markdown",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "spring_feather"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "polished field",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "polished_field"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "solitary moon",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "solitary_moon"
+          },
+          {
+            "downstream_blocks": [
+              "autumn_sound"
+            ],
+            "language": "python",
+            "name": "blue haze",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "blue_haze"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "autumn sound",
+            "type": "dbt",
+            "upstream_blocks": [
+              "blue_haze"
+            ],
+            "uuid": "autumn_sound"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "wandering voice",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "wandering_voice"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "summer dew",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "summer_dew"
+          },
+          {
+            "downstream_blocks": [
+              "export_titanic_clean"
+            ],
+            "language": "python",
+            "name": "fill_in_missing_values",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "fill_in_missing_values"
+          },
+          {
+            "downstream_blocks": [
+              "hidden_wildflower"
+            ],
+            "language": "python",
+            "name": "export_titanic_clean",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "fill_in_missing_values"
+            ],
+            "uuid": "export_titanic_clean"
+          },
+          {
+            "downstream_blocks": [
+              "empty_shadow"
+            ],
+            "language": "python",
+            "name": "hidden wildflower",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "export_titanic_clean"
+            ],
+            "uuid": "hidden_wildflower"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "empty shadow",
+            "type": "transformer",
+            "upstream_blocks": [
+              "hidden_wildflower"
+            ],
+            "uuid": "empty_shadow"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "winter waterfall",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "winter_waterfall"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403057
+    },
+    "dark_dust": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "dark dust",
+        "tags": [],
+        "type": "python",
+        "uuid": "dark_dust",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "summer_wood"
+            ],
+            "language": "python",
+            "name": "quiet violet",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "quiet_violet"
+          },
+          {
+            "downstream_blocks": [
+              "crimson_frog"
+            ],
+            "language": "python",
+            "name": "summer wood",
+            "type": "transformer",
+            "upstream_blocks": [
+              "quiet_violet"
+            ],
+            "uuid": "summer_wood"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "crimson frog",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "summer_wood"
+            ],
+            "uuid": "crimson_frog"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "purple dawn",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "purple_dawn"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403065
+    },
+    "pipeline_with_variables": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "pipeline with variables",
+        "tags": [
+          "AWS",
+          "Azure"
+        ],
+        "type": "python",
+        "updated_at": null,
+        "uuid": "pipeline_with_variables",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "twilight paper",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "twilight_paper"
+          }
+        ]
+      },
+      "updated_at": 1702284950.40307
+    },
+    "data_integration_blocks_client": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "data integration blocks client",
+        "tags": [],
+        "type": "python",
+        "uuid": "data_integration_blocks_client",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "destination_pg_yaml",
+              "source_pg_python"
+            ],
+            "language": "yaml",
+            "name": "source pg yaml",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "withered_smoke"
+            ],
+            "uuid": "source_pg_yaml"
+          },
+          {
+            "downstream_blocks": [
+              "destination_pg_yaml"
+            ],
+            "language": "python",
+            "name": "titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "titanic"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "destination pg yaml",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "source_pg_yaml",
+              "titanic"
+            ],
+            "uuid": "destination_pg_yaml"
+          },
+          {
+            "downstream_blocks": [
+              "destination_pg_python"
+            ],
+            "language": "python",
+            "name": "source pg python",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "withered_smoke",
+              "withered_wildflower",
+              "source_pg_yaml"
+            ],
+            "uuid": "source_pg_python"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "destination pg python",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "source_pg_python"
+            ],
+            "uuid": "destination_pg_python"
+          },
+          {
+            "downstream_blocks": [
+              "source_pg_python",
+              "source_pg_yaml"
+            ],
+            "language": "python",
+            "name": "withered smoke",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "withered_smoke"
+          },
+          {
+            "downstream_blocks": [
+              "source_pg_python"
+            ],
+            "language": "python",
+            "name": "withered wildflower",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "withered_wildflower"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403086
+    },
+    "hidden_sea": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "hidden sea",
+        "tags": null,
+        "type": "streaming",
+        "updated_at": null,
+        "uuid": "hidden_sea",
+        "blocks": []
+      },
+      "updated_at": 1702284950.403088
+    },
+    "cool_adfasddfgfgfdawn": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "cool adfasddfgfgfdawn",
+        "tags": [],
+        "type": "python",
+        "updated_at": null,
+        "uuid": "cool_adfasddfgfgfdawn",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "2",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "letter_2"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "1",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "letter_1"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403094
+    },
+    "sparkling_river": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "sparkling river",
+        "tags": [],
+        "type": "python",
+        "uuid": "sparkling_river",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "Documentation for solitary_butterfly",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "documentation_for_solitary_butterfly"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "solitary butterfly",
+            "type": "transformer",
+            "upstream_blocks": [],
+            "uuid": "solitary_butterfly"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "purple rain",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "purple_rain"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403102
+    },
+    "icy_dawn": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "icy dawn",
+        "tags": [],
+        "type": "python",
+        "uuid": "icy_dawn",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "r",
+            "name": "throbbing sun",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "throbbing_sun"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "old waterfall",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "old_waterfall"
+          },
+          {
+            "downstream_blocks": [
+              "solitary_rain"
+            ],
+            "language": "r",
+            "name": "empty feather",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "empty_feather"
+          },
+          {
+            "downstream_blocks": [
+              "winter_sunset"
+            ],
+            "language": "sql",
+            "name": "solitary rain",
+            "type": "transformer",
+            "upstream_blocks": [
+              "empty_feather"
+            ],
+            "uuid": "solitary_rain"
+          },
+          {
+            "downstream_blocks": [
+              "frosty_night"
+            ],
+            "language": "r",
+            "name": "winter sunset",
+            "type": "transformer",
+            "upstream_blocks": [
+              "solitary_rain"
+            ],
+            "uuid": "winter_sunset"
+          },
+          {
+            "downstream_blocks": [
+              "shy_moon"
+            ],
+            "language": "sql",
+            "name": "frosty night",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "winter_sunset"
+            ],
+            "uuid": "frosty_night"
+          },
+          {
+            "downstream_blocks": [
+              "icy_bird"
+            ],
+            "language": "r",
+            "name": "shy moon",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "frosty_night"
+            ],
+            "uuid": "shy_moon"
+          },
+          {
+            "downstream_blocks": [
+              "icy_thunder"
+            ],
+            "language": "python",
+            "name": "icy bird",
+            "type": "transformer",
+            "upstream_blocks": [
+              "shy_moon"
+            ],
+            "uuid": "icy_bird"
+          },
+          {
+            "downstream_blocks": [
+              "restless_glitter"
+            ],
+            "language": "python",
+            "name": "icy thunder",
+            "type": "transformer",
+            "upstream_blocks": [
+              "icy_bird"
+            ],
+            "uuid": "icy_thunder"
+          },
+          {
+            "downstream_blocks": [
+              "withered_wood"
+            ],
+            "language": "python",
+            "name": "restless glitter",
+            "type": "transformer",
+            "upstream_blocks": [
+              "icy_thunder"
+            ],
+            "uuid": "restless_glitter"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "withered wood",
+            "type": "transformer",
+            "upstream_blocks": [
+              "restless_glitter"
+            ],
+            "uuid": "withered_wood"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403125
+    },
+    "icy_darkness": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "icy darkness",
+        "tags": [],
+        "type": "python",
+        "updated_at": null,
+        "uuid": "icy_darkness",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "dawn_water"
+            ],
+            "language": "python",
+            "name": "morning darkness",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "morning_darkness"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "dawn water",
+            "type": "transformer",
+            "upstream_blocks": [
+              "morning_darkness"
+            ],
+            "uuid": "dawn_water"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403132
+    },
+    "fragrant_grass": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "pipeline with variables",
+        "tags": [
+          "demo"
+        ],
+        "type": "python",
+        "uuid": "fragrant_grass",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "twilight paper",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "twilight_paper"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403137
+    },
+    "little_dust": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "little dust",
+        "tags": [],
+        "type": "python",
+        "uuid": "little_dust",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "restless voice",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "restless_voice"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403142
+    },
+    "solitary_sky": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "solitary sky",
+        "tags": [],
+        "type": "integration",
+        "uuid": "solitary_sky",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "green voice",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "green_voice"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403146
+    },
+    "morning_silence": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "morning silence",
+        "tags": [],
+        "type": "python",
+        "uuid": "morning_silence",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "Documentation for late_sun",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "documentation_for_late_sun"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "late sun",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "late_sun"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403151
+    },
+    "billowing_dream": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "billowing dream",
+        "tags": [],
+        "type": "python",
+        "uuid": "billowing_dream",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "small_frost"
+            ],
+            "language": "python",
+            "name": "lively violet",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "lively_violet"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "small frost",
+            "type": "global_data_product",
+            "upstream_blocks": [
+              "lively_violet"
+            ],
+            "uuid": "small_frost"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403157
+    },
+    "spring_smoke": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "spring smoke",
+        "tags": [],
+        "type": "integration",
+        "uuid": "spring_smoke",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "quiet sea",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "quiet_sea"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403161
+    },
+    "restless_morning": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "restless morning",
+        "tags": [],
+        "type": "python",
+        "uuid": "restless_morning",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "black_tree"
+            ],
+            "language": "python",
+            "name": "still shape",
+            "type": "global_data_product",
+            "upstream_blocks": [],
+            "uuid": "still_shape"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "black tree",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "still_shape"
+            ],
+            "uuid": "black_tree"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403167
+    },
+    "snowy_silence": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "snowy silence",
+        "tags": [],
+        "type": "python",
+        "uuid": "snowy_silence",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "old flower",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "old_flower"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "late morning",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "late_morning"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403173
+    },
+    "green_wildflower": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "green wildflower",
+        "tags": [],
+        "type": "python",
+        "uuid": "green_wildflower",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "wild_leaf"
+            ],
+            "language": "python",
+            "name": "load_data_from_internet",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_data_from_internet"
+          },
+          {
+            "downstream_blocks": [
+              "wild_leaf"
+            ],
+            "language": "sql",
+            "name": "icy star",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "icy_star"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "wild leaf",
+            "type": "transformer",
+            "upstream_blocks": [
+              "icy_star",
+              "load_data_from_internet"
+            ],
+            "uuid": "wild_leaf"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403181
+    },
+    "pipeline_gdp": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "pipeline gdp",
+        "tags": [],
+        "type": "python",
+        "uuid": "pipeline_gdp",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "histogram_for_restaurant_user_transactions_1693978385426",
+              "line_chart_for_restaurant_user_transactions_1693979438332",
+              "table_for_restaurant_user_transactions_1693979819546",
+              "time_series_line_chart_for_restaurant_user_transactions_1693981628999"
+            ],
+            "language": "python",
+            "name": "restaurant_user_transactions",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "restaurant_user_transactions"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "polished brook",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "polished_brook"
+          },
+          {
+            "downstream_blocks": [
+              "time_series_bar_chart_for_product_purchases_1693981396696"
+            ],
+            "language": "python",
+            "name": "product_purchases",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "product_purchases"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403198
+    },
+    "withered_leaf": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "withered leaf",
+        "tags": [],
+        "type": "integration",
+        "uuid": "withered_leaf",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "polished_pine"
+            ],
+            "language": "yaml",
+            "name": "throbbing grass",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "throbbing_grass"
+          },
+          {
+            "downstream_blocks": [
+              "broken_dust"
+            ],
+            "language": "python",
+            "name": "polished pine",
+            "type": "transformer",
+            "upstream_blocks": [
+              "throbbing_grass"
+            ],
+            "uuid": "polished_pine"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "broken dust",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "polished_pine"
+            ],
+            "uuid": "broken_dust"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403205
+    },
+    "winter_pond": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "winter pond",
+        "tags": [],
+        "type": "python",
+        "uuid": "winter_pond",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "broken dawn",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "broken_dawn"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403209
+    },
+    "damp_butterfly": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "damp butterfly",
+        "tags": [],
+        "type": "python",
+        "uuid": "damp_butterfly",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "damp pond",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "damp_pond"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403213
+    },
+    "dynamic_dynamic_child_upstream": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "dynamic dynamic child upstream",
+        "tags": [
+          "dynamic"
+        ],
+        "type": "python",
+        "uuid": "dynamic_dynamic_child_upstream",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "dynamic_child_a",
+              "dynamic_child_child_a",
+              "upstream_reduce_output_multiple"
+            ],
+            "language": "python",
+            "name": "dynamic_parent_b",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "dynamic_parent_b"
+          },
+          {
+            "downstream_blocks": [
+              "dynamic_child_child_a",
+              "dynamic_child_child_b"
+            ],
+            "language": "python",
+            "name": "dynamic_child_a",
+            "type": "transformer",
+            "upstream_blocks": [
+              "dynamic_parent_b"
+            ],
+            "uuid": "dynamic_child_a"
+          },
+          {
+            "downstream_blocks": [
+              "upstream_reduce_output_multiple"
+            ],
+            "language": "python",
+            "name": "dynamic_child_child_a",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "dynamic_parent_b",
+              "dynamic_child_a"
+            ],
+            "uuid": "dynamic_child_child_a"
+          },
+          {
+            "downstream_blocks": [
+              "upstream_reduce_output_multiple"
+            ],
+            "language": "python",
+            "name": "dynamic_child_child_b",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "dynamic_child_a"
+            ],
+            "uuid": "dynamic_child_child_b"
+          },
+          {
+            "downstream_blocks": [
+              "upstream_reduce_output"
+            ],
+            "language": "python",
+            "name": "upstream reduce output multiple",
+            "type": "custom",
+            "upstream_blocks": [
+              "dynamic_child_child_a",
+              "dynamic_child_child_b",
+              "dynamic_parent_b"
+            ],
+            "uuid": "upstream_reduce_output_multiple"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "upstream_reduce_output",
+            "type": "custom",
+            "upstream_blocks": [
+              "upstream_reduce_output_multiple"
+            ],
+            "uuid": "upstream_reduce_output"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403226
+    },
+    "polished_fog": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "polished fog",
+        "tags": [],
+        "type": "python",
+        "uuid": "polished_fog",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "cool_shadow"
+            ],
+            "language": "python",
+            "name": "withered sun",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "withered_sun"
+          },
+          {
+            "downstream_blocks": [
+              "cool_shadow"
+            ],
+            "language": "sql",
+            "name": "winter moon",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "winter_moon"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "cool shadow",
+            "type": "transformer",
+            "upstream_blocks": [
+              "winter_moon",
+              "withered_sun"
+            ],
+            "uuid": "cool_shadow"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403234
+    },
+    "wild_wind": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "wild wind",
+        "tags": [],
+        "type": "integration",
+        "uuid": "wild_wind",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "small_mountain"
+            ],
+            "language": "yaml",
+            "name": "cold shape",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "cold_shape"
+          },
+          {
+            "downstream_blocks": [
+              "dry_breeze"
+            ],
+            "language": "python",
+            "name": "small mountain",
+            "type": "transformer",
+            "upstream_blocks": [
+              "cold_shape"
+            ],
+            "uuid": "small_mountain"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "dry breeze",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "small_mountain"
+            ],
+            "uuid": "dry_breeze"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403241
+    },
+    "icy_voice": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "icy voice",
+        "tags": null,
+        "type": "python",
+        "updated_at": null,
+        "uuid": "icy_voice",
+        "blocks": []
+      },
+      "updated_at": 1702284950.403243
+    },
+    "dynamic_reduce_all_levels": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "dynamic reduce all levels",
+        "tags": [
+          "dynamic"
+        ],
+        "type": "python",
+        "uuid": "dynamic_reduce_all_levels",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "child_a_30"
+            ],
+            "language": "python",
+            "name": "parent 30",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "parent_30"
+          },
+          {
+            "downstream_blocks": [
+              "child_b_30",
+              "broken_shadow"
+            ],
+            "language": "python",
+            "name": "child a 30",
+            "type": "transformer",
+            "upstream_blocks": [
+              "parent_30"
+            ],
+            "uuid": "child_a_30"
+          },
+          {
+            "downstream_blocks": [
+              "child_c_30"
+            ],
+            "language": "python",
+            "name": "child b 30",
+            "type": "custom",
+            "upstream_blocks": [
+              "child_a_30"
+            ],
+            "uuid": "child_b_30"
+          },
+          {
+            "downstream_blocks": [
+              "child_d_30"
+            ],
+            "language": "python",
+            "name": "child c 30",
+            "type": "custom",
+            "upstream_blocks": [
+              "child_b_30"
+            ],
+            "uuid": "child_c_30"
+          },
+          {
+            "downstream_blocks": [
+              "final_30",
+              "purple_lake"
+            ],
+            "language": "python",
+            "name": "child d 30",
+            "type": "custom",
+            "upstream_blocks": [
+              "child_c_30"
+            ],
+            "uuid": "child_d_30"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "final 30",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "child_d_30"
+            ],
+            "uuid": "final_30"
+          },
+          {
+            "downstream_blocks": [
+              "broken_shadow",
+              "purple_lake"
+            ],
+            "language": "python",
+            "name": "load_titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_titanic"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "broken shadow",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic",
+              "child_a_30"
+            ],
+            "uuid": "broken_shadow"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "purple lake",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "load_titanic",
+              "child_d_30"
+            ],
+            "uuid": "purple_lake"
+          }
+        ]
+      },
+      "updated_at": 1702284950.40326
+    },
+    "withered_sunset": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "example_pipeline",
+        "tags": [],
+        "type": "python",
+        "uuid": "withered_sunset",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "fill_in_missing_values",
+              "summer_dew",
+              "wandering_voice",
+              "blue_haze",
+              "solitary_moon",
+              "spring_feather"
+            ],
+            "language": "python",
+            "name": "load_titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_titanic"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "spring feather",
+            "type": "markdown",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "spring_feather"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "polished field",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "polished_field"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "solitary moon",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "solitary_moon"
+          },
+          {
+            "downstream_blocks": [
+              "autumn_sound"
+            ],
+            "language": "python",
+            "name": "blue haze",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "blue_haze"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "autumn sound",
+            "type": "dbt",
+            "upstream_blocks": [
+              "blue_haze"
+            ],
+            "uuid": "autumn_sound"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "wandering voice",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "wandering_voice"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "summer dew",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "summer_dew"
+          },
+          {
+            "downstream_blocks": [
+              "export_titanic_clean"
+            ],
+            "language": "python",
+            "name": "fill_in_missing_values",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "fill_in_missing_values"
+          },
+          {
+            "downstream_blocks": [
+              "hidden_wildflower"
+            ],
+            "language": "python",
+            "name": "export_titanic_clean",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "fill_in_missing_values"
+            ],
+            "uuid": "export_titanic_clean"
+          },
+          {
+            "downstream_blocks": [
+              "empty_shadow"
+            ],
+            "language": "python",
+            "name": "hidden wildflower",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "export_titanic_clean"
+            ],
+            "uuid": "hidden_wildflower"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "empty shadow",
+            "type": "transformer",
+            "upstream_blocks": [
+              "hidden_wildflower"
+            ],
+            "uuid": "empty_shadow"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "winter waterfall",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "winter_waterfall"
+          }
+        ]
+      },
+      "updated_at": 1702284950.40329
+    },
+    "billowing_bird": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "billowing bird",
+        "tags": [],
+        "type": "python",
+        "uuid": "billowing_bird",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "throbbing_dawn"
+            ],
+            "language": "python",
+            "name": "titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "titanic"
+          },
+          {
+            "downstream_blocks": [
+              "throbbing_dawn"
+            ],
+            "language": "sql",
+            "name": "shy waterfall",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "shy_waterfall"
+          },
+          {
+            "downstream_blocks": [
+              "young_dew"
+            ],
+            "language": "python",
+            "name": "throbbing dawn",
+            "type": "transformer",
+            "upstream_blocks": [
+              "titanic",
+              "shy_waterfall"
+            ],
+            "uuid": "throbbing_dawn"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "young dew",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "throbbing_dawn"
+            ],
+            "uuid": "young_dew"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403299
+    },
+    "twilight_water": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "twilight water",
+        "tags": [],
+        "type": "python",
+        "uuid": "twilight_water",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "summer_grass"
+            ],
+            "language": "python",
+            "name": "still frost",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "still_frost"
+          },
+          {
+            "downstream_blocks": [
+              "cold_bird"
+            ],
+            "language": "python",
+            "name": "summer grass",
+            "type": "transformer",
+            "upstream_blocks": [
+              "still_frost"
+            ],
+            "uuid": "summer_grass"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "cold bird",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "summer_grass",
+              "load_data_from_internet"
+            ],
+            "uuid": "cold_bird"
+          },
+          {
+            "downstream_blocks": [
+              "cold_bird"
+            ],
+            "language": "python",
+            "name": "load_data_from_internet",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_data_from_internet"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403307
+    },
+    "lively_wood": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "lively wood",
+        "tags": [],
+        "type": "python",
+        "uuid": "lively_wood",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "demo/models/example/my_second_dbt_model"
+            ],
+            "language": "python",
+            "name": "nameless dawn",
+            "type": "sensor",
+            "upstream_blocks": [],
+            "uuid": "nameless_dawn"
+          },
+          {
+            "downstream_blocks": [
+              "demo/models/example/my_second_dbt_model"
+            ],
+            "language": "sql",
+            "name": "demo/models/example/my_first_dbt_model",
+            "type": "dbt",
+            "upstream_blocks": [
+              "aged_bush"
+            ],
+            "uuid": "demo/models/example/my_first_dbt_model"
+          },
+          {
+            "downstream_blocks": [
+              "demo/models/example/my_first_dbt_model"
+            ],
+            "language": "python",
+            "name": "aged bush",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "aged_bush"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "demo/models/example/my_second_dbt_model",
+            "type": "dbt",
+            "upstream_blocks": [
+              "nameless_dawn",
+              "demo/models/example/my_first_dbt_model"
+            ],
+            "uuid": "demo/models/example/my_second_dbt_model"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403316
+    },
+    "long_darkness": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "long darkness",
+        "tags": null,
+        "type": "python",
+        "updated_at": null,
+        "uuid": "long_darkness",
+        "blocks": []
+      },
+      "updated_at": 1702284950.403319
+    },
+    "floral_field": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "floral field",
+        "tags": [],
+        "type": "integration",
+        "uuid": "floral_field",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "wandering_cherry"
+            ],
+            "language": "yaml",
+            "name": "damp shape",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "damp_shape"
+          },
+          {
+            "downstream_blocks": [
+              "fragrant_mountain"
+            ],
+            "language": "python",
+            "name": "wandering cherry",
+            "type": "transformer",
+            "upstream_blocks": [
+              "damp_shape"
+            ],
+            "uuid": "wandering_cherry"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "fragrant mountain",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "wandering_cherry"
+            ],
+            "uuid": "fragrant_mountain"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403377
+    },
+    "winter_shape": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "winter shape",
+        "tags": [],
+        "type": "python",
+        "uuid": "winter_shape",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "proud_meadow"
+            ],
+            "language": "sql",
+            "name": "little field",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "little_field"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "proud meadow",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "little_field"
+            ],
+            "uuid": "proud_meadow"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "empty cherry",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "empty_cherry"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403385
+    },
+    "quiet_rain": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "quiet rain",
+        "tags": null,
+        "type": "streaming",
+        "updated_at": null,
+        "uuid": "quiet_rain",
+        "blocks": []
+      },
+      "updated_at": 1702284950.403387
+    },
+    "twilight_grass": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "twilight grass",
+        "tags": [],
+        "type": "python",
+        "updated_at": null,
+        "uuid": "twilight_grass",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "late fire",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "late_fire"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403391
+    },
+    "cool_snosdfsdfwflake": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "cool snosdfsdfwflake",
+        "tags": [],
+        "type": "python",
+        "updated_at": null,
+        "uuid": "cool_snosdfsdfwflake",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "cool_snosdfsdfwflake_block_3",
+            "type": "transformer",
+            "upstream_blocks": [
+              "cool_snosdfsdfwflake_block_1",
+              "cool_snosdfsdfwflake_block_2"
+            ],
+            "uuid": "cool_snosdfsdfwflake_block_3"
+          },
+          {
+            "downstream_blocks": [
+              "cool_snosdfsdfwflake_block_3"
+            ],
+            "language": "python",
+            "name": "cool_snosdfsdfwflake_block_2",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "cool_snosdfsdfwflake_block_2"
+          },
+          {
+            "downstream_blocks": [
+              "cool_snosdfsdfwflake_block_3"
+            ],
+            "language": "python",
+            "name": "cool_snosdfsdfwflake_block_1",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "cool_snosdfsdfwflake_block_1"
+          }
+        ]
+      },
+      "updated_at": 1702284950.4034
+    },
+    "delicate_thunder": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "delicate thunder",
+        "tags": null,
+        "type": "python",
+        "updated_at": null,
+        "uuid": "delicate_thunder",
+        "blocks": []
+      },
+      "updated_at": 1702284950.403402
+    },
+    "using_ai_1": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "using ai 1",
+        "tags": [],
+        "type": "python",
+        "uuid": "using_ai_1",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "snowy frost",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "snowy_frost"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403406
+    },
+    "quiet_firefly": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "quiet firefly",
+        "tags": [],
+        "type": "python",
+        "uuid": "quiet_firefly",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "lively water",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "lively_water"
+          }
+        ]
+      },
+      "updated_at": 1702284950.40341
+    },
+    "morning_rain": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "morning rain",
+        "tags": [],
+        "type": "streaming",
+        "updated_at": null,
+        "uuid": "morning_rain",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "restless_bush"
+            ],
+            "language": "yaml",
+            "name": "falling meadow",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "falling_meadow"
+          },
+          {
+            "downstream_blocks": [
+              "wandering_bush"
+            ],
+            "language": "python",
+            "name": "restless bush",
+            "type": "transformer",
+            "upstream_blocks": [
+              "falling_meadow"
+            ],
+            "uuid": "restless_bush"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "wandering bush",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "restless_bush"
+            ],
+            "uuid": "wandering_bush"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403417
+    },
+    "delicate_forest": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "delicate forest",
+        "tags": [],
+        "type": "integration",
+        "uuid": "delicate_forest",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "cool_feather"
+            ],
+            "language": "yaml",
+            "name": "silent brook",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "silent_brook"
+          },
+          {
+            "downstream_blocks": [
+              "small_sea"
+            ],
+            "language": "python",
+            "name": "cool feather",
+            "type": "transformer",
+            "upstream_blocks": [
+              "silent_brook"
+            ],
+            "uuid": "cool_feather"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "small sea",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "cool_feather"
+            ],
+            "uuid": "small_sea"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403424
+    },
+    "spring_dew": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "spring dew",
+        "tags": [],
+        "type": "python",
+        "uuid": "spring_dew",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "withered_wind"
+            ],
+            "language": "python",
+            "name": "twilight meadow",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "twilight_meadow"
+          },
+          {
+            "downstream_blocks": [
+              "withered_wind",
+              "twilight_pond"
+            ],
+            "language": "python",
+            "name": "lively darkness",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "lively_darkness"
+          },
+          {
+            "downstream_blocks": [
+              "twilight_pond"
+            ],
+            "language": "python",
+            "name": "withered wind",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "lively_darkness",
+              "twilight_meadow"
+            ],
+            "uuid": "withered_wind"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "twilight pond",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "withered_wind",
+              "lively_darkness"
+            ],
+            "uuid": "twilight_pond"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403432
+    },
+    "dawn_meadow": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "dawn meadow",
+        "tags": [],
+        "type": "python",
+        "uuid": "dawn_meadow",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "proud_snow"
+            ],
+            "language": "python",
+            "name": "load_data_from_internet",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_data_from_internet"
+          },
+          {
+            "downstream_blocks": [
+              "proud_snow"
+            ],
+            "language": "sql",
+            "name": "spring firefly",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "spring_firefly"
+          },
+          {
+            "downstream_blocks": [
+              "polished_sea"
+            ],
+            "language": "python",
+            "name": "proud snow",
+            "type": "transformer",
+            "upstream_blocks": [
+              "spring_firefly",
+              "load_data_from_internet"
+            ],
+            "uuid": "proud_snow"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "polished sea",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "proud_snow"
+            ],
+            "uuid": "polished_sea"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403442
+    },
+    "cool_adfasdfdawn_copy": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "cool_adfasdfdawn_copy",
+        "tags": [],
+        "type": "python",
+        "uuid": "cool_adfasdfdawn_copy",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "2",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "letter_2"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "3",
+            "type": "transformer",
+            "upstream_blocks": [],
+            "uuid": "letter_3"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "1",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "letter_1"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "holy water",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "holy_water"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "wild darkness",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "wild_darkness"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403453
+    },
+    "winter_cherry": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "winter cherry",
+        "tags": [],
+        "type": "python",
+        "uuid": "winter_cherry",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "extra_sales_from_tesla"
+            ],
+            "language": "python",
+            "name": "tesla",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "tesla"
+          },
+          {
+            "downstream_blocks": [
+              "upload_sales_info_to_tesla"
+            ],
+            "language": "python",
+            "name": "extra sales from tesla",
+            "type": "transformer",
+            "upstream_blocks": [
+              "tesla"
+            ],
+            "uuid": "extra_sales_from_tesla"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "upload sales info to tesla",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "extra_sales_from_tesla"
+            ],
+            "uuid": "upload_sales_info_to_tesla"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403459
+    },
+    "black_bird": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "black bird",
+        "tags": [],
+        "type": "python",
+        "uuid": "black_bird",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "ancient star",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "ancient_star"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403465
+    },
+    "crystal_herald": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "crystal herald",
+        "tags": [],
+        "type": "python",
+        "uuid": "crystal_herald",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "dynamic_child_generic_command",
+              "demo/models/example/my_first_dbt_model"
+            ],
+            "language": "python",
+            "name": "dynamic_parent_a",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "dynamic_parent_a"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "dynamic child generic command",
+            "type": "dbt",
+            "upstream_blocks": [
+              "dynamic_parent_a"
+            ],
+            "uuid": "dynamic_child_generic_command"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "demo/models/example/my_first_dbt_model",
+            "type": "dbt",
+            "upstream_blocks": [
+              "dynamic_parent_a"
+            ],
+            "uuid": "demo/models/example/my_first_dbt_model"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403475
+    },
+    "little_sea": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "little sea",
+        "tags": [],
+        "type": "python",
+        "uuid": "little_sea",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "lively_haze"
+            ],
+            "language": "python",
+            "name": "nameless sea",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "nameless_sea"
+          },
+          {
+            "downstream_blocks": [
+              "delicate_snowflake"
+            ],
+            "language": "python",
+            "name": "lively haze",
+            "type": "transformer",
+            "upstream_blocks": [
+              "nameless_sea"
+            ],
+            "uuid": "lively_haze"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "delicate snowflake",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "lively_haze"
+            ],
+            "uuid": "delicate_snowflake"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403481
+    },
+    "ancient_forest": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "ancient forest",
+        "tags": [
+          "identity",
+          "postgres",
+          "s3"
+        ],
+        "type": "streaming",
+        "updated_at": null,
+        "uuid": "ancient_forest",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "hidden_cherry"
+            ],
+            "language": "yaml",
+            "name": "cold fire",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "cold_fire"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "hidden cherry",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "cold_fire"
+            ],
+            "uuid": "hidden_cherry"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403487
+    },
+    "holy_sound": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "holy sound",
+        "tags": [],
+        "type": "integration",
+        "uuid": "holy_sound",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "damp_sea"
+            ],
+            "language": "yaml",
+            "name": "bold voice",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "bold_voice"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "damp sea",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "bold_voice"
+            ],
+            "uuid": "damp_sea"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403493
+    },
+    "red_haze": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "red haze",
+        "tags": [],
+        "type": "python",
+        "uuid": "red_haze",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "frosty_mountain"
+            ],
+            "language": "python",
+            "name": "load_data_from_internet",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "holy_cloud"
+            ],
+            "uuid": "load_data_from_internet"
+          },
+          {
+            "downstream_blocks": [
+              "load_data_from_internet"
+            ],
+            "language": "python",
+            "name": "holy cloud",
+            "type": "sensor",
+            "upstream_blocks": [],
+            "uuid": "holy_cloud"
+          },
+          {
+            "downstream_blocks": [
+              "frosty_mountain"
+            ],
+            "language": "sql",
+            "name": "weathered cloud",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "weathered_cloud"
+          },
+          {
+            "downstream_blocks": [
+              "wandering_darkness"
+            ],
+            "language": "python",
+            "name": "frosty mountain",
+            "type": "transformer",
+            "upstream_blocks": [
+              "weathered_cloud",
+              "load_data_from_internet"
+            ],
+            "uuid": "frosty_mountain"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "wandering darkness",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "frosty_mountain"
+            ],
+            "uuid": "wandering_darkness"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403507
+    },
+    "letter_22213144442312": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "22213144442312",
+        "tags": null,
+        "type": "python",
+        "updated_at": null,
+        "uuid": "letter_22213144442312",
+        "blocks": []
+      },
+      "updated_at": 1702284950.40351
+    },
+    "letter_2221314afsdfsdf4442312": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "2221314afsdfsdf4442312",
+        "tags": [
+          "identity",
+          "postgres",
+          "s3"
+        ],
+        "type": "integration",
+        "uuid": "letter_2221314afsdfsdf4442312",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "winter_sunset"
+            ],
+            "language": "python",
+            "name": "frosty firefly",
+            "type": "global_data_product",
+            "upstream_blocks": [],
+            "uuid": "frosty_firefly"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "winter sunset",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "frosty_firefly"
+            ],
+            "uuid": "winter_sunset"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "polished sky",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "polished_sky"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "late flower",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "late_flower"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "load_data_from_internet",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_data_from_internet"
+          },
+          {
+            "downstream_blocks": [
+              "billowing_forest"
+            ],
+            "language": "python",
+            "name": "aged_bush",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "aged_bush"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "billowing forest",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "aged_bush"
+            ],
+            "uuid": "billowing_forest"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403525
+    },
+    "throbbing_hill": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "throbbing hill",
+        "tags": [],
+        "type": "integration",
+        "uuid": "throbbing_hill",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "dry_fog"
+            ],
+            "language": "yaml",
+            "name": "sparkling sea",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "sparkling_sea"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "dry fog",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "sparkling_sea"
+            ],
+            "uuid": "dry_fog"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403531
+    },
+    "purple_sun": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "purple sun",
+        "tags": null,
+        "type": "python",
+        "updated_at": null,
+        "uuid": "purple_sun",
+        "blocks": []
+      },
+      "updated_at": 1702284950.403533
+    },
+    "ancient_water": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "ancient water",
+        "tags": [
+          "dbt",
+          "partnerstack"
+        ],
+        "type": "python",
+        "uuid": "ancient_water",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "holy_dawn"
+            ],
+            "language": "python",
+            "name": "polished sun",
+            "type": "global_data_product",
+            "upstream_blocks": [],
+            "uuid": "polished_sun"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "holy dawn",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "polished_sun"
+            ],
+            "uuid": "holy_dawn"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "empty resonance",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "empty_resonance"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "holy forest",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "holy_forest"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403543
+    },
+    "wild_rain": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "wild rain",
+        "tags": [],
+        "type": "python",
+        "uuid": "wild_rain",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "load_titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_titanic"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403547
+    },
+    "interactions_testing_2": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "interactions testing 2",
+        "tags": [],
+        "type": "python",
+        "uuid": "interactions_testing_2",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "falling butterfly",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "falling_butterfly"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "cold glitter",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "cold_glitter"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "white snow",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "white_snow"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403554
+    },
+    "patient_mountain": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "patient mountain",
+        "tags": [],
+        "type": "integration",
+        "uuid": "patient_mountain",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "bitter_morning"
+            ],
+            "language": "yaml",
+            "name": "patient sky",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "patient_sky"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "bitter morning",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "patient_sky"
+            ],
+            "uuid": "bitter_morning"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403561
+    },
+    "aged_violet": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "aged violet",
+        "tags": [],
+        "type": "streaming",
+        "updated_at": null,
+        "uuid": "aged_violet",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "dry_flower"
+            ],
+            "language": "yaml",
+            "name": "lively bush",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "lively_bush"
+          },
+          {
+            "downstream_blocks": [
+              "white_pine"
+            ],
+            "language": "python",
+            "name": "dry flower",
+            "type": "transformer",
+            "upstream_blocks": [
+              "lively_bush"
+            ],
+            "uuid": "dry_flower"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "white pine",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "dry_flower"
+            ],
+            "uuid": "white_pine"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403569
+    },
+    "snowflake": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "snowflake",
+        "tags": [],
+        "type": "python",
+        "uuid": "snowflake",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "still sun",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "still_sun"
+          },
+          {
+            "downstream_blocks": [
+              "demo/models/example/my_first_dbt_model"
+            ],
+            "language": "python",
+            "name": "wandering sun",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "wandering_sun"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "demo/models/example/my_first_dbt_model",
+            "type": "dbt",
+            "upstream_blocks": [
+              "wandering_sun"
+            ],
+            "uuid": "demo/models/example/my_first_dbt_model"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403576
+    },
+    "delicate_glade": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "delicate glade",
+        "tags": [],
+        "type": "python",
+        "uuid": "delicate_glade",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "rough silence",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "rough_silence"
+          }
+        ]
+      },
+      "updated_at": 1702284950.40358
+    },
+    "snowy_snow": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "pipeline with variables",
+        "tags": [
+          "Spark",
+          "PySpark"
+        ],
+        "type": "python",
+        "uuid": "snowy_snow",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "twilight paper",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "twilight_paper"
+          },
+          {
+            "downstream_blocks": [
+              "misty_mountain"
+            ],
+            "language": "python",
+            "name": "floral_hill1111111111",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "floral_hill1111111111"
+          },
+          {
+            "downstream_blocks": [
+              "lingering_rain"
+            ],
+            "language": "python",
+            "name": "misty mountain",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "floral_hill1111111111"
+            ],
+            "uuid": "misty_mountain"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "lingering rain",
+            "type": "transformer",
+            "upstream_blocks": [
+              "misty_mountain"
+            ],
+            "uuid": "lingering_rain"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403588
+    },
+    "dawn_frost": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "dawn frost",
+        "tags": [],
+        "type": "python",
+        "uuid": "dawn_frost",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "broken_meadow"
+            ],
+            "language": "python",
+            "name": "red feather",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "red_feather"
+          },
+          {
+            "downstream_blocks": [
+              "spring_river"
+            ],
+            "language": "python",
+            "name": "broken meadow",
+            "type": "transformer",
+            "upstream_blocks": [
+              "red_feather"
+            ],
+            "uuid": "broken_meadow"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "spring river",
+            "type": "custom",
+            "upstream_blocks": [
+              "broken_meadow"
+            ],
+            "uuid": "spring_river"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "damp shape",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "damp_shape"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "autumn wind",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "autumn_wind"
+          },
+          {
+            "downstream_blocks": [
+              "rough_haze"
+            ],
+            "language": "python",
+            "name": "holy sky",
+            "type": "data_exporter",
+            "upstream_blocks": [],
+            "uuid": "holy_sky"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "rough haze",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "holy_sky"
+            ],
+            "uuid": "rough_haze"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403602
+    },
+    "white_river": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "white river",
+        "tags": [],
+        "type": "python",
+        "uuid": "white_river",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "wandering_frost"
+            ],
+            "language": "python",
+            "name": "cool meadow",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "cool_meadow"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "wandering wildflower",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "wandering_wildflower"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "wandering frost",
+            "type": "transformer",
+            "upstream_blocks": [
+              "cool_meadow"
+            ],
+            "uuid": "wandering_frost"
+          }
+        ]
+      },
+      "updated_at": 1702284950.40361
+    },
+    "interactions_trigger": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "interactions trigger",
+        "tags": [
+          "interactions",
+          "testing"
+        ],
+        "type": "python",
+        "uuid": "interactions_trigger",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "show_country_and_age"
+            ],
+            "language": "python",
+            "name": "fetch country",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "fetch_country"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "show country and age",
+            "type": "transformer",
+            "upstream_blocks": [
+              "fetch_country"
+            ],
+            "uuid": "show_country_and_age"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "hidden wood",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "hidden_wood"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403617
+    },
+    "autumn_sky": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "autumn sky",
+        "tags": null,
+        "type": "python",
+        "updated_at": null,
+        "uuid": "autumn_sky",
+        "blocks": []
+      },
+      "updated_at": 1702284950.403619
+    },
+    "cold_moon": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "cold moon",
+        "tags": [],
+        "type": "python",
+        "uuid": "cold_moon",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "demo/models/example/my_second_dbt_model"
+            ],
+            "language": "sql",
+            "name": "demo/models/example/my_first_dbt_model",
+            "type": "dbt",
+            "upstream_blocks": [],
+            "uuid": "demo/models/example/my_first_dbt_model"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "demo/models/example/my_second_dbt_model",
+            "type": "dbt",
+            "upstream_blocks": [
+              "demo/models/example/my_first_dbt_model"
+            ],
+            "uuid": "demo/models/example/my_second_dbt_model"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403625
+    },
+    "fragrant_mountain": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "fragrant mountain",
+        "tags": [],
+        "type": "python",
+        "uuid": "fragrant_mountain",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "proud_dew"
+            ],
+            "language": "python",
+            "name": "little voice",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "little_voice"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "proud dew",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "little_voice"
+            ],
+            "uuid": "proud_dew"
+          }
+        ]
+      },
+      "updated_at": 1702284950.40363
+    },
+    "hidden_dew": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "hidden dew",
+        "tags": [],
+        "type": "python",
+        "uuid": "hidden_dew",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "late_wave"
+            ],
+            "language": "python",
+            "name": "purple paper",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "purple_paper"
+          },
+          {
+            "downstream_blocks": [
+              "late_wave"
+            ],
+            "language": "sql",
+            "name": "cool tree",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "cool_tree"
+          },
+          {
+            "downstream_blocks": [
+              "muddy_wind"
+            ],
+            "language": "python",
+            "name": "late wave",
+            "type": "transformer",
+            "upstream_blocks": [
+              "cool_tree",
+              "purple_paper"
+            ],
+            "uuid": "late_wave"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "muddy wind",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "late_wave"
+            ],
+            "uuid": "muddy_wind"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403639
+    },
+    "red_morning": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "red morning",
+        "tags": null,
+        "type": "python",
+        "updated_at": null,
+        "uuid": "red_morning",
+        "blocks": []
+      },
+      "updated_at": 1702284950.403641
+    },
+    "young_glitter": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "young glitter",
+        "tags": null,
+        "type": "python",
+        "updated_at": null,
+        "uuid": "young_glitter",
+        "blocks": []
+      },
+      "updated_at": 1702284950.403644
+    },
+    "shy_pond": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "shy pond",
+        "tags": [],
+        "type": "python",
+        "uuid": "shy_pond",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "bitter_silence"
+            ],
+            "language": "python",
+            "name": "divine wave",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "divine_wave"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "bitter silence",
+            "type": "transformer",
+            "upstream_blocks": [
+              "divine_wave"
+            ],
+            "uuid": "bitter_silence"
+          }
+        ]
+      },
+      "updated_at": 1702284950.40365
+    },
+    "withered_feather": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "withered feather",
+        "tags": null,
+        "type": "integration",
+        "updated_at": null,
+        "uuid": "withered_feather",
+        "blocks": []
+      },
+      "updated_at": 1702284950.403653
+    },
+    "proud_pond": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "proud pond",
+        "tags": [],
+        "type": "python",
+        "uuid": "proud_pond",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "billowing_morning"
+            ],
+            "language": "python",
+            "name": "lively_dust",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "lively_dust"
+          },
+          {
+            "downstream_blocks": [
+              "billowing_morning"
+            ],
+            "language": "sql",
+            "name": "purple waterfall",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "purple_waterfall"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "misty hill",
+            "type": "transformer",
+            "upstream_blocks": [],
+            "uuid": "misty_hill"
+          },
+          {
+            "downstream_blocks": [
+              "billowing_morning"
+            ],
+            "language": "python",
+            "name": "ancient frog",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "ancient_frog"
+          },
+          {
+            "downstream_blocks": [
+              "red_sunset"
+            ],
+            "language": "python",
+            "name": "billowing morning",
+            "type": "transformer",
+            "upstream_blocks": [
+              "ancient_frog",
+              "lively_dust",
+              "purple_waterfall"
+            ],
+            "uuid": "billowing_morning"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "red sunset",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "billowing_morning"
+            ],
+            "uuid": "red_sunset"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403667
+    },
+    "asdfasdfasdff": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "asdfasdfasdff",
+        "tags": [],
+        "type": "python",
+        "uuid": "asdfasdfasdff",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "bar_chart_for_billowing_dust_1693440411008",
+              "dawn_dew"
+            ],
+            "language": "python",
+            "name": "billowing dust",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "billowing_dust"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "dawn dew",
+            "type": "custom",
+            "upstream_blocks": [
+              "billowing_dust"
+            ],
+            "uuid": "dawn_dew"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403674
+    },
+    "billowing_field": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "billowing field",
+        "tags": [],
+        "type": "python",
+        "uuid": "billowing_field",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "bold_dawn"
+            ],
+            "language": "python",
+            "name": "test/growth/dronewtf",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "bitter_wave"
+            ],
+            "uuid": "test/growth/dronewtf"
+          },
+          {
+            "downstream_blocks": [
+              "test/growth/dronewtf"
+            ],
+            "language": "python",
+            "name": "bitter wave",
+            "type": "sensor",
+            "upstream_blocks": [],
+            "uuid": "bitter_wave"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "bold dawn",
+            "type": "markdown",
+            "upstream_blocks": [
+              "test/growth/dronewtf"
+            ],
+            "uuid": "bold_dawn"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "autumn_sound",
+            "type": "dbt",
+            "upstream_blocks": [],
+            "uuid": "autumn_sound"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403685
+    },
+    "purple_frost": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "purple frost",
+        "tags": [],
+        "type": "python",
+        "uuid": "purple_frost",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "morning rain",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "morning_rain"
+          }
+        ]
+      },
+      "updated_at": 1702284950.40369
+    },
+    "patient_wind": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "patient wind",
+        "tags": [],
+        "type": "python",
+        "uuid": "patient_wind",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "still_morning"
+            ],
+            "language": "sql",
+            "name": "autumn resonance",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "autumn_resonance"
+          },
+          {
+            "downstream_blocks": [
+              "still_morning"
+            ],
+            "language": "python",
+            "name": "divine wood",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "divine_wood"
+          },
+          {
+            "downstream_blocks": [
+              "still_shadow"
+            ],
+            "language": "sql",
+            "name": "still morning",
+            "type": "transformer",
+            "upstream_blocks": [
+              "autumn_resonance",
+              "divine_wood"
+            ],
+            "uuid": "still_morning"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "still shadow",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "still_morning"
+            ],
+            "uuid": "still_shadow"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "load_titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_titanic"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403704
+    },
+    "lingering_dew": {
+      "added_at": null,
+      "pipeline": {
+        "description": "asdasdsd",
+        "name": "lingering dew",
+        "tags": [],
+        "type": "integration",
+        "uuid": "lingering_dew",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "green fire",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "green_fire"
+          },
+          {
+            "downstream_blocks": [
+              "still_shadow",
+              "drone_more_please"
+            ],
+            "language": "python",
+            "name": "snowy thunder",
+            "type": "data_exporter",
+            "upstream_blocks": [],
+            "uuid": "snowy_thunder"
+          },
+          {
+            "downstream_blocks": [
+              "misty_sea"
+            ],
+            "language": "python",
+            "name": "drone_more_please",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "snowy_thunder"
+            ],
+            "uuid": "drone_more_please"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "misty sea",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "drone_more_please"
+            ],
+            "uuid": "misty_sea"
+          },
+          {
+            "downstream_blocks": [
+              "test/growth/dronewtf"
+            ],
+            "language": "python",
+            "name": "still shadow",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "snowy_thunder"
+            ],
+            "uuid": "still_shadow"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "test/growth/dronewtf",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "still_shadow"
+            ],
+            "uuid": "test/growth/dronewtf"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403717
+    },
+    "crimson_surf": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "crimson surf",
+        "tags": [],
+        "type": "python",
+        "updated_at": null,
+        "uuid": "crimson_surf",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "2",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "letter_2"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "1",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "letter_1"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "3",
+            "type": "transformer",
+            "upstream_blocks": [],
+            "uuid": "letter_3"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403725
+    },
+    "restless_night": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "restless night",
+        "tags": [],
+        "type": "python",
+        "uuid": "restless_night",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "spring_dawn"
+            ],
+            "language": "sql",
+            "name": "heroku_cherre_person",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "heroku_cherre_person"
+          },
+          {
+            "downstream_blocks": [
+              "spring_dawn"
+            ],
+            "language": "sql",
+            "name": "heroku_dbusa_person",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "heroku_dbusa_person"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "spring_dawn",
+            "type": "transformer",
+            "upstream_blocks": [
+              "heroku_cherre_person",
+              "heroku_dbusa_person"
+            ],
+            "uuid": "spring_dawn"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "withered pond",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "withered_pond"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403736
+    },
+    "proud_tree": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "proud tree",
+        "tags": [],
+        "type": "python",
+        "uuid": "proud_tree",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "lively_resonance"
+            ],
+            "language": "python",
+            "name": "load_data_from_internet",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_data_from_internet"
+          },
+          {
+            "downstream_blocks": [
+              "lively_resonance"
+            ],
+            "language": "sql",
+            "name": "lively fire",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "lively_fire"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "lively resonance",
+            "type": "transformer",
+            "upstream_blocks": [
+              "lively_fire",
+              "load_data_from_internet"
+            ],
+            "uuid": "lively_resonance"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403744
+    },
+    "unified_pipeline": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "unified pipeline",
+        "tags": [
+          "testing"
+        ],
+        "type": "python",
+        "uuid": "unified_pipeline",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "lingering_leaf"
+            ],
+            "language": "yaml",
+            "name": "source_postgresql_normal",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "source_postgresql_normal"
+          },
+          {
+            "downstream_blocks": [
+              "red_morning"
+            ],
+            "language": "python",
+            "name": "lingering leaf",
+            "type": "transformer",
+            "upstream_blocks": [
+              "source_postgresql_normal"
+            ],
+            "uuid": "lingering_leaf"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "red morning",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "lingering_leaf"
+            ],
+            "uuid": "red_morning"
+          },
+          {
+            "downstream_blocks": [
+              "source_postgresql_python"
+            ],
+            "language": "python",
+            "name": "old fog",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "old_fog"
+          },
+          {
+            "downstream_blocks": [
+              "source_postgresql_python"
+            ],
+            "language": "python",
+            "name": "dawn sound",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "dawn_sound"
+          },
+          {
+            "downstream_blocks": [
+              "divine_thunder"
+            ],
+            "language": "python",
+            "name": "source_postgresql_python",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "old_fog",
+              "dawn_sound"
+            ],
+            "uuid": "source_postgresql_python"
+          },
+          {
+            "downstream_blocks": [
+              "dry_cherry"
+            ],
+            "language": "python",
+            "name": "divine thunder",
+            "type": "transformer",
+            "upstream_blocks": [
+              "source_postgresql_python"
+            ],
+            "uuid": "divine_thunder"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "dry cherry",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "divine_thunder"
+            ],
+            "uuid": "dry_cherry"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403764
+    },
+    "falling_smoke": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "falling smoke",
+        "tags": [],
+        "type": "python",
+        "uuid": "falling_smoke",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "purple_sun"
+            ],
+            "language": "python",
+            "name": "load_data_from_internet",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "old_glitter"
+            ],
+            "uuid": "load_data_from_internet"
+          },
+          {
+            "downstream_blocks": [
+              "load_data_from_internet"
+            ],
+            "language": "python",
+            "name": "old glitter",
+            "type": "sensor",
+            "upstream_blocks": [],
+            "uuid": "old_glitter"
+          },
+          {
+            "downstream_blocks": [
+              "purple_sun"
+            ],
+            "language": "sql",
+            "name": "holy leaf",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "holy_leaf"
+          },
+          {
+            "downstream_blocks": [
+              "floral_glitter"
+            ],
+            "language": "python",
+            "name": "purple sun",
+            "type": "transformer",
+            "upstream_blocks": [
+              "holy_leaf",
+              "load_data_from_internet"
+            ],
+            "uuid": "purple_sun"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "floral glitter",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "purple_sun"
+            ],
+            "uuid": "floral_glitter"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403776
+    },
+    "dry_shape": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "dry shape",
+        "tags": [],
+        "type": "python",
+        "uuid": "dry_shape",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "sparkling_fog"
+            ],
+            "language": "python",
+            "name": "old sun",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "old_sun"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "sparkling fog",
+            "type": "transformer",
+            "upstream_blocks": [
+              "old_sun"
+            ],
+            "uuid": "sparkling_fog"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "winter paper",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "winter_paper"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "cold dew",
+            "type": "global_data_product",
+            "upstream_blocks": [],
+            "uuid": "cold_dew"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403785
+    },
+    "solitary_star": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "solitary star",
+        "tags": [],
+        "type": "python",
+        "uuid": "solitary_star",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "lively_frog"
+            ],
+            "language": "python",
+            "name": "misty wind",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "misty_wind"
+          },
+          {
+            "downstream_blocks": [
+              "lively_frog"
+            ],
+            "language": "sql",
+            "name": "patient voice",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "patient_voice"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "lively frog",
+            "type": "transformer",
+            "upstream_blocks": [
+              "patient_voice",
+              "misty_wind"
+            ],
+            "uuid": "lively_frog"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403792
+    },
+    "old_shape": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "old shape",
+        "tags": [],
+        "type": "python",
+        "uuid": "old_shape",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "restless_feather"
+            ],
+            "language": "python",
+            "name": "old sun",
+            "type": "global_data_product",
+            "upstream_blocks": [],
+            "uuid": "old_sun"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "restless feather",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "old_sun"
+            ],
+            "uuid": "restless_feather"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403798
+    },
+    "floral_night": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "floral night",
+        "tags": [],
+        "type": "integration",
+        "uuid": "floral_night",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "delicate_dust"
+            ],
+            "language": "python",
+            "name": "little paper",
+            "type": "transformer",
+            "upstream_blocks": [
+              "blue_wildflower"
+            ],
+            "uuid": "little_paper"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "delicate dust",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "little_paper"
+            ],
+            "uuid": "delicate_dust"
+          },
+          {
+            "downstream_blocks": [
+              "little_paper"
+            ],
+            "language": "yaml",
+            "name": "blue wildflower",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "blue_wildflower"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403805
+    },
+    "ancient_rain": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "ancient rain",
+        "tags": [],
+        "type": "python",
+        "uuid": "ancient_rain",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "cold grass",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "cold_grass"
+          }
+        ]
+      },
+      "updated_at": 1702284950.40381
+    },
+    "holy_river": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "holy river",
+        "tags": [],
+        "type": "python",
+        "uuid": "holy_river",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "damp_paper"
+            ],
+            "language": "python",
+            "name": "still shape",
+            "type": "global_data_product",
+            "upstream_blocks": [],
+            "uuid": "still_shape"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "damp_paper",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "still_shape"
+            ],
+            "uuid": "damp_paper"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403815
+    },
+    "data_integration_pipeline_normal_test": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "data integration pipeline normal test",
+        "tags": [
+          "testing"
+        ],
+        "type": "integration",
+        "uuid": "data_integration_pipeline_normal_test",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "spring_brook"
+            ],
+            "language": "yaml",
+            "name": "source_postgresql_normal",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "source_postgresql_normal"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "spring brook",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "source_postgresql_normal"
+            ],
+            "uuid": "spring_brook"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403821
+    },
+    "ancient_sea": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "ancient sea",
+        "tags": null,
+        "type": "python",
+        "updated_at": null,
+        "uuid": "ancient_sea",
+        "blocks": []
+      },
+      "updated_at": 1702284950.403823
+    },
+    "icy_water": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "icy water",
+        "tags": null,
+        "type": "python",
+        "updated_at": null,
+        "uuid": "icy_water",
+        "blocks": []
+      },
+      "updated_at": 1702284950.403825
+    },
+    "di_client": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "di client",
+        "tags": [],
+        "type": "python",
+        "uuid": "di_client",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "pgdestination",
+              "divine_cherry"
+            ],
+            "language": "yaml",
+            "name": "pgsource",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "pgsource"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "divine cherry",
+            "type": "custom",
+            "upstream_blocks": [
+              "pgsource"
+            ],
+            "uuid": "divine_cherry"
+          },
+          {
+            "downstream_blocks": [
+              "late_bush"
+            ],
+            "language": "yaml",
+            "name": "pgdestination",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "pgsource"
+            ],
+            "uuid": "pgdestination"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "late bush",
+            "type": "custom",
+            "upstream_blocks": [
+              "pgdestination"
+            ],
+            "uuid": "late_bush"
+          },
+          {
+            "downstream_blocks": [
+              "pgsource_python",
+              "pgdestination_python"
+            ],
+            "language": "python",
+            "name": "data integration uuid",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "data_integration_uuid"
+          },
+          {
+            "downstream_blocks": [
+              "pgsource_python",
+              "pgdestination_python"
+            ],
+            "language": "python",
+            "name": "data integration config",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "data_integration_config"
+          },
+          {
+            "downstream_blocks": [
+              "pgdestination_python"
+            ],
+            "language": "python",
+            "name": "pgsource python",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "data_integration_uuid",
+              "data_integration_config"
+            ],
+            "uuid": "pgsource_python"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "pgdestination python",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "pgsource_python",
+              "data_integration_uuid",
+              "data_integration_config"
+            ],
+            "uuid": "pgdestination_python"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403874
+    },
+    "example_pipeline": {
+      "added_at": null,
+      "pipeline": {
+        "created_at": "2023-09-01 12:00:00",
+        "description": null,
+        "name": "example_pipeline",
+        "tags": [],
+        "type": "python",
+        "uuid": "example_pipeline",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "fill_in_missing_values",
+              "summer_dew",
+              "wandering_voice",
+              "blue_haze",
+              "solitary_moon",
+              "spring_feather",
+              "bar_chart_for_load_titanic_1695423547036"
+            ],
+            "language": "python",
+            "name": "load_titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_titanic"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "spring feather",
+            "type": "markdown",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "spring_feather"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "polished field",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "polished_field"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "solitary moon",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "solitary_moon"
+          },
+          {
+            "downstream_blocks": [
+              "autumn_sound"
+            ],
+            "language": "python",
+            "name": "blue haze",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "blue_haze"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "autumn sound",
+            "type": "dbt",
+            "upstream_blocks": [
+              "blue_haze"
+            ],
+            "uuid": "autumn_sound"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "wandering voice",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "wandering_voice"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "summer dew",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "summer_dew"
+          },
+          {
+            "downstream_blocks": [
+              "export_titanic_clean"
+            ],
+            "language": "python",
+            "name": "fill_in_missing_values",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "fill_in_missing_values"
+          },
+          {
+            "downstream_blocks": [
+              "hidden_wildflower"
+            ],
+            "language": "python",
+            "name": "export_titanic_clean",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "fill_in_missing_values"
+            ],
+            "uuid": "export_titanic_clean"
+          },
+          {
+            "downstream_blocks": [
+              "empty_shadow"
+            ],
+            "language": "python",
+            "name": "hidden wildflower",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "export_titanic_clean"
+            ],
+            "uuid": "hidden_wildflower"
+          },
+          {
+            "downstream_blocks": [
+              "aged_cloud"
+            ],
+            "language": "python",
+            "name": "empty shadow",
+            "type": "transformer",
+            "upstream_blocks": [
+              "hidden_wildflower"
+            ],
+            "uuid": "empty_shadow"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "aged cloud",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "empty_shadow"
+            ],
+            "uuid": "aged_cloud"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "winter waterfall",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "winter_waterfall"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "growth/test",
+            "type": "transformer",
+            "upstream_blocks": [],
+            "uuid": "growth/test"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403907
+    },
+    "summer_resonance": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "summer resonance",
+        "tags": [],
+        "type": "integration",
+        "uuid": "summer_resonance",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "sparkling_sunset"
+            ],
+            "language": "yaml",
+            "name": "little smoke",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "little_smoke"
+          },
+          {
+            "downstream_blocks": [
+              "patient_snowflake"
+            ],
+            "language": "python",
+            "name": "sparkling sunset",
+            "type": "transformer",
+            "upstream_blocks": [
+              "little_smoke"
+            ],
+            "uuid": "sparkling_sunset"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "patient snowflake",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "sparkling_sunset"
+            ],
+            "uuid": "patient_snowflake"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403917
+    },
+    "dbt_pipeline": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "dbt pipeline",
+        "tags": [
+          "testing"
+        ],
+        "type": "python",
+        "uuid": "dbt_pipeline",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "nameless_violet"
+            ],
+            "language": "sql",
+            "name": "bitter water",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "demo/models/example/my_second_dbt_model"
+            ],
+            "uuid": "bitter_water"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "nameless violet",
+            "type": "dbt",
+            "upstream_blocks": [
+              "bitter_water"
+            ],
+            "uuid": "nameless_violet"
+          },
+          {
+            "downstream_blocks": [
+              "demo/models/example/my_second_dbt_model"
+            ],
+            "language": "sql",
+            "name": "demo/models/example/my_first_dbt_model",
+            "type": "dbt",
+            "upstream_blocks": [],
+            "uuid": "demo/models/example/my_first_dbt_model"
+          },
+          {
+            "downstream_blocks": [
+              "bitter_water"
+            ],
+            "language": "sql",
+            "name": "demo/models/example/my_second_dbt_model",
+            "type": "dbt",
+            "upstream_blocks": [
+              "demo/models/example/my_first_dbt_model"
+            ],
+            "uuid": "demo/models/example/my_second_dbt_model"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403926
+    },
+    "dry_rain": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "dry rain",
+        "tags": [],
+        "type": "integration",
+        "uuid": "dry_rain",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "lively_grass"
+            ],
+            "language": "yaml",
+            "name": "young water",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "young_water"
+          },
+          {
+            "downstream_blocks": [
+              "icy_morning"
+            ],
+            "language": "python",
+            "name": "lively grass",
+            "type": "transformer",
+            "upstream_blocks": [
+              "young_water"
+            ],
+            "uuid": "lively_grass"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "icy morning",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "lively_grass"
+            ],
+            "uuid": "icy_morning"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403935
+    },
+    "rough_water": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "rough water",
+        "tags": [],
+        "type": "python",
+        "uuid": "rough_water",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "weathered frog",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "weathered_frog"
+          }
+        ]
+      },
+      "updated_at": 1702284950.40394
+    },
+    "hidden_night": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "hidden night",
+        "tags": [],
+        "type": "python",
+        "uuid": "hidden_night",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "solitary forest",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "solitary_forest"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "delicate grass",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "delicate_grass"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403945
+    },
+    "fragrant_sound": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "fragrant sound",
+        "tags": [],
+        "type": "python",
+        "uuid": "fragrant_sound",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "morning_dew"
+            ],
+            "language": "python",
+            "name": "load_titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_titanic"
+          },
+          {
+            "downstream_blocks": [
+              "morning_dew"
+            ],
+            "language": "sql",
+            "name": "blue sunset",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "blue_sunset"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "morning dew",
+            "type": "transformer",
+            "upstream_blocks": [
+              "blue_sunset",
+              "load_titanic"
+            ],
+            "uuid": "morning_dew"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403953
+    },
+    "lingering_voice": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "lingering voice",
+        "tags": null,
+        "type": "integration",
+        "updated_at": null,
+        "uuid": "lingering_voice",
+        "blocks": []
+      },
+      "updated_at": 1702284950.403955
+    },
+    "cool_adfasdfdawn": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "cool adfasdfdawn",
+        "tags": [],
+        "type": "python",
+        "uuid": "cool_adfasdfdawn",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "2",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "letter_2"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "3",
+            "type": "transformer",
+            "upstream_blocks": [],
+            "uuid": "letter_3"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "1",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "letter_1"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "holy water",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "holy_water"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "wild darkness",
+            "type": "scratchpad",
+            "upstream_blocks": [],
+            "uuid": "wild_darkness"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403967
+    },
+    "wispy_field": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "wispy field",
+        "tags": [],
+        "type": "python",
+        "uuid": "wispy_field",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "Documentation for wispy_field_block_3",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "documentation_for_wispy_field_block_3"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "wispy_field_block_3",
+            "type": "transformer",
+            "upstream_blocks": [
+              "wispy_field_block_1",
+              "wispy_field_block_2"
+            ],
+            "uuid": "wispy_field_block_3"
+          },
+          {
+            "downstream_blocks": [
+              "wispy_field_block_3"
+            ],
+            "language": "python",
+            "name": "wispy_field_block_2",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "wispy_field_block_2"
+          },
+          {
+            "downstream_blocks": [
+              "wispy_field_block_3"
+            ],
+            "language": "python",
+            "name": "wispy_field_block_1",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "wispy_field_block_1"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403976
+    },
+    "small_shape": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "small shape",
+        "tags": null,
+        "type": "streaming",
+        "updated_at": null,
+        "uuid": "small_shape",
+        "blocks": []
+      },
+      "updated_at": 1702284950.403978
+    },
+    "long_firefly": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "long firefly",
+        "tags": [],
+        "type": "python",
+        "updated_at": null,
+        "uuid": "long_firefly",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "long_firefly_block_3",
+            "type": "transformer",
+            "upstream_blocks": [
+              "long_firefly_block_1",
+              "long_firefly_block_2"
+            ],
+            "uuid": "long_firefly_block_3"
+          },
+          {
+            "downstream_blocks": [
+              "long_firefly_block_3"
+            ],
+            "language": "python",
+            "name": "long_firefly_block_2",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "long_firefly_block_2"
+          },
+          {
+            "downstream_blocks": [
+              "long_firefly_block_3"
+            ],
+            "language": "python",
+            "name": "long_firefly_block_1",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "long_firefly_block_1"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403986
+    },
+    "pipeline_that_has_gdp_copy": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "pipeline_that_has_gdp_copy",
+        "tags": [],
+        "type": "python",
+        "uuid": "pipeline_that_has_gdp_copy",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "red_rain1",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "red_rain1"
+          },
+          {
+            "downstream_blocks": [
+              "morning_darkness"
+            ],
+            "language": "python",
+            "name": "gdp1",
+            "type": "global_data_product",
+            "upstream_blocks": [],
+            "uuid": "gdp1"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "morning darkness",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "gdp1"
+            ],
+            "uuid": "morning_darkness"
+          }
+        ]
+      },
+      "updated_at": 1702284950.403994
+    },
+    "dynamic_pipeline_testing": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "dynamic pipeline testing",
+        "tags": [
+          "dynamic"
+        ],
+        "type": "python",
+        "uuid": "dynamic_pipeline_testing",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "dawn_glitter",
+              "billowing_bush"
+            ],
+            "language": "python",
+            "name": "silent dream",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "silent_dream"
+          },
+          {
+            "downstream_blocks": [
+              "divine_bush"
+            ],
+            "language": "python",
+            "name": "dawn glitter",
+            "type": "transformer",
+            "upstream_blocks": [
+              "silent_dream"
+            ],
+            "uuid": "dawn_glitter"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "divine bush",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "dawn_glitter"
+            ],
+            "uuid": "divine_bush"
+          },
+          {
+            "downstream_blocks": [
+              "crimson_sound"
+            ],
+            "language": "python",
+            "name": "billowing bush",
+            "type": "custom",
+            "upstream_blocks": [
+              "silent_dream"
+            ],
+            "uuid": "billowing_bush"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "crimson sound",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "billowing_bush"
+            ],
+            "uuid": "crimson_sound"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404005
+    },
+    "long_wave": {
+      "added_at": null,
+      "pipeline": {
+        "description": "This python script provides a template for a custom transformation. The function transform_custom takes two parameters: data and *args, **kwargs. It returns the value of 1 + 1. The output of the function is tested using the test_output function which checks if the output is not None.",
+        "name": "long wave",
+        "tags": [],
+        "type": "python",
+        "uuid": "long_wave",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "Documentation for long_wave",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "documentation_for_long_wave"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "Documentation for long_wave_block_3",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "documentation_for_long_wave_block_3"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "long_wave_block_3",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "long_wave_block_2"
+            ],
+            "uuid": "long_wave_block_3"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "Documentation for long_wave_block_2",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "documentation_for_long_wave_block_2"
+          },
+          {
+            "downstream_blocks": [
+              "long_wave_block_3"
+            ],
+            "language": "python",
+            "name": "long_wave_block_2",
+            "type": "transformer",
+            "upstream_blocks": [
+              "long_wave_block_1"
+            ],
+            "uuid": "long_wave_block_2"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "Documentation for long_wave_block_1",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "documentation_for_long_wave_block_1"
+          },
+          {
+            "downstream_blocks": [
+              "long_wave_block_2",
+              "silent_sunset"
+            ],
+            "language": "python",
+            "name": "long_wave_block_1",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "long_wave_block_1"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "Documentation for silent_sunset",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "documentation_for_silent_sunset"
+          },
+          {
+            "downstream_blocks": [
+              "weathered_glade"
+            ],
+            "language": "python",
+            "name": "silent sunset",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "long_wave_block_1"
+            ],
+            "uuid": "silent_sunset"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "Documentation for documentation_for_weathered_glade",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "documentation_for_documentation_for_weathered_glade"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "Documentation for weathered_glade",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "documentation_for_weathered_glade"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "weathered glade",
+            "type": "custom",
+            "upstream_blocks": [
+              "silent_sunset"
+            ],
+            "uuid": "weathered_glade"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404031
+    },
+    "late_wind": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "late wind",
+        "tags": [],
+        "type": "integration",
+        "uuid": "late_wind",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "small sun",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "small_sun"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404035
+    },
+    "damp_silence": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "damp silence",
+        "tags": null,
+        "type": "python",
+        "updated_at": null,
+        "uuid": "damp_silence",
+        "blocks": []
+      },
+      "updated_at": 1702284950.404038
+    },
+    "winter_bird": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "winter bird",
+        "tags": [],
+        "type": "python",
+        "uuid": "winter_bird",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "green_star"
+            ],
+            "language": "python",
+            "name": "load_titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_titanic"
+          },
+          {
+            "downstream_blocks": [
+              "polished_sky"
+            ],
+            "language": "sql",
+            "name": "green star",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "green_star"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "polished sky",
+            "type": "transformer",
+            "upstream_blocks": [
+              "green_star"
+            ],
+            "uuid": "polished_sky"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404046
+    },
+    "shy_bush": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "shy bush",
+        "tags": [],
+        "type": "python",
+        "updated_at": null,
+        "uuid": "shy_bush",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "1",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "letter_1"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "2",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "letter_2"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404052
+    },
+    "polished_snow": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "pipeline with variables",
+        "tags": [
+          "gcp"
+        ],
+        "type": "python",
+        "updated_at": null,
+        "uuid": "polished_snow",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "twilight paper",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "twilight_paper"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404056
+    },
+    "divine_butterfly": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "divine butterfly",
+        "tags": [],
+        "type": "python",
+        "uuid": "divine_butterfly",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "weathered_darkness"
+            ],
+            "language": "python",
+            "name": "throbbing pine",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "throbbing_pine"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "weathered darkness",
+            "type": "transformer",
+            "upstream_blocks": [
+              "throbbing_pine"
+            ],
+            "uuid": "weathered_darkness"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404062
+    },
+    "dawn_flower": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "dawn flower",
+        "tags": [],
+        "type": "python",
+        "uuid": "dawn_flower",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "broken_hill"
+            ],
+            "language": "python",
+            "name": "load_titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_titanic"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "broken hill",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "broken_hill"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404069
+    },
+    "throbbing_wave": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "throbbing wave",
+        "tags": [],
+        "type": "python",
+        "uuid": "throbbing_wave",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "shy_hill"
+            ],
+            "language": "python",
+            "name": "dark violet",
+            "type": "transformer",
+            "upstream_blocks": [],
+            "uuid": "dark_violet"
+          },
+          {
+            "downstream_blocks": [
+              "wispy_tree"
+            ],
+            "language": "python",
+            "name": "shy hill",
+            "type": "transformer",
+            "upstream_blocks": [
+              "dark_violet"
+            ],
+            "uuid": "shy_hill"
+          },
+          {
+            "downstream_blocks": [
+              "divine_haze"
+            ],
+            "language": "python",
+            "name": "wispy tree",
+            "type": "transformer",
+            "upstream_blocks": [
+              "shy_hill"
+            ],
+            "uuid": "wispy_tree"
+          },
+          {
+            "downstream_blocks": [
+              "misty_flower"
+            ],
+            "language": "python",
+            "name": "divine haze",
+            "type": "transformer",
+            "upstream_blocks": [
+              "wispy_tree"
+            ],
+            "uuid": "divine_haze"
+          },
+          {
+            "downstream_blocks": [
+              "little_wood"
+            ],
+            "language": "yaml",
+            "name": "misty flower",
+            "type": "dbt",
+            "upstream_blocks": [
+              "divine_haze"
+            ],
+            "uuid": "misty_flower"
+          },
+          {
+            "downstream_blocks": [
+              "autumn_sound"
+            ],
+            "language": "yaml",
+            "name": "little_wood",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "misty_flower"
+            ],
+            "uuid": "little_wood"
+          },
+          {
+            "downstream_blocks": [
+              "drone_more_please"
+            ],
+            "language": "yaml",
+            "name": "autumn_sound",
+            "type": "dbt",
+            "upstream_blocks": [
+              "little_wood"
+            ],
+            "uuid": "autumn_sound"
+          },
+          {
+            "downstream_blocks": [
+              "nameless_frog"
+            ],
+            "language": "python",
+            "name": "drone_more_please",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "autumn_sound"
+            ],
+            "uuid": "drone_more_please"
+          },
+          {
+            "downstream_blocks": [
+              "winter_glade"
+            ],
+            "language": "python",
+            "name": "nameless frog",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "drone_more_please"
+            ],
+            "uuid": "nameless_frog"
+          },
+          {
+            "downstream_blocks": [
+              "aged_glitter"
+            ],
+            "language": "python",
+            "name": "winter glade",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "nameless_frog"
+            ],
+            "uuid": "winter_glade"
+          },
+          {
+            "downstream_blocks": [
+              "empty_feather"
+            ],
+            "language": "python",
+            "name": "aged glitter",
+            "type": "transformer",
+            "upstream_blocks": [
+              "winter_glade"
+            ],
+            "uuid": "aged_glitter"
+          },
+          {
+            "downstream_blocks": [
+              "test/growth/dronewtf"
+            ],
+            "language": "r",
+            "name": "empty_feather",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "aged_glitter"
+            ],
+            "uuid": "empty_feather"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "test/growth/dronewtf",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "empty_feather"
+            ],
+            "uuid": "test/growth/dronewtf"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404096
+    },
+    "holy_grass": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "holy grass",
+        "tags": [],
+        "type": "python",
+        "uuid": "holy_grass",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "holy_grass_block_2"
+            ],
+            "language": "python",
+            "name": "holy_grass_block_1",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "holy_grass_block_1"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "holy_grass_block_3",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "holy_grass_block_2"
+            ],
+            "uuid": "holy_grass_block_3"
+          },
+          {
+            "downstream_blocks": [
+              "holy_grass_block_3"
+            ],
+            "language": "python",
+            "name": "holy_grass_block_2",
+            "type": "transformer",
+            "upstream_blocks": [
+              "holy_grass_block_1"
+            ],
+            "uuid": "holy_grass_block_2"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404104
+    },
+    "white_cloud": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "white cloud",
+        "tags": [],
+        "type": "python",
+        "uuid": "white_cloud",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "green_wildflower"
+            ],
+            "language": "python",
+            "name": "dry cloud",
+            "type": "data_exporter",
+            "upstream_blocks": [],
+            "uuid": "dry_cloud"
+          },
+          {
+            "downstream_blocks": [
+              "hidden_firefly"
+            ],
+            "language": "python",
+            "name": "green wildflower",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "dry_cloud"
+            ],
+            "uuid": "green_wildflower"
+          },
+          {
+            "downstream_blocks": [
+              "young_bush"
+            ],
+            "language": "python",
+            "name": "hidden firefly",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "green_wildflower"
+            ],
+            "uuid": "hidden_firefly"
+          },
+          {
+            "downstream_blocks": [
+              "damp_paper"
+            ],
+            "language": "python",
+            "name": "young bush",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "hidden_firefly"
+            ],
+            "uuid": "young_bush"
+          },
+          {
+            "downstream_blocks": [
+              "frosty_frost"
+            ],
+            "language": "python",
+            "name": "damp paper",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "young_bush"
+            ],
+            "uuid": "damp_paper"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "frosty frost",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "damp_paper"
+            ],
+            "uuid": "frosty_frost"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404116
+    },
+    "elden_glade": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "elden glade",
+        "tags": [],
+        "type": "python",
+        "uuid": "elden_glade",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "rough_dew"
+            ],
+            "language": "python",
+            "name": "outstanding monk",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "outstanding_monk"
+          },
+          {
+            "downstream_blocks": [
+              "rough_dew",
+              "gracious_bonsai"
+            ],
+            "language": "python",
+            "name": "illusory elm",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "illusory_elm"
+          },
+          {
+            "downstream_blocks": [
+              "floral_artificer",
+              "holy_elm"
+            ],
+            "language": "python",
+            "name": "rough dew",
+            "type": "transformer",
+            "upstream_blocks": [
+              "outstanding_monk",
+              "illusory_elm"
+            ],
+            "uuid": "rough_dew"
+          },
+          {
+            "downstream_blocks": [
+              "kinetic_mana",
+              "royal_elm"
+            ],
+            "language": "python",
+            "name": "floral artificer",
+            "type": "transformer",
+            "upstream_blocks": [
+              "rough_dew"
+            ],
+            "uuid": "floral_artificer"
+          },
+          {
+            "downstream_blocks": [
+              "sincere_artifact"
+            ],
+            "language": "python",
+            "name": "kinetic mana",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "floral_artificer"
+            ],
+            "uuid": "kinetic_mana"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "sincere artifact",
+            "type": "custom",
+            "upstream_blocks": [
+              "royal_elm",
+              "kinetic_mana"
+            ],
+            "uuid": "sincere_artifact"
+          },
+          {
+            "downstream_blocks": [
+              "sincere_artifact"
+            ],
+            "language": "python",
+            "name": "royal elm",
+            "type": "custom",
+            "upstream_blocks": [
+              "floral_artificer"
+            ],
+            "uuid": "royal_elm"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "gracious bonsai",
+            "type": "custom",
+            "upstream_blocks": [
+              "illusory_elm"
+            ],
+            "uuid": "gracious_bonsai"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "holy elm",
+            "type": "custom",
+            "upstream_blocks": [
+              "rough_dew"
+            ],
+            "uuid": "holy_elm"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404135
+    },
+    "dynamic_2": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "dynamic 2",
+        "tags": [
+          "dynamic"
+        ],
+        "type": "python",
+        "uuid": "dynamic_2",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "dynamic_child_a"
+            ],
+            "language": "python",
+            "name": "dynamic parent A",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "dynamic_parent_a"
+          },
+          {
+            "downstream_blocks": [
+              "dynamic_child_a",
+              "upstream_reduce_output",
+              "dynamic_child_child_a"
+            ],
+            "language": "python",
+            "name": "dynamic parent B",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "dynamic_parent_b"
+          },
+          {
+            "downstream_blocks": [
+              "dynamic_child_a"
+            ],
+            "language": "python",
+            "name": "regular parent A",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "regular_parent_a"
+          },
+          {
+            "downstream_blocks": [
+              "dynamic_child_child_a",
+              "dynamic_child_child_b"
+            ],
+            "language": "python",
+            "name": "dynamic child A",
+            "type": "transformer",
+            "upstream_blocks": [
+              "dynamic_parent_a",
+              "regular_parent_a",
+              "dynamic_parent_b"
+            ],
+            "uuid": "dynamic_child_a"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "dynamic_child_child_a",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "dynamic_child_a",
+              "dynamic_parent_b"
+            ],
+            "uuid": "dynamic_child_child_a"
+          },
+          {
+            "downstream_blocks": [
+              "upstream_reduce_output"
+            ],
+            "language": "python",
+            "name": "dynamic child child B",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "dynamic_child_a"
+            ],
+            "uuid": "dynamic_child_child_b"
+          },
+          {
+            "downstream_blocks": [
+              "upstream_reduce_output"
+            ],
+            "language": "python",
+            "name": "regular parent B",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "regular_parent_b"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "upstream reduce output",
+            "type": "custom",
+            "upstream_blocks": [
+              "dynamic_child_child_b",
+              "regular_parent_b",
+              "dynamic_parent_b"
+            ],
+            "uuid": "upstream_reduce_output"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404152
+    },
+    "unify_pipeline_destination": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "unify pipeline destination",
+        "tags": [
+          "testing"
+        ],
+        "type": "python",
+        "uuid": "unify_pipeline_destination",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "destination_postgresql"
+            ],
+            "language": "python",
+            "name": "api data",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "api_data"
+          },
+          {
+            "downstream_blocks": [
+              "destination_postgresql"
+            ],
+            "language": "python",
+            "name": "titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "titanic"
+          },
+          {
+            "downstream_blocks": [
+              "destination_postgresql"
+            ],
+            "language": "python",
+            "name": "input only",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "input_only"
+          },
+          {
+            "downstream_blocks": [
+              "destination_postgresql"
+            ],
+            "language": "yaml",
+            "name": "source_postgresql_normal",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "source_postgresql_normal"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "destination_postgresql",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "source_postgresql_normal",
+              "api_data",
+              "titanic",
+              "input_only"
+            ],
+            "uuid": "destination_postgresql"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404163
+    },
+    "rough_wind": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "rough wind",
+        "tags": [],
+        "type": "python",
+        "uuid": "rough_wind",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "black_brook"
+            ],
+            "language": "python",
+            "name": "delicate shadow",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "delicate_shadow"
+          },
+          {
+            "downstream_blocks": [
+              "silent_darkness"
+            ],
+            "language": "python",
+            "name": "black brook",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "delicate_shadow"
+            ],
+            "uuid": "black_brook"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "Documentation for silent_darkness",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "documentation_for_silent_darkness"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "silent darkness",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "black_brook"
+            ],
+            "uuid": "silent_darkness"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404173
+    },
+    "pipeline_that_has_gdp": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "pipeline that has gdp",
+        "tags": [],
+        "type": "python",
+        "uuid": "pipeline_that_has_gdp",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "red_rain1",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "red_rain1"
+          },
+          {
+            "downstream_blocks": [
+              "morning_darkness"
+            ],
+            "language": "python",
+            "name": "gdp1111",
+            "type": "global_data_product",
+            "upstream_blocks": [],
+            "uuid": "gdp1111"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "morning darkness",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "gdp1111"
+            ],
+            "uuid": "morning_darkness"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404181
+    },
+    "misty_morning": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "example_pipeline",
+        "tags": [],
+        "type": "python",
+        "uuid": "misty_morning",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "fill_in_missing_values",
+              "summer_dew",
+              "wandering_voice",
+              "blue_haze",
+              "solitary_moon",
+              "spring_feather"
+            ],
+            "language": "python",
+            "name": "load_titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_titanic"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "spring feather",
+            "type": "markdown",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "spring_feather"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "polished field",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "polished_field"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "solitary moon",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "solitary_moon"
+          },
+          {
+            "downstream_blocks": [
+              "autumn_sound"
+            ],
+            "language": "python",
+            "name": "blue haze",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "blue_haze"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "autumn sound",
+            "type": "dbt",
+            "upstream_blocks": [
+              "blue_haze"
+            ],
+            "uuid": "autumn_sound"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "wandering voice",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "wandering_voice"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "summer dew",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "summer_dew"
+          },
+          {
+            "downstream_blocks": [
+              "export_titanic_clean"
+            ],
+            "language": "python",
+            "name": "fill_in_missing_values",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "fill_in_missing_values"
+          },
+          {
+            "downstream_blocks": [
+              "hidden_wildflower"
+            ],
+            "language": "python",
+            "name": "export_titanic_clean",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "fill_in_missing_values"
+            ],
+            "uuid": "export_titanic_clean"
+          },
+          {
+            "downstream_blocks": [
+              "empty_shadow"
+            ],
+            "language": "python",
+            "name": "hidden wildflower",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "export_titanic_clean"
+            ],
+            "uuid": "hidden_wildflower"
+          },
+          {
+            "downstream_blocks": [
+              "aged_cloud"
+            ],
+            "language": "python",
+            "name": "empty shadow",
+            "type": "transformer",
+            "upstream_blocks": [
+              "hidden_wildflower"
+            ],
+            "uuid": "empty_shadow"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "aged cloud",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "empty_shadow"
+            ],
+            "uuid": "aged_cloud"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "winter waterfall",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "winter_waterfall"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "growth/test",
+            "type": "transformer",
+            "upstream_blocks": [],
+            "uuid": "growth/test"
+          }
+        ]
+      },
+      "updated_at": 1702284950.40422
+    },
+    "proud_grass": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "proud grass",
+        "tags": [
+          "testing"
+        ],
+        "type": "python",
+        "uuid": "proud_grass",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "restless tree",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "restless_tree"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404224
+    },
+    "wispy_knight": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "wispy knight",
+        "tags": [],
+        "type": "python",
+        "uuid": "wispy_knight",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "charismatic_sword",
+              "holy_sorcerer"
+            ],
+            "language": "python",
+            "name": "load_titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_titanic"
+          },
+          {
+            "downstream_blocks": [
+              "charismatic_sword"
+            ],
+            "language": "sql",
+            "name": "holy sorcerer",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "holy_sorcerer"
+          },
+          {
+            "downstream_blocks": [
+              "crystal_quest"
+            ],
+            "language": "python",
+            "name": "charismatic sword",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "load_titanic",
+              "holy_sorcerer"
+            ],
+            "uuid": "charismatic_sword"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "crystal quest",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "charismatic_sword"
+            ],
+            "uuid": "crystal_quest"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404233
+    },
+    "unify_destination_block_python": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "unify destination block python",
+        "tags": [
+          "testing"
+        ],
+        "type": "python",
+        "uuid": "unify_destination_block_python",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "destination_postgresql_python"
+            ],
+            "language": "python",
+            "name": "input_only",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "input_only"
+          },
+          {
+            "downstream_blocks": [
+              "destination_postgresql_python"
+            ],
+            "language": "python",
+            "name": "api_data",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "api_data"
+          },
+          {
+            "downstream_blocks": [
+              "destination_postgresql_python"
+            ],
+            "language": "python",
+            "name": "titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "titanic"
+          },
+          {
+            "downstream_blocks": [
+              "destination_postgresql_python"
+            ],
+            "language": "yaml",
+            "name": "source_postgresql_normal",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "source_postgresql_normal"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "destination postgresql python",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "input_only",
+              "api_data",
+              "titanic",
+              "source_postgresql_normal"
+            ],
+            "uuid": "destination_postgresql_python"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404245
+    },
+    "white_feather": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "example_pipeline",
+        "tags": [],
+        "type": "python",
+        "uuid": "white_feather",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "fill_in_missing_values",
+              "summer_dew",
+              "wandering_voice",
+              "blue_haze",
+              "solitary_moon",
+              "spring_feather",
+              "histogram_for_load_titanic_1695862064031"
+            ],
+            "language": "python",
+            "name": "load_titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_titanic"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "spring feather",
+            "type": "markdown",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "spring_feather"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "polished field",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "polished_field"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "solitary moon",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "solitary_moon"
+          },
+          {
+            "downstream_blocks": [
+              "autumn_sound"
+            ],
+            "language": "python",
+            "name": "blue haze",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "blue_haze"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "autumn sound",
+            "type": "dbt",
+            "upstream_blocks": [
+              "blue_haze"
+            ],
+            "uuid": "autumn_sound"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "wandering voice",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "wandering_voice"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "summer dew",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "summer_dew"
+          },
+          {
+            "downstream_blocks": [
+              "export_titanic_clean"
+            ],
+            "language": "python",
+            "name": "fill_in_missing_values",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "fill_in_missing_values"
+          },
+          {
+            "downstream_blocks": [
+              "hidden_wildflower"
+            ],
+            "language": "python",
+            "name": "export_titanic_clean",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "fill_in_missing_values"
+            ],
+            "uuid": "export_titanic_clean"
+          },
+          {
+            "downstream_blocks": [
+              "empty_shadow"
+            ],
+            "language": "python",
+            "name": "hidden wildflower",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "export_titanic_clean"
+            ],
+            "uuid": "hidden_wildflower"
+          },
+          {
+            "downstream_blocks": [
+              "aged_cloud"
+            ],
+            "language": "python",
+            "name": "empty shadow",
+            "type": "transformer",
+            "upstream_blocks": [
+              "hidden_wildflower"
+            ],
+            "uuid": "empty_shadow"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "aged cloud",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "empty_shadow"
+            ],
+            "uuid": "aged_cloud"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "winter waterfall",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "winter_waterfall"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "growth/test",
+            "type": "transformer",
+            "upstream_blocks": [],
+            "uuid": "growth/test"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404273
+    },
+    "billowing_waterfall": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "example_pipeline",
+        "tags": [],
+        "type": "python",
+        "uuid": "billowing_waterfall",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "fill_in_missing_values",
+              "summer_dew",
+              "wandering_voice",
+              "blue_haze",
+              "solitary_moon",
+              "spring_feather",
+              "histogram_for_load_titanic_1691095789740",
+              "bar_chart_for_load_titanic_1691095796425"
+            ],
+            "language": "python",
+            "name": "load_titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_titanic"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "spring feather",
+            "type": "markdown",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "spring_feather"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "polished field",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "polished_field"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "solitary moon",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "solitary_moon"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "Documentation for blue_haze",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "documentation_for_blue_haze"
+          },
+          {
+            "downstream_blocks": [
+              "autumn_sound"
+            ],
+            "language": "python",
+            "name": "blue haze",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "blue_haze"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "autumn sound",
+            "type": "dbt",
+            "upstream_blocks": [
+              "blue_haze"
+            ],
+            "uuid": "autumn_sound"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "wandering voice",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "wandering_voice"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "summer dew",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "summer_dew"
+          },
+          {
+            "downstream_blocks": [
+              "export_titanic_clean"
+            ],
+            "language": "python",
+            "name": "fill_in_missing_values",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "fill_in_missing_values"
+          },
+          {
+            "downstream_blocks": [
+              "hidden_wildflower"
+            ],
+            "language": "python",
+            "name": "export_titanic_clean",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "fill_in_missing_values"
+            ],
+            "uuid": "export_titanic_clean"
+          },
+          {
+            "downstream_blocks": [
+              "empty_shadow"
+            ],
+            "language": "python",
+            "name": "hidden wildflower",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "export_titanic_clean"
+            ],
+            "uuid": "hidden_wildflower"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "empty shadow",
+            "type": "transformer",
+            "upstream_blocks": [
+              "hidden_wildflower"
+            ],
+            "uuid": "empty_shadow"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "winter waterfall",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "winter_waterfall"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404299
+    },
+    "lively_shadow": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "lively shadow",
+        "tags": [],
+        "type": "python",
+        "updated_at": null,
+        "uuid": "lively_shadow",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "wandering waterfall",
+            "type": "data_exporter",
+            "upstream_blocks": [],
+            "uuid": "wandering_waterfall"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404303
+    },
+    "purple_morning": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "purple morning",
+        "tags": null,
+        "type": "python",
+        "updated_at": null,
+        "uuid": "purple_morning",
+        "blocks": []
+      },
+      "updated_at": 1702284950.404305
+    },
+    "user_transactions": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "user transactions",
+        "tags": [],
+        "type": "python",
+        "uuid": "user_transactions",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "product_purchases",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "product_purchases"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404309
+    },
+    "twilight_frog": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "twilight frog",
+        "tags": [],
+        "type": "integration",
+        "uuid": "twilight_frog",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "destination_postgresql"
+            ],
+            "language": "yaml",
+            "name": "source_postgresql_normal",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "source_postgresql_normal"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "destination postgresql",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "source_postgresql_normal"
+            ],
+            "uuid": "destination_postgresql"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404316
+    },
+    "crimson_water": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "example_pipeline",
+        "tags": [],
+        "type": "python",
+        "uuid": "crimson_water",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "fill_in_missing_values",
+              "summer_dew",
+              "wandering_voice",
+              "blue_haze",
+              "solitary_moon",
+              "spring_feather"
+            ],
+            "language": "python",
+            "name": "load_titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_titanic"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "spring feather",
+            "type": "markdown",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "spring_feather"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "polished field",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "polished_field"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "solitary moon",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "solitary_moon"
+          },
+          {
+            "downstream_blocks": [
+              "autumn_sound"
+            ],
+            "language": "python",
+            "name": "blue haze",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "blue_haze"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "autumn sound",
+            "type": "dbt",
+            "upstream_blocks": [
+              "blue_haze"
+            ],
+            "uuid": "autumn_sound"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "wandering voice",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "wandering_voice"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "summer dew",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "summer_dew"
+          },
+          {
+            "downstream_blocks": [
+              "export_titanic_clean"
+            ],
+            "language": "python",
+            "name": "fill_in_missing_values",
+            "type": "transformer",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "fill_in_missing_values"
+          },
+          {
+            "downstream_blocks": [
+              "hidden_wildflower"
+            ],
+            "language": "python",
+            "name": "export_titanic_clean",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "fill_in_missing_values"
+            ],
+            "uuid": "export_titanic_clean"
+          },
+          {
+            "downstream_blocks": [
+              "empty_shadow"
+            ],
+            "language": "python",
+            "name": "hidden wildflower",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "export_titanic_clean"
+            ],
+            "uuid": "hidden_wildflower"
+          },
+          {
+            "downstream_blocks": [
+              "aged_cloud"
+            ],
+            "language": "python",
+            "name": "empty shadow",
+            "type": "transformer",
+            "upstream_blocks": [
+              "hidden_wildflower"
+            ],
+            "uuid": "empty_shadow"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "aged cloud",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "empty_shadow"
+            ],
+            "uuid": "aged_cloud"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "winter waterfall",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "winter_waterfall"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "growth/test",
+            "type": "transformer",
+            "upstream_blocks": [],
+            "uuid": "growth/test"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404585
+    },
+    "snowy_wind": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "snowy wind",
+        "tags": [],
+        "type": "python",
+        "uuid": "snowy_wind",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "summer_fog",
+              "empty_sun"
+            ],
+            "language": "yaml",
+            "name": "muddy glitter",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "muddy_glitter"
+          },
+          {
+            "downstream_blocks": [
+              "empty_sun"
+            ],
+            "language": "python",
+            "name": "summer fog",
+            "type": "transformer",
+            "upstream_blocks": [
+              "muddy_glitter"
+            ],
+            "uuid": "summer_fog"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "empty sun",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "summer_fog",
+              "muddy_glitter"
+            ],
+            "uuid": "empty_sun"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404593
+    },
+    "interactions_testing": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "interactions testing",
+        "tags": [
+          "interactions",
+          "testing"
+        ],
+        "type": "python",
+        "uuid": "interactions_testing",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "check_age"
+            ],
+            "language": "python",
+            "name": "load country",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "load_country"
+          },
+          {
+            "downstream_blocks": [
+              "wispy_smoke"
+            ],
+            "language": "python",
+            "name": "check age",
+            "type": "custom",
+            "upstream_blocks": [
+              "load_country"
+            ],
+            "uuid": "check_age"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "wispy smoke",
+            "type": "custom",
+            "upstream_blocks": [
+              "check_age"
+            ],
+            "uuid": "wispy_smoke"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404601
+    },
+    "green_moon": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "green moon",
+        "tags": [],
+        "type": "python",
+        "updated_at": null,
+        "uuid": "green_moon",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "2",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "letter_2"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "1",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "letter_1"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404606
+    },
+    "snowy_smoke": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "snowy smoke",
+        "tags": null,
+        "type": "python",
+        "updated_at": null,
+        "uuid": "snowy_smoke",
+        "blocks": []
+      },
+      "updated_at": 1702284950.404608
+    },
+    "unified_pipeline_demo": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "unified pipeline demo",
+        "tags": [
+          "parallel",
+          "testing"
+        ],
+        "type": "python",
+        "uuid": "unified_pipeline_demo",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "source_postgresql"
+            ],
+            "language": "python",
+            "name": "divine glitter",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "divine_glitter"
+          },
+          {
+            "downstream_blocks": [
+              "source_postgresql"
+            ],
+            "language": "python",
+            "name": "nothing2",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "nothing2"
+          },
+          {
+            "downstream_blocks": [
+              "falling_shadow"
+            ],
+            "language": "yaml",
+            "name": "source_postgresql",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "divine_glitter",
+              "nothing2"
+            ],
+            "uuid": "source_postgresql"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "falling shadow",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "source_postgresql"
+            ],
+            "uuid": "falling_shadow"
+          }
+        ]
+      },
+      "updated_at": 1702284950.40462
+    },
+    "withered_wave": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "withered wave",
+        "tags": [],
+        "type": "python",
+        "updated_at": null,
+        "uuid": "withered_wave",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "withered_wave_block_3",
+            "type": "transformer",
+            "upstream_blocks": [
+              "withered_wave_block_1",
+              "withered_wave_block_2"
+            ],
+            "uuid": "withered_wave_block_3"
+          },
+          {
+            "downstream_blocks": [
+              "withered_wave_block_3"
+            ],
+            "language": "python",
+            "name": "withered_wave_block_2",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "withered_wave_block_2"
+          },
+          {
+            "downstream_blocks": [
+              "withered_wave_block_3"
+            ],
+            "language": "python",
+            "name": "withered_wave_block_1",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "withered_wave_block_1"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404628
+    },
+    "pipeline_hook": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "pipeline hook",
+        "tags": [],
+        "type": "python",
+        "uuid": "pipeline_hook",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "great fire",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "great_fire"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404632
+    },
+    "destination_parallel": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "destination parallel",
+        "tags": [
+          "testing"
+        ],
+        "type": "python",
+        "uuid": "destination_parallel",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "wandering_bush"
+            ],
+            "language": "python",
+            "name": "api_data",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "api_data"
+          },
+          {
+            "downstream_blocks": [
+              "wandering_bush"
+            ],
+            "language": "python",
+            "name": "titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "titanic"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "wandering_bush",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "api_data",
+              "titanic"
+            ],
+            "uuid": "wandering_bush"
+          }
+        ]
+      },
+      "updated_at": 1702284950.40464
+    },
+    "frosty_night": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "frosty night",
+        "tags": [],
+        "type": "integration",
+        "uuid": "frosty_night",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "little morning",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "little_morning"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404643
+    },
+    "wandering_waterfall": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "wandering waterfall",
+        "tags": [],
+        "type": "integration",
+        "uuid": "wandering_waterfall",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "morning_brook"
+            ],
+            "language": "yaml",
+            "name": "still dust",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "still_dust"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "morning brook",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "still_dust"
+            ],
+            "uuid": "morning_brook"
+          }
+        ]
+      },
+      "updated_at": 1702284950.40465
+    },
+    "di_client_2": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "di client 2",
+        "tags": [],
+        "type": "python",
+        "uuid": "di_client_2",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "pgclient_destination"
+            ],
+            "language": "python",
+            "name": "pgclient",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "pgclient"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "pgclient destination",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "pgclient"
+            ],
+            "uuid": "pgclient_destination"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404656
+    },
+    "rough_violet": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "rough violet",
+        "tags": [],
+        "type": "python",
+        "updated_at": null,
+        "uuid": "rough_violet",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "lively river",
+            "type": "global_data_product",
+            "upstream_blocks": [],
+            "uuid": "lively_river"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404659
+    },
+    "throbbing_firefly": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "throbbing firefly",
+        "tags": [],
+        "type": "python",
+        "uuid": "throbbing_firefly",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "muddy_moon"
+            ],
+            "language": "python",
+            "name": "hidden star",
+            "type": "custom",
+            "upstream_blocks": [],
+            "uuid": "hidden_star"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "muddy moon",
+            "type": "custom",
+            "upstream_blocks": [
+              "hidden_star"
+            ],
+            "uuid": "muddy_moon"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404666
+    },
+    "withered_flower": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "withered flower",
+        "tags": [],
+        "type": "python",
+        "uuid": "withered_flower",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "wild_forest"
+            ],
+            "language": "python",
+            "name": "delicate grass",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "delicate_grass"
+          },
+          {
+            "downstream_blocks": [
+              "aged_snowflake"
+            ],
+            "language": "python",
+            "name": "wild forest",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "delicate_grass"
+            ],
+            "uuid": "wild_forest"
+          },
+          {
+            "downstream_blocks": [
+              "illusory_elm"
+            ],
+            "language": "python",
+            "name": "aged snowflake",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "wild_forest"
+            ],
+            "uuid": "aged_snowflake"
+          },
+          {
+            "downstream_blocks": [
+              "elemental_ronin"
+            ],
+            "language": "python",
+            "name": "illusory_elm",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "aged_snowflake"
+            ],
+            "uuid": "illusory_elm"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "elemental ronin",
+            "type": "transformer",
+            "upstream_blocks": [
+              "illusory_elm"
+            ],
+            "uuid": "elemental_ronin"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404676
+    },
+    "green_mountain": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "green mountain",
+        "tags": null,
+        "type": "python",
+        "updated_at": null,
+        "uuid": "green_mountain",
+        "blocks": []
+      },
+      "updated_at": 1702284950.404678
+    },
+    "summer_night": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "summer night",
+        "tags": [],
+        "type": "python",
+        "updated_at": null,
+        "uuid": "summer_night",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "summer_night_block_3",
+            "type": "transformer",
+            "upstream_blocks": [
+              "summer_night_block_1",
+              "summer_night_block_2"
+            ],
+            "uuid": "summer_night_block_3"
+          },
+          {
+            "downstream_blocks": [
+              "summer_night_block_3"
+            ],
+            "language": "python",
+            "name": "summer_night_block_2",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "summer_night_block_2"
+          },
+          {
+            "downstream_blocks": [
+              "summer_night_block_3"
+            ],
+            "language": "python",
+            "name": "summer_night_block_1",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "summer_night_block_1"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404685
+    },
+    "withered_dawn": {
+      "added_at": null,
+      "pipeline": {
+        "description": "This data pipeline is used to export data from a DataFrame object to a Redshift cluster.",
+        "name": "withered dawn",
+        "tags": [],
+        "type": "python",
+        "uuid": "withered_dawn",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "Documentation for withered_dawn",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "documentation_for_withered_dawn"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "Documentation for holy_bird",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "documentation_for_holy_bird"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "holy bird",
+            "type": "data_exporter",
+            "upstream_blocks": [],
+            "uuid": "holy_bird"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "Documentation for morning_waterfall",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "documentation_for_morning_waterfall"
+          },
+          {
+            "downstream_blocks": [
+              "misty_violet"
+            ],
+            "language": "python",
+            "name": "morning waterfall",
+            "type": "data_exporter",
+            "upstream_blocks": [],
+            "uuid": "morning_waterfall"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "markdown",
+            "name": "Documentation for misty_violet",
+            "type": "markdown",
+            "upstream_blocks": [],
+            "uuid": "documentation_for_misty_violet"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "misty violet",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "morning_waterfall"
+            ],
+            "uuid": "misty_violet"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404698
+    },
+    "with_attached_hook": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "with_attached_hook",
+        "tags": [],
+        "type": "python",
+        "updated_at": null,
+        "uuid": "with_attached_hook",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "fancy paper",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "fancy_paper"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404702
+    },
+    "small_shapeasdasdadasd": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "small shapeasdasdadasd",
+        "tags": [],
+        "type": "python",
+        "uuid": "small_shapeasdasdadasd",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "small_shapeasdasdadasd_block_1",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "small_shapeasdasdadasd_block_1"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "frosty_night",
+            "type": "data_exporter",
+            "upstream_blocks": [],
+            "uuid": "frosty_night"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "sql",
+            "name": "fragrant_wildflower",
+            "type": "data_exporter",
+            "upstream_blocks": [],
+            "uuid": "fragrant_wildflower"
+          },
+          {
+            "downstream_blocks": [
+              "load_titanic"
+            ],
+            "language": "python",
+            "name": "holy_grass_block_3",
+            "type": "data_exporter",
+            "upstream_blocks": [],
+            "uuid": "holy_grass_block_3"
+          },
+          {
+            "downstream_blocks": [
+              "blue_paper"
+            ],
+            "language": "python",
+            "name": "load_titanic",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "holy_grass_block_3"
+            ],
+            "uuid": "load_titanic"
+          },
+          {
+            "downstream_blocks": [
+              "autumn_snow"
+            ],
+            "language": "python",
+            "name": "blue paper",
+            "type": "global_data_product",
+            "upstream_blocks": [
+              "load_titanic"
+            ],
+            "uuid": "blue_paper"
+          },
+          {
+            "downstream_blocks": [
+              "weathered_shape"
+            ],
+            "language": "python",
+            "name": "autumn snow",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "blue_paper"
+            ],
+            "uuid": "autumn_snow"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "weathered shape",
+            "type": "transformer",
+            "upstream_blocks": [
+              "autumn_snow"
+            ],
+            "uuid": "weathered_shape"
+          },
+          {
+            "downstream_blocks": [
+              "restless_morning"
+            ],
+            "language": "python",
+            "name": "cold meadow",
+            "type": "transformer",
+            "upstream_blocks": [],
+            "uuid": "cold_meadow"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "restless morning",
+            "type": "transformer",
+            "upstream_blocks": [
+              "cold_meadow"
+            ],
+            "uuid": "restless_morning"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "wild lake",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "wild_lake"
+          },
+          {
+            "downstream_blocks": [
+              "old_cherry"
+            ],
+            "language": "python",
+            "name": "old sunset",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "old_sunset"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "old cherry",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "old_sunset"
+            ],
+            "uuid": "old_cherry"
+          },
+          {
+            "downstream_blocks": [
+              "lively_sunset"
+            ],
+            "language": "python",
+            "name": "shy wood",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "shy_wood"
+          },
+          {
+            "downstream_blocks": [
+              "still_fire"
+            ],
+            "language": "python",
+            "name": "lively sunset",
+            "type": "data_loader",
+            "upstream_blocks": [
+              "shy_wood"
+            ],
+            "uuid": "lively_sunset"
+          },
+          {
+            "downstream_blocks": [
+              "twilight_water"
+            ],
+            "language": "sql",
+            "name": "still fire",
+            "type": "custom",
+            "upstream_blocks": [
+              "lively_sunset"
+            ],
+            "uuid": "still_fire"
+          },
+          {
+            "downstream_blocks": [
+              "misty_pine"
+            ],
+            "language": "python",
+            "name": "twilight water",
+            "type": "transformer",
+            "upstream_blocks": [
+              "still_fire"
+            ],
+            "uuid": "twilight_water"
+          },
+          {
+            "downstream_blocks": [
+              "export_titanic_clean"
+            ],
+            "language": "python",
+            "name": "misty pine",
+            "type": "transformer",
+            "upstream_blocks": [
+              "twilight_water"
+            ],
+            "uuid": "misty_pine"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "export_titanic_clean",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "misty_pine"
+            ],
+            "uuid": "export_titanic_clean"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404732
+    },
+    "muddy_firefly": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "muddy firefly",
+        "tags": [],
+        "type": "integration",
+        "uuid": "muddy_firefly",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "cold_surf"
+            ],
+            "language": "yaml",
+            "name": "misty fire",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "misty_fire"
+          },
+          {
+            "downstream_blocks": [
+              "restless_night"
+            ],
+            "language": "python",
+            "name": "cold surf",
+            "type": "transformer",
+            "upstream_blocks": [
+              "misty_fire"
+            ],
+            "uuid": "cold_surf"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "restless night",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "cold_surf"
+            ],
+            "uuid": "restless_night"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404738
+    },
+    "spark": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "spark",
+        "tags": [
+          "Spark",
+          "PySpark"
+        ],
+        "type": "pyspark",
+        "uuid": "spark",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "quiet fire",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "quiet_fire"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404742
+    },
+    "floral_star": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "floral star",
+        "tags": [],
+        "type": "python",
+        "uuid": "floral_star",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "lively night",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "lively_night"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404746
+    },
+    "dawn_thunder": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "dawn thunder",
+        "tags": [],
+        "type": "integration",
+        "uuid": "dawn_thunder",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "autumn_grass"
+            ],
+            "language": "yaml",
+            "name": "green water",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "green_water"
+          },
+          {
+            "downstream_blocks": [
+              "silent_dew"
+            ],
+            "language": "python",
+            "name": "autumn grass",
+            "type": "transformer",
+            "upstream_blocks": [
+              "green_water"
+            ],
+            "uuid": "autumn_grass"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "yaml",
+            "name": "silent dew",
+            "type": "data_exporter",
+            "upstream_blocks": [
+              "autumn_grass"
+            ],
+            "uuid": "silent_dew"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404754
+    },
+    "young_shape": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "young shape",
+        "tags": [],
+        "type": "python",
+        "uuid": "young_shape",
+        "blocks": [
+          {
+            "downstream_blocks": [
+              "young_shape_block_3"
+            ],
+            "language": "python",
+            "name": "young_shape_block_2",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "young_shape_block_2"
+          },
+          {
+            "downstream_blocks": [
+              "young_shape_block_3"
+            ],
+            "language": "python",
+            "name": "young_shape_block_1",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "young_shape_block_1"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "young_shape_block_3",
+            "type": "transformer",
+            "upstream_blocks": [
+              "young_shape_block_1",
+              "young_shape_block_2"
+            ],
+            "uuid": "young_shape_block_3"
+          },
+          {
+            "downstream_blocks": [
+              "bar_chart_for_load_titanic_1693292685024",
+              "histogram_for_load_titanic_1693348918007"
+            ],
+            "language": "python",
+            "name": "load_titanic",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "load_titanic"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "aged morning",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "aged_morning"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404763
+    },
+    "asdfasdfasdf111f": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "asdfasdfasdf111f",
+        "tags": [],
+        "type": "python",
+        "updated_at": null,
+        "uuid": "asdfasdfasdf111f",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "1",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "letter_1"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "2",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "letter_2"
+          },
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "3",
+            "type": "transformer",
+            "upstream_blocks": [],
+            "uuid": "letter_3"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404769
+    },
+    "test_interval_kwargs": {
+      "added_at": null,
+      "pipeline": {
+        "description": null,
+        "name": "test interval kwargs",
+        "tags": [],
+        "type": "python",
+        "uuid": "test_interval_kwargs",
+        "blocks": [
+          {
+            "downstream_blocks": [],
+            "language": "python",
+            "name": "little_glitter",
+            "type": "data_loader",
+            "upstream_blocks": [],
+            "uuid": "little_glitter"
+          }
+        ]
+      },
+      "updated_at": 1702284950.404773
+    }
+  }
+}

--- a/mage_ai/tests/cache/test_pipeline_cache.py
+++ b/mage_ai/tests/cache/test_pipeline_cache.py
@@ -168,7 +168,6 @@ class PipelineCacheTest(BaseApiTestCase):
             name=uuid.uuid4().hex,
             tags=[uuid.uuid4().hex, uuid.uuid4().hex],
             type=uuid.uuid4().hex,
-            updated_at=uuid.uuid4().hex,
             uuid=uuid.uuid4().hex,
         )
 

--- a/mage_ai/tests/data_preparation/models/test_pipeline.py
+++ b/mage_ai/tests/data_preparation/models/test_pipeline.py
@@ -129,7 +129,6 @@ class PipelineTest(AsyncDBTestCase):
             conditionals=[],
             settings=dict(triggers=None),
             created_at='2023-08-01 08:08:24+00:00',
-            updated_at=None,
             widgets=[
                 dict(
                     language='python',
@@ -278,7 +277,6 @@ class PipelineTest(AsyncDBTestCase):
             conditionals=[],
             settings=dict(triggers=None),
             created_at='2023-08-01 08:08:24+00:00',
-            updated_at=None,
             widgets=[],
         ))
 
@@ -389,7 +387,6 @@ class PipelineTest(AsyncDBTestCase):
             conditionals=[],
             settings=dict(triggers=None),
             created_at='2023-08-01 08:08:24+00:00',
-            updated_at=None,
             widgets=[],
         ))
 
@@ -557,7 +554,6 @@ class PipelineTest(AsyncDBTestCase):
             conditionals=[],
             settings=dict(triggers=None),
             created_at='2023-08-01 08:08:24+00:00',
-            updated_at=None,
             widgets=[],
         ))
 
@@ -684,7 +680,6 @@ class PipelineTest(AsyncDBTestCase):
                     run_pipeline_in_one_process=False,
                     spark_config={},
                     type='integration',
-                    updated_at=None,
                     uuid='test_pipeline_9',
                     remote_variables_dir=None,
                     variables_dir=self.repo_path,


### PR DESCRIPTION
# Description
- The `updated_at` attribute in the Pipeline model was causing git merge conflicts since that value was changing too frequently. In order to display a pipeline's "Updated at" property in the UI or when a pipeline was last saved, we get the modified time of the pipeline's `metadata.yaml` config file.
- If an existing pipeline already has an `updated_at` property in its `metadata.yaml` config file, it will be removed when the pipeline is next saved. The last modified time of the pipeline's config file will still be used for its `updated_at` value in the pipeline response.

# How Has This Been Tested?
Pipeline's "Updated at" values still visible in the Pipelines Dashboard:
<img width="1363" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/a4b2c46f-8621-4e71-bc80-06c9b6714f45">

Pipeline "Last saved at" date (in the footer on the right) uses pipeline config file's last modified time:
<img width="1363" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/65ef1c6c-c1c2-4616-9696-d2de4da04685">



# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
