### PR TITLE
[jk] Reuse callback and conditional blocks

### DIFF
--- a/mage_ai/api/resources/SearchResultResource.py
+++ b/mage_ai/api/resources/SearchResultResource.py
@@ -42,9 +42,7 @@ def filter_results(result: Dict) -> bool:
         return False
 
     if block_type in [
-        BlockType.CALLBACK,
         BlockType.CHART,
-        BlockType.CONDITIONAL,
         BlockType.EXTENSION,
     ]:
         return False

--- a/mage_ai/frontend/components/FileBrowser/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/index.tsx
@@ -13,7 +13,11 @@ import { ThemeContext } from 'styled-components';
 import { useMutation } from 'react-query';
 import { createPortal } from 'react-dom';
 
-import BlockType, { BlockRequestPayloadType, BlockTypeEnum } from '@interfaces/BlockType';
+import BlockType, {
+  ADD_ON_BLOCK_TYPES,
+  BlockRequestPayloadType,
+  BlockTypeEnum,
+} from '@interfaces/BlockType';
 import FileHeaderMenu from './FileHeaderMenu';
 import FileType from '@interfaces/FileType';
 import FlyoutMenu from '@oracle/components/FlyoutMenu';
@@ -323,7 +327,10 @@ function FileBrowser({
               require_unique_name: false,
             },
             block => {
-              if (isIntegrationPipeline && dataExporterBlock) {
+              if (isIntegrationPipeline
+                && dataExporterBlock
+                && !ADD_ON_BLOCK_TYPES.includes(block.type)
+              ) {
                 // @ts-ignore
                 updateDestinationBlock({
                   block: {

--- a/mage_ai/frontend/components/FileBrowser/index.tsx
+++ b/mage_ai/frontend/components/FileBrowser/index.tsx
@@ -411,7 +411,7 @@ function FileBrowser({
   const selectedBlock = useMemo(() => selectedFile && getBlockFromFile(selectedFile), [
     selectedFile,
   ]);
-  const draggingBlock  = useMemo(() => draggingFile && getBlockFromFile(draggingFile), [
+  const draggingBlock  = useMemo(() => draggingFile && getBlockFromFile(draggingFile, null, true), [
     draggingFile,
   ]);
 

--- a/mage_ai/frontend/components/FileBrowser/utils.ts
+++ b/mage_ai/frontend/components/FileBrowser/utils.ts
@@ -22,7 +22,6 @@ import FileType, {
 } from '@interfaces/FileType';
 import { groupBy, prependArray, removeAtIndex, sortByKey } from '@utils/array';
 import { getBlockType } from '@components/FileEditor/utils';
-import { dig } from '@utils/hash';
 import { cleanName, singularize } from '@utils/string';
 
 export function getFullPath(
@@ -123,7 +122,7 @@ export function getBlockFromFile(
   }
 
   const blockTypesToInclude = draggableBlockTypesOnly ? DRAGGABLE_BLOCK_TYPES : BLOCK_TYPES;
-  if (blockTypesToInclude.concat(BlockTypeEnum.DBT).includes(blockType) && validBlockFileExtension(fileName)) {
+  if (blockTypesToInclude.includes(blockType) && validBlockFileExtension(fileName)) {
     const idx = fileName.lastIndexOf('.');
     const extension = fileName.slice(idx + 1);
 

--- a/mage_ai/frontend/components/FileEditor/index.tsx
+++ b/mage_ai/frontend/components/FileEditor/index.tsx
@@ -43,9 +43,6 @@ import {
   getBlockType,
 } from './utils';
 import { find } from '@utils/array';
-import { getBlockFromFile } from '../FileBrowser/utils';
-import { getFullPath } from '@utils/files';
-import { getNonPythonBlockFromFile } from '@components/FileBrowser/utils';
 import { isJsonString } from '@utils/string';
 import { errorOrSuccess, onSuccess } from '@api/utils/response';
 import { onlyKeysPresent } from '@utils/hooks/keyboardShortcuts/utils';

--- a/mage_ai/frontend/components/FileEditor/utils.ts
+++ b/mage_ai/frontend/components/FileEditor/utils.ts
@@ -27,7 +27,7 @@ export const getBlockType = (path: string[]): BlockTypeEnum => {
       let part2 = part?.toLowerCase();
 
       if (part2 in ALL_BLOCK_TYPES_WITH_SINGULAR_FOLDERS) {
-        value = part2
+        value = part2;
       } else {
         part2 = singularize(part2);
         if (part2 in ALL_BLOCK_TYPES) {
@@ -50,7 +50,8 @@ export const getBlockType = (path: string[]): BlockTypeEnum => {
     const extensionRegex = new RegExp(`${extensions}$`);
     const fileName = path.join(osPath.sep);
 
-    if (fileName.match(extensionRegex)) {
+    if (fileName.match(extensionRegex)
+      && (path.includes(BlockTypeEnum.DBT) || path.includes('dbts'))) {
       return BlockTypeEnum.DBT;
     }
   }

--- a/mage_ai/frontend/components/FileEditor/utils.ts
+++ b/mage_ai/frontend/components/FileEditor/utils.ts
@@ -1,5 +1,6 @@
 import * as osPath from 'path';
 import BlockType, {
+  ADD_ON_BLOCK_TYPES,
   ALL_BLOCK_TYPES,
   ALL_BLOCK_TYPES_WITH_SINGULAR_FOLDERS,
   BlockColorEnum,
@@ -122,7 +123,7 @@ export function buildAddBlockRequestPayload(
     blockReqPayload.color = BlockColorEnum.TEAL;
   }
 
-  if (isIntegrationPipeline) {
+  if (isIntegrationPipeline && !ADD_ON_BLOCK_TYPES.includes(blockType)) {
     const dataLoaderBlock: BlockType = find(pipeline.blocks, ({ type }) => BlockTypeEnum.DATA_LOADER === type);
     const transformerBlock: BlockType = find(pipeline.blocks, ({ type }) => BlockTypeEnum.TRANSFORMER === type);
     const upstreamBlocks = [];

--- a/mage_ai/frontend/interfaces/BlockType.ts
+++ b/mage_ai/frontend/interfaces/BlockType.ts
@@ -74,6 +74,11 @@ export const SIDEKICK_BLOCK_TYPES = [
   BlockTypeEnum.EXTENSION,
 ];
 
+export const ADD_ON_BLOCK_TYPES = [
+  BlockTypeEnum.CALLBACK,
+  BlockTypeEnum.CONDITIONAL,
+];
+
 export enum BlockColorEnum {
   BLUE = 'blue',
   GREY = 'grey',

--- a/mage_ai/frontend/interfaces/BlockType.ts
+++ b/mage_ai/frontend/interfaces/BlockType.ts
@@ -88,19 +88,23 @@ export const BLOCK_TYPES = [
   BlockTypeEnum.CUSTOM,
   BlockTypeEnum.DATA_EXPORTER,
   BlockTypeEnum.DATA_LOADER,
+  BlockTypeEnum.DBT,
+  BlockTypeEnum.MARKDOWN,
   BlockTypeEnum.SCRATCHPAD,
   BlockTypeEnum.SENSOR,
-  BlockTypeEnum.MARKDOWN,
   BlockTypeEnum.TRANSFORMER,
 ];
 
 export const DRAGGABLE_BLOCK_TYPES = [
+  BlockTypeEnum.CALLBACK,
+  BlockTypeEnum.CONDITIONAL,
   BlockTypeEnum.CUSTOM,
   BlockTypeEnum.DATA_EXPORTER,
   BlockTypeEnum.DATA_LOADER,
+  BlockTypeEnum.DBT,
+  BlockTypeEnum.MARKDOWN,
   BlockTypeEnum.SCRATCHPAD,
   BlockTypeEnum.SENSOR,
-  BlockTypeEnum.MARKDOWN,
   BlockTypeEnum.TRANSFORMER,
 ];
 

--- a/mage_ai/frontend/interfaces/FileType.ts
+++ b/mage_ai/frontend/interfaces/FileType.ts
@@ -78,7 +78,7 @@ export const FILE_EXTENSION_PRIORITY = {
   [FileExtensionEnum.JSON]: 6,
   [FileExtensionEnum.CSV]: 7,
   [FileExtensionEnum.SH]: 8,
-}
+};
 
 export const SUPPORTED_EDITABLE_FILE_EXTENSIONS_REGEX =
   new RegExp(SUPPORTED_EDITABLE_FILE_EXTENSIONS.map(ext => `\.${ext}$`).join('|'));


### PR DESCRIPTION
# Description
There is currently no easy way to reuse callback and conditional blocks through the UI. This PR allows the user to reuse callback and conditional blocks with 2 different methods:
1. On the Pipeline Editor page, [drag and drop](https://docs.mage.ai/developer-ux/code-editor#adding-blocks-made-easy) a conditional/callback block from the file browser onto the Notebook.
2. On the Pipeline Editor page, [search](https://docs.mage.ai/developer-ux/code-editor#adding-blocks-made-easy) for the name of the callback/conditional block and click the search result to add it to the pipeline (it will automatically be added in the Sidekick under the "Add-on blocks" tab.

# How Has This Been Tested?
- [x] Tested on standard batch pipeline
- [x] Tested on integration pipeline (drag and drop only, block search not available in integration pipelines)
- [X] Tested on streaming pipeline (drag and drop only, block search not available in streaming pipelines)

Adding callback and conditional blocks via drag and drop:
![drag and drop](https://github.com/mage-ai/mage-ai/assets/78053898/85e7c559-e874-462b-827d-93e005c32a7f)

Adding callback and conditional blocks via block search:
![search block](https://github.com/mage-ai/mage-ai/assets/78053898/b684af76-4169-48c9-8ee6-aca56175882d)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
