### PR TITLE
[xy] Fix list index out of range for dynamic blocks.

### DIFF
--- a/mage_ai/data_preparation/models/block/dynamic/variables.py
+++ b/mage_ai/data_preparation/models/block/dynamic/variables.py
@@ -522,9 +522,8 @@ def fetch_input_variables_for_dynamic_upstream_blocks(
                 global_vars=global_vars,
                 **kwargs,
             )
-
             input_vars.append(ir[0])
-            kwargs_vars.append(kr[0])
+            kwargs_vars.append(kr[0] if len(kr) > 0 else None)
             upstream_block_uuids.append(up[0])
 
     return input_vars, kwargs_vars, upstream_block_uuids


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix list index out of range for dynamic blocks.

<img width="428" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/b9832f4a-5383-40ce-9196-96743dcf9f1c">

When setting both regular block and dynamic block as upstream blocks, dynamic child block throws the "list index out of range" error upon execution

```
Error

Traceback (most recent call last):

  File "/usr/local/lib/python3.10/site-packages/mage_ai/shared/retry.py", line 38, in retry_func

    return func(*args, **kwargs)

  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/executors/block_executor.py", line 588, in __execute_with_retry

    return self._execute(

  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/executors/block_executor.py", line 1077, in _execute

    result = self.block.execute_sync(

  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/models/block/__init__.py", line 1315, in execute_sync

    raise err

  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/models/block/__init__.py", line 1224, in execute_sync

    output = self.execute_block(

  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/models/block/__init__.py", line 1512, in execute_block

    self.__get_outputs_from_input_vars(

  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/models/block/__init__.py", line 1454, in __get_outputs_from_input_vars

    input_vars, kwargs_vars, upstream_block_uuids = self.fetch_input_variables(

  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/models/block/__init__.py", line 1812, in fetch_input_variables

    return fetch_input_variables_for_dynamic_upstream_blocks(

  File "/usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/models/block/dynamic/variables.py", line 527, in fetch_input_variables_for_dynamic_upstream_blocks

    kwargs_vars.append(kr[0])

IndexError: list index out of range
```

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with the dynamic blocks. It succeeded
<img width="428" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/b9832f4a-5383-40ce-9196-96743dcf9f1c">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
