### PR TITLE
[jk] Avoid client error when making request before interactions are done loading

### DIFF
--- a/mage_ai/frontend/components/Interactions/InteractionSettings.tsx
+++ b/mage_ai/frontend/components/Interactions/InteractionSettings.tsx
@@ -72,7 +72,7 @@ function InteractionSettings({
   const [newVariableUUID, setNewVariableUUID] = useState<string>(null);
   const [visibleMappingForced, setVisibleMappingForced] = useState<{
     [index: string]: boolean;
-  }>({})
+  }>({});
 
   const {
     inputs,
@@ -158,7 +158,7 @@ function InteractionSettings({
 
       row?.forEach((layoutItem) => {
         if (!shouldDelete || variableUUID !== layoutItem?.variable) {
-          arr.push(layoutItem)
+          arr.push(layoutItem);
         }
       });
 

--- a/mage_ai/frontend/components/PipelineInteractions/index.tsx
+++ b/mage_ai/frontend/components/PipelineInteractions/index.tsx
@@ -99,6 +99,7 @@ function PipelineInteractions({
   const [newInteractionUUID, setNewInteractionUUID] = useState<string>(null);
   const [isAddingNewInteraction, setIsAddingNewInteraction] = useState<boolean>(false);
   const [mostRecentlyAddedInteractionUUID, setMostRecentlyAddedInteractionUUID] = useState<string>(null);
+  const isLoadingInteractions = !blockInteractionsMappingProp;
 
   const [interactionsMappingState, setInteractionsMappingState] = useState<{
     [interactionUUID: string]: InteractionType;
@@ -363,7 +364,7 @@ function PipelineInteractions({
         uuid: blockUUID,
       } = block || {
         uuid: null,
-      }
+      };
 
       const blockInteractions = blockInteractionsMapping?.[blockUUID] || [];
       const hasBlockInteractions = blockInteractions?.length >= 1;
@@ -372,6 +373,7 @@ function PipelineInteractions({
         <Button
           beforeIcon={hasBlockInteractions ? <Edit /> : <Add />}
           compact
+          disabled={isLoadingInteractions}
           onClick={(e) => {
             pauseEvent(e);
             setSelectedBlock(block);
@@ -391,8 +393,6 @@ function PipelineInteractions({
           key={blockUUID}
           noBorderRadius={idx >= 1}
           noPaddingContent
-          titleXPadding={PADDING_UNITS * UNIT}
-          titleYPadding={1.5 * UNIT}
           title={(
             <FlexContainer
               alignItems="center"
@@ -411,6 +411,8 @@ function PipelineInteractions({
               )}
             </FlexContainer>
           )}
+          titleXPadding={PADDING_UNITS * UNIT}
+          titleYPadding={1.5 * UNIT}
         >
           <ContainerStyle
             noBackground
@@ -426,8 +428,8 @@ function PipelineInteractions({
                 >
                   <BlockInteractionController
                     blockInteraction={blockInteraction}
-                    containerWidth={containerWidth}
                     containerRef={containerRef}
+                    containerWidth={containerWidth}
                     interaction={interactionsMapping?.[blockInteraction?.uuid]}
                     setInteractionsMapping={setInteractionsMapping}
                     showVariableUUID
@@ -436,17 +438,18 @@ function PipelineInteractions({
               ))}
             </Spacing>
           </ContainerStyle>
-        </AccordionPanel>
+        </AccordionPanel>,
       );
     });
 
     return arr;
   }, [
+    blockInteractionsMapping,
     blocks,
     containerRef,
     containerWidth,
     interactionsMapping,
-    setBlockInteractionsMapping,
+    isLoadingInteractions,
     setInteractionsMapping,
     setSelectedBlock,
   ]);
@@ -623,6 +626,7 @@ function PipelineInteractions({
       </FlexContainer>
     );
   }, [
+    createInteraction,
     editingBlock,
     editingBlockInteractions,
     isAddingNewInteraction,
@@ -665,7 +669,8 @@ function PipelineInteractions({
                   <Button
                     beforeIcon={<Add />}
                     compact
-                    onClick={() => setPermissions(prev => prev.concat([{
+                    disabled={isLoadingInteractions}
+                    onClick={() => setPermissions(prev => prev?.concat([{
                       roles: [],
                       triggers: [],
                     }]))}
@@ -863,7 +868,8 @@ function PipelineInteractions({
           <FlexContainer alignItems="center">
             <Button
               beforeIcon={<Save />}
-              loading={isLoadingUpdatePipelineInteraction}
+              disabled={isLoadingInteractions}
+              loading={isLoadingUpdatePipelineInteraction || isLoadingInteractions}
               onClick={() => savePipelineInteraction()}
               primary={touched}
               secondary={!touched}

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -354,7 +354,7 @@ function PipelineDetailPage({
       dataPipelineInteraction,
     ]);
   const interactions: InteractionType[] =
-    useMemo(() => dataInteractions?.interactions || {}, [
+    useMemo(() => dataInteractions?.interactions || [], [
       dataInteractions,
     ]);
 

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -329,7 +329,7 @@ function PipelineDetailPage({
     },
     {
       condition: () => isInteractionsEnabled,
-      delay: 6000,
+      delay: 3000,
     },
   );
 
@@ -345,7 +345,7 @@ function PipelineDetailPage({
     },
     {
       condition: () => isInteractionsEnabled,
-      delay: 6000,
+      delay: 3000,
     },
   );
 


### PR DESCRIPTION
# Description
- There was a client error when user tried to add a permission in the interactions settings before the interactions were done loading. This PR prevents the error but also adds a load state for the interactions settings so that users are not able to prematurely create interactions or permissions before the existing interactions are loaded, which could result in overwriting existing interactions/permissions.
- Decrease fetch delay for interactions from 6 seconds to 3 seconds.

# How Has This Been Tested?
Pipeline with no interactions (zero state):
![zero state interactions](https://github.com/mage-ai/mage-ai/assets/78053898/1c2d5cec-d508-429b-ad27-3bfe9521847b)

Pipeline with existing interactions:
![interactions load](https://github.com/mage-ai/mage-ai/assets/78053898/d1600984-64ab-44f4-89da-cffb66f687c5)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
