### PR TITLE
[jk] Limit block output for dynamic blocks in UI

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -2161,6 +2161,9 @@ class Block(DataIntegrationMixin, SparkBlock, ProjectPlatformAccessible):
                 )
                 pairs.append(tup)
 
+            if len(pairs) > 10:
+                # Limit the number of dynamic block children we display output for in the UI
+                pairs = pairs[:DATAFRAME_SAMPLE_COUNT_PREVIEW]
             for pair in pairs:
                 child_data = None
                 metadata = None


### PR DESCRIPTION
# Description
- If there are too many dynamic block children, it can cause significant slowdowns on the Pipeline Editor page when trying to render the block outputs. This PR limits the output displayed for dynamic blocks.

# How Has This Been Tested?
- Tested locally

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
