### PR TITLE
[jk] Update tag and block cache when cloning pipeline

### DIFF
--- a/mage_ai/api/resources/PipelineResource.py
+++ b/mage_ai/api/resources/PipelineResource.py
@@ -371,7 +371,7 @@ class PipelineResource(BaseResource):
             pipeline = custom_template.create_pipeline(name)
         elif clone_pipeline_uuid is not None:
             source = Pipeline.get(clone_pipeline_uuid)
-            pipeline = Pipeline.duplicate(source, name)
+            pipeline = await Pipeline.duplicate(source, name)
         else:
             pipeline = Pipeline.create(
                 name,

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -289,7 +289,7 @@ class Pipeline:
             return ret_file, pipeline_config
 
     @classmethod
-    def duplicate(
+    async def duplicate(
         cls,
         source_pipeline: 'Pipeline',
         duplicate_pipeline_name: str = None,
@@ -324,6 +324,21 @@ class Pipeline:
             duplicate_pipeline.config_path,
             yaml.dump(duplicate_pipeline_dict)
         )
+
+        tags = duplicate_pipeline_dict.get('tags')
+        blocks = duplicate_pipeline_dict.get('blocks')
+        if tags:
+            from mage_ai.cache.tag import TagCache
+
+            tag_cache = await TagCache.initialize_cache()
+            for tag_uuid in tags:
+                tag_cache.add_pipeline(tag_uuid, duplicate_pipeline)
+        if blocks:
+            from mage_ai.cache.block import BlockCache
+
+            block_cache = await BlockCache.initialize_cache()
+            for block in blocks:
+                block_cache.add_pipeline(block, duplicate_pipeline)
 
         return cls.get(
             duplicate_pipeline_uuid,

--- a/mage_ai/tests/data_preparation/models/test_pipeline.py
+++ b/mage_ai/tests/data_preparation/models/test_pipeline.py
@@ -582,9 +582,9 @@ class PipelineTest(AsyncDBTestCase):
         self.assertFalse(os.access(block4.file_path, os.F_OK))
         self.assertFalse(os.access(block5.file_path, os.F_OK))
 
-    def test_duplicate_standard_pipeline(self):
+    async def test_duplicate_standard_pipeline(self):
         pipeline = self.__create_pipeline_with_blocks('test_pipeline_7a')
-        duplicate_pipeline = Pipeline.duplicate(pipeline, 'duplicate_pipeline')
+        duplicate_pipeline = await Pipeline.duplicate(pipeline, 'duplicate_pipeline')
         for block_uuid in pipeline.blocks_by_uuid:
             original = pipeline.blocks_by_uuid[block_uuid]
             duplicate = duplicate_pipeline.blocks_by_uuid[block_uuid]
@@ -605,9 +605,9 @@ class PipelineTest(AsyncDBTestCase):
             )
             self.assertEqual(original.upstream_block_uuids, duplicate.upstream_block_uuids)
 
-    def test_duplicate_integration_pipeline(self):
+    async def test_duplicate_integration_pipeline(self):
         pipeline = self.__create_pipeline_with_integration('test_pipeline_7b')
-        duplicate_pipeline = Pipeline.duplicate(pipeline, 'duplicate_pipeline_2')
+        duplicate_pipeline = await Pipeline.duplicate(pipeline, 'duplicate_pipeline_2')
         for block_uuid in pipeline.blocks_by_uuid:
             original = pipeline.blocks_by_uuid[block_uuid]
             duplicate = duplicate_pipeline.blocks_by_uuid[block_uuid]


### PR DESCRIPTION
# Description
- See title.

# How Has This Been Tested?
- [X] Confirmed tag cache was updated when cloning standard, streaming, and integration pipeline.
- [X] Confirmed block-to-pipeline cache was updated (and "shared pipelines" in block settings were accurate) when cloning standard, streaming, and integration pipeline.

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
