### PR TITLE
Pyarrow version conflicts from Snowflake connector

### DIFF
--- a/mage_integrations/requirements.txt
+++ b/mage_integrations/requirements.txt
@@ -34,7 +34,7 @@ requests_mock==1.10.0
 simple_salesforce~=1.12.5
 simplejson
 singer_sdk~=0.34.1
-snowflake-connector-python==3.4.0
+snowflake-connector-python==3.5.0
 sshtunnel==0.4.0
 stripe==5.5.0
 terminaltables==3.1.10


### PR DESCRIPTION
# Description
The mageai integration uses [Pyarrow version 14.0.1](https://github.com/mage-ai/mage-ai/blob/ed6ade4ddab27e847baadd0f96bd58e13bfcbb42/mage_integrations/requirements.txt#L26) and [Snowflake connector 3.4.0](https://github.com/mage-ai/mage-ai/blob/ed6ade4ddab27e847baadd0f96bd58e13bfcbb42/mage_integrations/requirements.txt#L37). But snowflake 3.4.0 restricts pyarrow>=10.0.1,<10.1.0. This requires building multiple pyarrow versions when using custom pyarrow build.

## Fix
[This issue](https://github.com/snowflakedb/snowflake-connector-python/issues/1566) addresses the strict pyarrow version dependency by snowflake. The fix is [released](https://github.com/snowflakedb/snowflake-connector-python/issues/1566#issuecomment-1810831158) in snowflake version 3.5.0. So, we are upgrading to Snowflake Connector 3.5.0


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [ ] After updating to Snowflake connector 3.5.0, [Pyarrow version 14.0.1](https://github.com/mage-ai/mage-ai/blob/ed6ade4ddab27e847baadd0f96bd58e13bfcbb42/mage_integrations/requirements.txt#L26) is good enough. 


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
@wangxiaoyou1993 
