### PR TITLE
[jk] Allow file to be opened in Pipeline Editor without Command Center enabled

### DIFF
--- a/mage_ai/frontend/components/shared/Header/index.tsx
+++ b/mage_ai/frontend/components/shared/Header/index.tsx
@@ -42,7 +42,7 @@ import { CustomEventUUID, CUSTOM_EVENT_NAME_COMMAND_CENTER_STATE_CHANGED } from 
 import { LinkStyle } from '@components/PipelineDetail/FileHeaderMenu/index.style';
 import { MONO_FONT_FAMILY_BOLD } from '@oracle/styles/fonts/primary';
 import { REQUIRE_USER_AUTHENTICATION, getUser } from '@utils/session';
-import { PADDING, PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
+import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { getSetSettings } from '@storage/CommandCenter/utils';
 import { launchCommandCenter } from '@components/CommandCenter/utils';
 import { pauseEvent } from '@utils/events';
@@ -163,7 +163,13 @@ function Header({
         }
       });
     }
-  }, [commandCenterEnabled, featureUUIDs, project, updateProject]);
+  }, [
+    commandCenterEnabled,
+    featureUUIDs?.COMMAND_CENTER,
+    project?.features,
+    showError,
+    updateProject,
+  ]);
 
   const logout = () => {
     AuthToken.logout(() => {

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1037,6 +1037,7 @@ function PipelineDetailPage({
   }, [addNewBlockAtIndex, blocks.length]);
 
   const {
+    renderApplications,
     startApplication,
   } = useApplicationManager();
 
@@ -3458,6 +3459,11 @@ function PipelineDetailPage({
           }
         />
       </PipelineLayout>
+
+      {(!!project && !featureEnabled?.(featureUUIDs?.COMMAND_CENTER))
+        ? renderApplications()
+        : null
+      }
     </>
   );
 }


### PR DESCRIPTION
# Description
- In the Pipeline Editor, users weren't able to open a file by clicking on it in the File Browser, which should open it in an Arcane Library popup window. This PR fixes this.

# How Has This Been Tested?
Before (file wont open until you enable Command Center):
![before - cant open file in pipeline editor](https://github.com/mage-ai/mage-ai/assets/78053898/3a92fe32-9c9d-427a-8104-db50aff5f0f2)

After (file does open even before enabling Command Center):
![after - files can be opened](https://github.com/mage-ai/mage-ai/assets/78053898/8ab2303e-2119-45f0-8e43-ec8dbd1137bb)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
