### PR TITLE
[xy] Show pandas datetime in iso format in notebook.

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -2302,7 +2302,7 @@ class Block(DataIntegrationMixin, SparkBlock, ProjectPlatformAccessible):
                     sample_data=dict(
                         columns=columns_to_display,
                         rows=json.loads(
-                            data[columns_to_display].to_json(orient='split')
+                            data[columns_to_display].to_json(orient='split', date_format='iso'),
                         )['data']
                     ),
                     shape=[row_count, column_count],
@@ -2378,7 +2378,9 @@ df = get_variable('{self.pipeline.uuid}', '{self.uuid}', 'df')
             data = dict(
                 sample_data=dict(
                     columns=columns_to_display,
-                    rows=json.loads(df[columns_to_display].to_json(orient='split'))['data']
+                    rows=json.loads(
+                        df[columns_to_display].to_json(orient='split', date_format='iso'),
+                    )['data']
                 ),
                 type=DataType.TABLE,
                 variable_uuid=variable_uuid,

--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -224,6 +224,7 @@ def __custom_output():
         _sample = _internal_output_return.iloc[:{DATAFRAME_SAMPLE_COUNT_PREVIEW}]
         _columns = _sample.columns.tolist()[:{DATAFRAME_ANALYSIS_MAX_COLUMNS}]
         _rows = simplejson.loads(_sample[_columns].fillna('').to_json(
+            date_format='iso',
             default_handler=str,
             orient='split',
         ))['data']


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Show pandas datetime in iso format in notebook.

Doc: https://pandas.pydata.org/pandas-docs/version/0.23/generated/pandas.DataFrame.to_json.html


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested in local Mage notebook

before the fix
<img width="345" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/fe1a6484-7802-4527-84d6-579a510fc781">

with the fix
<img width="500" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/19a1e59b-ba85-48a4-88d6-38a2c98e57d6">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
