### PR TITLE
[xy] Use utc time as the default time for monitor_stats.

### DIFF
--- a/mage_ai/orchestration/monitor/monitor_stats.py
+++ b/mage_ai/orchestration/monitor/monitor_stats.py
@@ -42,7 +42,7 @@ class MonitorStats:
         **kwargs,
     ) -> Dict:
         if end_time is None:
-            end_time = datetime.now()
+            end_time = datetime.utcnow()
         else:
             end_time = dateutil.parser.parse(end_time)
         if start_time is None:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Use utc time as the default time for monitor_stats so that it can show latest pipeline runs when container is using a different timezone

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally. The overview page shows correct number of pipeline runs after fix.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
