### PR TITLE
Fixed postgreSQL reserved words

### DIFF
--- a/mage_integrations/mage_integrations/destinations/postgresql/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/postgresql/__init__.py
@@ -70,6 +70,7 @@ class PostgreSQL(Destination):
         table_name: str,
         database_name: str = None,
         unique_constraints: List[str] = None,
+        allow_reserved_words: bool = False,
     ) -> List[str]:
         results = self.build_connection().load(f"""
 SELECT
@@ -93,7 +94,8 @@ WHERE TABLE_NAME = '{table_name}' AND TABLE_SCHEMA = '{schema_name}'
                 columns=new_columns,
                 full_table_name=self.full_table_name(schema_name, table_name),
                 column_identifier=self.quote,
-                use_lowercase=self.use_lowercase
+                use_lowercase=self.use_lowercase,
+                allow_reserved_words=self.allow_reserved_words
             ),
         ]
 

--- a/mage_integrations/mage_integrations/destinations/sql/utils.py
+++ b/mage_integrations/mage_integrations/destinations/sql/utils.py
@@ -90,6 +90,7 @@ def build_alter_table_command(
     full_table_name: str,
     column_identifier: str = '',
     use_lowercase: bool = True,
+    allow_reserved_words: bool = False
 ) -> str:
     if not columns:
         return None


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
PostgreSQL destination failed when building ALTER TABLE SQL commands. That happened because recently added `ALLOW_RESERVED_WORDS` setting was not being called withing build_alt_commands method.

This PR corrects the `ALLOW_RESERVED_WORDS` setting.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
Tested using a PostgreSQL Source and Destination.
A table was modified to force  build_alt_commands method.

## Logs
![Screenshot from 2024-02-23 04-31-45](https://github.com/mage-ai/mage-ai/assets/14100959/f7f0b85b-942c-4c9d-8f2d-00c445514215)



# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code


cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 