### PR TITLE
[jk] Fix double scrollbars and draggable height

### DIFF
--- a/mage_ai/frontend/components/ComputeManagement/index.tsx
+++ b/mage_ai/frontend/components/ComputeManagement/index.tsx
@@ -751,6 +751,7 @@ function ComputeManagement({
     <TripleLayout
       after={after}
       afterDividerContrast
+      afterDraggableTopOffset={HEADER_HEIGHT}
       afterHeightOffset={HEADER_HEIGHT}
       afterHidden={afterHidden && !selectedSql}
       afterMousedownActive={afterMousedownActive}

--- a/mage_ai/frontend/components/PipelineLayout/index.tsx
+++ b/mage_ai/frontend/components/PipelineLayout/index.tsx
@@ -232,6 +232,7 @@ function PipelineLayout({
         setBeforeHidden={setBeforeHidden}
         setBeforeMousedownActive={setBeforeMousedownActive}
         setBeforeWidth={setBeforeWidth}
+        subtractTopFromBeforeDraggableHeight
       >
         {children}
       </TripleLayout>

--- a/mage_ai/frontend/components/PipelineRun/shared/buildTableSidekick.tsx
+++ b/mage_ai/frontend/components/PipelineRun/shared/buildTableSidekick.tsx
@@ -105,14 +105,12 @@ export default function({
   return (
     <>
       {showTabs && (
-        <Spacing py={PADDING_UNITS}>
-          <ButtonTabs
-            onClickTab={setSelectedTab}
-            selectedTabUUID={selectedTab?.uuid}
-            tabs={TABS}
-            underlineStyle
-          />
-        </Spacing>
+        <ButtonTabs
+          onClickTab={setSelectedTab}
+          selectedTabUUID={selectedTab?.uuid}
+          tabs={TABS}
+          underlineStyle
+        />
       )}
 
       {(!showTabs || TAB_TREE.uuid === selectedTab?.uuid) && (

--- a/mage_ai/frontend/components/RuntimeVariables/index.style.tsx
+++ b/mage_ai/frontend/components/RuntimeVariables/index.style.tsx
@@ -1,10 +1,23 @@
 import styled from 'styled-components';
 
 import dark from '@oracle/styles/themes/dark';
+import { PADDING } from '@oracle/styles/units/spacing';
 
-export const ContainerStyle = styled.div<{ height: number }>`
+export const ContainerStyle = styled.div<{
+  height: number;
+  includePadding?: boolean;
+  overflow?: boolean;
+}>`
   display: flex;
   flex-direction: column;
   height: ${props => props.height}px;
   border-bottom: 1px solid ${dark.borders.medium};
+
+  ${({ includePadding }) => includePadding && `
+    padding: ${PADDING}px;
+  `}
+
+  ${({ overflow }) => overflow && `
+    overflow: auto;
+  `}
 `;

--- a/mage_ai/frontend/components/TripleLayout/index.style.tsx
+++ b/mage_ai/frontend/components/TripleLayout/index.style.tsx
@@ -138,6 +138,7 @@ const ASIDE_DRAGGABLE_STYLE = css<{
   active?: boolean;
   left?: number;
   disabled?: boolean;
+  subtractTopFromHeight?: boolean;
   top?: number;
   topOffset?: number;
 }>`
@@ -154,6 +155,10 @@ const ASIDE_DRAGGABLE_STYLE = css<{
   ${props => `
     height: calc(100% + ${props?.top || 0}px);
     top: ${-(props?.top || 0) + (props.topOffset || 0)}px;
+  `}
+
+  ${props => props.subtractTopFromHeight && `
+    height: calc(100% - ${props?.top || 0}px);
   `}
 
   ${props => !props.disabled && `
@@ -307,6 +312,7 @@ export const DraggableStyle = styled.div<{
   disabled?: boolean;
   left?: number;
   right?: number;
+  subtractTopFromHeight?: boolean;
   top?: number;
   topOffset?: number;
 }>`

--- a/mage_ai/frontend/components/TripleLayout/index.tsx
+++ b/mage_ai/frontend/components/TripleLayout/index.tsx
@@ -59,6 +59,7 @@ import { useWindowSize } from '@utils/sizes';
 type TripleLayoutProps = {
   after?: any;
   afterDividerContrast?: boolean;
+  afterDraggableTopOffset?: number;
   afterFooter?: any;
   afterFooterBottomOffset?: number;
   afterHeader?: any;
@@ -113,6 +114,7 @@ type TripleLayoutProps = {
 function TripleLayout({
   after,
   afterDividerContrast,
+  afterDraggableTopOffset = 0,
   afterFooter,
   afterFooterBottomOffset,
   afterHeader,
@@ -129,7 +131,7 @@ function TripleLayout({
   before,
   beforeContentHeightOffset,
   beforeDividerContrast,
-  beforeDraggableTopOffset,
+  beforeDraggableTopOffset = 0,
   beforeFooter,
   beforeHeader,
   beforeHeaderOffset,
@@ -594,7 +596,8 @@ function TripleLayout({
             disabled={afterHidden}
             left={0}
             ref={refAfterInnerDraggable}
-            top={contained ? 0 : ASIDE_HEADER_HEIGHT}
+            top={contained ? (0 + afterDraggableTopOffset) : ASIDE_HEADER_HEIGHT}
+            topOffset={afterDraggableTopOffset}
           />
 
           {hasAfterNavigationItems && (
@@ -640,6 +643,7 @@ function TripleLayout({
     after,
     afterContent,
     afterDividerContrast,
+    afterDraggableTopOffset,
     afterHeightOffset,
     afterHidden,
     afterMousedownActive,

--- a/mage_ai/frontend/components/TripleLayout/index.tsx
+++ b/mage_ai/frontend/components/TripleLayout/index.tsx
@@ -106,6 +106,7 @@ type TripleLayoutProps = {
   setBeforeHidden?: (value: boolean) => void;
   setBeforeMousedownActive?: (value: boolean) => void;
   setBeforeWidth?: (width: number) => void;
+  subtractTopFromBeforeDraggableHeight?: boolean;
   uuid?: string;
 };
 
@@ -159,6 +160,7 @@ function TripleLayout({
   setBeforeHidden,
   setBeforeMousedownActive,
   setBeforeWidth,
+  subtractTopFromBeforeDraggableHeight,
   uuid,
 }: TripleLayoutProps) {
   const { width: widthWindow } = useWindowSize();
@@ -235,6 +237,7 @@ function TripleLayout({
     }
   // getOffsetLeft intentionally left out of dependency array
   // If it was included, the before panel would not resize correctly.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     afterHidden,
     afterWidth,
@@ -284,6 +287,9 @@ function TripleLayout({
       document?.removeEventListener?.('mouseup', removeMousemove, false);
       removeMousemove();
     };
+  // getOffsetLeft intentionally left out of dependency array
+  // If it was included, the after panel would not resize correctly.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     afterHidden,
     beforeHidden,
@@ -410,6 +416,7 @@ function TripleLayout({
     afterHeaderOffset,
     afterHeightOffset,
     afterHidden,
+    afterInnerHeightMinus,
     afterOverflow,
     afterSubheader,
     afterWidthFinal,
@@ -721,6 +728,7 @@ function TripleLayout({
               disabled={beforeHidden}
               left={beforeWidthFinal + leftOffset}
               ref={refBeforeInnerDraggable}
+              subtractTopFromHeight={subtractTopFromBeforeDraggableHeight}
               top={contained ? 0 : ASIDE_HEADER_HEIGHT}
               topOffset={beforeDraggableTopOffset}
             />
@@ -755,11 +763,11 @@ function TripleLayout({
 
         <MainContentStyle
           autoLayout={autoLayout}
+          footerOffset={footerOffset}
           headerOffset={contained
             ? headerOffset
             : ((mainContainerHeader ? ALL_HEADERS_HEIGHT : ASIDE_HEADER_HEIGHT) + headerOffset)
           }
-          footerOffset={footerOffset}
           inline={inline}
           style={{
             width: inline ? null : mainWidth,
@@ -789,6 +797,7 @@ function TripleLayout({
     before,
     beforeContent,
     beforeDividerContrast,
+    beforeDraggableTopOffset,
     beforeHeightOffset,
     beforeHidden,
     beforeMousedownActive,
@@ -810,6 +819,7 @@ function TripleLayout({
     noBackground,
     refBeforeInnerDraggable,
     setBeforeWidth,
+    subtractTopFromBeforeDraggableHeight,
   ]);
 
   return (

--- a/mage_ai/frontend/components/VersionControl/index.tsx
+++ b/mage_ai/frontend/components/VersionControl/index.tsx
@@ -1,5 +1,3 @@
-import * as osPath from 'path';
-import { DiffEditor } from '@monaco-editor/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation } from 'react-query';
 
@@ -10,14 +8,11 @@ import Dashboard from '@components/Dashboard';
 import Divider from '@oracle/elements/Divider';
 import FileBrowser from '@components/FileBrowser';
 import FileType from '@interfaces/FileType';
-import Flex from '@oracle/components/Flex';
-import FlexContainer from '@oracle/components/FlexContainer';
 import GitBranchType from '@interfaces/GitBranchType';
 import GitFileType from '@interfaces/GitFileType';
 import GitFiles from './GitFiles';
 import MultiColumnController from '@components/MultiColumnController';
 import Remote from './Remote';
-import StyledScrollbarContainer from '@components/shared/StyledScrollbarContainer';
 import Select from '@oracle/elements/Inputs/Select';
 import Spacing from '@oracle/elements/Spacing';
 import Spinner from '@oracle/components/Spinner';
@@ -27,10 +22,6 @@ import api from '@api';
 import useFileComponents from '@components/Files/useFileComponents';
 import usePrevious from '@utils/usePrevious';
 import useStatus from '@utils/models/status/useStatus';
-import {
-  DIFF_STYLES,
-  DiffContainerStyle,
-} from './index.style';
 import { HEADER_HEIGHT } from '@components/shared/Header/index.style';
 import {
   LOCAL_STORAGE_GIT_REMOTE_NAME,
@@ -46,7 +37,7 @@ import { get, set } from '@storage/localStorage';
 import { getFullPath } from '@components/FileBrowser/utils';
 import { goToWithQuery } from '@utils/routing';
 import { ignoreKeys, isEmptyObject } from '@utils/hash';
-import { fileInMapping, filePathRelativeToRepoPath } from './utils';
+import { fileInMapping } from './utils';
 import { queryFromUrl } from '@utils/url';
 import { unique } from '@utils/array';
 import { useError } from '@context/Error';
@@ -54,10 +45,6 @@ import { useError } from '@context/Error';
 function VersionControl() {
   const fileTreeRef = useRef(null);
   const refSelectBaseBranch = useRef(null);
-
-  const {
-    status,
-  } = useStatus();
 
   const [showError] = useError(null, {}, [], {
     uuid: 'VersionControlPage',

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -32,12 +32,14 @@ import TriggerEdit from '@components/Triggers/Edit';
 import Toolbar from '@components/shared/Table/Toolbar';
 import TriggersTable from '@components/Triggers/Table';
 import api from '@api';
+import {
+  ContainerStyle as RuntimeVariablesContainerStyle,
+} from '@components/RuntimeVariables/index.style';
 import { ICON_SIZE_SMALL } from '@oracle/styles/units/icons';
 import {
   Interactions as InteractionsIcon,
   Once,
 } from '@oracle/icons';
-import { PADDING_UNITS } from '@oracle/styles/units/spacing';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
 import { SHARED_BUTTON_PROPS } from '@components/shared/AddButton';
 import { VerticalDividerStyle } from '@oracle/elements/Divider/index.style';
@@ -242,7 +244,11 @@ function PipelineSchedules({
             />
           )}
           {!hasVariables && (
-            <Spacing p={PADDING_UNITS}>
+            <RuntimeVariablesContainerStyle
+              height={runtimeVariablesHeight}
+              includePadding
+              overflow
+            >
               <Text>
                 This pipeline has no runtime variables.
               </Text>
@@ -262,7 +268,7 @@ function PipelineSchedules({
                   </Text>
                 </Spacing>
               }
-            </Spacing>
+            </RuntimeVariablesContainerStyle>
           )}
         </>
       );


### PR DESCRIPTION
# Description
Fix the following bugs:
- There is an extra scrollbar (unstyled) in the Pipeline Editor when vertically scrolling the page.
<img width="1527" alt="extra scrollbar on Pipeline Editor" src="https://github.com/mage-ai/mage-ai/assets/78053898/cd3b35e9-5fe2-4498-bcb5-7a81b406c5cf">

- Double scrollbar in Sidekick on Triggers/Trigger detail/Pipeline runs page for a pipeline.
<img width="1528" alt="double scrollbar pipeline runs" src="https://github.com/mage-ai/mage-ai/assets/78053898/185a369e-9f82-47c4-9b28-0d371826c5f5">

- Incomplete height of after DraggableStyle on Compute Management page (visible on hover).
<img width="1482" alt="incomplete height of draggable on Compute Mgmt page" src="https://github.com/mage-ai/mage-ai/assets/78053898/dc612291-7aaa-4dd6-b978-ef3361c898d1">

# How Has This Been Tested?
- Confirmed UI issues were fixed locally.

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
