### PR TITLE
[xy] Interpolate global vars in k8s executor namespace

### DIFF
--- a/mage_ai/data_preparation/executors/k8s_block_executor.py
+++ b/mage_ai/data_preparation/executors/k8s_block_executor.py
@@ -1,6 +1,9 @@
 from typing import Dict
 
+from jinja2 import Template
+
 from mage_ai.data_preparation.executors.block_executor import BlockExecutor
+from mage_ai.data_preparation.shared.utils import get_template_vars
 from mage_ai.services.k8s.config import K8sExecutorConfig
 from mage_ai.services.k8s.constants import DEFAULT_NAMESPACE
 from mage_ai.services.k8s.job_manager import JobManager as K8sJobManager
@@ -29,9 +32,13 @@ class K8sBlockExecutor(BlockExecutor):
             job_name_prefix = self.executor_config.job_name_prefix
 
         if self.executor_config.namespace:
-            namespace = self.executor_config.namespace
+            namespace = Template(self.executor_config.namespace).render(
+                variables=lambda x: global_vars.get(x) if global_vars else None,
+                **get_template_vars()
+            )
         else:
             namespace = DEFAULT_NAMESPACE
+
         job_manager = K8sJobManager(
             job_name=f'mage-{job_name_prefix}-block-{block_run_id}',
             logger=self.logger,

--- a/mage_ai/data_preparation/executors/k8s_pipeline_executor.py
+++ b/mage_ai/data_preparation/executors/k8s_pipeline_executor.py
@@ -42,6 +42,7 @@ class K8sPipelineExecutor(PipelineExecutor):
     ) -> None:
         job_manager = self.get_job_manager(
             pipeline_run_id=pipeline_run_id,
+            global_vars=global_vars,
             **kwargs,
         )
         cmd = self._run_commands(
@@ -57,15 +58,18 @@ class K8sPipelineExecutor(PipelineExecutor):
     def get_job_manager(
         self,
         pipeline_run_id: int = None,
+        global_vars: Dict = None,
         **kwargs,
     ) -> K8sJobManager:
+        if global_vars is None:
+            global_vars = dict()
         if not self.executor_config.job_name_prefix:
             job_name_prefix = 'data-prep'
         else:
             job_name_prefix = self.executor_config.job_name_prefix
 
         if self.executor_config.namespace:
-            global_vars = kwargs.get('global_vars', dict())
+
             namespace = Template(self.executor_config.namespace).render(
                 variables=lambda x: global_vars.get(x) if global_vars else None,
                 **get_template_vars()

--- a/mage_ai/data_preparation/executors/k8s_pipeline_executor.py
+++ b/mage_ai/data_preparation/executors/k8s_pipeline_executor.py
@@ -1,8 +1,11 @@
 import traceback
 from typing import Dict
 
+from jinja2 import Template
+
 from mage_ai.data_preparation.executors.pipeline_executor import PipelineExecutor
 from mage_ai.data_preparation.models.pipeline import Pipeline
+from mage_ai.data_preparation.shared.utils import get_template_vars
 from mage_ai.services.k8s.config import K8sExecutorConfig
 from mage_ai.services.k8s.constants import DEFAULT_NAMESPACE
 from mage_ai.services.k8s.job_manager import JobManager as K8sJobManager
@@ -62,7 +65,11 @@ class K8sPipelineExecutor(PipelineExecutor):
             job_name_prefix = self.executor_config.job_name_prefix
 
         if self.executor_config.namespace:
-            namespace = self.executor_config.namespace
+            global_vars = kwargs.get('global_vars', dict())
+            namespace = Template(self.executor_config.namespace).render(
+                variables=lambda x: global_vars.get(x) if global_vars else None,
+                **get_template_vars()
+            )
         else:
             namespace = DEFAULT_NAMESPACE
 

--- a/mage_ai/services/k8s/job_manager.py
+++ b/mage_ai/services/k8s/job_manager.py
@@ -24,6 +24,14 @@ class JobManager():
         logger=None,
         logging_tags: Dict = None,
     ):
+        """Initialize the kubernetes job manager.
+
+        Args:
+            job_name (str, optional): The name of the job.
+            namespace (str, optional): The namespace of the executor pod.
+            logger (None, optional): Logger to log the messages.
+            logging_tags (Dict, optional): Logging tags to be included in the log messages.
+        """
         self.job_name = job_name
         self.namespace = namespace
         self.logger = logger


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Close: https://github.com/mage-ai/mage-ai/issues/4488

Support dynamic namespace in k8s executor by interpolating vars in the namespace
https://docs.mage.ai/development/variables/overview

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with local kubernetes cluster


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
