### PR TITLE
[dy] Filter out sensitive config

### DIFF
--- a/mage_ai/data_preparation/preferences.py
+++ b/mage_ai/data_preparation/preferences.py
@@ -81,9 +81,11 @@ def build_sync_config(project_sync_config: Dict) -> Dict:
         sync_config = project_sync_config
 
     # Set the enable_git_integration field from environment variables
-    sync_config['enable_git_integration'] = get_value_for_sync_config(
+    enable_git_integration = get_value_for_sync_config(
         GIT_ENABLE_GIT_INTEGRATION_VAR
     )
+    if enable_git_integration is not None:
+        sync_config['enable_git_integration'] = enable_git_integration
 
     return sync_config
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Filter out access token from error message when using HTTPS connection. It doesn't seem to consistently get included in the logs (seems to be dependent on the URL format), so trying a change to catch errors and remove the token from the error message.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with malformed Github url 


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
