### PR TITLE
Trino temp table location fix - Fixes issue https://github.com/mage-ai/mage-ai/issues/4738

### DIFF
--- a/mage_integrations/README.md
+++ b/mage_integrations/README.md
@@ -131,6 +131,16 @@ For each stream in `TEST_CATALOG.json`, find the nested `metadata` key and add a
 ...
 ```
 
+Additonally, also add to add ```"selected": true``` to at least one column in each field for SQL sources.
+
+```json
+{
+  "stream": "commits",
+  "tap_stream_id": "commits",
+  "selected": true
+}
+```
+
 ## Test stream execution and save to output file
 
 Finally! It's time to test our stream execution. Run the following command to execute the stream and save the output to a file:

--- a/mage_integrations/README.md
+++ b/mage_integrations/README.md
@@ -131,7 +131,7 @@ For each stream in `TEST_CATALOG.json`, find the nested `metadata` key and add a
 ...
 ```
 
-Additonally, also add to add ```"selected": true``` to at least one column in each field for SQL sources.
+Additonally, also add to add ```"selected": true``` to at least one column in each stream for SQL sources.
 
 ```json
 {

--- a/mage_integrations/mage_integrations/destinations/trino/README.md
+++ b/mage_integrations/mage_integrations/destinations/trino/README.md
@@ -21,6 +21,9 @@ You must enter the following credentials when configuring this source:
 | `query_max_length` | The maximum number of characters allowed for the SQL query text. | `1000000` (default value) |
 | `ssl` | In order to disable SSL verification, set the verify parameter to `false`. | `false` (default value) |
 | `location` | Used by deltalake connector to specify the location of the data. | `s3://[bucket]/` |
+| `ignore_location_for_temp_tables` | Ignore 'with location' property for temp tables. | `false` (default value) |
+
+Trino delta lake setup with glue metastore cannot delete underlying data from storage when table is created as an external table (i.e. tables created with property `with location`). Mage creates temp tables with `with location` property by default. To avoid this, set `ignore_location_for_temp_tables` to `true`.
 
 ### Connectors
 

--- a/mage_integrations/mage_integrations/destinations/trino/connectors/base.py
+++ b/mage_integrations/mage_integrations/destinations/trino/connectors/base.py
@@ -54,7 +54,23 @@ class TrinoConnector(Destination):
         table_name: str,
         database_name: str = None,
         unique_constraints: List[str] = None,
+        temp_table: bool = False,
     ) -> List[str]:
+        """
+        Build create table commands for Trino
+        """
+
+        # Trino delta lake with glue matastore does not delete the underlying data when dropping a table
+        # if the location is specified during table creation as they are considered external tables
+        # We want to be able to delete the underlying data when dropping a table
+        # so we need to ignore the location for temp tables
+        breakpoint()
+        ignore_location_for_temp_tables = self.config.get('ignore_location_for_temp_tables', False)
+        if temp_table and ignore_location_for_temp_tables:
+            location = None
+        else:
+            location = self.table_location(table_name)
+
         return [
             build_create_table_command(
                 column_identifier='"',
@@ -62,7 +78,7 @@ class TrinoConnector(Destination):
                 columns=schema['properties'].keys(),
                 full_table_name=f'{schema_name}.{table_name}',
                 if_not_exists=True,
-                location=self.table_location(table_name),
+                location=location,
                 # Unique constraint is not supported
                 # https://trino.io/docs/current/sql/create-table.html
                 unique_constraints=None,
@@ -131,6 +147,7 @@ DESCRIBE {schema_name}.{table_name}
                 table_name=f'temp_{table_name}',
                 database_name=database_name,
                 unique_constraints=unique_constraints,
+                temp_table=True,
             ) + self.wrap_insert_commands([
                 f'INSERT INTO {full_table_name_temp} ({insert_columns})',
                 'VALUES {insert_values}',

--- a/mage_integrations/mage_integrations/destinations/trino/connectors/base.py
+++ b/mage_integrations/mage_integrations/destinations/trino/connectors/base.py
@@ -64,7 +64,7 @@ class TrinoConnector(Destination):
         # if the location is specified during table creation as they are considered external tables
         # We want to be able to delete the underlying data when dropping a table
         # so we need to ignore the location for temp tables
-        breakpoint()
+
         ignore_location_for_temp_tables = self.config.get('ignore_location_for_temp_tables', False)
         if temp_table and ignore_location_for_temp_tables:
             location = None

--- a/mage_integrations/mage_integrations/destinations/trino/connectors/base.py
+++ b/mage_integrations/mage_integrations/destinations/trino/connectors/base.py
@@ -60,8 +60,9 @@ class TrinoConnector(Destination):
         Build create table commands for Trino
         """
 
-        # Trino delta lake with glue matastore does not delete the underlying data when dropping a table
-        # if the location is specified during table creation as they are considered external tables
+        # Trino delta lake with glue matastore does not delete the underlying data 
+        # when dropping a table if the location is specified during table creation 
+        # as they are considered external tables
         # We want to be able to delete the underlying data when dropping a table
         # so we need to ignore the location for temp tables
 

--- a/mage_integrations/mage_integrations/destinations/trino/connectors/base.py
+++ b/mage_integrations/mage_integrations/destinations/trino/connectors/base.py
@@ -60,8 +60,8 @@ class TrinoConnector(Destination):
         Build create table commands for Trino
         """
 
-        # Trino delta lake with glue matastore does not delete the underlying data 
-        # when dropping a table if the location is specified during table creation 
+        # Trino delta lake with glue matastore does not delete the underlying data
+        # when dropping a table if the location is specified during table creation
         # as they are considered external tables
         # We want to be able to delete the underlying data when dropping a table
         # so we need to ignore the location for temp tables

--- a/mage_integrations/mage_integrations/destinations/trino/templates/config.json
+++ b/mage_integrations/mage_integrations/destinations/trino/templates/config.json
@@ -9,5 +9,6 @@
   "ssl": false,
   "table": "",
   "username": "",
-  "location": ""
+  "location": "",
+  "ignore_location_for_temp_tables": "false"
 }


### PR DESCRIPTION
# Description
Mage version
0.9.65

Describe the bug
Trino delta lake setup with glue metastore unable to delete underlying data from storage when temp tables are dropped. It happens because when property 'with location' is used to create tables, they are considered as external tables. So when these tables are dropped, it drops the meta information but does not delete underlying data. Which means when next time the pipeline runs, it already finds the data sitting in the location specified and raises error about using system.register_table() function.

To reproduce
Setup trino delta lake connector with glue metastore
Provide a location parameter in the trino configuration
Run a integration pipeline once (It should succeed since this is the first time and temp table does not exist)
Run the integration pipeline again
Expected behavior
The pipeline should successfully run

Screenshots
[before-update.zip](https://github.com/mage-ai/mage-ai/files/14567185/before-update.zip)


Operating system
Any

Additional context
No response


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
Manually. See attached videos


# Checklist
- [ X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X ] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
@wangxiaoyou1993 @tommydangerous 
