### PR TITLE
[xy] Support extra connection arguments in mysql source and destination.

### DIFF
--- a/mage_integrations/mage_integrations/connections/mysql/__init__.py
+++ b/mage_integrations/mage_integrations/connections/mysql/__init__.py
@@ -1,10 +1,13 @@
-from mage_integrations.connections.sql.base import Connection
-from mysql.connector import connect
-from sshtunnel import SSHTunnelForwarder
 import enum
 import io
 import os
+from typing import Dict
+
 import paramiko
+from mysql.connector import connect
+from sshtunnel import SSHTunnelForwarder
+
+from mage_integrations.connections.sql.base import Connection
 
 
 class ConnectionMethod(str, enum.Enum):
@@ -21,6 +24,7 @@ class MySQL(Connection):
         username: str,
         port: int = None,
         connection_method: ConnectionMethod = ConnectionMethod.DIRECT,
+        conn_kwargs: Dict = None,
         ssh_host: str = None,
         ssh_port: int = 22,
         ssh_username: str = None,
@@ -40,6 +44,7 @@ class MySQL(Connection):
         self.ssh_username = ssh_username
         self.ssh_password = ssh_password
         self.ssh_pkey = ssh_pkey
+        self.conn_kwargs = conn_kwargs or dict()
 
         self.ssh_tunnel = None
 
@@ -74,6 +79,7 @@ class MySQL(Connection):
             password=self.password,
             port=port,
             user=self.username,
+            **self.conn_kwargs,
         )
 
     def close_connection(self, connection):

--- a/mage_integrations/mage_integrations/destinations/mysql/README.md
+++ b/mage_integrations/mage_integrations/destinations/mysql/README.md
@@ -22,6 +22,9 @@ You must enter the following credentials when configuring this source:
 | `ssh_username` | (Optional) The username used to connect to the bastion server. | `username` |
 | `ssh_password` | (Optional) The password used to connect to the bastion server. It should be set if you authenticate with the bastion server with password. | `password` |
 | `ssh_pkey` | (Optional) The path to the private key used to connect to the bastion server or the content of the key file. It should be set if you authenticate with the bastion server with private key. | `/path/to/private/key` |
+| `conn_kwargs` | (Optional) Extra [connection keyword arguments](https://dev.mysql.com/doc/connector-python/en/connector-python-connectargs.html) in dictionary format. | `{"ssl_ca": "CARoot.pem", "ssl_cert": "certificate.pem", "ssl_key: "key.pem"'}` |
+| `ssl_cert` | (Optional) The host of the intermediate bastion server. | `123.45.67.89` |
+| `ssl_key` | (Optional) The host of the intermediate bastion server. | `123.45.67.89` |
 | `use_lowercase` | (Optional) Whether to use lower case for column names. | `true` or `false` |
 
 ### Optional Configs

--- a/mage_integrations/mage_integrations/destinations/mysql/README.md
+++ b/mage_integrations/mage_integrations/destinations/mysql/README.md
@@ -23,8 +23,6 @@ You must enter the following credentials when configuring this source:
 | `ssh_password` | (Optional) The password used to connect to the bastion server. It should be set if you authenticate with the bastion server with password. | `password` |
 | `ssh_pkey` | (Optional) The path to the private key used to connect to the bastion server or the content of the key file. It should be set if you authenticate with the bastion server with private key. | `/path/to/private/key` |
 | `conn_kwargs` | (Optional) Extra [connection keyword arguments](https://dev.mysql.com/doc/connector-python/en/connector-python-connectargs.html) in dictionary format. | `{"ssl_ca": "CARoot.pem", "ssl_cert": "certificate.pem", "ssl_key: "key.pem"'}` |
-| `ssl_cert` | (Optional) The host of the intermediate bastion server. | `123.45.67.89` |
-| `ssl_key` | (Optional) The host of the intermediate bastion server. | `123.45.67.89` |
 | `use_lowercase` | (Optional) Whether to use lower case for column names. | `true` or `false` |
 
 ### Optional Configs

--- a/mage_integrations/mage_integrations/destinations/mysql/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/mysql/__init__.py
@@ -31,6 +31,7 @@ class MySQL(Destination):
             port=self.config.get('port'),
             username=self.config['username'],
             connection_method=self.config.get('connection_method', ConnectionMethod.DIRECT),
+            conn_kwargs=self.config.get('conn_kwargs'),
             ssh_host=self.config.get('ssh_host'),
             ssh_port=self.config.get('ssh_port', 22),
             ssh_username=self.config.get('ssh_username'),

--- a/mage_integrations/mage_integrations/sources/mysql/README.md
+++ b/mage_integrations/mage_integrations/sources/mysql/README.md
@@ -16,6 +16,7 @@ You must enter the following credentials when configuring this source:
 | `username` | Name of the user that will access the database (must have permissions to read and write to specified schema). | `root` |
 | `password` | Password for the user to access the database. | `abc123...` |
 | `connection_method` | The method used to connect to MySQL server, either "direct" or "ssh_tunnel". | `direct` or `ssh_tunnel` |
+| `conn_kwargs` | (Optional) Extra [connection keyword arguments](https://dev.mysql.com/doc/connector-python/en/connector-python-connectargs.html) in dictionary format. | `{"ssl_ca": "CARoot.pem", "ssl_cert": "certificate.pem", "ssl_key: "key.pem"'}` |
 | `ssh_host` | (Optional) The host of the intermediate bastion server. | `123.45.67.89` |
 | `ssh_port` | (Optional) The port of the intermediate bastion server. Default value: 22 | `22` |
 | `ssh_username` | (Optional) The username used to connect to the bastion server. | `username` |

--- a/mage_integrations/mage_integrations/sources/mysql/__init__.py
+++ b/mage_integrations/mage_integrations/sources/mysql/__init__.py
@@ -19,6 +19,7 @@ class MySQL(Source):
             port=self.config.get('port', 3306),
             username=self.config['username'],
             connection_method=self.config.get('connection_method', ConnectionMethod.DIRECT),
+            conn_kwargs=self.config.get('conn_kwargs'),
             ssh_host=self.config.get('ssh_host'),
             ssh_port=self.config.get('ssh_port', 22),
             ssh_username=self.config.get('ssh_username'),

--- a/mage_integrations/mage_integrations/tests/destinations/mysql/test_mysql.py
+++ b/mage_integrations/mage_integrations/tests/destinations/mysql/test_mysql.py
@@ -34,6 +34,7 @@ class MySQLDestinationTests(unittest.TestCase, SQLDestinationMixin):
         port=None,
         username='username',
         connection_method='direct',
+        conn_kwargs=None,
         ssh_host=None,
         ssh_port=22,
         ssh_username=None,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Support extra connection arguments in mysql source and destination.

Close: https://github.com/mage-ai/mage-ai/issues/4579

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with mysql source and destination locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
