### PR TITLE
[dy] Expire certain pipeline runs

### DIFF
--- a/mage_ai/frontend/components/Triggers/Detail/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Detail/index.tsx
@@ -162,10 +162,12 @@ function TriggerDetail({
     mutate: fetchPipelineRuns,
   } = api.pipeline_runs.pipeline_schedules.list(
     pipelineScheduleID,
-    pipelineRunsRequestQuery, {
-    refreshInterval: 3000,
-    revalidateOnFocus: true,
-  });
+    pipelineRunsRequestQuery,
+    {
+      refreshInterval: 3000,
+      revalidateOnFocus: true,
+    },
+  );
   const pipelineRuns = useMemo(() => dataPipelineRuns?.pipeline_runs || [], [dataPipelineRuns]);
   const totalRuns = useMemo(() => dataPipelineRuns?.metadata?.count || [], [dataPipelineRuns]);
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

The `/pipeline_runs` query seems to be fetching cached data which is fine in most cases, but if there is a running pipeline run, the status of the pipeline run can sometimes get stuck. I'm added a check to expire a pipeline run in the session if it is in progress, so that the status can be properly updated in future queries.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with in progress pipeline runs

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
