### PR TITLE
[xy] Use milliseconds in parquet by default.

### DIFF
--- a/mage_ai/io/base.py
+++ b/mage_ai/io/base.py
@@ -209,12 +209,18 @@ class BaseFile(BaseIO):
             format (Union[FileFormat, str]): Format to write the data frame as.
             output (Union[IO, os.PathLike]): Output stream/filepath to write data frame to.
         """
+        if format is None:
+            format = FileFormat.PARQUET
         writer = self.__get_writer(df, format)
         if format == FileFormat.HDF5:
             if isinstance(output, IO):
                 raise ValueError('Cannot write HDF5 file to buffer of any type.')
             name = os.path.splitext(os.path.basename(output))[0]
             kwargs.setdefault('key', name)
+        elif format == FileFormat.PARQUET:
+            if 'coerce_timestamps' not in kwargs:
+                kwargs['coerce_timestamps'] = 'ms'
+                kwargs['allow_truncated_timestamps'] = True
         writer(output, **kwargs)
 
     def __get_writer(

--- a/mage_integrations/mage_integrations/destinations/amazon_s3/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/amazon_s3/__init__.py
@@ -115,7 +115,11 @@ class AmazonS3(Destination):
 
         buffer = BytesIO()
         if self.file_type == 'parquet':
-            df.to_parquet(buffer)
+            df.to_parquet(
+                buffer,
+                coerce_timestamps='ms',
+                allow_truncated_timestamps=True,
+            )
         elif self.file_type == 'csv':
             df.to_csv(buffer, index=False)
         else:

--- a/mage_integrations/mage_integrations/destinations/google_cloud_storage/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/google_cloud_storage/__init__.py
@@ -54,7 +54,11 @@ class GoogleCloudStorage(Destination):
 
         buffer = BytesIO()
         if self.file_type == 'parquet':
-            df.to_parquet(buffer)
+            df.to_parquet(
+                buffer,
+                coerce_timestamps='ms',
+                allow_truncated_timestamps=True,
+            )
         elif self.file_type == 'csv':
             df.to_csv(buffer, index=False)
         else:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Upgrade of pyarrow package causes the datetime to be written in nanoseconds in S3 and GCS.
This PR updates it to use milliseconds in parquet by default so that there're no problems creating Redshift/BigQuery tables from S3/GCS.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally by exporting datetime data to S3 and create external Redshift table from S3 path. It works after the fix.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
