### PR TITLE
Fix Google Ads Catalog to Data Integration Block

### DIFF
--- a/mage_integrations/mage_integrations/sources/google_ads/tap_google_ads/streams.py
+++ b/mage_integrations/mage_integrations/sources/google_ads/tap_google_ads/streams.py
@@ -596,7 +596,7 @@ class ReportStream(BaseStream):
             "type": ["null", "object"],
             "is_report": True,
             "properties": {
-                "_sdc_record_hash": {"type": "string"}
+                "_sdc_record_hash": {"type": ["string"]}
             },
         }
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
In a specific type of stream, Google Ads Source Catalog sets a column type as a  string, whereas Mage frontend require a python list ( array ) to filter each result.

Because of this, Schema properties cant be modified while using Batch pipelines ( see linked issue for a real example ). This PR aims to fix this and allow Schema Properties to be modified.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
Tested using a local mage instance and a developer google ads account

## Schema Properties example

![Screenshot from 2024-02-09 17-41-10](https://github.com/mage-ai/mage-ai/assets/14100959/368ab702-5951-4e91-b6c2-d055668f8647)



# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code


cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 