### PR TITLE
[jk] Fix block run sorting

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
@@ -35,13 +35,15 @@ import { openSaveFileDialog } from '@components/PipelineDetail/utils';
 import { queryFromUrl } from '@utils/url';
 import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
 
-export const DEFAULT_SORTABLE_BR_COL_INDEXES = [0, 1, 3, 4, 5];
+// The DEFAULT_SORTABLE_BR_COL_INDEXES and COL_IDX_TO_BLOCK_RUN_ATTR_MAPPING
+// must be updated if the columns in the Block Runs table are rearranged.
+export const DEFAULT_SORTABLE_BR_COL_INDEXES = [0, 2, 4, 5, 6];
 export const COL_IDX_TO_BLOCK_RUN_ATTR_MAPPING = {
   0: 'status',
-  1: 'block_uuid',
-  3: 'created_at',
-  4: 'started_at',
-  5: 'completed_at',
+  2: 'block_uuid',
+  4: 'created_at',
+  5: 'started_at',
+  6: 'completed_at',
 };
 
 type BlockRunsTableProps = {


### PR DESCRIPTION
# Description
- Update block runs column indexes and mapping used for block run sorting (since the block runs table columns had been rearranged).

# How Has This Been Tested?
- Locally

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
