### PR TITLE
[jk] Bugfixes - table render / rename destination block

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -2497,6 +2497,7 @@ df = get_variable('{self.pipeline.uuid}', '{self.uuid}', 'df')
     def to_dict(
         self,
         include_block_catalog: bool = False,
+        include_block_pipelines: bool = False,
         include_callback_blocks: bool = False,
         include_content: bool = False,
         include_outputs: bool = False,
@@ -2514,6 +2515,9 @@ df = get_variable('{self.pipeline.uuid}', '{self.uuid}', 'df')
 
         if include_block_catalog and self.is_data_integration() and self.pipeline:
             data['catalog'] = self.get_catalog_from_file()
+
+        if include_block_pipelines:
+            data['pipelines'] = self.get_pipelines_from_cache()
 
         if include_outputs:
             include_outputs_use = include_outputs

--- a/mage_ai/data_preparation/models/block/integration/__init__.py
+++ b/mage_ai/data_preparation/models/block/integration/__init__.py
@@ -416,9 +416,10 @@ class SourceBlock(IntegrationBlock):
 class DestinationBlock(IntegrationBlock):
     def to_dict(
         self,
-        include_content=False,
-        include_outputs=False,
-        sample_count=None,
+        include_content: bool = False,
+        include_outputs: bool = False,
+        include_block_pipelines: bool = False,
+        sample_count: int = None,
         check_if_file_exists: bool = False,
         destination_table: str = None,
         state_stream: str = None,
@@ -444,6 +445,7 @@ class DestinationBlock(IntegrationBlock):
             super().to_dict(
                 include_content=include_content,
                 include_outputs=include_outputs,
+                include_block_pipelines=include_block_pipelines,
                 sample_count=sample_count,
                 check_if_file_exists=check_if_file_exists,
             ),
@@ -452,9 +454,10 @@ class DestinationBlock(IntegrationBlock):
 
     async def to_dict_async(
         self,
-        include_content=False,
-        include_outputs=False,
-        sample_count=None,
+        include_content: bool = False,
+        include_outputs: bool = False,
+        include_block_pipelines: bool = False,
+        sample_count: int = None,
         check_if_file_exists: bool = False,
         destination_table: str = None,
         state_stream: str = None,
@@ -463,6 +466,7 @@ class DestinationBlock(IntegrationBlock):
         return self.to_dict(
             include_content=include_content,
             include_outputs=include_outputs,
+            include_block_pipelines=include_block_pipelines,
             sample_count=sample_count,
             check_if_file_exists=check_if_file_exists,
             destination_table=destination_table,

--- a/mage_ai/data_preparation/models/block/integration/__init__.py
+++ b/mage_ai/data_preparation/models/block/integration/__init__.py
@@ -469,7 +469,7 @@ class DestinationBlock(IntegrationBlock):
             state_stream=state_stream,
         )
 
-    def update(self, data, update_state=False):
+    def update(self, data, update_state=False, **kwargs):
         if update_state:
             from mage_ai.data_preparation.models.pipelines.integration_pipeline import (
                 IntegrationPipeline,
@@ -493,7 +493,7 @@ class DestinationBlock(IntegrationBlock):
                     bookmark_values=bookmark_values
                 )
 
-        return super().update(data)
+        return super().update(data, **kwargs)
 
     def output_variables(self, execution_partition: str = None) -> List[str]:
         return []

--- a/mage_ai/frontend/components/CodeBlockV2/Output/index.tsx
+++ b/mage_ai/frontend/components/CodeBlockV2/Output/index.tsx
@@ -272,7 +272,7 @@ function CodeBlockOutput({
             width,
           }) => (
             <DataTable
-              columns={data?.columns}
+              columns={data?.columns || []}
               disableScrolling={!selected}
               index={data?.index}
               key={`data-table-${data?.index}`}
@@ -284,7 +284,7 @@ function CodeBlockOutput({
               noBorderLeft
               noBorderRight
               noBorderTop={!data?.borderTop}
-              rows={data?.rows}
+              rows={data?.rows || []}
               width={columnWidth}
             />
           ),


### PR DESCRIPTION
# Description
- Prevent table rendering error when columns and rows undefined.
- Fix error (`DestinationBlock.update() got an unexpected kwarg 'detach'`) when trying to rename a destination block in an integration pipeline.
- Include block pipelines in data integration pipeline destination block (previously wasn't included, which was causing the "Renaming this block will affect X pipelines. The renamed block may need to be re-added to the shared pipeline(s)." warning to not appear when renaming the destination block specifically).

# How Has This Been Tested?
- Tested locally and confirmed errors no longer appear

<img width="1124" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/1265d69d-455c-4e3b-a164-c299d2e3f947">

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
