### PR TITLE
[jk] Bugfix for save block shortcut

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
@@ -105,7 +105,10 @@ function ConfigureBlock({
       if (event.key === 'Escape') {
         onClose();
       } else if (event.key === 'Enter') {
-        handleOnSave();
+        const buttonText = event.target.innerText;
+        if (!buttonText.startsWith('Save and') && buttonText !== 'Cancel') {
+          handleOnSave();
+        }
       }
     };
 

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -2008,7 +2008,7 @@ function PipelineDetailPage({
               setErrors(() => ({
                 errors,
                 links: [{
-                  label: 'View existing block file contents and optionally add to pipeline (if applicable).',
+                  label: 'View existing block file contents.',
                   onClick: () => {
                     openFile(filePath);
                     setErrors(null);


### PR DESCRIPTION
# Description
- Fix this bug: Pressing keyboard's "Enter" key on "Save" button for ConfigureBlock popup for new block caused "Block already exists" error since 2 POST requests were being made, one for the button click action and one for the keyboard shortcut event.
- This PR prevents the keyboard shortcut event for a duplicate POST request when the user presses "Enter" while focused on the `Save and...` (i.e. "replace"/"update"/"add") or `Cancel` buttons.

# How Has This Been Tested?
- Tested locally on Chrome, Firefox, and Safari browsers

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
