### PR TITLE
[dy] Add DB locking

### DIFF
--- a/mage_ai/orchestration/db/database_manager.py
+++ b/mage_ai/orchestration/db/database_manager.py
@@ -1,10 +1,75 @@
+import contextlib
+import enum
 import logging
 import os
+from typing import Generator
 
 from alembic import command
 from alembic.config import Config
+from sqlalchemy import text
 
-from mage_ai.orchestration.db import db_connection_url
+from mage_ai.orchestration.db import db_connection, db_connection_url
+
+
+@enum.unique
+class DBLocks(enum.IntEnum):
+    """
+    Cross-db Identifiers for advisory global database locks.
+
+    Postgres uses int64 lock ids so we use the integer value, MySQL uses names, so we
+    call ``str()`, which is implemented using the ``_name_`` field.
+
+    Based on airflow.utils.db.DBLocks
+    """
+
+    MIGRATIONS = enum.auto()
+
+    def __str__(self):
+        return f'mage_{self._name_}'
+
+
+@contextlib.contextmanager
+def create_db_lock(
+    session,
+    lock: DBLocks,
+    lock_timeout: int = 30000,  # 30 seconds
+) -> Generator[None, None, None]:
+    """
+    Contextmanager that will create and teardown a global db lock.
+
+    Based on airflow.utils.db.create_global_lock
+    """
+    conn = session.get_bind().connect()
+    dialect = conn.dialect
+
+    lock_acquired = False
+
+    try:
+        if dialect.name == 'postgresql':
+            conn.execute(
+                text('SET LOCK_TIMEOUT to :timeout'), {'timeout': lock_timeout}
+            )
+            conn.execute(text('SELECT pg_advisory_lock(:id)'), {'id': lock.value})
+        elif dialect.name == 'mysql' and dialect.server_version_info >= (5, 6):
+            conn.execute(
+                text('SELECT GET_LOCK(:id, :timeout)'),
+                {'id': str(lock), 'timeout': lock_timeout},
+            )
+
+        lock_acquired = True
+        yield
+    finally:
+        if dialect.name == 'postgresql':
+            conn.execute(text('SET LOCK_TIMEOUT TO DEFAULT'))
+            (unlocked,) = conn.execute(
+                text('SELECT pg_advisory_unlock(:id)'), {'id': lock.value}
+            ).fetchone()
+            if lock_acquired and not unlocked:
+                raise RuntimeError('Error releasing DB lock!')
+        elif dialect.name == 'mysql' and dialect.server_version_info >= (5, 6):
+            conn.execute(text('select RELEASE_LOCK(:id)'), {'id': str(lock)})
+
+        conn.close()
 
 
 class DatabaseManager:
@@ -43,7 +108,10 @@ class DatabaseManager:
         if sqlalchemy_engine_logger.level == logging.NOTSET:
             sqlalchemy_engine_logger.setLevel(logging.WARN)
 
-        command.upgrade(alembic_cfg, 'head')
+        if db_connection.session is None:
+            db_connection.start_session()
+        with create_db_lock(db_connection.session, DBLocks.MIGRATIONS):
+            command.upgrade(alembic_cfg, revision='head')
 
 
 class SqliteDatabaseManager(DatabaseManager):


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Add DB locking for postgres and mysql. Mage doesn't work properly with mysql yet, but I added it in case we support it in the future. Each instance of mage will attempt to acquire the lock for 30 seconds after starting, and if it cannot acquire it an error will be thrown.

The code for this is based off of airflow's db locking implementation.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with separate webserver and scheduler using postgres and mysql db
<img width="864" alt="Screenshot 2024-02-22 at 3 59 57 PM" src="https://github.com/mage-ai/mage-ai/assets/14357209/5c840bf4-2a1e-4669-bc46-c5d354447d89">




# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
