### PR TITLE
[jk] Clean up chart block widths in Pipeline Editor

### DIFF
--- a/mage_ai/frontend/components/ChartBlock/index.tsx
+++ b/mage_ai/frontend/components/ChartBlock/index.tsx
@@ -829,7 +829,7 @@ function ChartBlock({
   );
 
   return (
-    <Col sm={12} md={12 * widthPercentage}>
+    <Col md={12 * widthPercentage} sm={12}>
       <ChartBlockStyle ref={ref}>
         <Spacing mt={1} pt={1} px={1}>
           <FlexContainer
@@ -842,6 +842,10 @@ function ChartBlock({
                 bold={false}
                 fullWidth
                 inputValue={newBlockUuid}
+                inputWidth={ref?.current?.getBoundingClientRect()?.width < 265
+                  ? (UNIT * 7)
+                  : null
+                }
                 notRequired
                 onBlur={() => setTimeout(() => setIsEditingBlock(false), 300)}
                 onChange={(e) => {

--- a/mage_ai/frontend/components/ChartBlock/index.tsx
+++ b/mage_ai/frontend/components/ChartBlock/index.tsx
@@ -360,11 +360,18 @@ function ChartBlock({
     selected,
   ]);
 
+  const widthPercentage =
+    useMemo(() => configuration[VARIABLE_NAME_WIDTH_PERCENTAGE] || 1, [configuration]);
+
   const isEditingPrevious = usePrevious(isEditing);
   const widthPrevious = usePrevious(width);
+  const widthPercentagePrevious = usePrevious(configuration?.[VARIABLE_NAME_WIDTH_PERCENTAGE]);
   useEffect(() => {
     const rect = refChartContainer?.current?.getBoundingClientRect();
-    if (isEditingPrevious !== isEditing || widthPrevious !== width) {
+    if (isEditingPrevious !== isEditing
+      || widthPrevious !== width
+      || widthPercentagePrevious !== widthPercentage
+    ) {
       setChartWidth(0);
       setTimeout(() => {
         const w = refChartContainer?.current?.getBoundingClientRect()?.width;
@@ -382,6 +389,8 @@ function ChartBlock({
     setChartWidth,
     width,
     widthPrevious,
+    widthPercentage,
+    widthPercentagePrevious,
   ]);
 
   const availableVariables = useMemo(() => {
@@ -525,9 +534,6 @@ function ChartBlock({
     upstreamBlocks,
     upstreamBlocksPrevious,
   ]);
-
-  const widthPercentage =
-    useMemo(() => configuration[VARIABLE_NAME_WIDTH_PERCENTAGE] || 1, [configuration]);
 
   const {
     code: configurationOptionsElsForCode,

--- a/mage_ai/frontend/components/CodeBlock/CommandButtons/AddChartMenu.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CommandButtons/AddChartMenu.tsx
@@ -8,7 +8,10 @@ import {
   DEFAULT_SETTINGS_BY_CHART_TYPE,
 } from '@components/ChartBlock/constants';
 import { UNIT } from '@oracle/styles/units/spacing';
-import { capitalizeRemoveUnderscoreLower, getNewUUID } from '@utils/string';
+import {
+  capitalizeRemoveUnderscoreLower,
+  randomSimpleHashGenerator,
+} from '@utils/string';
 
 type AddChartMenuProps = {
   addWidget: (widget: BlockType, opts?: {
@@ -58,19 +61,19 @@ function AddChartMenu({
 
     let widgetName = chartType;
     if (block) {
-      widgetName = `${widgetName} for ${block.uuid}`;
+      widgetName = `${block.uuid}_${widgetName}`;
     }
 
     return {
       label: () => capitalizeRemoveUnderscoreLower(chartType),
       onClick: () => addWidget({
         ...widget,
-        name: `${widgetName} ${getNewUUID()}`,
         configuration: {
           ...widget.configuration,
           ...configuration,
         },
         content,
+        name: `${widgetName}_${randomSimpleHashGenerator()}`,
       }, {
         onCreateCallback: (widget: BlockType) => {
           if (block && BlockLanguageEnum.SQL !== block.language) {
@@ -92,7 +95,7 @@ function AddChartMenu({
       uuid: chartType,
     };
   }), [
-    CHART_TYPES,
+    addWidget,
     block,
     runBlock,
   ]);
@@ -132,7 +135,6 @@ function AddChartMenu({
       uuid: label(),
     };
   }), [
-    CHART_TEMPLATES,
     addWidget,
     block,
     runBlock,

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -34,7 +34,6 @@ import Checkbox from '@oracle/elements/Checkbox';
 import Circle from '@oracle/elements/Circle';
 import CodeEditor, {
   CodeEditorSharedProps,
-  OnDidChangeCursorPositionParameterType,
 } from '@components/CodeEditor';
 import CodeOutput from './CodeOutput';
 import CommandButtons, { CommandButtonsSharedProps } from './CommandButtons';
@@ -151,7 +150,6 @@ import {
   TAB_SPARK_OUTPUT,
   TAB_SPARK_SQLS,
   TAB_SPARK_STAGES,
-  TAB_SPARK_TASKS,
 } from './constants';
 import {
   KEY_CODE_CONTROL,
@@ -164,7 +162,6 @@ import { OpenDataIntegrationModalType } from '@components/DataIntegrationModal/c
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { RunBlockAndTrackProps } from '@components/CodeBlockV2/constants';
 import { SCROLLBAR_WIDTH } from '@oracle/styles/scrollbars';
-import { SINGLE_LINE_HEIGHT } from '@components/CodeEditor/index.style';
 import { ViewKeyEnum } from '@components/Sidekick/constants';
 import { addScratchpadNote, addSqlBlockNote } from '@components/PipelineDetail/AddNewBlocks/utils';
 import { buildBlockRefKey } from '@components/PipelineDetail/utils';

--- a/mage_ai/frontend/oracle/components/LabelWithValueClicker.tsx
+++ b/mage_ai/frontend/oracle/components/LabelWithValueClicker.tsx
@@ -115,6 +115,7 @@ function LabelWithValueClicker({
             disableWordBreak={disableWordBreak}
             monospace={monospace}
             small={small}
+            title={inputWidth ? value : null}
             width={inputWidth}
           >
             {value}

--- a/mage_ai/frontend/utils/string.ts
+++ b/mage_ai/frontend/utils/string.ts
@@ -340,7 +340,7 @@ export function formatNumberToDuration(duration: number): string {
     }
   }
 
-  return displayText
+  return displayText;
 }
 
 export function alphabet(): string[] {
@@ -366,7 +366,7 @@ export function removeANSI(text: string): string {
 export function stringSimilarity(str1: string, str2: string, gramSize: number = 2) {
   function getNGrams(s: string, len: number) {
     s = ' '.repeat(len - 1) + s.toLowerCase() + ' '.repeat(len - 1);
-    let v = new Array(s.length - len + 1);
+    const v = new Array(s.length - len + 1);
     for (let i = 0; i < v.length; i++) {
       v[i] = s.slice(i, i + len);
     }
@@ -375,16 +375,16 @@ export function stringSimilarity(str1: string, str2: string, gramSize: number = 
 
   if (!str1?.length || !str2?.length) { return 0.0; }
 
-  let s1 = str1.length < str2.length ? str1 : str2;
-  let s2 = str1.length < str2.length ? str2 : str1;
+  const s1 = str1.length < str2.length ? str1 : str2;
+  const s2 = str1.length < str2.length ? str2 : str1;
 
-  let pairs1 = getNGrams(s1, gramSize);
-  let pairs2 = getNGrams(s2, gramSize);
-  let set = new Set<string>(pairs1);
+  const pairs1 = getNGrams(s1, gramSize);
+  const pairs2 = getNGrams(s2, gramSize);
+  const set = new Set<string>(pairs1);
 
-  let total = pairs2.length;
+  const total = pairs2.length;
   let hits = 0;
-  for (let item of pairs2) {
+  for (const item of pairs2) {
     if (set.delete(item)) {
       hits++;
     }
@@ -419,6 +419,6 @@ export function hexToRgb(hex) {
   return result ? {
     r: parseInt(result[1], 16),
     g: parseInt(result[2], 16),
-    b: parseInt(result[3], 16)
+    b: parseInt(result[3], 16),
   } : null;
 }


### PR DESCRIPTION
# Description
- Clean up chart block default name (was excessively long with timestamp).
- Fix chart width when selecting between half and full width (wasn't re-rendering).
- On very small chart block widths, decrease chart block name width with ellipsis (user can hover to view chart block name in tooltip).

# How Has This Been Tested?
Before (long chart block name / no re-render when selecting half width / no shorted name on very small widths):
![Before - chart widths bad formatting](https://github.com/mage-ai/mage-ai/assets/78053898/ba99b116-db1d-464e-b0a2-b9f2ad455de5)

After (includes chart block polish):
![After - chart width polish](https://github.com/mage-ai/mage-ai/assets/78053898/28f32209-d40d-485b-97f8-fd9fdfef496f)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
