### PR TITLE
[enhancement] mongodb stream full_document config option

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -279,7 +279,8 @@
                 "streaming/sources/kafka",
                 "streaming/sources/kinesis",
                 "streaming/sources/nats",
-                "streaming/sources/rabbitmq"
+                "streaming/sources/rabbitmq",
+                "streaming/sources/mongodb"
               ]
             },
             {

--- a/docs/streaming/sources/mongodb.mdx
+++ b/docs/streaming/sources/mongodb.mdx
@@ -1,0 +1,13 @@
+---
+title: MongoDB
+---
+
+## Basic Config
+
+```yaml
+connector_type: mongodb
+connection_str: "mongodb://localhost:27017/" #Must be replica set and MongoVersion is higher than Mongo5.1
+database: "test"
+collection: "test"
+```
+The following additional configuration options can be included: batch_size, pipeline, starting_after, full_document. Instructions on how to use these options can be found in the [pymongo documentation](https://pymongo.readthedocs.io/en/stable/api/pymongo/collection.html#pymongo.collection.Collection.watch).

--- a/mage_ai/streaming/sources/mongodb.py
+++ b/mage_ai/streaming/sources/mongodb.py
@@ -18,6 +18,7 @@ class MongoDBConfig(BaseConfig):
     pipeline: Optional[_Pipeline] = None
     operation_time: Optional[Timestamp] = None
     start_after: Optional[Mapping[str, Any]] = None
+    full_document: Optional[str] = None
 
 
 class MongoSource(BaseSource):
@@ -45,6 +46,9 @@ class MongoSource(BaseSource):
 
         if hasattr(self.config, 'start_after') and self.config.start_after is not None:
             watch_args['start_after'] = self.config.start_after
+
+        if hasattr(self.config, 'full_document'):
+            watch_args['full_document'] = self.config.full_documentd
 
         return watch_args
 


### PR DESCRIPTION
# Description

- Added an additional configuration option to the MongoDB streaming source to enable full_document options available on the pymongo.Collection.watch() method.
- Added documentation for the MongoDB streaming source, which was previously missing.


# How Has This Been Tested?
Existing unit tests pass, no significant changes to tests needed.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
