### PR TITLE
[jk] UI bugfixes on Version Control page

### DIFF
--- a/mage_ai/frontend/components/VersionControl/Branches/index.tsx
+++ b/mage_ai/frontend/components/VersionControl/Branches/index.tsx
@@ -383,7 +383,7 @@ function Branches({
           <Button
             beforeIcon={<PaginateArrowLeft />}
             linkProps={{
-              href: `/version-control?tab=${TAB_REMOTE.uuid}`,
+              href: `/version-control?tab=${encodeURIComponent(TAB_REMOTE.uuid)}`,
             }}
             noBackground
             noHoverUnderline

--- a/mage_ai/frontend/components/VersionControl/index.tsx
+++ b/mage_ai/frontend/components/VersionControl/index.tsx
@@ -41,6 +41,9 @@ import { queryFromUrl } from '@utils/url';
 import { unique } from '@utils/array';
 import { useError } from '@context/Error';
 
+const VERSION_CONTROL_PAGE_UUID = 'version_control/index';
+const DEFAULT_ASIDE_WIDTH = 30 * UNIT;
+
 function VersionControl() {
   const fileTreeRef = useRef(null);
   const refSelectBaseBranch = useRef(null);
@@ -50,8 +53,11 @@ function VersionControl() {
   });
 
   const [afterHidden, setAfterHidden] = useState(true);
-  const [afterWidth, setAfterWidth] = useState(30 * UNIT);
-  const [beforeWidth, setBeforeWidth] = useState(30 * UNIT);
+  const [afterWidth, setAfterWidth] = useState(DEFAULT_ASIDE_WIDTH);
+
+  const beforeWidthStorageKey = `layout_before_${VERSION_CONTROL_PAGE_UUID}_width`;
+  const defaultBeforeWidth = get(beforeWidthStorageKey, DEFAULT_ASIDE_WIDTH);
+  const [beforeWidth, setBeforeWidth] = useState(defaultBeforeWidth);
 
   const [originalContent, setOriginalContent] = useState({});
 
@@ -627,6 +633,7 @@ function VersionControl() {
       />
     );
   }, [
+    branchBase,
     branches,
     browser,
     beforeWidth,
@@ -648,7 +655,7 @@ function VersionControl() {
       setAfterWidth={setAfterWidth}
       setBeforeWidth={setBeforeWidth}
       title="Version control"
-      uuid="Version control/index"
+      uuid={VERSION_CONTROL_PAGE_UUID}
     >
       <Spacing p={PADDING_UNITS}>
         {!dataBranch && <Spinner inverted />}

--- a/mage_ai/frontend/components/VersionControl/index.tsx
+++ b/mage_ai/frontend/components/VersionControl/index.tsx
@@ -21,7 +21,6 @@ import Tooltip from '@oracle/components/Tooltip';
 import api from '@api';
 import useFileComponents from '@components/Files/useFileComponents';
 import usePrevious from '@utils/usePrevious';
-import useStatus from '@utils/models/status/useStatus';
 import { HEADER_HEIGHT } from '@components/shared/Header/index.style';
 import {
   LOCAL_STORAGE_GIT_REMOTE_NAME,


### PR DESCRIPTION
# Description
Fix the following bugs:
- Clicking `<- Remote & Auth` button on Version Control page while on Branches tab redirected to blank tab.
- When initially loading the Version Control page, the two column widths in the before panel did not take up the entire width of the before panel (some blank space was visible).

Addresses github issue https://github.com/mage-ai/mage-ai/issues/4538

# How Has This Been Tested?
Before:
![Before - version control page](https://github.com/mage-ai/mage-ai/assets/78053898/56e8e8f5-9282-4fd4-a7bb-04eb1a4928c9)

After:
![After - version control page](https://github.com/mage-ai/mage-ai/assets/78053898/397772ce-d416-4438-a603-2315a93387e9)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
