### PR TITLE
[jk] Bugfixes for Overview Dashboard

### DIFF
--- a/mage_ai/frontend/components/BlockLayout/BlockLayoutItem/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/BlockLayoutItem/index.tsx
@@ -35,6 +35,7 @@ type BlockLayoutItemProps = {
   detail?: boolean;
   disableDrag?: boolean;
   height?: number;
+  isLoading?: boolean;
   first?: boolean;
   onDrop?: (opts: {
     blockLayoutItem: BlockLayoutItemType;
@@ -62,6 +63,7 @@ function BlockLayoutItem({
   disableDrag,
   first,
   height,
+  isLoading,
   onDrop,
   onSave,
   pageBlockLayoutUUID,
@@ -294,6 +296,7 @@ function BlockLayoutItem({
                     {(isHovering || menuVisible) && (
                       <Button
                         iconOnly
+                        loading={isLoading}
                         noBackground
                         onClick={() => {
                           setMenuVisible(true);

--- a/mage_ai/frontend/components/BlockLayout/BlockLayoutItem/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/BlockLayoutItem/index.tsx
@@ -295,6 +295,7 @@ function BlockLayoutItem({
                   >
                     {(isHovering || menuVisible) && (
                       <Button
+                        disabled={isLoading}
                         iconOnly
                         loading={isLoading}
                         noBackground

--- a/mage_ai/frontend/components/BlockLayout/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/index.tsx
@@ -17,7 +17,6 @@ import CodeEditor from '@components/CodeEditor';
 import Divider from '@oracle/elements/Divider';
 import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
-import FlyoutMenuWrapper from '@oracle/components/FlyoutMenu/FlyoutMenuWrapper';
 import Headline from '@oracle/elements/Headline';
 import LayoutDivider from './LayoutDivider';
 import Link from '@oracle/elements/Link';
@@ -653,329 +652,333 @@ function BlockLayout({
     selectedBlockItem,
   ]);
 
-  const before = useMemo(() => (
-    <div
-      style={{
-        paddingBottom: UNITS_BETWEEN_ITEMS_IN_SECTIONS * UNIT,
-        paddingTop: typeof topOffset === 'undefined' ? ASIDE_HEADER_HEIGHT : 0,
-      }}
-    >
-      <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
-        <Spacing mb={1}>
-          <Text bold>
-            Chart name
-          </Text>
-          <Text muted small>
-            Human readable name for your chart.
-          </Text>
-        </Spacing>
-
-        <TextInput
-          // @ts-ignore
-          onChange={e => setObjectAttributes(prev => ({
-            ...prev,
-            name_new: e.target.value,
-          }))}
-          placeholder="Type name for chart..."
-          primary
-          setContentOnMount
-          value={objectAttributes?.name_new || ''}
-        />
-      </Spacing>
-
-      <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
-        <Spacing mb={1}>
-          <Text bold>
-            Chart type
-          </Text>
-          <Text muted small>
-            Choose how you want to display your data.
-          </Text>
-        </Spacing>
-
-        <Select
-          onChange={e => setObjectAttributes(prev => ({
-            ...prev,
-            configuration: {
-              chart_type: e.target.value,
-            },
-          }))}
-          placeholder="Select chart type"
-          primary
-          value={objectAttributes?.configuration?.chart_type || ''}
-        >
-          {CHART_TYPES.concat(ChartTypeEnum.CUSTOM).map(val => (
-            <option key={val} value={val}>
-              {capitalize(val)}
-            </option>
-          ))}
-        </Select>
-      </Spacing>
-
-      <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
-        <Divider light />
-      </Spacing>
-
-      <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
-        <Headline>
-          Data source
-        </Headline>
-      </Spacing>
-
-      <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
-        <Spacing mb={1}>
-          <Text bold>
-            Data source type
-          </Text>
-          <Text muted small>
-            Configure where the data for this chart comes from.
-          </Text>
-        </Spacing>
-
-        <Select
-          onChange={e => setObjectAttributes(prev => ({
-            ...prev,
-            data_source: {
-              ...prev?.data_source,
-              type: e.target.value,
-            },
-          }))}
-          placeholder="Select data source type"
-          primary
-          value={objectAttributes?.data_source?.type || ''}
-        >
-          {DATA_SOURCES.map(val => (
-            <option key={val} value={val}>
-              {capitalize(DATA_SOURCES_HUMAN_READABLE_MAPPING[val])}
-            </option>
-          ))}
-        </Select>
-      </Spacing>
-
-      {[
-        DataSourceEnum.BLOCK,
-        DataSourceEnum.BLOCK_RUNS,
-        DataSourceEnum.PIPELINE_RUNS,
-        DataSourceEnum.PIPELINE_SCHEDULES,
-      ].includes(objectAttributes?.data_source?.type) && (
-        <>
-          <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
-            <Spacing mb={1}>
-              <Text bold>
-                Pipeline UUID
-              </Text>
-              <Text muted small>
-                Select the pipeline the data source comes from.
-              </Text>
-            </Spacing>
-
-            <Select
-              monospace
-              // @ts-ignore
-              onChange={e => setObjectAttributes(prev => ({
-                ...prev,
-                data_source: {
-                  ...prev?.data_source,
-                  block_uuid: null,
-                  pipeline_schedule_id: null,
-                  pipeline_uuid: e.target.value,
-                },
-              }))}
-              primary
-              value={objectAttributes?.data_source?.pipeline_uuid || ''}
-            >
-              <option value={null} />
-
-              {pipelines?.map(({ uuid }) => (
-                <option key={uuid} value={uuid}>
-                  {uuid}
-                </option>
-              ))}
-            </Select>
-          </Spacing>
-        </>
-      )}
-
-      {[
-        DataSourceEnum.PIPELINE_RUNS,
-      ].includes(objectAttributes?.data_source?.type) && (
-        <>
-          <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
-            <Spacing mb={1}>
-              <Text bold>
-                Trigger
-              </Text>
-              <Text muted small>
-                Select the trigger that the pipeline runs should belong to.
-              </Text>
-            </Spacing>
-
-            <Select
-              monospace
-              // @ts-ignore
-              onChange={e => setObjectAttributes(prev => ({
-                ...prev,
-                data_source: {
-                  ...prev?.data_source,
-                  pipeline_schedule_id: e.target.value,
-                },
-              }))}
-              primary
-              value={objectAttributes?.data_source?.pipeline_schedule_id || ''}
-            >
-              <option value={null} />
-
-              {pipelineSchedules?.map(({ id, name }) => (
-                <option key={id} value={id}>
-                  {name}
-                </option>
-              ))}
-            </Select>
-          </Spacing>
-        </>
-      )}
-
-      {DataSourceEnum.BLOCK === objectAttributes?.data_source?.type && (
-        <>
-          <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
-            <Spacing mb={1}>
-              <Text bold>
-                Block UUID
-              </Text>
-              <Text muted small>
-                Select the block the data source comes from.
-              </Text>
-            </Spacing>
-
-            <Select
-              monospace
-              // @ts-ignore
-              onChange={e => setObjectAttributes(prev => ({
-                ...prev,
-                data_source: {
-                  ...prev?.data_source,
-                  block_uuid: e.target.value,
-                },
-              }))}
-              primary
-              value={objectAttributes?.data_source?.block_uuid || ''}
-            >
-              <option value={null} />
-
-              {blocksFromPipeline?.map(({ uuid }) => (
-                <option key={uuid} value={uuid}>
-                  {uuid}
-                </option>
-              ))}
-            </Select>
-          </Spacing>
-
-          <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
-            <Spacing mb={1}>
-              <Text bold>
-                Partitions
-              </Text>
-              <Text muted small>
-                Enter a positive or a negative number.
-                If positive, then data from the block will be the most recent N partitions.
-                If negative, then data from the block will be the oldest N partitions.
-              </Text>
-
-              <Spacing mt={1}>
-                <Text muted small>
-                  Leave blank if you want the chart to execute the block and display the data
-                  produced from that ad hoc block execution.
-                </Text>
-              </Spacing>
-            </Spacing>
-
-            <TextInput
-              monospace
-              // @ts-ignore
-              onChange={e => setObjectAttributes(prev => ({
-                ...prev,
-                data_source: {
-                  ...prev?.data_source,
-                  partitions: typeof e.target.value !== 'undefined'
-                    ? Number(e.target.value)
-                    : e.target.value,
-                },
-              }))}
-              placeholder="Enter number of partitions"
-              primary
-              setContentOnMount
-              type="number"
-              value={objectAttributes?.data_source?.partitions || ''}
-            />
-          </Spacing>
-        </>
-      )}
-
-      <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
-        <Spacing mb={1}>
-          <Text bold>
-            Refresh interval
-          </Text>
-          <Text muted small>
-            How frequent do you want this chart to automatically fetch new data from its
-            data source? Enter a number in milliseconds (e.g. 1000ms is 1 second).
-          </Text>
-        </Spacing>
-
-        <TextInput
-          monospace
-          // @ts-ignore
-          onChange={e => setObjectAttributes(prev => ({
-            ...prev,
-            data_source: {
-              ...prev?.data_source,
-              refresh_interval: e.target.value,
-            },
-          }))}
-          placeholder="Enter number for refresh interval"
-          primary
-          setContentOnMount
-          type="number"
-          value={objectAttributes?.data_source?.refresh_interval || 60000}
-        />
-      </Spacing>
-
-      <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
-        <Divider light />
-      </Spacing>
-
-      <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
-        <Headline>
-          Chart display settings
-        </Headline>
-      </Spacing>
-
-      <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
-        <Text default>
-          Number of columns from data source: {typeof blockForChartConfigurations?.data?.columns !== 'undefined' ? (
-            <Text bold inline monospace>
-              {blockForChartConfigurations?.data?.columns?.length}
+  const before = useMemo(() => (beforeHidden
+    ? null
+    : (
+      <div
+        style={{
+          paddingBottom: UNITS_BETWEEN_ITEMS_IN_SECTIONS * UNIT,
+          paddingTop: typeof topOffset === 'undefined' ? ASIDE_HEADER_HEIGHT : 0,
+        }}
+      >
+        <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
+          <Spacing mb={1}>
+            <Text bold>
+              Chart name
             </Text>
-          ) : <Spacing mt={1}><Spinner inverted small /></Spacing>}
-        </Text>
-      </Spacing>
+            <Text muted small>
+              Human readable name for your chart.
+            </Text>
+          </Spacing>
 
-      <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
-        <ChartConfigurations
-          block={blockForChartConfigurations}
-          updateConfiguration={(configuration) => {
-            setObjectAttributes(prev => ({
+          <TextInput
+            // @ts-ignore
+            onChange={e => setObjectAttributes(prev => ({
+              ...prev,
+              name_new: e.target.value,
+            }))}
+            placeholder="Type name for chart..."
+            primary
+            setContentOnMount
+            value={objectAttributes?.name_new || ''}
+          />
+        </Spacing>
+
+        <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
+          <Spacing mb={1}>
+            <Text bold>
+              Chart type
+            </Text>
+            <Text muted small>
+              Choose how you want to display your data.
+            </Text>
+          </Spacing>
+
+          <Select
+            onChange={e => setObjectAttributes(prev => ({
               ...prev,
               configuration: {
-                ...prev?.configuration,
-                ...configuration,
+                chart_type: e.target.value,
               },
-            }));
-          }}
-        />
-      </Spacing>
-    </div>
+            }))}
+            placeholder="Select chart type"
+            primary
+            value={objectAttributes?.configuration?.chart_type || ''}
+          >
+            {CHART_TYPES.concat(ChartTypeEnum.CUSTOM).map(val => (
+              <option key={val} value={val}>
+                {capitalize(val)}
+              </option>
+            ))}
+          </Select>
+        </Spacing>
+
+        <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
+          <Divider light />
+        </Spacing>
+
+        <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
+          <Headline>
+            Data source
+          </Headline>
+        </Spacing>
+
+        <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
+          <Spacing mb={1}>
+            <Text bold>
+              Data source type
+            </Text>
+            <Text muted small>
+              Configure where the data for this chart comes from.
+            </Text>
+          </Spacing>
+
+          <Select
+            onChange={e => setObjectAttributes(prev => ({
+              ...prev,
+              data_source: {
+                ...prev?.data_source,
+                type: e.target.value,
+              },
+            }))}
+            placeholder="Select data source type"
+            primary
+            value={objectAttributes?.data_source?.type || ''}
+          >
+            {DATA_SOURCES.map(val => (
+              <option key={val} value={val}>
+                {capitalize(DATA_SOURCES_HUMAN_READABLE_MAPPING[val])}
+              </option>
+            ))}
+          </Select>
+        </Spacing>
+
+        {[
+          DataSourceEnum.BLOCK,
+          DataSourceEnum.BLOCK_RUNS,
+          DataSourceEnum.PIPELINE_RUNS,
+          DataSourceEnum.PIPELINE_SCHEDULES,
+        ].includes(objectAttributes?.data_source?.type) && (
+          <>
+            <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
+              <Spacing mb={1}>
+                <Text bold>
+                  Pipeline UUID
+                </Text>
+                <Text muted small>
+                  Select the pipeline the data source comes from.
+                </Text>
+              </Spacing>
+
+              <Select
+                monospace
+                // @ts-ignore
+                onChange={e => setObjectAttributes(prev => ({
+                  ...prev,
+                  data_source: {
+                    ...prev?.data_source,
+                    block_uuid: null,
+                    pipeline_schedule_id: null,
+                    pipeline_uuid: e.target.value,
+                  },
+                }))}
+                primary
+                value={objectAttributes?.data_source?.pipeline_uuid || ''}
+              >
+                <option value={null} />
+
+                {pipelines?.map(({ uuid }) => (
+                  <option key={uuid} value={uuid}>
+                    {uuid}
+                  </option>
+                ))}
+              </Select>
+            </Spacing>
+          </>
+        )}
+
+        {[
+          DataSourceEnum.PIPELINE_RUNS,
+        ].includes(objectAttributes?.data_source?.type) && (
+          <>
+            <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
+              <Spacing mb={1}>
+                <Text bold>
+                  Trigger
+                </Text>
+                <Text muted small>
+                  Select the trigger that the pipeline runs should belong to.
+                </Text>
+              </Spacing>
+
+              <Select
+                monospace
+                // @ts-ignore
+                onChange={e => setObjectAttributes(prev => ({
+                  ...prev,
+                  data_source: {
+                    ...prev?.data_source,
+                    pipeline_schedule_id: e.target.value,
+                  },
+                }))}
+                primary
+                value={objectAttributes?.data_source?.pipeline_schedule_id || ''}
+              >
+                <option value={null} />
+
+                {pipelineSchedules?.map(({ id, name }) => (
+                  <option key={id} value={id}>
+                    {name}
+                  </option>
+                ))}
+              </Select>
+            </Spacing>
+          </>
+        )}
+
+        {DataSourceEnum.BLOCK === objectAttributes?.data_source?.type && (
+          <>
+            <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
+              <Spacing mb={1}>
+                <Text bold>
+                  Block UUID
+                </Text>
+                <Text muted small>
+                  Select the block the data source comes from.
+                </Text>
+              </Spacing>
+
+              <Select
+                monospace
+                // @ts-ignore
+                onChange={e => setObjectAttributes(prev => ({
+                  ...prev,
+                  data_source: {
+                    ...prev?.data_source,
+                    block_uuid: e.target.value,
+                  },
+                }))}
+                primary
+                value={objectAttributes?.data_source?.block_uuid || ''}
+              >
+                <option value={null} />
+
+                {blocksFromPipeline?.map(({ uuid }) => (
+                  <option key={uuid} value={uuid}>
+                    {uuid}
+                  </option>
+                ))}
+              </Select>
+            </Spacing>
+
+            <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
+              <Spacing mb={1}>
+                <Text bold>
+                  Partitions
+                </Text>
+                <Text muted small>
+                  Enter a positive or a negative number.
+                  If positive, then data from the block will be the most recent N partitions.
+                  If negative, then data from the block will be the oldest N partitions.
+                </Text>
+
+                <Spacing mt={1}>
+                  <Text muted small>
+                    Leave blank if you want the chart to execute the block and display the data
+                    produced from that ad hoc block execution.
+                  </Text>
+                </Spacing>
+              </Spacing>
+
+              <TextInput
+                monospace
+                // @ts-ignore
+                onChange={e => setObjectAttributes(prev => ({
+                  ...prev,
+                  data_source: {
+                    ...prev?.data_source,
+                    partitions: typeof e.target.value !== 'undefined'
+                      ? Number(e.target.value)
+                      : e.target.value,
+                  },
+                }))}
+                placeholder="Enter number of partitions"
+                primary
+                setContentOnMount
+                type="number"
+                value={objectAttributes?.data_source?.partitions || ''}
+              />
+            </Spacing>
+          </>
+        )}
+
+        <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
+          <Spacing mb={1}>
+            <Text bold>
+              Refresh interval
+            </Text>
+            <Text muted small>
+              How frequent do you want this chart to automatically fetch new data from its
+              data source? Enter a number in milliseconds (e.g. 1000ms is 1 second).
+            </Text>
+          </Spacing>
+
+          <TextInput
+            monospace
+            // @ts-ignore
+            onChange={e => setObjectAttributes(prev => ({
+              ...prev,
+              data_source: {
+                ...prev?.data_source,
+                refresh_interval: e.target.value,
+              },
+            }))}
+            placeholder="Enter number for refresh interval"
+            primary
+            setContentOnMount
+            type="number"
+            value={objectAttributes?.data_source?.refresh_interval || 60000}
+          />
+        </Spacing>
+
+        <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
+          <Divider light />
+        </Spacing>
+
+        <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
+          <Headline>
+            Chart display settings
+          </Headline>
+        </Spacing>
+
+        <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
+          <Text default>
+            Number of columns from data source: {typeof blockForChartConfigurations?.data?.columns !== 'undefined' ? (
+              <Text bold inline monospace>
+                {blockForChartConfigurations?.data?.columns?.length}
+              </Text>
+            ) : <Spacing mt={1}><Spinner inverted small /></Spacing>}
+          </Text>
+        </Spacing>
+
+        <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
+          <ChartConfigurations
+            block={blockForChartConfigurations}
+            updateConfiguration={(configuration) => {
+              setObjectAttributes(prev => ({
+                ...prev,
+                configuration: {
+                  ...prev?.configuration,
+                  ...configuration,
+                },
+              }));
+            }}
+          />
+        </Spacing>
+      </div>
+    )
   ), [
+    beforeHidden,
     blockForChartConfigurations,
     blocksFromPipeline,
     objectAttributes,

--- a/mage_ai/frontend/components/BlockLayout/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/index.tsx
@@ -90,6 +90,7 @@ function BlockLayout({
   const windowSize = useWindowSize();
 
   const [selectedBlockItem, setSelectedBlockItemState] = useState<BlockLayoutItemType>(null);
+  const [deletingBlockUUID, setDeletingBlockUUID] = useState<string>(null);
 
   const refreshInterval = useMemo(() => selectedBlockItem?.data_source?.refresh_interval, [
     selectedBlockItem,
@@ -193,6 +194,7 @@ function BlockLayout({
               setSelectedBlockItem(blockItemNew);
             }
 
+            setDeletingBlockUUID(null);
             fetchBlockLayoutItem();
           },
           onErrorCallback: (response, errors) => showError({
@@ -314,6 +316,8 @@ function BlockLayout({
     } else {
       newLayout[rowIndex] = newRow;
     }
+
+    setDeletingBlockUUID(blockUUID);
 
     // @ts-ignore
     updateBlockLayoutItem({
@@ -484,6 +488,7 @@ function BlockLayout({
               createNewBlockItem={createNewBlockItem}
               first={0 === idx2}
               height={height}
+              isLoading={deletingBlockUUID === blockUUID && isLoadingUpdateBlockLayoutItem}
               onDrop={({
                 columnIndex,
                 rowIndex,
@@ -541,6 +546,8 @@ function BlockLayout({
     blocks,
     containerRect,
     createNewBlockItem,
+    deletingBlockUUID,
+    isLoadingUpdateBlockLayoutItem,
     layout,
     moveBlockLayoutItem,
     removeBlockLayoutItem,

--- a/mage_ai/frontend/components/BlockLayout/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/index.tsx
@@ -687,7 +687,7 @@ function BlockLayout({
             placeholder="Type name for chart..."
             primary
             setContentOnMount
-            value={objectAttributes?.name_new || ''}
+            value={objectAttributes?.name || ''}
           />
         </Spacing>
 

--- a/mage_ai/frontend/components/BlockLayout/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/index.tsx
@@ -959,13 +959,25 @@ function BlockLayout({
         </Spacing>
 
         <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>
-          <Text default>
-            Number of columns from data source: {typeof blockForChartConfigurations?.data?.columns !== 'undefined' ? (
-              <Text bold inline monospace>
-                {blockForChartConfigurations?.data?.columns?.length}
+          {!blockForChartConfigurations?.data_source
+            ? (
+              <Text default>
+                Please select a data source type above.
               </Text>
-            ) : <Spacing mt={1}><Spinner inverted small /></Spacing>}
-          </Text>
+            ): (
+              <Text default>
+                Number of columns from data source: {
+                  typeof blockForChartConfigurations?.data?.columns !== 'undefined'
+                  ? (
+                    <Text bold inline monospace>
+                      {blockForChartConfigurations?.data?.columns?.length}
+                    </Text>
+                  ): (
+                    <Spacing mt={1}><Spinner inverted small /></Spacing>
+                )}
+              </Text>
+            )
+          }
         </Spacing>
 
         <Spacing mt={UNITS_BETWEEN_ITEMS_IN_SECTIONS} px={PADDING_UNITS}>

--- a/mage_ai/frontend/components/BlockLayout/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/index.tsx
@@ -1102,6 +1102,7 @@ function BlockLayout({
       beforeMousedownActive={beforeMousedownActive}
       beforeWidth={beforeWidth}
       contained
+      excludeOffsetFromBeforeDraggableLeft
       headerOffset={topOffset || 0}
       hideAfterCompletely
       hideBeforeCompletely

--- a/mage_ai/frontend/components/BlockLayout/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/index.tsx
@@ -1175,6 +1175,8 @@ function BlockLayout({
         {!selectedBlockItem && !isEmpty && rowsEl}
         {!selectedBlockItem && isEmpty && emtpyState}
       </DndProvider>
+
+      <Spacing mb={2} />
     </TripleLayout>
   );
 }

--- a/mage_ai/frontend/components/BlockLayout/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/index.tsx
@@ -1036,6 +1036,7 @@ function BlockLayout({
       afterMousedownActive={afterMousedownActive}
       afterWidth={afterWidth}
       before={before}
+      beforeDraggableTopOffset={topOffset ? (topOffset - ASIDE_HEADER_HEIGHT) : 0}
       beforeFooter={!beforeHidden && (
         <Spacing p={PADDING_UNITS}>
           <FlexContainer>

--- a/mage_ai/frontend/components/Dashboard/index.tsx
+++ b/mage_ai/frontend/components/Dashboard/index.tsx
@@ -170,7 +170,6 @@ function Dashboard({
             setAfterWidth={setWidthAfter}
             setBeforeMousedownActive={setMousedownActiveBefore}
             setBeforeWidth={setWidthBefore}
-            // beforeWidth={VERTICAL_NAVIGATION_WIDsTH + (before ? beforeWidth : 0)}
           >
             {subheaderChildren && (
               <Subheader noPadding={subheaderNoPadding}>

--- a/mage_ai/frontend/components/GlobalDataProductDetail/index.tsx
+++ b/mage_ai/frontend/components/GlobalDataProductDetail/index.tsx
@@ -333,6 +333,7 @@ function GlobalDataProductDetail({
       )}
       beforeHidden={beforeHidden}
       beforeWidth={beforeWidth}
+      excludeOffsetFromBeforeDraggableLeft
       leftOffset={VERTICAL_NAVIGATION_WIDTH}
       setBeforeHidden={setBeforeHidden}
       setBeforeWidth={setBeforeWidth}

--- a/mage_ai/frontend/components/TripleLayout/index.tsx
+++ b/mage_ai/frontend/components/TripleLayout/index.tsx
@@ -88,6 +88,7 @@ type TripleLayoutProps = {
   children?: any;
   contained?: boolean;
   containerRef?: any;
+  excludeOffsetFromBeforeDraggableLeft?: boolean;
   footerOffset?: number;
   header?: any;
   headerOffset?: number;
@@ -143,6 +144,7 @@ function TripleLayout({
   children,
   contained,
   containerRef,
+  excludeOffsetFromBeforeDraggableLeft,
   footerOffset,
   header,
   headerOffset = 0,
@@ -210,7 +212,7 @@ function TripleLayout({
             newWidth = (width - (afterHidden ? 0 : afterWidth)) - MAIN_MIN_WIDTH;
           }
           // Not sure why we need to multiply by 2, but we do.
-          newWidth -= (leftOffset * 2);
+          newWidth -= (leftOffset * (excludeOffsetFromBeforeDraggableLeft ? 1 : 2));
           setBeforeWidth(Math.max(newWidth, BEFORE_MIN_WIDTH));
         }
       };
@@ -730,7 +732,7 @@ function TripleLayout({
               active={beforeMousedownActive}
               contrast={beforeDividerContrast}
               disabled={beforeHidden}
-              left={beforeWidthFinal + leftOffset}
+              left={beforeWidthFinal + (excludeOffsetFromBeforeDraggableLeft ? 0 : leftOffset)}
               ref={refBeforeInnerDraggable}
               subtractTopFromHeight={subtractTopFromBeforeDraggableHeight}
               top={contained ? 0 : ASIDE_HEADER_HEIGHT}
@@ -809,6 +811,7 @@ function TripleLayout({
     beforeWidthFinal,
     children,
     contained,
+    excludeOffsetFromBeforeDraggableLeft,
     footerOffset,
     hasBeforeNavigationItems,
     header,

--- a/mage_ai/frontend/pages/overview/index.tsx
+++ b/mage_ai/frontend/pages/overview/index.tsx
@@ -28,7 +28,6 @@ import Tooltip from '@oracle/components/Tooltip';
 import Widget from '@components/PipelineRun/Widget';
 import api from '@api';
 import dark from '@oracle/styles/themes/dark';
-import usePrevious from '@utils/usePrevious';
 import {
   AggregationFunctionEnum,
   ChartStyleEnum,
@@ -50,7 +49,7 @@ import { BlockTypeEnum } from '@interfaces/BlockType';
 import { DataSourceEnum } from '@interfaces/BlockLayoutItemType';
 import { ErrorProvider } from '@context/Error';
 import { HEADER_HEIGHT } from '@components/shared/Header/index.style';
-import { MonitorStatsEnum, RunCountStatsType } from '@interfaces/MonitorStatsType';
+import { MonitorStatsEnum } from '@interfaces/MonitorStatsType';
 import { NAV_TAB_PIPELINES } from '@components/CustomTemplates/BrowseTemplates/constants';
 import { RunStatus } from '@interfaces/BlockRunType';
 import { SHARED_UTC_TOOLTIP_PROPS } from '@components/PipelineRun/shared/constants';
@@ -69,7 +68,8 @@ import {
   TAB_DASHBOARD,
   TAB_TODAY,
 } from '@components/Dashboard/constants';
-import { UNIT, UNITS_BETWEEN_SECTIONS } from '@oracle/styles/units/spacing';
+import { UNITS_BETWEEN_SECTIONS } from '@oracle/styles/units/spacing';
+import { VERTICAL_NAVIGATION_WIDTH } from '@components/Dashboard/index.style';
 import {
   capitalize,
   cleanName,
@@ -652,7 +652,7 @@ def d(df):
 
       {TAB_DASHBOARD.uuid === selectedTab?.uuid && (
         <BlockLayout
-          leftOffset={9 * UNIT}
+          leftOffset={VERTICAL_NAVIGATION_WIDTH - 1}
           pageBlockLayoutTemplate={pageBlockLayoutTemplate}
           topOffset={HEADER_HEIGHT + refSubheader?.current?.getBoundingClientRect()?.height}
           uuid="overview/dashboard"

--- a/mage_ai/frontend/pages/overview/index.tsx
+++ b/mage_ai/frontend/pages/overview/index.tsx
@@ -640,7 +640,7 @@ def d(df):
             </Spacing>
             <ButtonTabs
               onClickTab={({ uuid }) => {
-                setSelectedTab(() => allTabs.find(t => uuid === t.uuid))
+                setSelectedTab(() => allTabs.find(t => uuid === t.uuid));
               }}
               regularSizeText
               selectedTabUUID={timePeriod}


### PR DESCRIPTION
# Description
Fix the following bugs on the Overview Dashboard:
- Remove the vertical line on the Overview page, Dashboard tab (addresses github issue https://github.com/mage-ai/mage-ai/issues/4652).
- Infinite spinner when creating new chart in project overview dashboard and no data source selected
- Unnecessary extra right padding after before panel when creating/editing a chart
- Before panel draggable border extending into subheader in create/edit chart view
- Unclickable bottom add chart divider line
- Chart name not getting updated on subsequent charts being edited/created after creating/updating an initial chart


Fixed positioning of before draggable border on Global Data Products detail page (similar to bug on Overview dashboard Edit Chart view). Screenshot of the bug below:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/8c7944f5-ee8c-4c1e-ba4b-a1932ca8cccf)

UX improvement:
- Show spinner when deleting block layout item. It can take some time to finish deleting a chart from the Overview Dashboard, but without a spinner, user doesn't know the delete is in progress.

# How Has This Been Tested?
- Tested locally

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
