### PR TITLE
[dy] Add upsert to MySQL, BQ, and Snowflake

### DIFF
--- a/mage_ai/data_preparation/templates/data_exporters/mysql.py
+++ b/mage_ai/data_preparation/templates/data_exporters/mysql.py
@@ -23,8 +23,8 @@ def export_data_to_mysql(df: DataFrame, **kwargs) -> None:
     with MySQL.with_config(ConfigFileLoader(config_path, config_profile)) as loader:
         loader.export(
             df,
-            None,
-            table_name,
+            schema_name=None,
+            table_name=table_name,
             index=False,  # Specifies whether to include index in exported table
             if_exists='replace',  # Specify resolution policy if table name already exists
         )

--- a/mage_ai/io/base.py
+++ b/mage_ai/io/base.py
@@ -51,6 +51,7 @@ class ExportWritePolicy(str, Enum):
     APPEND = 'append'
     FAIL = 'fail'
     REPLACE = 'replace'
+    UPSERT = 'upsert'
 
 
 class BaseIO(ABC):

--- a/mage_ai/io/base.py
+++ b/mage_ai/io/base.py
@@ -51,7 +51,6 @@ class ExportWritePolicy(str, Enum):
     APPEND = 'append'
     FAIL = 'fail'
     REPLACE = 'replace'
-    UPSERT = 'upsert'
 
 
 class BaseIO(ABC):

--- a/mage_ai/io/bigquery.py
+++ b/mage_ai/io/bigquery.py
@@ -288,14 +288,23 @@ WHERE table_id = '{table_name}'
                             **configuration_params,
                         )
 
+                        parts = temp_table_id.split('.')
+                        if len(parts) == 2:
+                            temp_table_name = parts[1]
+                        elif len(parts) == 3:
+                            temp_table_name = parts[2]
+                        column_types = self.get_column_types(schema, temp_table_name)
+                        columns = list(column_types.keys())
+                        if not columns:
+                            columns = df.columns.str.replace(' ', '_')
+
                         on_conditions = []
                         for col in unique_constraints:
                             on_conditions.append(
                                 f'((a.{col} IS NULL AND b.{col} IS NULL) OR a.{col} = b.{col})',
                             )
 
-                        columns_cleaned = df.columns.str.replace(' ', '_')
-                        insert_columns = ', '.join([f'`{col}`' for col in columns_cleaned])
+                        insert_columns = ', '.join([f'`{col}`' for col in columns])
 
                         merge_commands = [
                             f'MERGE INTO `{table_id}` AS a',
@@ -305,11 +314,11 @@ WHERE table_id = '{table_name}'
 
                         if UNIQUE_CONFLICT_METHOD_UPDATE == unique_conflict_method:
                             set_command = ', '.join(
-                                [f'a.`{col}` = b.`{col}`' for col in columns_cleaned],
+                                [f'a.`{col}` = b.`{col}`' for col in columns],
                             )
                             merge_commands.append(f'WHEN MATCHED THEN UPDATE SET {set_command}')
 
-                        merge_values = f"({', '.join([f'b.`{col}`' for col in columns_cleaned])})"
+                        merge_values = f"({', '.join([f'b.`{col}`' for col in columns])})"
                         merge_commands.append(
                             f'WHEN NOT MATCHED THEN INSERT ({insert_columns}) VALUES {merge_values}',  # noqa: E501
                         )

--- a/mage_ai/io/mysql.py
+++ b/mage_ai/io/mysql.py
@@ -8,6 +8,7 @@ from mysql.connector.cursor import MySQLCursor
 from pandas import DataFrame, Series
 
 from mage_ai.io.config import BaseConfigLoader, ConfigKey
+from mage_ai.io.constants import UNIQUE_CONFLICT_METHOD_UPDATE
 from mage_ai.io.export_utils import PandasTypes
 from mage_ai.io.sql import BaseSQL
 from mage_ai.shared.parsers import encode_complex
@@ -60,7 +61,7 @@ class MySQL(BaseSQL):
     ) -> str:
         if unique_constraints is None:
             unique_constraints = []
-        query = []
+        columns_and_types = []
         for cname in dtypes:
             if overwrite_types is not None and cname in overwrite_types.keys():
                 dtypes[cname] = overwrite_types[cname]
@@ -68,9 +69,22 @@ class MySQL(BaseSQL):
                 cleaned_col_name = clean_name(cname, case_sensitive=case_sensitive)
             else:
                 cleaned_col_name = cname
-            query.append(f'`{cleaned_col_name}` {dtypes[cname]} NULL')
+            columns_and_types.append(f'`{cleaned_col_name}` {dtypes[cname]} NULL')
 
-        return f'CREATE TABLE {table_name} (' + ','.join(query) + ');'
+        if unique_constraints:
+            unique_constraints = [
+                clean_name(col, case_sensitive=case_sensitive)
+                for col in unique_constraints
+            ]
+            index_name = '_'.join([
+                clean_name(table_name, case_sensitive=case_sensitive),
+            ] + unique_constraints)
+            index_name = f'unique{index_name}'[:64]
+            columns_and_types.append(
+                f"CONSTRAINT {index_name} Unique({', '.join(unique_constraints)})"
+            )
+
+        return f'CREATE TABLE {table_name} (' + ','.join(columns_and_types) + ');'
 
     def open(self) -> None:
         with self.printer.print_msg('Opening connection to MySQL database'):
@@ -94,6 +108,9 @@ class MySQL(BaseSQL):
         dtypes: List[str],
         full_table_name: str,
         buffer: Union[IO, None] = None,
+        case_sensitive: bool = False,
+        unique_constraints: List[str] = None,
+        unique_conflict_method: str = None,
         **kwargs,
     ) -> None:
         def serialize_obj(val):
@@ -133,9 +150,24 @@ class MySQL(BaseSQL):
         for _, row in df_.iterrows():
             values.append(tuple([str(val) if type(val) is pd.Timestamp else val for val in row]))
 
-        insert_columns = ', '.join([f'`{col}`'for col in columns])
+        cleaned_columns = [clean_name(col, case_sensitive=case_sensitive) for col in columns]
+        insert_columns = ', '.join([f'`{col}`'for col in cleaned_columns])
 
-        sql = f'INSERT INTO {full_table_name} ({insert_columns}) VALUES ({values_placeholder})'
+        query = [
+            f'INSERT INTO {full_table_name} ({insert_columns})',
+            f'VALUES ({values_placeholder})',
+        ]
+
+        if unique_constraints and unique_conflict_method:
+            if UNIQUE_CONFLICT_METHOD_UPDATE == unique_conflict_method:
+                update_command = [f'{col} = new.{col}' for col in cleaned_columns]
+                query += [
+                    'AS new',
+                    f"ON DUPLICATE KEY UPDATE {', '.join(update_command)}",
+                ]
+
+        sql = '\n'.join(query)
+
         cursor.executemany(sql, values)
 
     def get_type(self, column: Series, dtype: str) -> str:

--- a/mage_ai/io/snowflake.py
+++ b/mage_ai/io/snowflake.py
@@ -202,6 +202,8 @@ class Snowflake(BaseSQLConnection):
         schema: str = None,
         if_exists: str = 'append',
         query_string: Union[str, None] = None,
+        unique_conflict_method: str = None,
+        unique_constraints: List[str] = None,
         verbose: bool = True,
         **kwargs,
     ) -> None:
@@ -266,7 +268,7 @@ class Snowflake(BaseSQLConnection):
                         cur.execute(f'DROP TABLE "{schema}"."{table_name}"', timeout=self.timeout)
                         should_create_table = True
 
-                if ExportWritePolicy.UPSERT == if_exists and df is not None:
+                if unique_constraints and unique_conflict_method and df is not None:
                     self.__upsert_df_into_table(
                         table_name,
                         df,
@@ -274,6 +276,8 @@ class Snowflake(BaseSQLConnection):
                         database,
                         schema,
                         should_create_table=should_create_table,
+                        unique_conflict_method=unique_conflict_method,
+                        unique_constraints=unique_constraints,
                         **kwargs,
                     )
                 else:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Add ability to use upsert in MySQL, BigQuery, and Snowflake IO classes. The implementation is based on the destinations in the mage_integrations module, but modified slightly to work with the IO classes.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested by upserting conflicting rows into BQ, MySQL, and Snowflake tables


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
