### PR TITLE
[jk] Sync block contents for replica block when minimizing

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -1584,7 +1584,7 @@ function CodeBlock({
           }
           textareaFocused={isReplicated ? null : textareaFocused}
           uuid={`${block?.uuid}/${block?.type}`}
-          value={content}
+          value={isReplicated ? block?.content : content}
           width="100%"
         />
       );


### PR DESCRIPTION
# Description
- Fixes bug where replica block content in Pipeline Editor was not staying synced with the most up-to-date code of the replicated block when minimizing the replica block.

# How Has This Been Tested?
Before (replica block content reverts to stale content after minimizing):
![Before - unsynced replica block content](https://github.com/mage-ai/mage-ai/assets/78053898/48f0af6f-02d2-4eca-b06c-45841d22bb43)

After (replica block content stays up-to-date):
![After - synced replica block content](https://github.com/mage-ai/mage-ai/assets/78053898/4cdfb29a-7fde-40b2-9b5c-ab7feb6e8379)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
