### PR TITLE
Wrong cloud storage reference

### DIFF
--- a/docs/streaming/destinations/google-cloud-storage.mdx
+++ b/docs/streaming/destinations/google-cloud-storage.mdx
@@ -17,7 +17,7 @@ path_to_credentials_json_file: /path/to/your/service/account/key.json
 * `bucket`: The Google Cloud Storage bucket you want to use to store the data.
 * `prefix`: The Google Cloud Storage path prefix. The whole S3 path will be `s3://{bucket}/{prefix}`.
 * `file_type`: `parquet` or `csv`
-* `buffer_size_mb` and `buffer_timeout_seconds`: Mage puts messages in a buffer before uploading to S3.
+* `buffer_size_mb` and `buffer_timeout_seconds`: Mage puts messages in a buffer before uploading to Google Cloud Storage.
   You can configure the size and timeout of the buffer to control the file size and the delay.
 * `path_to_credentials_json_file`: Google service account credential json file. If Mage is running on GCP, you can leave this value null and then Mage will use the instance service account to authenticate.
 


### PR DESCRIPTION
Instead of S3, it should be Google Cloud Storage, as this page is referencing Google Cloud Storage

# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [ ] Test A
- [ ] Test B


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
