### PR TITLE
[xh]Oracledb add export

### DIFF
--- a/mage_ai/data_preparation/templates/constants.py
+++ b/mage_ai/data_preparation/templates/constants.py
@@ -612,6 +612,13 @@ TEMPLATES_ONLY_FOR_V2 = [
         block_type=BlockType.DATA_EXPORTER,
         groups=[GROUP_DATABASES],
         language=BlockLanguage.PYTHON,
+        name='OracleDB',
+        path='data_exporters/oracledb.py',
+    ),
+    dict(
+        block_type=BlockType.DATA_EXPORTER,
+        groups=[GROUP_DATABASES],
+        language=BlockLanguage.PYTHON,
         name='PostgreSQL',
         path='data_exporters/postgres.py',
     ),

--- a/mage_ai/io/export_utils.py
+++ b/mage_ai/io/export_utils.py
@@ -108,6 +108,7 @@ def gen_table_creation_query(
     case_sensitive: bool = False,
     unique_constraints: List[str] = None,
     overwrite_types: Dict = None,
+    skip_semicolon_at_end: bool = False,
 ) -> str:
     """
     Generates a database table creation query from a data frame.
@@ -157,4 +158,6 @@ def gen_table_creation_query(
         query.append(
             f"CONSTRAINT {index_name} UNIQUE ({', '.join(unique_constraints_escaped)})",
         )
+    if skip_semicolon_at_end:
+        return f'CREATE TABLE {full_table_name} (' + ','.join(query) + ')'
     return f'CREATE TABLE {full_table_name} (' + ','.join(query) + ');'

--- a/mage_ai/io/oracledb.py
+++ b/mage_ai/io/oracledb.py
@@ -1,13 +1,17 @@
 import warnings
-from typing import Union
+from typing import IO, Any, List, Union
 
+import numpy as np
 import oracledb
-from pandas import DataFrame, read_sql
+import simplejson
+from pandas import DataFrame, Series, read_sql
 
-from mage_ai.io.base import QUERY_ROW_LIMIT
+from mage_ai.io.base import QUERY_ROW_LIMIT, ExportWritePolicy
 from mage_ai.io.config import BaseConfigLoader, ConfigKey
+from mage_ai.io.export_utils import PandasTypes
 from mage_ai.io.sql import BaseSQL
 from mage_ai.server.logger import Logger
+from mage_ai.shared.parsers import encode_complex
 
 logger = Logger().new_server_logger(__name__)
 
@@ -122,3 +126,134 @@ SELECT *
 FROM subquery
 FETCH FIRST {limit} ROWS ONLY
                 """
+
+    def table_exists(self, schema_name: str, table_name: str) -> bool:
+        with self.conn.cursor() as cur:
+            try:
+                cur.execute(f"select * from {table_name} where rownum=1")
+            except Exception as exc:
+                logger.info(f"Table not existing: {table_name}. Exception: {exc}")
+                return False
+        return True
+
+    def get_type(self, column: Series, dtype: str) -> str:
+        if dtype in (
+            PandasTypes.MIXED,
+            PandasTypes.UNKNOWN_ARRAY,
+            PandasTypes.COMPLEX,
+        ):
+            return 'CHAR(255)'
+        elif dtype in (PandasTypes.DATETIME, PandasTypes.DATETIME64):
+            try:
+                if column.dt.tz:
+                    return 'TIMESTAMP'
+            except AttributeError:
+                pass
+            return 'TIMESTAMP'
+        elif dtype == PandasTypes.TIME:
+            try:
+                if column.dt.tz:
+                    return 'TIMESTAMP'
+            except AttributeError:
+                pass
+            return 'TIMESTAMP'
+        elif dtype == PandasTypes.DATE:
+            return 'DATE'
+        elif dtype == PandasTypes.STRING:
+            return 'CHAR(255)'
+        elif dtype == PandasTypes.CATEGORICAL:
+            return 'CHAR(255)'
+        elif dtype == PandasTypes.BYTES:
+            return 'CHAR(255)'
+        elif dtype in (PandasTypes.FLOATING, PandasTypes.DECIMAL, PandasTypes.MIXED_INTEGER_FLOAT):
+            return 'NUMBER'
+        elif dtype == PandasTypes.INTEGER:
+            max_int, min_int = column.max(), column.min()
+            if np.int16(max_int) == max_int and np.int16(min_int) == min_int:
+                return 'NUMBER'
+            elif np.int32(max_int) == max_int and np.int32(min_int) == min_int:
+                return 'NUMBER'
+            else:
+                return 'NUMBER'
+        elif dtype == PandasTypes.BOOLEAN:
+            return 'CHAR(52)'
+        elif dtype in (PandasTypes.TIMEDELTA, PandasTypes.TIMEDELTA64, PandasTypes.PERIOD):
+            return 'NUMBER'
+        elif dtype == PandasTypes.EMPTY:
+            return 'CHAR(255)'
+        else:
+            print(f'Invalid datatype provided: {dtype}')
+
+        return 'CHAR(255)'
+
+    def export(
+        self,
+        df: DataFrame,
+        table_name: str = None,
+        if_exists: ExportWritePolicy = ExportWritePolicy.REPLACE,
+        **kwargs,
+    ) -> None:
+        super().export(
+            df,
+            **kwargs,
+            table_name=table_name,
+            if_exists=if_exists,
+            # Oracle cursor execute will automatically add a semicolon at the end of the query.
+            skip_semicolon_at_end=True
+        )
+
+    def upload_dataframe(
+        self,
+        cursor: Any,
+        df: DataFrame,
+        db_dtypes: List[str],
+        dtypes: List[str],
+        full_table_name: str,
+        buffer: Union[IO, None] = None,
+        **kwargs,
+    ) -> None:
+        def serialize_obj(val):
+            if type(val) is dict or type(val) is np.ndarray:
+                return simplejson.dumps(
+                    val,
+                    default=encode_complex,
+                    ignore_nan=True,
+                )
+            elif type(val) is list and len(val) >= 1 and type(val[0]) is dict:
+                return simplejson.dumps(
+                    val,
+                    default=encode_complex,
+                    ignore_nan=True,
+                )
+            return val
+
+        # Create values
+        df_ = df.copy()
+        columns = df_.columns
+        for col in columns:
+            dtype = df_[col].dtype
+            if dtype == PandasTypes.OBJECT:
+                df_[col] = df_[col].apply(lambda x: serialize_obj(x))
+            elif dtype in (
+                PandasTypes.MIXED,
+                PandasTypes.UNKNOWN_ARRAY,
+                PandasTypes.COMPLEX,
+            ):
+                df_[col] = df_[col].astype('string')
+
+            # Remove extraneous surrounding double quotes
+            # that get added while performing conversion to string.
+            df_[col] = df_[col].apply(lambda x: x.strip('"') if x and isinstance(x, str) else x)
+        df_.replace({np.NaN: None}, inplace=True)
+        values = []
+        for i in range(0, len(df_)):
+            values.append(tuple(df_.fillna('').values[i]))
+
+        # Create values placeholder
+        colmn_names = df.columns.tolist()
+        values_placeholder = ""
+        for i in range(0, len(colmn_names)):
+            values_placeholder += f':{str(i + 1)},'
+
+        insert_sql = f'INSERT INTO {full_table_name} VALUES({values_placeholder.rstrip(",")})'
+        cursor.executemany(insert_sql, values)

--- a/mage_ai/io/sql.py
+++ b/mage_ai/io/sql.py
@@ -56,6 +56,7 @@ class BaseSQL(BaseSQLConnection):
         case_sensitive: bool = False,
         unique_constraints: List[str] = None,
         overwrite_types: Dict = None,
+        skip_semicolon_at_end: bool = False,
         **kwargs,
     ) -> str:
         if unique_constraints is None:
@@ -68,6 +69,7 @@ class BaseSQL(BaseSQLConnection):
             case_sensitive=case_sensitive,
             unique_constraints=unique_constraints,
             overwrite_types=overwrite_types,
+            skip_semicolon_at_end=skip_semicolon_at_end,
         )
 
     def build_create_table_as_command(
@@ -234,6 +236,7 @@ class BaseSQL(BaseSQLConnection):
         query_string: Union[str, None] = None,
         unique_conflict_method: str = None,
         unique_constraints: List[str] = None,
+        skip_semicolon_at_end: bool = False,
         **kwargs,
     ) -> None:
         """
@@ -350,6 +353,7 @@ class BaseSQL(BaseSQLConnection):
                             case_sensitive=case_sensitive,
                             unique_constraints=unique_constraints,
                             overwrite_types=overwrite_types,
+                            skip_semicolon_at_end=skip_semicolon_at_end,
                         )
                         cur.execute(query)
                     self.upload_dataframe(


### PR DESCRIPTION
# Description
This PR add export function to oracle io, so data can be exported to oracle destination

# How Has This Been Tested?
 Mage UI

UI select Oracle DB exporter:

![UI](https://github.com/mage-ai/mage-ai/assets/5386254/e457f7ef-8746-4862-a8eb-e0081d8401c5)

Oracle DB destination code:
![export_function](https://github.com/mage-ai/mage-ai/assets/5386254/5a878ef8-013c-4667-ab2e-8b3500245c36)

Oracle DB exported table (1) including newly created table (2) also tested with new rows added:
![export result](https://github.com/mage-ai/mage-ai/assets/5386254/c9d7a9a0-5f4f-48ff-b44e-0f9307443003)

Oracle DB exported table with datetime type:
![export result of datetime type](https://github.com/mage-ai/mage-ai/assets/5386254/18d42b15-eb1f-49bf-a898-39997a0cf1ba)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
@wangxiaoyou1993 
