### PR TITLE
[jk] Fix "filter is not a function" type error in schema props

### DIFF
--- a/mage_ai/frontend/utils/models/block.ts
+++ b/mage_ai/frontend/utils/models/block.ts
@@ -598,7 +598,7 @@ export function addTypesToProperty(
   property: PropertyColumnMoreType,
 ) {
   const {
-    type: types,
+    type: types = [],
     typesDerived: typesDerived1,
   } = property || {};
   const property2 = {

--- a/mage_ai/frontend/utils/models/block.ts
+++ b/mage_ai/frontend/utils/models/block.ts
@@ -636,7 +636,7 @@ export function removeTypesFromProperty(
 ) {
   const {
     format,
-    type: types,
+    type: types = [],
     typesDerived: typesDerived1,
   } = property || {};
   const property2 = {

--- a/mage_ai/frontend/utils/models/block.ts
+++ b/mage_ai/frontend/utils/models/block.ts
@@ -538,7 +538,7 @@ export function getStreamMetadataByColumn(stream: StreamType): {
     }
 
     return acc;
-  }, {})
+  }, {});
 }
 
 export function getColumnFromMetadata(metadata: MetadataType): string {
@@ -604,9 +604,9 @@ export function addTypesToProperty(
   const property2 = {
     ...property,
   };
-
-  let types2 = [...types];
-  let typesDerived2 = [...typesDerived1];
+  const typesArr = !Array.isArray(types) ? [types] : types;
+  const types2 = [...typesArr];
+  const typesDerived2 = [...typesDerived1];
 
   typesDerivedToAdd?.forEach((td) => {
     if (COLUMN_TYPE_CUSTOM_DATE_TIME === td) {
@@ -643,7 +643,8 @@ export function removeTypesFromProperty(
     ...property,
   };
 
-  let types2 = [...types];
+  const typesArr = !Array.isArray(types) ? [types] : types;
+  let types2 = [...typesArr];
   let typesDerived2 = [...typesDerived1];
 
   typesDerivedToRemove?.forEach((td) => {
@@ -675,10 +676,18 @@ export function hydrateProperty(
     type: types = [],
   } = property || {};
 
-  const typesDerived = types?.filter(i => ![
+  let typesArr = types;
+  if (!Array.isArray(types)) {
+    if (!types) {
+      typesArr = [];
+    } else {
+      typesArr = [types];
+    }
+  }
+  const typesDerived = typesArr?.filter(i => ![
     COLUMN_TYPE_CUSTOM_DATE_TIME,
     ColumnFormatEnum.UUID,
-  ]?.includes(i))
+  ]?.includes(i));
 
   if (ColumnFormatMapping[format]) {
     if (!typesDerived?.includes(ColumnFormatMapping[format])) {
@@ -707,7 +716,7 @@ export function groupStreamsForTables(streamMapping: StreamMapping): {
       groupHeader: null,
       streams: sortByKey(Object.values(noParents), (stream: StreamType) => getStreamID(stream)),
     },
-    ...sortByKey(Object.entries(parents), ([parentStreamID,]) => parentStreamID).map(([
+    ...sortByKey(Object.entries(parents), ([parentStreamID]) => parentStreamID).map(([
       groupHeader,
       mapping,
     ]) => ({
@@ -862,7 +871,7 @@ export function updateStreamMappingWithPropertyAttributeValues(
               },
             };
 
-            metadataByColumn[column] = md
+            metadataByColumn[column] = md;
           } else if (attributesOnStream.includes(attribute as AttributeUUIDEnum)) {
             if (!streamUpdated?.[attribute]) {
               streamUpdated[attribute] = [];
@@ -981,7 +990,7 @@ export function buildInputsFromUpstreamBlocks(
     return acc.concat({
       block: b,
       input,
-    })
+    });
   }, []);
 }
 


### PR DESCRIPTION
# Description
- Fixes this issue: There was an error (screenshot below) causing the app to crash when user was viewing the "Schema properties" of a data stream for an integration block in a standard pipeline. This was due to an unexpected column type (a non-array value received).
<img width="854" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/b74dafe1-90e6-470a-8202-f6f89923efbb">

# How Has This Been Tested?
- Tested locally. Was able to recreate error and confirmed it no longer appeared.

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
