### PR TITLE
[xy] Separate scheduler logs and pipeline logs.

### DIFF
--- a/mage_ai/data_preparation/logging/logger_manager.py
+++ b/mage_ai/data_preparation/logging/logger_manager.py
@@ -25,6 +25,7 @@ class LoggerManager:
         logs_dir: str = None,
         pipeline_uuid: str = None,
         block_uuid: str = None,
+        filename: str = None,
         partition: str = None,
         repo_config: RepoConfig = None,
         subpartition: str = None,
@@ -45,6 +46,7 @@ class LoggerManager:
         self.logs_dir = logs_dir
         self.pipeline_uuid = pipeline_uuid
         self.block_uuid = block_uuid
+        self.filename = filename
         self.partition = partition
         self.subpartition = subpartition
 
@@ -201,7 +203,9 @@ class LoggerManager:
         if create_dir:
             self.create_log_filepath_dir(prefix)
 
-        if self.block_uuid is None:
+        if self.filename is not None:
+            log_filepath = os.path.join(prefix, self.filename)
+        elif self.block_uuid is None:
             log_filepath = os.path.join(prefix, 'pipeline.log')
         else:
             log_filepath = os.path.join(prefix, f'{self.block_uuid}.log')

--- a/mage_ai/data_preparation/models/file.py
+++ b/mage_ai/data_preparation/models/file.py
@@ -426,6 +426,7 @@ class File:
         update_file_cache()
 
     def to_dict(self, include_content: bool = False, include_metadata: bool = False):
+        file_exists = self.exists()
         data = dict(
             name=self.filename,
             path=os.path.join(self.dir_path, self.filename),
@@ -436,21 +437,23 @@ class File:
         if include_content:
             data['content'] = self.content()
 
-        if include_metadata:
+        if include_metadata and file_exists:
             data['size'] = self.size
             data['modified_timestamp'] = self.modified_timestamp
 
         return data
 
     async def to_dict_async(self, include_content=False):
+        file_exists = self.exists()
         data = dict(
             name=self.filename,
             path=os.path.join(self.dir_path, self.filename),
-            size=self.size,
-            modified_timestamp=self.modified_timestamp,
+            size=self.size if file_exists else None,
+            modified_timestamp=self.modified_timestamp if file_exists else None,
         )
         if include_content:
             data['content'] = await self.content_async()
+
         return data
 
 

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -831,6 +831,13 @@ class PipelineRun(PipelineRunProjectPlatformMixin, BaseModel):
 
     @property
     def logs(self) -> List[Dict]:
+        """
+        Retrieves logs for the pipeline and scheduler.
+
+        Returns:
+            List[Dict]: A list containing dictionaries of logs for the pipeline and scheduler.
+                Each dictionary represents logs for a specific component.
+        """
         pipeline_logs = LoggerManagerFactory.get_logger_manager(
             pipeline_uuid=self.pipeline_uuid,
             partition=self.execution_partition,
@@ -882,6 +889,19 @@ class PipelineRun(PipelineRunProjectPlatformMixin, BaseModel):
         return pipeline_runs
 
     async def logs_async(self) -> List[Dict]:
+        """
+        Asynchronously retrieves logs for the pipeline and scheduler.
+
+        If the project platform is activated, it asynchronously retrieves logs using
+        the specific method for project platform.
+
+        Otherwise, it asynchronously retrieves logs for the pipeline and scheduler
+        separately.
+
+        Returns:
+            List[Dict]: A list containing dictionaries of logs for the pipeline and scheduler.
+                Each dictionary represents logs for a specific component.
+        """
         if project_platform_activated():
             return await self.logs_async_project_platform()
 

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -830,12 +830,19 @@ class PipelineRun(PipelineRunProjectPlatformMixin, BaseModel):
         return pipeline.type if pipeline is not None else None
 
     @property
-    def logs(self):
-        return LoggerManagerFactory.get_logger_manager(
+    def logs(self) -> List[Dict]:
+        pipeline_logs = LoggerManagerFactory.get_logger_manager(
             pipeline_uuid=self.pipeline_uuid,
             partition=self.execution_partition,
             repo_config=self.pipeline.repo_config,
         ).get_logs()
+        scheduler_logs = LoggerManagerFactory.get_logger_manager(
+            pipeline_uuid=self.pipeline_uuid,
+            filename='scheduler.log',
+            partition=self.execution_partition,
+            repo_config=self.pipeline.repo_config,
+        ).get_logs()
+        return [pipeline_logs, scheduler_logs]
 
     @classmethod
     def recently_completed_pipeline_runs(
@@ -874,15 +881,22 @@ class PipelineRun(PipelineRunProjectPlatformMixin, BaseModel):
 
         return pipeline_runs
 
-    async def logs_async(self):
+    async def logs_async(self) -> List[Dict]:
         if project_platform_activated():
             return await self.logs_async_project_platform()
 
-        return await LoggerManagerFactory.get_logger_manager(
+        pipeline_logs = await LoggerManagerFactory.get_logger_manager(
             pipeline_uuid=self.pipeline_uuid,
             partition=self.execution_partition,
             repo_config=self.pipeline.repo_config,
         ).get_logs_async()
+        scheduler_logs = await LoggerManagerFactory.get_logger_manager(
+            pipeline_uuid=self.pipeline_uuid,
+            filename='scheduler.log',
+            partition=self.execution_partition,
+            repo_config=self.pipeline.repo_config,
+        ).get_logs_async()
+        return [pipeline_logs, scheduler_logs]
 
     @property
     def pipeline_schedule_name(self):

--- a/mage_ai/orchestration/db/models/schedules_project_platform.py
+++ b/mage_ai/orchestration/db/models/schedules_project_platform.py
@@ -329,7 +329,7 @@ class PipelineRunProjectPlatformMixin:
 
         return variables
 
-    async def logs_async_project_platform(self):
+    async def logs_async_project_platform(self) -> List[Dict]:
         repo_path = None
         if self.pipeline_schedule:
             repo_path = self.pipeline_schedule.repo_path
@@ -339,11 +339,18 @@ class PipelineRunProjectPlatformMixin:
             repo_path=repo_path,
         )
 
-        return await LoggerManagerFactory.get_logger_manager(
+        pipeline_logs = await LoggerManagerFactory.get_logger_manager(
             pipeline_uuid=self.pipeline_uuid,
             partition=self.execution_partition,
             repo_config=pipeline.repo_config,
         ).get_logs_async()
+        scheduler_logs = await LoggerManagerFactory.get_logger_manager(
+            pipeline_uuid=self.pipeline_uuid,
+            filename='scheduler.log',
+            partition=self.execution_partition,
+            repo_config=pipeline.repo_config,
+        ).get_logs_async()
+        return [pipeline_logs, scheduler_logs]
 
 
 class BlockRunProjectPlatformMixin:

--- a/mage_ai/orchestration/pipeline_scheduler_original.py
+++ b/mage_ai/orchestration/pipeline_scheduler_original.py
@@ -95,6 +95,7 @@ class PipelineScheduler:
         # Initialize the logger
         self.logger_manager = LoggerManagerFactory.get_logger_manager(
             pipeline_uuid=self.pipeline.uuid,
+            filename='scheduler.log',
             partition=self.pipeline_run.execution_partition,
             repo_config=self.pipeline.repo_config,
         )

--- a/mage_ai/tests/orchestration/db/models/test_schedules.py
+++ b/mage_ai/tests/orchestration/db/models/test_schedules.py
@@ -1551,12 +1551,19 @@ class PipelineRunTests(DBTestCase):
             execution_date=execution_date,
         )
         execution_date_str = execution_date.strftime(format='%Y%m%dT%H%M%S')
-        expected_file_path = os.path.join(
+        execution_date_str = execution_date.strftime(format='%Y%m%dT%H%M%S')
+        expected_file_path1 = os.path.join(
             get_repo_config(self.repo_path).variables_dir,
             'pipelines/test_pipeline/.logs',
             f'{pipeline_run.pipeline_schedule_id}/{execution_date_str}/pipeline.log',
         )
-        self.assertEqual(pipeline_run.logs.get('path'), expected_file_path)
+        expected_file_path2 = os.path.join(
+            get_repo_config(self.repo_path).variables_dir,
+            'pipelines/test_pipeline/.logs',
+            f'{pipeline_run.pipeline_schedule_id}/{execution_date_str}/scheduler.log',
+        )
+        self.assertEqual(pipeline_run.logs[0].get('path'), expected_file_path1)
+        self.assertEqual(pipeline_run.logs[1].get('path'), expected_file_path2)
 
     def test_active_runs_for_pipelines(self):
         create_pipeline_with_blocks(
@@ -1832,9 +1839,10 @@ class PipelineRunProjectPlatformTests(ProjectPlatformMixin, AsyncDBTestCase):
             @classmethod
             def get_logger_manager(
                 cls,
-                pipeline_uuid: str,
-                partition: str,
-                repo_config: str,
+                pipeline_uuid: str = None,
+                filename: str = None,
+                partition: str = None,
+                repo_config: str = None,
             ):
                 self.assertEqual(pipeline_uuid, pipeline_run.pipeline_uuid)
                 self.assertEqual(partition, pipeline_run.execution_partition)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Separate scheduler logs and pipeline logs to avoid "stale file handle error".

When the scheduler and executor use the same file for logging, it could cause stale handle error since we use RotatingFileHandle.

This PR fixes it by separating the logging files.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested running scheduler and streaming pipeline locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
