### PR TITLE
[jk] Fix block caching when renaming/detaching blocks

### DIFF
--- a/mage_ai/api/resources/BlockResource.py
+++ b/mage_ai/api/resources/BlockResource.py
@@ -359,7 +359,7 @@ class BlockResource(GenericResource):
 
         for block in blocks_to_delete:
             if pipeline:
-                cache.remove_pipeline(block, pipeline.uuid, pipeline.repo_path)
+                cache.remove_pipeline(block.to_dict(), pipeline.uuid, pipeline.repo_path)
             cache_block_action_object.update_block(block, remove=True)
             block.delete(force=force)
 

--- a/mage_ai/api/resources/BlockResource.py
+++ b/mage_ai/api/resources/BlockResource.py
@@ -233,7 +233,7 @@ class BlockResource(GenericResource):
 
         if pipeline:
             cache = await BlockCache.initialize_cache()
-            cache.add_pipeline(block, pipeline)
+            cache.add_pipeline(block.to_dict(), pipeline)
 
         cache_block_action_object = await BlockActionObjectCache.initialize_cache()
         cache_block_action_object.update_block(block)

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -3429,7 +3429,6 @@ df = get_variable('{self.pipeline.uuid}', '{self.uuid}', 'df')
         old_file_path = self.file_path
         block_content = self.content
 
-        # load_titanic
         new_uuid = clean_name(name)
         self.name = name
         self.uuid = new_uuid

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -1265,7 +1265,7 @@ class Pipeline:
                 )
 
             for block in self.blocks_by_uuid.values():
-                if block.uuid not in block_uuids_to_add_to_cache:
+                if block_uuids_to_add_to_cache and block.uuid not in block_uuids_to_add_to_cache:
                     continue
 
                 if old_uuid:


### PR DESCRIPTION
# Description
- The block-to-pipelines cache wasn't getting updated properly when renaming or detaching a block in the Pipeline Editor.

# How Has This Been Tested?
- [X] Rename pipeline and confirm block cache was properly updated.

Renaming block:
![renaming block](https://github.com/mage-ai/mage-ai/assets/78053898/8cb120eb-63e9-4400-8e87-e4bcd3613214)

Detaching block:
![detaching block](https://github.com/mage-ai/mage-ai/assets/78053898/b47a0690-0bfc-4307-a763-d2c8961c0335)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
