### PR TITLE
[jk] Bugfix dock overlay

### DIFF
--- a/mage_ai/frontend/components/ApplicationManager/index.style.tsx
+++ b/mage_ai/frontend/components/ApplicationManager/index.style.tsx
@@ -11,7 +11,7 @@ import { transition } from '@oracle/styles/mixins';
 
 const SCALE_PERCENTAGE = 0.1;
 export const HEADER_HEIGHT = 6 * UNIT;
-export const OVERLAY_ID = 'application-minimized-overlay'
+export const OVERLAY_ID = 'application-minimized-overlay';
 const RESIZE_SIZE = 1 * UNIT;
 const RESIZE_SIZE_CORNER = 2 * UNIT;
 
@@ -66,7 +66,7 @@ function minimizedDimensions(): {
       height,
       width,
     },
-  } = buildDefaultLayout()
+  } = buildDefaultLayout();
 
   return {
     height: height * SCALE_PERCENTAGE,

--- a/mage_ai/frontend/components/ApplicationManager/index.style.tsx
+++ b/mage_ai/frontend/components/ApplicationManager/index.style.tsx
@@ -87,7 +87,7 @@ export const RootApplicationStyle = styled.div`
 
       &:hover {
         ${transition()}
-        transform: translateY(-38px);
+        transform: translateY(-56px);
       }
 
       .minimized {
@@ -134,7 +134,7 @@ export const DockStyle = styled.div`
 
   bottom: 0;
   display: flex;
-  height: 20px;
+  height: 2px;
   justify-content: center;
   position: fixed;
   width: 100%;

--- a/mage_ai/frontend/components/CommandCenter/index.tsx
+++ b/mage_ai/frontend/components/CommandCenter/index.tsx
@@ -1,6 +1,5 @@
-import { createRef, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { createRef, useEffect, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { useMutation } from 'react-query';
 import { useRouter } from 'next/router';
 
 import ApplicationHeaderTitle from './ApplicationHeaderTitle';
@@ -14,9 +13,6 @@ import ItemRow from './ItemRow';
 import LaunchKeyboardShortcutText from './LaunchKeyboardShortcutText';
 import Loading from '@oracle/components/Loading';
 import Spacing from '@oracle/elements/Spacing';
-import Text from '@oracle/elements/Text';
-import TextInput from '@oracle/elements/Inputs/TextInput';
-import api from '@api';
 import useApplicationManager from '@components/ApplicationManager/useApplicationManager';
 import useCache from '@storage/CommandCenter/useCache';
 import useExecuteActions from './useExecuteActions';
@@ -71,8 +67,6 @@ import {
 } from '@utils/events/constants';
 import {
   KEY_CODE_ARROW_DOWN,
-  KEY_CODE_ARROW_LEFT,
-  KEY_CODE_ARROW_RIGHT,
   KEY_CODE_ARROW_UP,
   KEY_CODE_BACKSPACE,
   KEY_CODE_C,
@@ -80,7 +74,6 @@ import {
   KEY_CODE_DELETE,
   KEY_CODE_ENTER,
   KEY_CODE_ESCAPE,
-  KEY_CODE_KEY_SYMBOL_MAPPING,
   KEY_CODE_META_LEFT,
   KEY_CODE_META_RIGHT,
   KEY_CODE_PERIOD,
@@ -109,7 +102,6 @@ import {
   rankItems,
   updateActionFromUpstreamResults,
 } from './utils';
-import { onSuccess } from '@api/utils/response';
 import { onlyKeysPresent } from '@utils/hooks/keyboardShortcuts/utils';
 import { pauseEvent } from '@utils/events';
 import { mergeDeep, setNested } from '@utils/hash';

--- a/mage_ai/frontend/components/TripleLayout/index.style.tsx
+++ b/mage_ai/frontend/components/TripleLayout/index.style.tsx
@@ -14,7 +14,7 @@ export const DRAGGABLE_WIDTH = UNIT;
 export const MAIN_MIN_WIDTH = UNIT * 13;
 
 export const ASIDE_HEADER_HEIGHT = PADDING_UNITS * 3 * UNIT;
-export const ASIDE_SUBHEADER_HEIGHT = 44;
+export const ASIDE_SUBHEADER_HEIGHT = 47;
 export const ALL_HEADERS_HEIGHT = 2 * PADDING_UNITS * 3 * UNIT;
 
 type ScrollbarTrackType = {

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -3368,9 +3368,12 @@ function PipelineDetailPage({
       <PipelineLayout
         after={sideKick}
         afterHeader={afterHeaderMemo}
-        afterHeightOffset={HEADER_HEIGHT}
+        afterHeightOffset={HEADER_HEIGHT - 1}
         afterHidden={afterHidden}
-        afterInnerHeightMinus={afterFooterBottomOffset}
+        afterInnerHeightMinus={ViewKeyEnum.INTERACTIONS === activeSidekickView
+          ? afterFooterBottomOffset
+          : null
+        }
         afterNavigationItems={buildNavigationItemsSidekick({
           activeView: activeSidekickView,
           pipeline,


### PR DESCRIPTION
# Description
- The bottom 20px of a page was unclickable (e.g. horizontal scrollbars at the page bottom could not be clicked on) due to the height of the hidden dock used for managing applications causing a z-index issue. This PR decreases the dock height so bottom elements can be interacted with.
- Also fix some spacing and scrollbar issues in the Sidekick on the Pipeline Editor page.

# How Has This Been Tested?
Bottom horizontal scrollbars can be clicked (previously, could not interact with them):
![horizontal scroll](https://github.com/mage-ai/mage-ai/assets/78053898/32ce0903-a419-4c47-9515-62c8806415bd)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
