### PR TITLE
[dy] Adjust alembic logger initialization

### DIFF
--- a/mage_ai/orchestration/db/alembic.ini
+++ b/mage_ai/orchestration/db/alembic.ini
@@ -72,13 +72,18 @@ sqlalchemy.url = sqlite:///mage-ai.db
 
 # Logging configuration
 [loggers]
-keys = sqlalchemy,alembic
+keys = root,sqlalchemy,alembic
 
 [handlers]
 keys = console
 
 [formatters]
 keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
 
 [logger_sqlalchemy]
 level = WARN

--- a/mage_ai/orchestration/db/alembic.ini
+++ b/mage_ai/orchestration/db/alembic.ini
@@ -72,18 +72,13 @@ sqlalchemy.url = sqlite:///mage-ai.db
 
 # Logging configuration
 [loggers]
-keys = root,sqlalchemy,alembic
+keys = sqlalchemy,alembic
 
 [handlers]
 keys = console
 
 [formatters]
 keys = generic
-
-[logger_root]
-level = WARN
-handlers = console
-qualname =
 
 [logger_sqlalchemy]
 level = WARN

--- a/mage_ai/orchestration/db/database_manager.py
+++ b/mage_ai/orchestration/db/database_manager.py
@@ -5,7 +5,6 @@ from alembic import command
 from alembic.config import Config
 
 from mage_ai.orchestration.db import db_connection_url
-from mage_ai.shared.logger import LoggingLevel
 
 
 class DatabaseManager:
@@ -16,7 +15,7 @@ class DatabaseManager:
     def script_location(self):
         pass
 
-    def run_migrations(self, log_level: LoggingLevel = None):
+    def run_migrations(self, log_level=None):
         cur_dirpath = os.path.abspath(os.path.dirname(__file__))
         alembic_cfg = Config(
             os.path.join(cur_dirpath, 'alembic.ini'),

--- a/mage_ai/orchestration/db/migrations/env.py
+++ b/mage_ai/orchestration/db/migrations/env.py
@@ -12,7 +12,10 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-if config.config_file_name is not None:
+if (
+    config.config_file_name is not None
+    and config.attributes.get('configure_logger', True)
+):
     fileConfig(config.config_file_name)
 
 logging.getLogger('alembic').setLevel(config.get_section_option('logger_alembic', 'level'))

--- a/mage_ai/tests/base_test.py
+++ b/mage_ai/tests/base_test.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 import sys
@@ -10,7 +11,6 @@ from mage_ai.data_preparation.repo_manager import init_project_uuid
 from mage_ai.orchestration.db import TEST_DB, db_connection
 from mage_ai.orchestration.db.database_manager import database_manager
 from mage_ai.settings.repo import get_variables_dir, set_repo_path
-from mage_ai.shared.logger import LoggingLevel
 
 if sys.version_info.major <= 3 and sys.version_info.minor <= 7:
     class AsyncDBTestCase():
@@ -42,7 +42,7 @@ else:
             if not Path(self.repo_path).exists():
                 Path(self.repo_path).mkdir()
             init_project_uuid()
-            database_manager.run_migrations(log_level=LoggingLevel.ERROR)
+            database_manager.run_migrations(log_level=logging.ERROR)
             db_connection.start_session()
 
         @classmethod
@@ -72,7 +72,7 @@ class DBTestCase(unittest.TestCase):
         if not Path(self.repo_path).exists():
             Path(self.repo_path).mkdir()
         init_project_uuid()
-        database_manager.run_migrations(log_level=LoggingLevel.ERROR)
+        database_manager.run_migrations(log_level=logging.ERROR)
         db_connection.start_session()
 
     @classmethod


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

I noticed that some server logs were not showing up in certain situations. After looking into it, it was happening when the alembic migrations were being run on the main server process. The `env.py` file was overriding the configuration of the root logger which causes most server logs to get hidden. This PR adjusts the `database_manager.run_migrations` methods to tell `env.py` to not configure the loggers, and to manually configure the `alembic` and `sqlalchemy.engine` loggers instead.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with `INSTANCE_TYPE="web_server"`

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
