### PR TITLE
[xy] Set default domain for salesforce source

### DIFF
--- a/mage_integrations/mage_integrations/sources/salesforce/__init__.py
+++ b/mage_integrations/mage_integrations/sources/salesforce/__init__.py
@@ -29,7 +29,7 @@ class Salesforce(Source):
             credentials=parse_credentials(self.config),
             quota_percent_total=self.config.get('quota_percent_total'),
             quota_percent_per_run=self.config.get('quota_percent_per_run'),
-            domain=self.config.get('domain'),
+            domain=self.config.get('domain', 'login'),
             select_fields_by_default=self.config.get('select_fields_by_default'),
             default_start_date=self.config.get('start_date'),
             api_type=self.config.get('api_type')

--- a/mage_integrations/mage_integrations/sources/salesforce/client/tap_salesforce/salesforce/credentials.py
+++ b/mage_integrations/mage_integrations/sources/salesforce/client/tap_salesforce/salesforce/credentials.py
@@ -80,6 +80,7 @@ class SalesforceAuthOAuth(SalesforceAuth):
         return f"https://{self.domain}.salesforce.com/services/oauth2/token"
 
     def login(self):
+        resp = None
         try:
             LOGGER.info("Attempting login via OAuth2")
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
* Set default domain to login for salesforce source.
* Fix unboundlocalerror when it fails to connect

<img width="372" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/946b551f-663b-4d76-915f-163781f2d6b8">


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with salesforce source locally
<img width="317" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/72d5dfef-b19d-4cbc-98e0-64cd024627de">


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
