### PR TITLE
[xy] Combine schedulers.

### DIFF
--- a/mage_ai/orchestration/pipeline_scheduler.py
+++ b/mage_ai/orchestration/pipeline_scheduler.py
@@ -1,6 +1,1 @@
-from mage_ai.settings.platform.constants import project_platform_activated
-
-if project_platform_activated():
-    from mage_ai.orchestration.pipeline_scheduler_project_platform import *
-else:
-    from mage_ai.orchestration.pipeline_scheduler_original import *
+from mage_ai.orchestration.pipeline_scheduler_original import *  # noqa: F401, F403

--- a/mage_ai/tests/orchestration/test_pipeline_scheduler_project_platform.py
+++ b/mage_ai/tests/orchestration/test_pipeline_scheduler_project_platform.py
@@ -9,7 +9,7 @@ from mage_ai.orchestration.db.models.schedules import (
     PipelineRun,
     PipelineSchedule,
 )
-from mage_ai.orchestration.pipeline_scheduler_project_platform import (
+from mage_ai.orchestration.pipeline_scheduler import (
     PipelineScheduler,
     check_sla,
     run_block,
@@ -21,7 +21,7 @@ from mage_ai.tests.shared.mixins import ProjectPlatformMixin
 
 
 @patch(
-    'mage_ai.orchestration.pipeline_scheduler.project_platform_activated',
+    'mage_ai.orchestration.pipeline_scheduler_original.project_platform_activated',
     lambda: True,
 )
 @patch(
@@ -31,7 +31,7 @@ from mage_ai.tests.shared.mixins import ProjectPlatformMixin
 class PipelineSchedulerProjectPlatformTests(ProjectPlatformMixin, DBTestCase):
     def test_init(self):
         with patch(
-            'mage_ai.orchestration.pipeline_scheduler_project_platform.project_platform_activated',
+            'mage_ai.orchestration.pipeline_scheduler_original.project_platform_activated',
             lambda: True,
         ):
             with patch(
@@ -62,11 +62,11 @@ class PipelineSchedulerProjectPlatformTests(ProjectPlatformMixin, DBTestCase):
 
     def test_run_block(self):
         with patch(
-            'mage_ai.orchestration.pipeline_scheduler_project_platform.project_platform_activated',
+            'mage_ai.orchestration.pipeline_scheduler_original.project_platform_activated',
             lambda: True,
         ):
             with patch(
-                'mage_ai.orchestration.pipeline_scheduler_project_platform.'
+                'mage_ai.orchestration.pipeline_scheduler_original.'
                 'project_platform_activated',
                 lambda: True,
             ):
@@ -145,12 +145,12 @@ class PipelineSchedulerProjectPlatformTests(ProjectPlatformMixin, DBTestCase):
                                     return fake_repo_config
 
                                 with patch(
-                                    'mage_ai.orchestration.pipeline_scheduler_project_platform.'
+                                    'mage_ai.orchestration.pipeline_scheduler_original.'
                                     'ExecutorFactory',
                                     FakeExecutorFactory,
                                 ):
                                     with patch(
-                                        'mage_ai.orchestration.pipeline_scheduler_project_platform.'
+                                        'mage_ai.orchestration.pipeline_scheduler_original.'
                                         'get_repo_config',
                                         __get_repo_config,
                                     ):
@@ -163,7 +163,7 @@ class PipelineSchedulerProjectPlatformTests(ProjectPlatformMixin, DBTestCase):
 
     def test_check_sla(self):
         with patch(
-            'mage_ai.orchestration.pipeline_scheduler_project_platform.project_platform_activated',
+            'mage_ai.orchestration.pipeline_scheduler_original.project_platform_activated',
             lambda: True,
         ):
             with patch(
@@ -197,7 +197,7 @@ class PipelineSchedulerProjectPlatformTests(ProjectPlatformMixin, DBTestCase):
         PipelineRunMock = MagicMock()
 
         with patch(
-            'mage_ai.orchestration.pipeline_scheduler_project_platform.PipelineRun',
+            'mage_ai.orchestration.pipeline_scheduler_original.PipelineRun',
             PipelineRunMock,
         ):
             with patch(
@@ -215,11 +215,11 @@ class PipelineSchedulerProjectPlatformTests(ProjectPlatformMixin, DBTestCase):
     @freeze_time('2023-11-11 12:30:00')
     def test_schedule_all(self):
         with patch(
-            'mage_ai.orchestration.pipeline_scheduler_project_platform.project_platform_activated',
+            'mage_ai.orchestration.pipeline_scheduler_original.project_platform_activated',
             lambda: True,
         ):
             with patch(
-                'mage_ai.orchestration.pipeline_scheduler_project_platform.'
+                'mage_ai.orchestration.pipeline_scheduler_original.'
                 'project_platform_activated',
                 lambda: True,
             ):
@@ -264,7 +264,7 @@ class PipelineSchedulerProjectPlatformTests(ProjectPlatformMixin, DBTestCase):
                                 pass
 
                         with patch(
-                            'mage_ai.orchestration.pipeline_scheduler_project_platform.'
+                            'mage_ai.orchestration.pipeline_scheduler_original.'
                             'PipelineScheduler',
                             PipelineSchedulerMock,
                         ):


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This PR combines the pipeline_scheduler_original and pipeline_scheduler_project_platform in one scheduler.

To separate the code logic for single project and project platform, this PR uses the generator method for different scenarios to generate the pipeline with active_schedules.
* gen_pipeline_with_schedules_single_project
* gen_pipeline_with_schedules_project_platform

The core logic of scheduling is same for both scenarios.

This PR still keeps the logic inside `pipeline_scheduler_original.py` to better view the code changes and update the `pipeline_scheduler.py` to only import `pipeline_scheduler_original`. Will delete the other `pipeline_scheduler_project_platform` file completely after the scheduler is proved to be running fine.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with both single project and project platform locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
