### PR TITLE
[xy] Set max width for yaml file to inf.

### DIFF
--- a/mage_ai/data_preparation/repo_manager.py
+++ b/mage_ai/data_preparation/repo_manager.py
@@ -22,6 +22,7 @@ from mage_ai.shared.environments import is_debug
 
 yml = ruamel.yaml.YAML()
 yml.preserve_quotes = True
+yml.width = float('inf')
 yml.indent(mapping=2, sequence=2, offset=0)
 
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Set max width for yaml file to inf to prevent long lines getting wrapped in the yaml file

Ref: https://stackoverflow.com/questions/42170709/prevent-long-lines-getting-wrapped-in-ruamel-yaml

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with the following steps
  -  Remove the project_uuid from the project metadata.yaml
  - Add the following config to project metadata.yaml
  ```
  notification_config:
    alert_on:
    - trigger_failure
    - trigger_passed_sla
    slack_config:
      webhook_url: "{{ env_var('MAGE_SLACK_WEBHOOK_URL') if env != 'dev' else mage_secret_var('SLACK_ETL_MONITORING') }}"
    teams_config:
      webhook_url: "{{ env_var('MAGE_TEAMS_WEBHOOK_URL') }}"
  ```
  - Restart the server
  - Before the fix, the long line get wrapped and the following error is thrown
  <img width="625" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/1f2369bd-0e08-4186-82aa-f1288c33cc60">
  - After the fix, the format of the yaml doesn't change and the server can start successfully.



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
