### PR TITLE
[jk] Delete backfills

### DIFF
--- a/docs/api-reference/backfills/overview.mdx
+++ b/docs/api-reference/backfills/overview.mdx
@@ -57,7 +57,7 @@ description: "Programmatically create multiple pipeline runs to backfill a pipel
 </ResponseField>
 
 <ResponseField name="interval_type" type="string">
-  `second`, `minute`, `hour`, `day`, `week`, `month`, `year`, `custom`
+  `minute`, `hour`, `day`, `week`, `month`, `year`
 </ResponseField>
 
 <ResponseField name="interval_units" type="integer">

--- a/docs/api-reference/backfills/update-backfill.mdx
+++ b/docs/api-reference/backfills/update-backfill.mdx
@@ -13,7 +13,7 @@ All default attributes for a backfill may be updated in addittion to the followi
   A datetime formatted string representing the end time of the backfill, e.g. `"2023-09-05 23:56:05"`.
 </ParamField>
 <ParamField query="interval_type" type="string">
-  The interval type for the backfill. One of: `second`, `minute`, `hour`, `day`, `week`, `month`, `year`, or `custom`.
+  The interval type for the backfill. One of: `minute`, `hour`, `day`, `week`, `month`, or `year`.
 </ParamField>
 <ParamField query="interval_units" type="integer">
   The number of interval units for the backfill.

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -157,7 +157,7 @@ function BackfillDetail({
       <>
         <PipelineRunsTable
           disableRowSelect={showPreviewRuns}
-          emptyMessage={!q?.status
+          emptyMessage={(!q?.status && !status)
             ? 'No runs available. Please complete backfill configuration by clicking "Edit backfill" above.'
             : 'No runs available'
           }

--- a/mage_ai/frontend/components/Backfills/Edit/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Edit/index.tsx
@@ -323,12 +323,14 @@ function BackfillEdit({
           <TextInput
             disabled={!intervalType}
             key="interval_unit_input"
+            minValue={1}
             monospace
             onChange={(e) => {
               e.preventDefault();
+              const updatedUnitValue = +e.target.value;
               setModel(s => ({
                 ...s,
-                interval_units: e.target.value,
+                interval_units: updatedUnitValue < 1 ? 1 : updatedUnitValue,
               }));
             }}
             placeholder={intervalType

--- a/mage_ai/frontend/components/Backfills/Edit/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Edit/index.tsx
@@ -379,6 +379,7 @@ function BackfillEdit({
       </FlexContainer>,
       <TextInput
         key="concurrency_input"
+        minValue={1}
         monospace
         onChange={(e) => {
           e.preventDefault();

--- a/mage_ai/frontend/components/Triggers/Table.tsx
+++ b/mage_ai/frontend/components/Triggers/Table.tsx
@@ -1,5 +1,5 @@
 import NextLink from 'next/link';
-import { createRef, useMemo, useRef, useState } from 'react';
+import { createRef, useRef, useState } from 'react';
 import { useMutation } from 'react-query';
 import { useRouter } from 'next/router';
 

--- a/mage_ai/frontend/components/shared/Table/useDeleteConfirmDialogue.tsx
+++ b/mage_ai/frontend/components/shared/Table/useDeleteConfirmDialogue.tsx
@@ -1,0 +1,123 @@
+import React, { createRef, useRef, useState } from 'react';
+import { useMutation } from 'react-query';
+import { useRouter } from 'next/router';
+
+import Button from '@oracle/elements/Button';
+import ClickOutside from '@oracle/components/ClickOutside';
+import PopupMenu from '@oracle/components/PopupMenu';
+import Spacing from '@oracle/elements/Spacing';
+import {
+  DELETE_CONFIRM_WIDTH,
+  DELETE_CONFIRM_LEFT_OFFSET_DIFF,
+  DELETE_CONFIRM_TOP_OFFSET_DIFF,
+  DELETE_CONFIRM_TOP_OFFSET_DIFF_FIRST,
+} from '@components/shared/Table/constants';
+import { ICON_SIZE_SMALL } from '@oracle/styles/units/icons';
+import { Trash } from '@oracle/icons';
+import { onSuccess } from '@api/utils/response';
+import { useError } from '@context/Error';
+
+type UseDeleteConfirmDialogueProps = {
+  fetchItems: () => void;
+  mutationFn: (variables: any) => any;
+  path: string;
+  pipelineUUID?: string;
+};
+
+function useDeleteConfirmDialogue({
+  fetchItems,
+  mutationFn,
+  path,
+  pipelineUUID,
+}: UseDeleteConfirmDialogueProps): {
+  deleteButton: (
+    itemToDeleteId: number,
+    itemIndex: number,
+    message: string,
+  ) => JSX.Element;
+} {
+  const router = useRouter();
+  const deleteButtonRefs = useRef({});
+  const [deleteConfirmationOpenIdx, setDeleteConfirmationOpenIdx] = useState<number>(null);
+  const [confirmDialogueTopOffset, setConfirmDialogueTopOffset] = useState<number>(0);
+  const [confirmDialogueLeftOffset, setConfirmDialogueLeftOffset] = useState<number>(0);
+
+  const [showError] = useError(null, {}, [], {
+    uuid: `${path}/${pipelineUUID}/delete/error`,
+  });
+
+  const [deleteItem] = useMutation(
+    (id: number) => mutationFn(id)(),
+    {
+      onSuccess: (response: any) => onSuccess(
+        response, {
+          callback: () => {
+            fetchItems?.();
+            if (pipelineUUID) {
+              router.push(
+                `/pipelines/[pipeline]/${path}`,
+                `/pipelines/${pipelineUUID}/${path}`,
+              );
+            }
+          },
+          onErrorCallback: (response, errors) => showError({
+            errors,
+            response,
+          }),
+        },
+      ),
+    },
+  );
+
+  const deleteButton = (
+    itemToDeleteId: number,
+    itemIndex: number,
+    message: string,
+  ) => {
+    deleteButtonRefs.current[itemToDeleteId] = createRef();
+
+    return (
+      <Spacing mr={1}>
+        <Button
+          default
+          iconOnly
+          noBackground
+          onClick={() => {
+            setDeleteConfirmationOpenIdx(itemToDeleteId);
+            setConfirmDialogueTopOffset(deleteButtonRefs.current[itemToDeleteId]?.current?.offsetTop || 0);
+            setConfirmDialogueLeftOffset(deleteButtonRefs.current[itemToDeleteId]?.current?.offsetLeft || 0);
+          }}
+          ref={deleteButtonRefs.current[itemToDeleteId]}
+          title="Delete"
+        >
+          <Trash default size={ICON_SIZE_SMALL} />
+        </Button>
+        <ClickOutside
+          onClickOutside={() => setDeleteConfirmationOpenIdx(null)}
+          open={deleteConfirmationOpenIdx === itemToDeleteId}
+        >
+          <PopupMenu
+            danger
+            left={(confirmDialogueLeftOffset || 0) - DELETE_CONFIRM_LEFT_OFFSET_DIFF}
+            onCancel={() => setDeleteConfirmationOpenIdx(null)}
+            onClick={() => {
+              setDeleteConfirmationOpenIdx(null);
+              deleteItem(itemToDeleteId);
+            }}
+            title={message}
+            top={(confirmDialogueTopOffset || 0)
+              - (itemIndex <= 1 ? DELETE_CONFIRM_TOP_OFFSET_DIFF_FIRST : DELETE_CONFIRM_TOP_OFFSET_DIFF)
+            }
+            width={DELETE_CONFIRM_WIDTH}
+          />
+        </ClickOutside>
+      </Spacing>
+    );
+  };
+
+  return {
+    deleteButton,
+  };
+}
+
+export default useDeleteConfirmDialogue;

--- a/mage_ai/frontend/interfaces/BackfillType.ts
+++ b/mage_ai/frontend/interfaces/BackfillType.ts
@@ -17,14 +17,12 @@ export enum IntervalTypeEnum {
 }
 
 export const INTERVAL_TYPES = [
-  // IntervalTypeEnum.SECOND,
   IntervalTypeEnum.MINUTE,
   IntervalTypeEnum.HOUR,
   IntervalTypeEnum.DAY,
   IntervalTypeEnum.WEEK,
   IntervalTypeEnum.MONTH,
   IntervalTypeEnum.YEAR,
-  IntervalTypeEnum.CUSTOM,
 ];
 
 type PipelineRunDateType = {

--- a/mage_ai/frontend/oracle/elements/Inputs/InputWrapper.tsx
+++ b/mage_ai/frontend/oracle/elements/Inputs/InputWrapper.tsx
@@ -74,6 +74,7 @@ export type InputWrapperProps = {
   maxWidth?: number;
   meta?: MetaType;
   minWidth?: number;
+  minValue?: number;
   monospace?: boolean;
   name?: string;
   negative?: boolean;
@@ -708,6 +709,7 @@ const InputWrapper = ({
   labelFixed,
   maxWidth,
   meta,
+  minValue,
   name,
   onChange,
   onClick,
@@ -869,6 +871,7 @@ const InputWrapper = ({
         hasContent: !!content,
         isFocused: showLabel,
         label: (label === 0 ? '0' : label),
+        min: (typeProp === 'number' && typeof minValue === 'number') ? minValue : null,
         name,
         onBlur: (e) => {
           if (props.onBlur) {

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/backfills/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/backfills/index.tsx
@@ -35,7 +35,8 @@ function PipelineBackfills({
   const router = useRouter();
   const pipelineUUID = pipeline.uuid;
   const {
-    data: dataPipelineRuns,
+    data: dataBackfills,
+    mutate: fetchBackfills,
   } = api.backfills.list({
     _limit: 20,
     _offset: 0,
@@ -44,7 +45,7 @@ function PipelineBackfills({
   }, {
     refreshInterval: 60000,
   });
-  const models = useMemo(() => dataPipelineRuns?.backfills || [], [dataPipelineRuns]);
+  const models = useMemo(() => dataBackfills?.backfills || [], [dataBackfills]);
 
   const q = queryFromUrl();
 
@@ -173,10 +174,11 @@ function PipelineBackfills({
       )}
       {models?.length >= 1 && (
         <BackfillsTable
+          fetchBackfills={fetchBackfills}
           models={models}
-          onClickRow={({ id }: BackfillType) => goToWithQuery({
-            backfill_id: id,
-          })}
+          // onClickRow={({ id }: BackfillType) => goToWithQuery({
+          //   backfill_id: id,
+          // })}
           pipeline={pipeline}
           selectedRow={selectedRow}
         />


### PR DESCRIPTION
# Description
- Add delete button to backfills table that allows user to delete backfills individually.
- Prevent user from setting a backfill interval unit value less  than 1, which could cause issues loading the backfills.

# How Has This Been Tested?
![delete backfill](https://github.com/mage-ai/mage-ai/assets/78053898/60628728-bf41-46d7-b033-d5f1a21e2a05)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
