### PR TITLE
[jk] Redirect to login page immediately

### DIFF
--- a/mage_ai/frontend/pages/index.tsx
+++ b/mage_ai/frontend/pages/index.tsx
@@ -26,7 +26,9 @@ const Home = () => {
   }, []);
 
   useEffect(() => {
-    if (dataStatus) {
+    if (dataPipelineRuns?.error?.code === 403) {
+      router.replace('/sign-in');
+    } else if (dataStatus) {
       const manage = dataStatus?.is_instance_manager;
       let pathname = completePath;
       if (basePath === '/') {


### PR DESCRIPTION
# Description
- There was a delay in redirecting to the login page from the home page when user authentication was enabled and user went to the homepage. This PR avoids the unnecessary redirect to the `/pipelines`, `/overview`, or `/manage` page and immediately redirects to the `/sign-in` page if user authentication is enabled and the user is not logged in.

# How Has This Been Tested?
- Tested locally in development and also on frontend production build.
- Tested with user authentication enabled and also disabled.

Before (Pipelines dashboard is briefly visible if user was not logged in):
![Before - delayed redirect](https://github.com/mage-ai/mage-ai/assets/78053898/705e09fe-c393-46ce-bdaf-e507cb26b1bf)

After (User is immediately redirected to login page):
![After - immediate redirect](https://github.com/mage-ai/mage-ai/assets/78053898/30a22b34-5377-4e65-8430-fa2fe1cf90b9)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
