### PR TITLE
[xy] Fix running dynamic blocks with k8s executor.

### DIFF
--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -267,6 +267,7 @@ def run(
             ExecutorFactory.get_block_executor(
                 pipeline,
                 block_uuid,
+                block_run_id=block_run_id,
                 execution_partition=execution_partition,
                 executor_type=executor_type,
             ).execute(


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix running dynamic blocks with k8s executor. Pass block_run_id to BlockExecutor init method.
Close: https://github.com/mage-ai/mage-ai/issues/4464

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested in local k8s cluster
<img width="931" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/875c4d6a-4feb-476e-a39f-8927971222c1">
<img width="1262" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/5b6a4fae-a477-4b77-9f6f-0f7f517e3ce8">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
