### PR TITLE
[jk] Fix buggy pipeline dashboard

### DIFF
--- a/mage_ai/frontend/components/BlockLayout/BlockLayoutItem/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/BlockLayoutItem/index.tsx
@@ -20,6 +20,7 @@ import { Ellipsis } from '@oracle/icons';
 import { ItemStyle, WIDTH_OFFSET } from './index.style';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { VARIABLE_NAME_HEIGHT } from '@interfaces/ChartBlockType';
+import { useError } from '@context/Error';
 
 type BlockLayoutItemProps = {
   block?: BlockLayoutItemType;
@@ -91,6 +92,10 @@ function BlockLayoutItem({
     dataState,
   ]);
 
+  const [showError] = useError(null, {}, [], {
+    uuid: `BlockLayoutItem/${pageBlockLayoutUUID}/${blockUUID}`,
+  });
+
   // Minimum 1000ms refresh interval
   const refreshInterval = useMemo(() => {
     const ri = blockLayoutItem?.data_source?.refresh_interval;
@@ -115,6 +120,17 @@ function BlockLayoutItem({
       revalidateOnFocus: !refreshInterval,
     },
   );
+
+  useEffect(() => {
+    if (dataBlockLayoutItem?.error) {
+      showError({
+        response: dataBlockLayoutItem,
+      });
+    }
+  }, [
+    dataBlockLayoutItem,
+    showError,
+]);
 
   useEffect(() => {
     if (!blockLayoutItem) {

--- a/mage_ai/frontend/components/BlockLayout/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/index.tsx
@@ -137,7 +137,7 @@ function BlockLayout({
   const setSelectedBlockItem = useCallback((prev1) => {
     setObjectAttributes((prev2) => {
       const data = {
-        ...prev2,
+        // ...prev2,
         ...prev1,
       };
 

--- a/mage_ai/frontend/components/BlockLayout/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/index.tsx
@@ -137,7 +137,6 @@ function BlockLayout({
   const setSelectedBlockItem = useCallback((prev1) => {
     setObjectAttributes((prev2) => {
       const data = {
-        // ...prev2,
         ...prev1,
       };
 

--- a/mage_ai/frontend/components/BlockLayout/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/index.tsx
@@ -687,7 +687,7 @@ function BlockLayout({
             placeholder="Type name for chart..."
             primary
             setContentOnMount
-            value={objectAttributes?.name || ''}
+            value={objectAttributes?.name_new || ''}
           />
         </Spacing>
 

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -72,6 +72,7 @@ type TableProps = {
 
 type DataTableProps = {
   columns: string[];
+  disableZeroIndexRowNumber?: boolean;
   noBorderBottom?: boolean;
   noBorderLeft?: boolean;
   noBorderRight?: boolean;
@@ -532,6 +533,7 @@ function DataTable({
   columnHeaderHeight,
   columns: columnsProp,
   disableScrolling,
+  disableZeroIndexRowNumber,
   height,
   index,
   invalidValues,
@@ -559,7 +561,7 @@ function DataTable({
 
   const columns = useMemo(() => range(numberOfIndexes).map((i: number, idx: number) => ({
     Header: range(idx + 1).map(() => ' ').join(' '),
-    accessor: (row, i) => i,
+    accessor: (row, i) => i + (disableZeroIndexRowNumber ? 1 : 0),
     sticky: 'left',
     // @ts-ignore
   })).concat(columnsProp?.map(col => ({
@@ -567,6 +569,7 @@ function DataTable({
     accessor: String(col),
   }))), [
     columnsProp,
+    disableZeroIndexRowNumber,
     numberOfIndexes,
   ]);
 


### PR DESCRIPTION
# Description
- Address issues mentioned in this github issue https://github.com/mage-ai/mage-ai/issues/4691
- Add error messaging when loading block layout item.

# How Has This Been Tested?
Confirmed the following bugs no longer appeared:
- [x] When you click "Create new chart" it seems to automatically template it off of the last chart that was modified.
- [x] If you have recently modified a chart and click new chart, the name of the new chart will be your existing chart and it seems that any change you make to it will override the existing chart
- [x] At no point in the process am I able to rename the chart
- [x] Sometimes when I click "Remove Chart" while testing, it also pops up the last chart I edited into edit mode

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
