### PR TITLE
[jk] Add check to avoid rendering of invalid JSX element

### DIFF
--- a/mage_ai/frontend/components/Logs/Detail/index.tsx
+++ b/mage_ai/frontend/components/Logs/Detail/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { createElement, isValidElement, useMemo, useState } from 'react';
 
 import Button from '@oracle/elements/Button';
 import ButtonTabs, { TabType } from '@oracle/components/Tabs/ButtonTabs';
@@ -18,6 +18,7 @@ import { Close } from '@oracle/icons';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { formatTimestamp } from '@utils/models/log';
 import { isJsonString } from '@utils/string';
+import { isObject } from '@utils/hash';
 import { sortByKey } from '@utils/array';
 
 const MESSAGE_KEY = 'message';
@@ -158,6 +159,14 @@ function LogDetail({
             } else if (isMessageKey && showFullLogMessage && isJsonString(v)) {
               valueTitle = JSON.stringify(JSON.parse(v), null, 2);
               valueToDisplay = <pre>{valueTitle}</pre>;
+              if (!isValidElement(valueToDisplay)
+                && isObject(valueToDisplay)
+                && valueToDisplay['_owner'] === null
+                && valueToDisplay.type === 'pre'
+                && typeof valueToDisplay?.props?.children === 'string'
+              ) {
+                valueToDisplay = createElement('pre', null, valueToDisplay.props.children);
+              }
             }
             if (typeof valueToDisplay === 'object') {
               try {


### PR DESCRIPTION
# Description
- There was an issue when expanding a log message that displayed an incorrectly formatted log message similar to this:
```
{
  "type": "pre",
  "key": null,
  "ref": null,
  "props": {
    "children": "some_string_value"
  },
  "_owner": null
}
```
The expanded log message should only contain the contents of this object's `props.children` value. This PR adds a check to render these contents only instead of including this entire object.

# How Has This Been Tested?
- Tested locally

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
