### PR TITLE
[xh] Oracle add thick mode support in standard pipeline

### DIFF
--- a/mage_ai/io/oracledb.py
+++ b/mage_ai/io/oracledb.py
@@ -1,4 +1,3 @@
-import logging
 import warnings
 from typing import Union
 
@@ -8,8 +7,9 @@ from pandas import DataFrame, read_sql
 from mage_ai.io.base import QUERY_ROW_LIMIT
 from mage_ai.io.config import BaseConfigLoader, ConfigKey
 from mage_ai.io.sql import BaseSQL
+from mage_ai.server.logger import Logger
 
-LOGGER = logging.getLogger(__name__)
+logger = Logger().new_server_logger(__name__)
 
 
 class OracleDB(BaseSQL):
@@ -44,7 +44,7 @@ class OracleDB(BaseSQL):
 
     def open(self) -> None:
         if self.settings['mode'] and self.settings['mode'].lower() == 'thick':
-            LOGGER.info('Initializing Oracle thick mode.')
+            logger.info('Initializing Oracle thick mode.')
             oracledb.init_oracle_client()
         with self.printer.print_msg(f'Opening connection to OracleDB database \
                                     ({self.settings["mode"]} mode)'):


### PR DESCRIPTION
# Description
Following up on this issue: https://github.com/mage-ai/mage-ai/issues/4654 to add oracle thick mode support in standard pipeline.


# How Has This Been Tested?
Mage UI to create standard pipeline and successfully load data:
![WX20240302-160237@2x](https://github.com/mage-ai/mage-ai/assets/5386254/c2bf41f6-adf5-457a-9fd2-54b37f5b6d4c)



# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
@wangxiaoyou1993 
