### PR TITLE
[jk] Update backfill policy to allow update on settings

### DIFF
--- a/mage_ai/api/policies/BackfillPolicy.py
+++ b/mage_ai/api/policies/BackfillPolicy.py
@@ -62,6 +62,7 @@ BackfillPolicy.allow_write([
     'interval_type',
     'interval_units',
     'name',
+    'settings',
     'start_datetime',
     'status',
     'variables',


### PR DESCRIPTION
# Description
- Fix backfill policy error when updating "Max concurrent runs" setting for backfill.

# How Has This Been Tested?
Confirmed the error below no longer appears when saving backfill with "Max concurrent runs" input filled:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/0cc6d343-de96-4721-9a32-93328687f0f8)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
