### PR TITLE
Fixed random input inside singer destinations

### DIFF
--- a/mage_integrations/mage_integrations/destinations/mongodb/target_mongodb/target.py
+++ b/mage_integrations/mage_integrations/destinations/mongodb/target_mongodb/target.py
@@ -92,10 +92,12 @@ class TargetMongoDb(Target):
         stats: dict[str, int] = defaultdict(int)
         for line in file_input.readlines():
 
-            if line.startswith('INFO'):
+            if line.startswith('{') is False:
                 continue
-
-            line_dict = json.loads(line)
+            try:
+                line_dict = json.loads(line)
+            except:
+                continue
 
             self._assert_line_requires(line_dict, requires={"type"})
 

--- a/mage_integrations/mage_integrations/destinations/salesforce/target_salesforce/target.py
+++ b/mage_integrations/mage_integrations/destinations/salesforce/target_salesforce/target.py
@@ -144,10 +144,13 @@ class TargetSalesforce(Target):
         stats: dict[str, int] = defaultdict(int)
         for line in file_input.readlines():
 
-            if line.startswith('INFO'):
+            if line.startswith('{') is False:
+                continue
+            try:
+                line_dict = json.loads(line)
+            except:
                 continue
 
-            line_dict = json.loads(line)
             if line_dict.get('stream') is not None and \
                self.config['table_name'] is not None:
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Some random inputs can be written inside a source output file, this can cause some destinations ( mainly singer-sdk based ones) to break. This PR aims to allow these destinations to ignore such inputs.

Now, the destination will check whether the given line starts with a '{' ( meaning it is a possible valid json-L) and validating this Json by running json.loads function

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
## Tests
To efectivly test this scenario, i've modified an output file and inserted both random strings and numbers on lines.
Example:

 
![Screenshot from 2024-02-23 16-13-56](https://github.com/mage-ai/mage-ai/assets/14100959/8e2bbd2d-5fe4-45be-8af0-558b505bff97)

## FULL TABLE SYNC
In order that the output file would not be overwritten, i've tested these changes by running the direct destination command inside Mage server Docker.

![Screenshot from 2024-02-23 16-13-03](https://github.com/mage-ai/mage-ai/assets/14100959/9e29cd70-ea6c-4b59-b01d-63faeb902743)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code


cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 