### PR TITLE
[jk] Limit number of block output files read and included in pipeline response

### DIFF
--- a/docs/design/data-pipeline-management.mdx
+++ b/docs/design/data-pipeline-management.mdx
@@ -263,6 +263,10 @@ in the following ways.
     variables_dir: /home/src/mage_data
     remote_variables_dir: gs://bucket/path_prefix
     ```
+    When using GCS for your remote variables directory, if you run into a "Your default credentials were not found"
+    error, you may need to set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to the path of your
+    `application_default_credentials.json` file with your Google Cloud credentials and the `GOOGLE_CLOUD_PROJECT`
+    environment variable to your Google Cloud project ID.
 
 ## Variable retention
 If you want to clean up the old variables in your variable storage, you can set the `variables_retention_period`

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -2204,6 +2204,7 @@ class Block(DataIntegrationMixin, SparkBlock, ProjectPlatformAccessible):
                 self.pipeline.uuid,
                 block_uuid,
                 partition=execution_partition,
+                max_results=DATAFRAME_SAMPLE_COUNT_PREVIEW,
             )
 
             if not include_print_outputs:

--- a/mage_ai/data_preparation/storage/gcs_storage.py
+++ b/mage_ai/data_preparation/storage/gcs_storage.py
@@ -29,11 +29,16 @@ class GCSStorage(BaseStorage):
             path += '/'
         return self.path_exists(path)
 
-    def listdir(self, path: str, suffix: str = None) -> List[str]:
+    def listdir(
+        self,
+        path: str,
+        suffix: str = None,
+        max_results: int = None,
+    ) -> List[str]:
         if not path.endswith('/'):
             path += '/'
         path = gcs_url_path(path)
-        blobs = self.bucket.list_blobs(prefix=path)
+        blobs = self.bucket.list_blobs(prefix=path, max_results=max_results)
         keys = []
         for blob in blobs:
             # Avoid finding files recursevively in the dir path.

--- a/mage_ai/data_preparation/storage/gcs_storage.py
+++ b/mage_ai/data_preparation/storage/gcs_storage.py
@@ -46,11 +46,11 @@ class GCSStorage(BaseStorage):
         specified, not just the directories themselves at the top level of the path.
 
         As a result, when fetching block output folders in a remote variables directory,
-        the json files inside of the block output folders (e.g. the "data.json" file in
-        folder "output_0") are counted towards the "max_results" limit. If max_results is
-        set to 10, only 3 output folders may be returned due to there being 3 json files
-        in each output folder. We do not increase the max_results or include a "delimiter"
-        argument because it would increase load times to unacceptable levels.
+        the json or parquet files inside of the block output folders (e.g. the "type.json"
+        file in folder "output_0") are counted towards the "max_results" limit. If max_results
+        is set to 10, less than 10 output folders may be returned due to there being multiple
+        json or other files in each output folder. We do not increase the max_results or
+        include a "delimiter" argument because it would increase load times to unacceptable levels.
 
         Example block output path in GCS:
             gs://mage_demo/pipelines/example_pipeline/.variables/example_block/output_0/

--- a/mage_ai/data_preparation/storage/local_storage.py
+++ b/mage_ai/data_preparation/storage/local_storage.py
@@ -19,12 +19,28 @@ class LocalStorage(BaseStorage):
     def isdir(self, path: str) -> bool:
         return os.path.isdir(path)
 
-    def listdir(self, path: str, suffix: str = None) -> List[str]:
+    def listdir(
+        self,
+        path: str,
+        suffix: str = None,
+        max_results: int = None,
+    ) -> List[str]:
+        paths = []
         if not os.path.exists(path):
-            return []
-        paths = os.listdir(path)
+            return paths
+
+        if max_results is not None:
+            with os.scandir(path) as it:
+                for idx, entry in enumerate(it):
+                    if entry.is_dir():
+                        paths.append(entry.name)
+                    if idx >= max_results - 1:
+                        break
+        else:
+            paths = os.listdir(path)
         if suffix is not None:
             paths = [p for p in paths if p.endswith(suffix)]
+
         return paths
 
     def makedirs(self, path: str, **kwargs) -> None:

--- a/mage_ai/data_preparation/storage/local_storage.py
+++ b/mage_ai/data_preparation/storage/local_storage.py
@@ -32,8 +32,7 @@ class LocalStorage(BaseStorage):
         if max_results is not None:
             with os.scandir(path) as it:
                 for idx, entry in enumerate(it):
-                    if entry.is_dir():
-                        paths.append(entry.name)
+                    paths.append(entry.name)
                     if idx >= max_results - 1:
                         break
         else:

--- a/mage_ai/data_preparation/storage/s3_storage.py
+++ b/mage_ai/data_preparation/storage/s3_storage.py
@@ -30,11 +30,16 @@ class S3Storage(BaseStorage):
             path += '/'
         return self.path_exists(path)
 
-    def listdir(self, path: str, suffix: str = None) -> List[str]:
+    def listdir(
+        self,
+        path: str,
+        suffix: str = None,
+        max_results: int = None,
+    ) -> List[str]:
         if not path.endswith('/'):
             path += '/'
         path = s3_url_path(path)
-        keys = self.client.listdir(path, suffix=suffix)
+        keys = self.client.listdir(path, suffix=suffix, max_results=max_results)
         return [k[len(path):].rstrip('/') for k in keys]
 
     def makedirs(self, path: str, **kwargs) -> None:

--- a/mage_ai/data_preparation/variable_manager.py
+++ b/mage_ai/data_preparation/variable_manager.py
@@ -271,6 +271,7 @@ class VariableManager:
         block_uuid: str,
         partition: str = None,
         clean_block_uuid: bool = True,
+        max_results: int = None,
     ) -> List[str]:
         variable_dir_path = os.path.join(
             self.pipeline_path(pipeline_uuid),
@@ -280,7 +281,7 @@ class VariableManager:
         )
         if not self.storage.path_exists(variable_dir_path):
             return []
-        variables = self.storage.listdir(variable_dir_path)
+        variables = self.storage.listdir(variable_dir_path, max_results=max_results)
         return sorted([v.split('.')[0] for v in variables])
 
     def pipeline_path(self, pipeline_uuid: str) -> str:

--- a/mage_ai/services/aws/s3/s3.py
+++ b/mage_ai/services/aws/s3/s3.py
@@ -45,11 +45,17 @@ class Client:
             },
         )
 
-    def listdir(self, prefix: str, delimiter: str = '/', suffix: str = None):
+    def listdir(
+        self,
+        prefix: str,
+        delimiter: str = '/',
+        suffix: str = None,
+        max_results: int = None,
+    ):
         keys = []
         response = self.client.list_objects_v2(
             Bucket=self.bucket,
-            MaxKeys=MAX_KEYS,
+            MaxKeys=max_results or MAX_KEYS,
             Prefix=prefix,
             Delimiter=delimiter,
         )


### PR DESCRIPTION
# Description
- If a user's block returned a list of many values (versus a list of a list with many values), it could cause significant slowdowns in the browser when loading the pipeline because a block output file is created for each value in the output list. For example, a block returning a list of 1000 items creates 1000 output files, which takes a long time to read so many files and resulting in an unintended large pipeline response.
- This PR limits the number of output files' contents included in the pipeline response to 10 files (previously all output files' contents were included).

# How Has This Been Tested?
- Tested using the same block that returned a list with 20k items
- [x] Tested with local variable manager (local storage)
- [x] Tested with AWS S3 variable manager (amazon s3 storage)
- [x] Tested with GCS variable manager (google cloud storage)

Before (took ~34 seconds to load the pipeline/page):
<img width="2055" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/b7e267bc-73ab-418f-a340-9f57ab6e6141">

After (took <1 second to load the pipeline/page):
<img width="2054" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/a7fa263b-ae92-492d-aa0c-5f6ff02d610d">


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
