### PR TITLE
[dy] Handle JSON reading errors for elasticsearch

### DIFF
--- a/mage_integrations/mage_integrations/destinations/target.py
+++ b/mage_integrations/mage_integrations/destinations/target.py
@@ -289,9 +289,9 @@ class Target(PluginBase, SingerReader, metaclass=abc.ABCMeta):
 
         self.logger.info(
             f"Target {self.name} completed reading {line_count} lines of input "
-            f"{counter[SingerMessageType.RECORD]} records, "
-            f"{counter[SingerMessageType.BATCH]} batch manifests, "
-            f"{counter[SingerMessageType.STATE]} state messages. "
+            f" {counter[SingerMessageType.RECORD]} records, "
+            f" {counter[SingerMessageType.BATCH]} batch manifests, "
+            f" {counter[SingerMessageType.STATE]} state messages. "
         )
 
         return counter


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Handle JSON decode errors when parsing the input file for the elasticsearch destination. This logic is similar to the default file parsing logic in the `Destination` class. However, the Elasticsearch destination has its custom sink and target class, so we can't easily use the existing logic.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with local Elasticsearch


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
