### PR TITLE
[Bug] Resolve "parsing error" in the trino.mdx screen

### DIFF
--- a/docs/integrations/databases/trino.mdx
+++ b/docs/integrations/databases/trino.mdx
@@ -62,7 +62,7 @@ labeled <b>default</b>.
 1. You can optionally check the box labeled <b>Use raw SQL</b>.
 If you do, read more about [how to use SQL blocks with raw SQL](/guides/blocks/sql-blocks#using-raw-sql).
 
-1. You can optionally overwrite your table columns types by adding a JSON to `overwrite_types` config, the format needs to be {"column_name":"VARCHAR"}
+1. You can optionally overwrite your table columns types by adding a JSON to `overwrite_types` config, the format needs to be `{"column_name":"VARCHAR"}`
 
 1. Write your SQL statements in the SQL block.
 


### PR DESCRIPTION
To resolve the issue https://github.com/mage-ai/mage-ai/issues/4638.

# Description
If you go to https://docs.mage.ai/integrations/databases/trino, it shows a "parsing error":
![image](https://github.com/mage-ai/mage-ai/assets/59368894/5b318c4e-742f-4161-bc36-43412a3b49ec)



# How Has This Been Tested?
Updated the docs/integrations/databases/trino.mdx Tested locally. No test required for `Suggest edits`


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation


cc:
@wangxiaoyou1993 
