### PR TITLE
[jk] Various bugfixes for pipeline search and filter

### DIFF
--- a/mage_ai/api/resources/PipelineResource.py
+++ b/mage_ai/api/resources/PipelineResource.py
@@ -231,10 +231,12 @@ class PipelineResource(BaseResource):
 
         if pipeline_types:
             for pipeline_dict in cache.get_models(types=pipeline_types):
-                pipelines.append(Pipeline(
-                    pipeline_dict['pipeline']['uuid'],
-                    config=pipeline_dict['pipeline'],
-                ))
+                pipeline_uuid_from_cache = pipeline_dict['pipeline']['uuid']
+                if pipeline_uuid_from_cache in pipeline_uuids:
+                    pipelines.append(Pipeline(
+                        pipeline_uuid_from_cache,
+                        config=pipeline_dict['pipeline'],
+                    ))
         else:
             for uuid in pipeline_uuids:
                 pipeline_dict = cache.get_model(dict(uuid=uuid))
@@ -262,8 +264,6 @@ class PipelineResource(BaseResource):
         mapping = {}
         if include_schedules:
             mapping = query_pipeline_schedules(pipeline_uuids)
-        if pipeline_types:
-            pipelines = [p for p in pipelines if p.type in pipeline_types]
 
         filtered_pipelines = []
         for pipeline in pipelines:

--- a/mage_ai/frontend/oracle/components/ToggleMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/ToggleMenu/index.tsx
@@ -18,6 +18,7 @@ import {
 import { ChevronRight } from '@oracle/icons';
 import { GoToWithFiltersProps, goToWithFilters } from '@utils/routing';
 import { MetaQueryEnum } from '@api/constants';
+import { ROW_LIMIT } from '@components/shared/Paginate';
 import { capitalize, removeUnderscore } from '@utils/string';
 
 type ToggleMenuProps = {
@@ -163,6 +164,7 @@ function ToggleMenu({
 
                 const filterQueryOptions: GoToWithFiltersProps = {
                   addingMultipleValues: true,
+                  itemsPerPage: ROW_LIMIT,
                   pushHistory: true,
                   resetLimitParams: resetLimitOnApply,
                   resetPage: resetPageOnApply,

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -156,6 +156,7 @@ function PipelineListPage() {
     clearTimeout(timeout.current);
 
     timeout.current = setTimeout(() => goToWithQuery({
+      [MetaQueryEnum.OFFSET]: 0,
       [PipelineQueryEnum.SEARCH]: searchQuery,
     }), 500);
   }, [

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -870,6 +870,7 @@ function PipelineListPage() {
         setFilters({});
         setSearchTextState('');
         goToWithQuery({
+          [MetaQueryEnum.LIMIT]: query?.[MetaQueryEnum.LIMIT] || ROW_LIMIT,
           [PipelineQueryEnum.SEARCH]: '',
         }, {
           replaceParams: true,

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -868,7 +868,12 @@ function PipelineListPage() {
       ]}
       onClickFilterDefaults={() => {
         setFilters({});
-        router.push('/pipelines');
+        setSearchTextState('');
+        goToWithQuery({
+          [PipelineQueryEnum.SEARCH]: '',
+        }, {
+          replaceParams: true,
+        });
       }}
       onFilterApply={(query, updatedQuery) => {
         // @ts-ignore
@@ -895,7 +900,6 @@ function PipelineListPage() {
     isLoadingDelete,
     newPipelineButtonMenuItems,
     query,
-    router,
     searchText,
     selectedPipeline,
     setSearchText,


### PR DESCRIPTION
# Description
Fix the following bugs:
- Pipeline search does not work properly when there is a "Type" filter applied.
- Searching for pipeline from page > 1 does not show any results because they are on page 1. 
- Clicking "Defaults" in pipeline filters does not clear search input.
- Applying pipeline filter sets items per page to 20 instead of 30 (the default items per page).
- Items per page was getting reset to the default 30 amount when applying pipeline filter defaults (items per page should be preserved instead since it is not related to filter defaults).

# How Has This Been Tested?
- Confirmed all bugs mentioned above were fixed locally.

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
