### PR TITLE
[jk] Increase visibility of code block context menu

### DIFF
--- a/mage_ai/frontend/components/CodeEditor/index.style.tsx
+++ b/mage_ai/frontend/components/CodeEditor/index.style.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 import dark from '@oracle/styles/themes/dark';
 import { FONT_FAMILY_REGULAR } from '@oracle/styles/fonts/primary';
-import { UNIT } from '@oracle/styles/units/spacing';
 
 export const NUMBER_OF_BUFFER_LINES = 2;
 export const SINGLE_LINE_HEIGHT = 21;
@@ -12,6 +11,10 @@ export const ContainerStyle = styled.div<{
   padding?: number;
 }>`
   font-family: ${FONT_FAMILY_REGULAR};
+
+  .context-view.monaco-menu-container {
+    background-color: ${dark.monotone.grey300};
+  }
 
   ${props => (typeof props.padding === 'number' && props.padding > 0) && `
     // padding-top: ${props.padding}px;


### PR DESCRIPTION
# Description
- Context menu of code block editor was difficult to read so this PR improves its visibility.

# How Has This Been Tested?
- Tested on Chrome, Firefox, and Safari

Before:
<img width="1115" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/eab83fdd-320b-4225-b772-19b9f46cd064">

After:
<img width="1115" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/12f52d82-576c-4833-9601-16f48c60d5b1">

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
