### PR TITLE
Fixed MongoDB reading input

### DIFF
--- a/mage_integrations/mage_integrations/destinations/mongodb/target_mongodb/sinks.py
+++ b/mage_integrations/mage_integrations/destinations/mongodb/target_mongodb/sinks.py
@@ -93,7 +93,7 @@ class MongoDbSink(BatchSink):
                     try:
                         find_id = ObjectId(find_id)
                     except Exception:
-                        self.logger.warn(f"Malformed id: {find_id}.\
+                        self.logger.info(f"Malformed id: {find_id}.\
                                          Skipping this record.")
                         continue
 

--- a/mage_integrations/mage_integrations/destinations/sink.py
+++ b/mage_integrations/mage_integrations/destinations/sink.py
@@ -439,7 +439,7 @@ class Sink(metaclass=abc.ABCMeta):
             new_version: The version number to activate.
         """
         _ = new_version
-        self.logger.warning(
+        self.logger.info(
             "ACTIVATE_VERSION message received but not implemented by this target. "
             "Ignoring.",
         )


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
When using Salesforce as a Source for data integration pipelines, one specific type of message may be issued ( ACTIVATE_VERSION ). MongoDB destination ignores this type of message and issues a WARNING level log.
However, this level seems to not exist in DI logging.

In order to allow for MongoDB destination to be used along with Salesforce source, this PR changes the WARNING level log to a INFO level log.



# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
Tested using a Salesforce Source and MongoDB destination

## New log message
![Screenshot from 2024-02-23 14-39-38](https://github.com/mage-ai/mage-ai/assets/14100959/25c96849-81c6-46a1-bef8-93e30f821146)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code


cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 
