### PR TITLE
[jk] Scrollbar polish

### DIFF
--- a/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/index.tsx
+++ b/mage_ai/frontend/components/IntegrationPipeline/SchemaSettings/index.tsx
@@ -201,6 +201,7 @@ function SchemaSettings({
           setSelectedStream(tab.uuid);
         }}
         selectedTabUUID={selectedTab?.uuid}
+        showScrollbar
         tabs={tabs}
       />
 

--- a/mage_ai/frontend/components/RuntimeVariables/index.style.tsx
+++ b/mage_ai/frontend/components/RuntimeVariables/index.style.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 import dark from '@oracle/styles/themes/dark';
 import { PADDING } from '@oracle/styles/units/spacing';
+import { ScrollbarStyledCss } from '@oracle/styles/scrollbars';
 
 export const ContainerStyle = styled.div<{
   height: number;
@@ -20,4 +21,6 @@ export const ContainerStyle = styled.div<{
   ${({ overflow }) => overflow && `
     overflow: auto;
   `}
+
+  ${ScrollbarStyledCss}
 `;

--- a/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.style.ts
+++ b/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.style.ts
@@ -10,9 +10,8 @@ export const UNDERLINE_HEIGHT = 2;
 export const TabsContainerStyle = styled.div<{
   allowScroll?: boolean;
   noPadding?: boolean;
+  showScrollbar?: boolean;
 }>`
-  ${hideScrollBar()}
-
   padding-left: ${PADDING_UNITS * UNIT}px;
   padding-right: ${PADDING_UNITS * UNIT}px;
 
@@ -22,6 +21,14 @@ export const TabsContainerStyle = styled.div<{
 
   ${props => props.allowScroll && `
     overflow: auto;
+  `}
+
+  ${({ showScrollbar }) => !showScrollbar && `
+    ${hideScrollBar()}
+  `}
+
+  ${({ showScrollbar }) => showScrollbar && `
+    padding-bottom: ${UNIT / 2}px;
   `}
 
   ${ScrollbarStyledCss}

--- a/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.tsx
+++ b/mage_ai/frontend/oracle/components/Tabs/ButtonTabs/index.tsx
@@ -30,6 +30,7 @@ type ButtonTabsProps = {
   selectedTabUUIDs?: {
     [tabUUID: string]: TabType;
   };
+  showScrollbar?: boolean;
   small?: boolean;
   tabs: TabType[];
   underlineColor?: string;
@@ -47,6 +48,7 @@ function ButtonTabs({
   regularSizeText,
   selectedTabUUID,
   selectedTabUUIDs,
+  showScrollbar,
   small,
   tabs,
   underlineColor,
@@ -211,6 +213,7 @@ function ButtonTabs({
       allowScroll={allowScroll}
       noPadding={noPadding}
       ref={ref}
+      showScrollbar={showScrollbar}
     >
       {el}
     </TabsContainerStyle>

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -237,7 +237,7 @@ function PipelineSchedules({
           />
           {hasVariables && (
             <RuntimeVariables
-              height={runtimeVariablesHeight}
+              height={runtimeVariablesHeight + 1}
               scheduleType={selectedSchedule?.schedule_type}
               variables={variablesOrig}
               variablesOverride={variablesOverride}
@@ -245,7 +245,7 @@ function PipelineSchedules({
           )}
           {!hasVariables && (
             <RuntimeVariablesContainerStyle
-              height={runtimeVariablesHeight}
+              height={runtimeVariablesHeight + 1}
               includePadding
               overflow
             >


### PR DESCRIPTION
# Description
- Make horizontal scrollbar visible when there are many streams in the Integration Pipeline edit page (may not be intuitive to users that they can scroll horizontally to view more streams).
- There was an unnecessary unstyled scrollbar (see screenshot below) in the Runtime Variables section of a pipeline's Trigger page, so this PR removes it and styles the scrollbar for condensed Sidekick widths.
![image](https://github.com/mage-ai/mage-ai/assets/78053898/e1cd02ca-d88d-4df8-8462-53cce310b34d)

# How Has This Been Tested?
Horizontal scrollbar beneath stream button tabs:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/835cfec4-48b4-4ab6-961b-8bdc94184ea5)

No unnecessary scrollbar:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/5d8049fd-8ca1-454e-92ab-8ea586933efa)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
