### PR TITLE
[dy] Add pagination to workspace roles

### DIFF
--- a/mage_ai/cluster_manager/kubernetes/workload_manager.py
+++ b/mage_ai/cluster_manager/kubernetes/workload_manager.py
@@ -74,7 +74,7 @@ class WorkloadManager:
             pass
 
         try:
-            config.load_kube_config()
+            config.load_kube_config('/home/src/testfiles/local-kube')
         except Exception:
             pass
 
@@ -236,6 +236,13 @@ class WorkloadManager:
         pvc_retention_policy = parameters.get('pvc_retention_policy') or 'Retain'
 
         ingress_name = workspace_config.ingress_name
+
+        self.__create_persistent_volume(
+            name,
+            volume_host_path='/Users/david_yang/mage/mage-ai/testfiles',
+            storage_request_size=storage_request_size,
+            access_mode=storage_access_mode,
+        )
 
         volumes = []
         volume_mounts = [{'name': 'mage-data', 'mountPath': '/home/src'}]

--- a/mage_ai/cluster_manager/kubernetes/workload_manager.py
+++ b/mage_ai/cluster_manager/kubernetes/workload_manager.py
@@ -74,7 +74,7 @@ class WorkloadManager:
             pass
 
         try:
-            config.load_kube_config('/home/src/testfiles/local-kube')
+            config.load_kube_config()
         except Exception:
             pass
 
@@ -236,13 +236,6 @@ class WorkloadManager:
         pvc_retention_policy = parameters.get('pvc_retention_policy') or 'Retain'
 
         ingress_name = workspace_config.ingress_name
-
-        self.__create_persistent_volume(
-            name,
-            volume_host_path='/Users/david_yang/mage/mage-ai/testfiles',
-            storage_request_size=storage_request_size,
-            access_mode=storage_access_mode,
-        )
 
         volumes = []
         volume_mounts = [{'name': 'mage-data', 'mountPath': '/home/src'}]

--- a/mage_ai/cluster_manager/manage.py
+++ b/mage_ai/cluster_manager/manage.py
@@ -70,11 +70,14 @@ def get_workspaces(cluster_type: ClusterType, **kwargs) -> List[Workspace]:
     repo_path = get_repo_path()
     projects_folder = os.path.join(repo_path, 'projects')
     if is_main_project:
+        # sort by file last modified time
         projects = [
-            f.name.split('.')[0]
+            f
             for f in os.scandir(projects_folder)
             if not f.is_dir() and f.name.endswith('.yaml')
         ]
+        projects.sort(key=lambda f: os.path.getmtime(f.path), reverse=True)
+        projects = [os.path.splitext(f.name)[0] for f in projects]
     else:
         instances = get_instances(cluster_type, **kwargs)
         projects = [instance.get('name') for instance in instances]

--- a/mage_ai/frontend/api/utils/use.ts
+++ b/mage_ai/frontend/api/utils/use.ts
@@ -283,6 +283,7 @@ export function useList(
   const {
     data,
     error,
+    isValidating,
     mutate,
   } = useSWR(
     pauseFetch ? null : buildUrl(resource, null, null, null, query),
@@ -294,6 +295,7 @@ export function useList(
     data,
     error,
     loading: !data && !error,
+    isValidating,
     mutate,
   };
 }

--- a/mage_ai/frontend/components/users/edit/Workspaces/index.tsx
+++ b/mage_ai/frontend/components/users/edit/Workspaces/index.tsx
@@ -6,10 +6,12 @@ import { useRouter } from 'next/router';
 import Button from '@oracle/elements/Button';
 import Chip from '@oracle/components/Chip';
 import FlexContainer from '@oracle/components/FlexContainer';
+import Paginate, { MAX_PAGES } from '@components/shared/Paginate';
 import PermissionType from '@interfaces/PermissionType';
 import RoleType from '@interfaces/RoleType';
 import Select from '@oracle/elements/Inputs/Select';
 import Spacing from '@oracle/elements/Spacing';
+import Spinner from '@oracle/components/Spinner';
 import Table from '@components/shared/Table';
 import Text from '@oracle/elements/Text';
 import UserType from '@interfaces/UserType';
@@ -17,9 +19,6 @@ import WorkspaceType from '@interfaces/WorkspaceType';
 import api from '@api';
 import { find, remove } from '@utils/array';
 import { onSuccess } from '@api/utils/response';
-import { set } from 'yaml/dist/schema/yaml-1.1/set';
-import Spinner from '@oracle/components/Spinner';
-import Paginate, { MAX_PAGES, ROW_LIMIT } from '@components/shared/Paginate';
 import { queryFromUrl, queryString } from '@utils/url';
 
 type UserWorkspacesEditProps = {

--- a/mage_ai/frontend/pages/manage/index.tsx
+++ b/mage_ai/frontend/pages/manage/index.tsx
@@ -51,7 +51,7 @@ function WorkspacePage() {
   });
   const project: ProjectType = useMemo(() => data?.projects?.[0], [data]);
 
-  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(true);
 
   const { data: dataWorkspaces, mutate: fetchWorkspaces } = api.workspaces.list(
     {
@@ -59,18 +59,10 @@ function WorkspacePage() {
       cluster_type: clusterType,
     },
     {
+      onSuccess: () => setIsRefreshing(false),
       revalidateOnFocus: false,
     },
   );
-  
-  const dataWorkspacesPrev = usePrevious(dataWorkspaces);
-  useEffect(() => {
-    if (dataWorkspaces == null) {
-      setIsRefreshing(true);
-    } else if (dataWorkspacesPrev == null) {
-      setIsRefreshing(false);
-    }
-  }, [dataWorkspaces, dataWorkspacesPrev]);
 
   const workspaces = useMemo(
     () => dataWorkspaces?.workspaces?.filter(({ name }) => name),
@@ -225,7 +217,7 @@ function WorkspacePage() {
           isLoading: isRefreshing,
           onClick: () => {
             setIsRefreshing(true);
-            fetchWorkspaces().then(() => setIsRefreshing(false));
+            fetchWorkspaces();
           },
           tooltip: 'Refresh workspaces',
         }}

--- a/mage_ai/frontend/pages/manage/index.tsx
+++ b/mage_ai/frontend/pages/manage/index.tsx
@@ -26,8 +26,6 @@ import { getFilters, setFilters } from '@storage/workspaces';
 import { goToWithQuery } from '@utils/routing';
 import { isEmptyObject, selectEntriesWithValues } from '@utils/hash';
 import { useModal } from '@context/Modal';
-import { set } from 'local-storage';
-import usePrevious from '@utils/usePrevious';
 
 function WorkspacePage() {
   const router = useRouter();
@@ -51,15 +49,12 @@ function WorkspacePage() {
   });
   const project: ProjectType = useMemo(() => data?.projects?.[0], [data]);
 
-  const [isRefreshing, setIsRefreshing] = useState(true);
-
-  const { data: dataWorkspaces, mutate: fetchWorkspaces } = api.workspaces.list(
+  const { data: dataWorkspaces, isValidating, mutate: fetchWorkspaces } = api.workspaces.list(
     {
       ...query,
       cluster_type: clusterType,
     },
     {
-      onSuccess: () => setIsRefreshing(false),
       revalidateOnFocus: false,
     },
   );
@@ -214,11 +209,8 @@ function WorkspacePage() {
         extraActionButtonProps={{
           Icon: Refresh,
           disabled: false,
-          isLoading: isRefreshing,
-          onClick: () => {
-            setIsRefreshing(true);
-            fetchWorkspaces();
-          },
+          isLoading: isValidating,
+          onClick: fetchWorkspaces,
           tooltip: 'Refresh workspaces',
         }}
         filterOptions={filterOptions}
@@ -240,7 +232,7 @@ function WorkspacePage() {
   }, [
     clusterType,
     fetchWorkspaces,
-    isRefreshing,
+    isValidating,
     query,
     router,
     showModal,

--- a/mage_ai/frontend/pages/manage/users/[user]/index.tsx
+++ b/mage_ai/frontend/pages/manage/users/[user]/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 
 import ErrorsType from '@interfaces/ErrorsType';
@@ -11,7 +11,7 @@ import api from '@api';
 import { PADDING_UNITS } from '@oracle/styles/units/spacing';
 import { USER_PASSWORD_CURRENT_FIELD_UUID } from '@components/users/edit/Form/constants';
 import { WorkspacesPageNameEnum } from '@components/workspaces/Dashboard/constants';
-import { displayErrorFromReadResponse } from '@api/utils/response';
+import { displayErrorFromReadResponse, onSuccess } from '@api/utils/response';
 
 type ManageUserDetailProps = {
   user: { id: number };
@@ -43,7 +43,6 @@ function ManageUserDetail({
       user_id: userID,
     },
     {
-      refreshInterval: 5000,
       revalidateOnFocus: true,
     },
   );

--- a/mage_ai/frontend/pages/manage/users/[user]/index.tsx
+++ b/mage_ai/frontend/pages/manage/users/[user]/index.tsx
@@ -37,13 +37,13 @@ function ManageUserDetail({
     displayErrorFromReadResponse(dataUser, setErrors);
   }, [dataUser]);
 
-  const { data: dataWorkspaces } = api.workspaces.list(
+  const { data: dataWorkspaces, isValidating } = api.workspaces.list(
     {
       cluster_type: clusterType,
       user_id: userID,
     },
     {
-      revalidateOnFocus: true,
+      revalidateOnFocus: false,
     },
   );
 
@@ -94,6 +94,7 @@ function ManageUserDetail({
       <UserWorkspacesEdit
         fetchUser={fetchUser}
         user={user}
+        isLoadingWorkspaces={isValidating}
         workspaces={workspaces}
       />
     </WorkspacesDashboard>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

The workspace roles page can potentially take a while to load all the workspace roles and then group them by workspace, so this PR adds pagination to limit the # of workspaces per page.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with kubernetes workspaces


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
