### PR TITLE
[jk] Widget policy update

### DIFF
--- a/mage_ai/api/policies/WidgetPolicy.py
+++ b/mage_ai/api/policies/WidgetPolicy.py
@@ -61,6 +61,7 @@ WidgetPolicy.allow_write([
     'priority',
     'retry_config',
     'status',
+    'timeout',
     'type',
     'upstream_blocks',
     'uuid',

--- a/mage_ai/cache/block.py
+++ b/mage_ai/cache/block.py
@@ -96,6 +96,8 @@ class BlockCache(BaseCache):
 
         mapping = self.get(self.cache_key)
         for k, v in mapping.items():
+            if not v:
+                continue
             pipeline_count_mapping[k] = len(v.get('pipelines', []))
 
         return pipeline_count_mapping

--- a/mage_ai/frontend/components/ChartBlock/index.tsx
+++ b/mage_ai/frontend/components/ChartBlock/index.tsx
@@ -770,7 +770,7 @@ function ChartBlock({
     updateConfiguration,
   ]);
 
-  const [updateBlock] = useMutation(
+  const [updateBlock]: any = useMutation(
     api.widgets.pipelines.useUpdate(pipeline?.uuid, block.uuid),
     {
       onSuccess: (response: any) => onSuccess(
@@ -778,7 +778,7 @@ function ChartBlock({
           callback: () => {
             setIsEditingBlock(false);
             fetchPipeline();
-            fetchFileTree();
+            fetchFileTree?.();
           },
           onErrorCallback: (response, errors) => setErrors?.({
             errors,
@@ -806,7 +806,6 @@ function ChartBlock({
         && String(keyHistory[0]) === String(KEY_CODE_ENTER)
         && String(keyHistory[1]) !== String(KEY_CODE_META)
       ) {
-        // @ts-ignore
         updateBlock({
           widget: {
             ...block,
@@ -862,7 +861,6 @@ function ChartBlock({
 
                   <Link
                     noWrapping
-                    // @ts-ignore
                     onClick={() => updateBlock({
                       widget: {
                         ...block,


### PR DESCRIPTION
# Description
- There was a WidgetPolicy error when trying to update a chart block name, so this PR fixes the policy issue.
- Also add a check to avoid `AttributeError: 'list' object has no attribute 'get'` when building the pipeline_count_mapping for the files in the file browser. This might happen when updating a chart block name.


# How Has This Been Tested?
- Confirmed the following policy error no longer appears when updating the chart name:
<img width="305" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/c17f2e6d-28e0-4cac-bb8c-d1f3516aca19">


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

