### PR TITLE
[dy] Add interval variables for cron based schedules

### DIFF
--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -1569,12 +1569,14 @@ class PipelineRun(PipelineRunProjectPlatformMixin, BaseModel):
                     self.pipeline_schedule.schedule_interval,
                     self.execution_date,
                 )
+                current = cron_itr.get_current(datetime)
                 interval_start_datetime_previous = cron_itr.get_prev(datetime)
+                # get_prev and get_next changes the state of the cron iterator, so we need
+                # to call get_next again to go back to the original state
                 cron_itr.get_next()
                 interval_end_datetime = cron_itr.get_next(datetime)
                 interval_seconds = (
-                    interval_end_datetime.timestamp()
-                    - interval_start_datetime.timestamp()
+                    interval_end_datetime.timestamp() - current.timestamp()
                 )
 
             if interval_seconds and not interval_end_datetime:

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -1548,7 +1548,12 @@ class PipelineRun(PipelineRunProjectPlatformMixin, BaseModel):
             interval_start_datetime = self.execution_date
             interval_start_datetime_previous = None
 
-            if ScheduleInterval.DAILY == self.pipeline_schedule.schedule_interval:
+            if (
+                ScheduleInterval.ONCE == self.pipeline_schedule.schedule_interval
+                or ScheduleInterval.ALWAYS_ON == self.pipeline_schedule.schedule_interval
+            ):
+                pass
+            elif ScheduleInterval.DAILY == self.pipeline_schedule.schedule_interval:
                 interval_seconds = 60 * 60 * 24
             elif ScheduleInterval.HOURLY == self.pipeline_schedule.schedule_interval:
                 interval_seconds = 60 * 60 * 1
@@ -1559,6 +1564,18 @@ class PipelineRun(PipelineRunProjectPlatformMixin, BaseModel):
                 )
             elif ScheduleInterval.WEEKLY == self.pipeline_schedule.schedule_interval:
                 interval_seconds = 60 * 60 * 24 * 7
+            else:
+                cron_itr = croniter(
+                    self.pipeline_schedule.schedule_interval,
+                    self.execution_date,
+                )
+                interval_start_datetime_previous = cron_itr.get_prev(datetime)
+                cron_itr.get_next()
+                interval_end_datetime = cron_itr.get_next(datetime)
+                interval_seconds = (
+                    interval_end_datetime.timestamp()
+                    - interval_start_datetime.timestamp()
+                )
 
             if interval_seconds and not interval_end_datetime:
                 interval_end_datetime = interval_start_datetime + timedelta(

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -1565,19 +1565,22 @@ class PipelineRun(PipelineRunProjectPlatformMixin, BaseModel):
             elif ScheduleInterval.WEEKLY == self.pipeline_schedule.schedule_interval:
                 interval_seconds = 60 * 60 * 24 * 7
             else:
-                cron_itr = croniter(
-                    self.pipeline_schedule.schedule_interval,
-                    self.execution_date,
-                )
-                current = cron_itr.get_current(datetime)
-                interval_start_datetime_previous = cron_itr.get_prev(datetime)
-                # get_prev and get_next changes the state of the cron iterator, so we need
-                # to call get_next again to go back to the original state
-                cron_itr.get_next()
-                interval_end_datetime = cron_itr.get_next(datetime)
-                interval_seconds = (
-                    interval_end_datetime.timestamp() - current.timestamp()
-                )
+                try:
+                    cron_itr = croniter(
+                        self.pipeline_schedule.schedule_interval,
+                        self.execution_date,
+                    )
+                    current = cron_itr.get_current(datetime)
+                    interval_start_datetime_previous = cron_itr.get_prev(datetime)
+                    # get_prev and get_next changes the state of the cron iterator, so we need
+                    # to call get_next again to go back to the original state
+                    cron_itr.get_next()
+                    interval_end_datetime = cron_itr.get_next(datetime)
+                    interval_seconds = (
+                        interval_end_datetime.timestamp() - current.timestamp()
+                    )
+                except Exception:
+                    pass
 
             if interval_seconds and not interval_end_datetime:
                 interval_end_datetime = interval_start_datetime + timedelta(

--- a/mage_ai/orchestration/db/models/schedules_project_platform.py
+++ b/mage_ai/orchestration/db/models/schedules_project_platform.py
@@ -5,6 +5,7 @@ from typing import Dict, List
 
 import dateutil.parser
 import pytz
+from croniter import croniter
 from dateutil.relativedelta import relativedelta
 from sqlalchemy import or_
 from sqlalchemy.sql import func
@@ -298,7 +299,12 @@ class PipelineRunProjectPlatformMixin:
             interval_start_datetime = self.execution_date
             interval_start_datetime_previous = None
 
-            if ScheduleInterval.DAILY == self.pipeline_schedule.schedule_interval:
+            if (
+                ScheduleInterval.ONCE == self.pipeline_schedule.schedule_interval
+                or ScheduleInterval.ALWAYS_ON == self.pipeline_schedule.schedule_interval
+            ):
+                pass
+            elif ScheduleInterval.DAILY == self.pipeline_schedule.schedule_interval:
                 interval_seconds = 60 * 60 * 24
             elif ScheduleInterval.HOURLY == self.pipeline_schedule.schedule_interval:
                 interval_seconds = 60 * 60 * 1
@@ -309,6 +315,18 @@ class PipelineRunProjectPlatformMixin:
                 )
             elif ScheduleInterval.WEEKLY == self.pipeline_schedule.schedule_interval:
                 interval_seconds = 60 * 60 * 24 * 7
+            else:
+                cron_itr = croniter(
+                    self.pipeline_schedule.schedule_interval,
+                    self.execution_date,
+                )
+                interval_start_datetime_previous = cron_itr.get_prev(datetime)
+                cron_itr.get_next()
+                interval_end_datetime = cron_itr.get_next(datetime)
+                interval_seconds = (
+                    interval_end_datetime.timestamp()
+                    - interval_start_datetime.timestamp()
+                )
 
             if interval_seconds and not interval_end_datetime:
                 interval_end_datetime = interval_start_datetime + timedelta(

--- a/mage_ai/orchestration/db/models/schedules_project_platform.py
+++ b/mage_ai/orchestration/db/models/schedules_project_platform.py
@@ -316,19 +316,22 @@ class PipelineRunProjectPlatformMixin:
             elif ScheduleInterval.WEEKLY == self.pipeline_schedule.schedule_interval:
                 interval_seconds = 60 * 60 * 24 * 7
             else:
-                cron_itr = croniter(
-                    self.pipeline_schedule.schedule_interval,
-                    self.execution_date,
-                )
-                current = cron_itr.get_current(datetime)
-                interval_start_datetime_previous = cron_itr.get_prev(datetime)
-                # get_prev and get_next changes the state of the cron iterator, so we need
-                # to call get_next again to go back to the original state
-                cron_itr.get_next()
-                interval_end_datetime = cron_itr.get_next(datetime)
-                interval_seconds = (
-                    interval_end_datetime.timestamp() - current.timestamp()
-                )
+                try:
+                    cron_itr = croniter(
+                        self.pipeline_schedule.schedule_interval,
+                        self.execution_date,
+                    )
+                    current = cron_itr.get_current(datetime)
+                    interval_start_datetime_previous = cron_itr.get_prev(datetime)
+                    # get_prev and get_next changes the state of the cron iterator, so we need
+                    # to call get_next again to go back to the original state
+                    cron_itr.get_next()
+                    interval_end_datetime = cron_itr.get_next(datetime)
+                    interval_seconds = (
+                        interval_end_datetime.timestamp() - current.timestamp()
+                    )
+                except Exception:
+                    pass
 
             if interval_seconds and not interval_end_datetime:
                 interval_end_datetime = interval_start_datetime + timedelta(

--- a/mage_ai/orchestration/db/models/schedules_project_platform.py
+++ b/mage_ai/orchestration/db/models/schedules_project_platform.py
@@ -320,12 +320,14 @@ class PipelineRunProjectPlatformMixin:
                     self.pipeline_schedule.schedule_interval,
                     self.execution_date,
                 )
+                current = cron_itr.get_current(datetime)
                 interval_start_datetime_previous = cron_itr.get_prev(datetime)
+                # get_prev and get_next changes the state of the cron iterator, so we need
+                # to call get_next again to go back to the original state
                 cron_itr.get_next()
                 interval_end_datetime = cron_itr.get_next(datetime)
                 interval_seconds = (
-                    interval_end_datetime.timestamp()
-                    - interval_start_datetime.timestamp()
+                    interval_end_datetime.timestamp() - current.timestamp()
                 )
 
             if interval_seconds and not interval_end_datetime:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Runs for schedules that used cron intervals were calculating the interval variables, so I'm adding that here.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with cron based schedule
![Screenshot 2024-03-01 at 5 07 06 PM](https://github.com/mage-ai/mage-ai/assets/14357209/8f5075f5-67a4-4361-bea8-c69a2676832f)


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
