### PR TITLE
[xy] Support filtering google sheets by sheet names

### DIFF
--- a/mage_integrations/mage_integrations/sources/google_sheets/README.md
+++ b/mage_integrations/mage_integrations/sources/google_sheets/README.md
@@ -10,6 +10,7 @@ You must enter the following credentials when configuring this source:
 | --- | --- | --- |
 | `path_to_credentials_json_file` | Google service account credential json file. | `/path/to/service_account_credentials.json` |
 | `spreadsheet_id` | The unique identifier of a spreadsheet. You can find it in the spreadsheet URL after `/spreadsheets/d/` | `abcdefg123456` |
+| `selected_sheet_names` | A list of sheet names to filter by | `["sheet1", "sheet2"]` |
 
 <br />
 

--- a/mage_integrations/mage_integrations/sources/google_sheets/__init__.py
+++ b/mage_integrations/mage_integrations/sources/google_sheets/__init__.py
@@ -30,7 +30,7 @@ class GoogleSheets(Source):
 
     def discover(self, streams: List[str] = None) -> Catalog:
         if streams is None:
-            streams = []
+            streams = self.config.get('selected_sheet_names') or []
 
         catalog_entries = []
 
@@ -227,8 +227,8 @@ class GoogleSheets(Source):
         try:
             sheet_json_schema, columns = self.__get_sheet_schema_columns(sheet_metadata)
         except Exception as err:
-            self.logger.warning(f'{err}')
-            self.logger.warning(f'SKIPPING Malformed sheet: {sheet_title}')
+            self.logger.error(f'{err}')
+            self.logger.error(f'SKIPPING Malformed sheet: {sheet_title}')
             sheet_json_schema, columns = None, None
 
         return sheet_json_schema, columns
@@ -275,7 +275,7 @@ class GoogleSheets(Source):
 
         # if no headers are present, log the message that sheet is skipped
         if not headers:
-            self.logger.warning(f'SKIPPING THE SHEET AS HEADERS ROW IS EMPTY. SHEET: {sheet_title}')
+            self.logger.info(f'SKIPPING THE SHEET AS HEADERS ROW IS EMPTY. SHEET: {sheet_title}')
 
         # Read column headers until end or 2 consecutive skipped headers
         for header in headers:

--- a/mage_integrations/mage_integrations/sources/google_sheets/templates/config.json
+++ b/mage_integrations/mage_integrations/sources/google_sheets/templates/config.json
@@ -1,4 +1,5 @@
 {
     "path_to_credentials_json_file": "path_to_credentials_json_file",
-    "spreadsheet_id": ""
+    "spreadsheet_id": "",
+    "selected_sheet_names": null
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Support filtering google sheets by sheet names to reduce google sheets API calls

This PR also fixes the logging

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with google sheets source with config like this

```yaml
path_to_credentials_json_file: /path/to/credentials.json
spreadsheet_id: abcdefg
selected_sheet_names:
- sheet1
- sheet2
- sheet3
```
only specified sheets are selected

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
