### PR TITLE
[xy] Improve the performance of loading dbt blocks.

### DIFF
--- a/mage_ai/api/resources/BlockLayoutItemResource.py
+++ b/mage_ai/api/resources/BlockLayoutItemResource.py
@@ -6,7 +6,7 @@ import urllib.parse
 
 from mage_ai.api.errors import ApiError
 from mage_ai.api.resources.GenericResource import GenericResource
-from mage_ai.data_preparation.models.block import Block
+from mage_ai.data_preparation.models.block.block_factory import BlockFactory
 from mage_ai.data_preparation.models.constants import BlockType
 from mage_ai.data_preparation.models.widget.constants import ChartType
 from mage_ai.data_preparation.variable_manager import get_global_variables
@@ -73,7 +73,7 @@ class BlockLayoutItemResource(GenericResource):
                 data_source_type = data_source_config.get('type')
                 pipeline_uuid = data_source_config.get('pipeline_uuid')
 
-                block = Block.get_block(
+                block = BlockFactory.get_block(
                     block_config.get('name') or file_path or uuid,
                     block_uuid,
                     block_type,

--- a/mage_ai/api/resources/BlockResource.py
+++ b/mage_ai/api/resources/BlockResource.py
@@ -12,6 +12,7 @@ from mage_ai.cache.block_action_object.constants import (
     OBJECT_TYPE_MAGE_TEMPLATE,
 )
 from mage_ai.data_preparation.models.block import Block
+from mage_ai.data_preparation.models.block.block_factory import BlockFactory
 from mage_ai.data_preparation.models.block.utils import clean_name
 from mage_ai.data_preparation.models.constants import (
     FILE_EXTENSION_TO_BLOCK_LANGUAGE,
@@ -163,7 +164,7 @@ class BlockResource(GenericResource):
             if payload.get('type') == BlockType.DBT and language == BlockLanguage.SQL and content:
                 from mage_ai.data_preparation.models.block.dbt import DBTBlock
 
-                dbt_block = DBTBlock(
+                dbt_block = DBTBlock.create(
                     name,
                     clean_name(name),
                     BlockType.DBT,
@@ -323,7 +324,7 @@ class BlockResource(GenericResource):
         if BlockType.DBT == block_type:
             from mage_ai.data_preparation.models.block.dbt import DBTBlock
 
-            block = DBTBlock(
+            block = DBTBlock.create(
                 block_uuid,
                 block_uuid,
                 block_type,
@@ -331,7 +332,7 @@ class BlockResource(GenericResource):
                 language=language,
             )
         else:
-            block = Block.get_block(block_uuid, block_uuid, block_type, language=language)
+            block = BlockFactory.get_block(block_uuid, block_uuid, block_type, language=language)
 
         if not block.exists():
             error.update(ApiError.RESOURCE_NOT_FOUND)

--- a/mage_ai/api/resources/CacheItemResource.py
+++ b/mage_ai/api/resources/CacheItemResource.py
@@ -50,7 +50,7 @@ class CacheItemResource(AsyncBaseResource):
         )
 
         if CacheItemType.DBT == item_type:
-            block = DBTBlock(
+            block = DBTBlock.create(
                 pk,
                 pk,
                 BlockType.DBT,

--- a/mage_ai/api/resources/PageBlockLayoutResource.py
+++ b/mage_ai/api/resources/PageBlockLayoutResource.py
@@ -3,7 +3,7 @@ import urllib.parse
 
 from mage_ai.api.errors import ApiError
 from mage_ai.api.resources.GenericResource import GenericResource
-from mage_ai.data_preparation.models.block import Block
+from mage_ai.data_preparation.models.block.block_factory import BlockFactory
 from mage_ai.presenters.block_layout.page import PageBlockLayout
 from mage_ai.shared.hash import extract, ignore_keys, merge_dict
 from mage_ai.shared.utils import clean_name
@@ -52,7 +52,7 @@ class PageBlockLayoutResource(GenericResource):
                     if len(parts) >= 2:
                         block_uuid_use = os.path.join(*parts[1:])
 
-                block = Block.get_block(
+                block = BlockFactory.get_block(
                     block_uuid_use,
                     block_uuid_use,
                     block_type,

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -837,7 +837,11 @@ class Block(DataIntegrationMixin, SparkBlock, ProjectPlatformAccessible):
                     language,
                 )
 
-        block = BlockFactory.block_class_from_type(block_type, pipeline=pipeline)(
+        block = BlockFactory.block_class_from_type(
+            block_type,
+            language=language,
+            pipeline=pipeline,
+        )(
             name,
             uuid,
             block_type,

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -724,41 +724,6 @@ class Block(DataIntegrationMixin, SparkBlock, ProjectPlatformAccessible):
             )
 
     @classmethod
-    def block_class_from_type(self, block_type: str, language=None, pipeline=None) -> 'Block':
-        from mage_ai.data_preparation.models.block.constants import BLOCK_TYPE_TO_CLASS
-        from mage_ai.data_preparation.models.block.integration import (
-            DestinationBlock,
-            SourceBlock,
-            TransformerBlock,
-        )
-        from mage_ai.data_preparation.models.block.r import RBlock
-        from mage_ai.data_preparation.models.block.sql import SQLBlock
-        from mage_ai.data_preparation.models.widget import Widget
-
-        if BlockType.CHART == block_type:
-            return Widget
-        elif BlockType.DBT == block_type:
-            from mage_ai.data_preparation.models.block.dbt import DBTBlock
-
-            return DBTBlock
-        elif pipeline and PipelineType.INTEGRATION == pipeline.type:
-            if BlockType.CALLBACK == block_type:
-                return CallbackBlock
-            elif BlockType.CONDITIONAL == block_type:
-                return ConditionalBlock
-            elif BlockType.DATA_LOADER == block_type:
-                return SourceBlock
-            elif BlockType.DATA_EXPORTER == block_type:
-                return DestinationBlock
-            else:
-                return TransformerBlock
-        elif BlockLanguage.SQL == language:
-            return SQLBlock
-        elif BlockLanguage.R == language:
-            return RBlock
-        return BLOCK_TYPE_TO_CLASS.get(block_type)
-
-    @classmethod
     def create(
         self,
         name: str,
@@ -777,6 +742,8 @@ class Block(DataIntegrationMixin, SparkBlock, ProjectPlatformAccessible):
         widget: bool = False,
         downstream_block_uuids: List[str] = None,
     ) -> 'Block':
+        from mage_ai.data_preparation.models.block.block_factory import BlockFactory
+
         """
         1. Create a new folder for block_type if not exist
         2. Create a new python file with code template
@@ -870,7 +837,7 @@ class Block(DataIntegrationMixin, SparkBlock, ProjectPlatformAccessible):
                     language,
                 )
 
-        block = self.block_class_from_type(block_type, pipeline=pipeline)(
+        block = BlockFactory.block_class_from_type(block_type, pipeline=pipeline)(
             name,
             uuid,
             block_type,
@@ -930,34 +897,6 @@ class Block(DataIntegrationMixin, SparkBlock, ProjectPlatformAccessible):
                 if (f.endswith('.py') or f.endswith('.sql')) and f != '__init__.py':
                     block_uuids[t.value].append(f.split('.')[0])
         return block_uuids
-
-    @classmethod
-    def get_block(
-        self,
-        name,
-        uuid,
-        block_type,
-        configuration=None,
-        content=None,
-        language=None,
-        pipeline=None,
-        status=BlockStatus.NOT_EXECUTED,
-    ) -> 'Block':
-        block_class = self.block_class_from_type(
-            block_type,
-            language=language,
-            pipeline=pipeline,
-        ) or Block
-        return block_class(
-            name,
-            uuid,
-            block_type,
-            configuration=configuration,
-            content=content,
-            language=language,
-            pipeline=pipeline,
-            status=status,
-        )
 
     @classmethod
     def get_block_from_file_path(self, file_path: str) -> 'Block':

--- a/mage_ai/data_preparation/models/block/block_factory.py
+++ b/mage_ai/data_preparation/models/block/block_factory.py
@@ -1,0 +1,74 @@
+from mage_ai.data_preparation.models.block import Block, CallbackBlock, ConditionalBlock
+from mage_ai.data_preparation.models.block.constants import BLOCK_TYPE_TO_CLASS
+from mage_ai.data_preparation.models.block.dbt.block_sql import DBTBlockSQL
+from mage_ai.data_preparation.models.block.dbt.block_yaml import DBTBlockYAML
+from mage_ai.data_preparation.models.block.integration import (
+    DestinationBlock,
+    SourceBlock,
+    TransformerBlock,
+)
+from mage_ai.data_preparation.models.block.r import RBlock
+from mage_ai.data_preparation.models.block.sql import SQLBlock
+from mage_ai.data_preparation.models.constants import (
+    BlockLanguage,
+    BlockStatus,
+    BlockType,
+    PipelineType,
+)
+from mage_ai.data_preparation.models.widget import Widget
+
+
+class BlockFactory:
+    @classmethod
+    def block_class_from_type(self, block_type: str, language=None, pipeline=None) -> 'Block':
+        if BlockType.CHART == block_type:
+            return Widget
+        elif BlockType.DBT == block_type:
+
+            if language == BlockLanguage.YAML:
+                return DBTBlockYAML
+            return DBTBlockSQL
+        elif pipeline and PipelineType.INTEGRATION == pipeline.type:
+            if BlockType.CALLBACK == block_type:
+                return CallbackBlock
+            elif BlockType.CONDITIONAL == block_type:
+                return ConditionalBlock
+            elif BlockType.DATA_LOADER == block_type:
+                return SourceBlock
+            elif BlockType.DATA_EXPORTER == block_type:
+                return DestinationBlock
+            else:
+                return TransformerBlock
+        elif BlockLanguage.SQL == language:
+            return SQLBlock
+        elif BlockLanguage.R == language:
+            return RBlock
+        return BLOCK_TYPE_TO_CLASS.get(block_type)
+
+    @classmethod
+    def get_block(
+        self,
+        name,
+        uuid,
+        block_type,
+        configuration=None,
+        content=None,
+        language=None,
+        pipeline=None,
+        status=BlockStatus.NOT_EXECUTED,
+    ) -> 'Block':
+        block_class = BlockFactory.block_class_from_type(
+            block_type,
+            language=language,
+            pipeline=pipeline,
+        ) or Block
+        return block_class(
+            name,
+            uuid,
+            block_type,
+            configuration=configuration,
+            content=content,
+            language=language,
+            pipeline=pipeline,
+            status=status,
+        )

--- a/mage_ai/data_preparation/models/block/block_factory.py
+++ b/mage_ai/data_preparation/models/block/block_factory.py
@@ -24,7 +24,6 @@ class BlockFactory:
         if BlockType.CHART == block_type:
             return Widget
         elif BlockType.DBT == block_type:
-
             if language == BlockLanguage.YAML:
                 return DBTBlockYAML
             return DBTBlockSQL

--- a/mage_ai/data_preparation/models/block/block_factory.py
+++ b/mage_ai/data_preparation/models/block/block_factory.py
@@ -1,7 +1,5 @@
 from mage_ai.data_preparation.models.block import Block, CallbackBlock, ConditionalBlock
 from mage_ai.data_preparation.models.block.constants import BLOCK_TYPE_TO_CLASS
-from mage_ai.data_preparation.models.block.dbt.block_sql import DBTBlockSQL
-from mage_ai.data_preparation.models.block.dbt.block_yaml import DBTBlockYAML
 from mage_ai.data_preparation.models.block.integration import (
     DestinationBlock,
     SourceBlock,
@@ -16,6 +14,12 @@ from mage_ai.data_preparation.models.constants import (
     PipelineType,
 )
 from mage_ai.data_preparation.models.widget import Widget
+
+try:
+    from mage_ai.data_preparation.models.block.dbt.block_sql import DBTBlockSQL
+    from mage_ai.data_preparation.models.block.dbt.block_yaml import DBTBlockYAML
+except Exception:
+    print('DBT library not installed.')
 
 
 class BlockFactory:

--- a/mage_ai/data_preparation/models/block/dbt/block.py
+++ b/mage_ai/data_preparation/models/block/dbt/block.py
@@ -26,19 +26,17 @@ from mage_ai.shared.parsers import encode_complex
 
 
 class DBTBlock(Block):
-    def __new__(cls, *args, **kwargs) -> 'DBTBlock':
+    @classmethod
+    def create(cls, *args, **kwargs) -> 'DBTBlock':
         """
         Factory for the child blocks
         """
         # Import Child blocks here to prevent cycle import
         from mage_ai.data_preparation.models.block.dbt.block_sql import DBTBlockSQL
         from mage_ai.data_preparation.models.block.dbt.block_yaml import DBTBlockYAML
-        if cls is DBTBlock:
-            if kwargs.get('language', BlockLanguage.SQL) == BlockLanguage.YAML:
-                return super(DBTBlock, cls).__new__(DBTBlockYAML)
-            return super(DBTBlock, cls).__new__(DBTBlockSQL)
-        else:
-            return super(DBTBlock, cls).__new__(cls, *args, **kwargs)
+        if kwargs.get('language', BlockLanguage.SQL) == BlockLanguage.YAML:
+            return DBTBlockYAML(*args, **kwargs)
+        return DBTBlockSQL(*args, **kwargs)
 
     @property
     def base_project_path(self) -> Union[str, os.PathLike]:

--- a/mage_ai/data_preparation/models/block/global_data_product/__init__.py
+++ b/mage_ai/data_preparation/models/block/global_data_product/__init__.py
@@ -2,12 +2,15 @@ from logging import Logger
 from typing import Dict, List
 
 from mage_ai.data_preparation.models.block import Block
-from mage_ai.data_preparation.models.global_data_product import GlobalDataProduct
-from mage_ai.orchestration.triggers import global_data_product as trigger
 
 
 class GlobalDataProductBlock(Block):
-    def get_global_data_product(self) -> GlobalDataProduct:
+    def get_global_data_product(self):
+        # Avoid circular dependency of Pipeline class
+        from mage_ai.data_preparation.models.global_data_product import (
+            GlobalDataProduct,
+        )
+
         override_configuration = (self.configuration or {}).get('global_data_product', {})
         global_data_product = GlobalDataProduct.get(override_configuration.get('uuid'))
 
@@ -31,6 +34,9 @@ class GlobalDataProductBlock(Block):
         logging_tags: Dict = None,
         **kwargs,
     ) -> List:
+        # Avoid circular dependency of Pipeline class
+        from mage_ai.orchestration.triggers import global_data_product as trigger
+
         trigger.trigger_and_check_status(
             self.get_global_data_product(),
             block=self,

--- a/mage_ai/data_preparation/models/block/platform/mixins.py
+++ b/mage_ai/data_preparation/models/block/platform/mixins.py
@@ -233,7 +233,7 @@ class ProjectPlatformAccessible:
                 ),
             )
 
-        return block_class(
+        return block_class.create(
             name,
             uuid,
             block_type,

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -17,6 +17,7 @@ from jinja2 import Template
 from mage_ai.authentication.permissions.constants import EntityName
 from mage_ai.cache.pipeline import PipelineCache
 from mage_ai.data_preparation.models.block import Block, run_blocks, run_blocks_sync
+from mage_ai.data_preparation.models.block.block_factory import BlockFactory
 from mage_ai.data_preparation.models.block.data_integration.utils import (
     convert_outputs_to_data,
 )
@@ -732,7 +733,8 @@ class Pipeline:
                 )
 
             language = c.get('language')
-            return Block.block_class_from_type(block_type, language=language, pipeline=self)(
+
+            return BlockFactory.block_class_from_type(block_type, language=language, pipeline=self)(
                 c.get('name'),
                 c.get('uuid'),
                 block_type,

--- a/mage_ai/shared/path_fixer.py
+++ b/mage_ai/shared/path_fixer.py
@@ -29,6 +29,9 @@ def add_absolute_path(file_path: str, add_base_repo_path: bool = True) -> str:
                 full_path = os.path.join(repo_path, parts[0])
                 if os.path.exists(full_path):
                     full_path = os.path.join(repo_path, file_path)
+                elif os.path.exists(os.path.join(repo_path, 'dbt', parts[0])):
+                    # DBT v1 paths
+                    full_path = os.path.join(repo_path, 'dbt', file_path)
                 else:
                     full_path = find_directory(repo_path, lambda x: x.endswith(file_path))
 

--- a/mage_ai/tests/data_preparation/models/block/dbt/test_block.py
+++ b/mage_ai/tests/data_preparation/models/block/dbt/test_block.py
@@ -38,7 +38,7 @@ class DBTBlockTest(AsyncDBTestCase):
         self.block_sql.language = BlockLanguage.SQL
         self.block_sql.pipeline = pipeline
 
-        self.dbt_block_sql = DBTBlock(
+        self.dbt_block_sql = DBTBlock.create(
             name='test_dbt_block_sql',
             uuid='test_dbt_block_sql',
             block_type=BlockType.DBT,
@@ -50,7 +50,7 @@ class DBTBlockTest(AsyncDBTestCase):
             pipeline=pipeline,
         )
 
-        self.dbt_block_yaml = DBTBlock(
+        self.dbt_block_yaml = DBTBlock.create(
             name='test_dbt_block_yaml',
             uuid='test_dbt_block_yaml',
             block_type=BlockType.DBT,

--- a/mage_ai/tests/data_preparation/models/block/dbt/test_block_sql.py
+++ b/mage_ai/tests/data_preparation/models/block/dbt/test_block_sql.py
@@ -23,7 +23,7 @@
 #     pipeline.repo_path = 'test_repo_path'
 #     pipeline.get_block.return_value = None
 
-#     return DBTBlock(
+#     return DBTBlock.create(
 #         name='test_dbt_block_sql',
 #         uuid='test_dbt_block_sql',
 #         block_type=BlockType.DBT,

--- a/mage_ai/tests/data_preparation/models/block/dbt/test_block_yaml.py
+++ b/mage_ai/tests/data_preparation/models/block/dbt/test_block_yaml.py
@@ -18,7 +18,7 @@
 
 
 # def build_block(pipeline, content: str) -> DBTBlock:
-#     return DBTBlock(
+#     return DBTBlock.create(
 #         name='test_dbt_block_yaml',
 #         uuid='test_dbt_block_yaml',
 #         block_type=BlockType.DBT,

--- a/mage_ai/tests/data_preparation/models/test_block.py
+++ b/mage_ai/tests/data_preparation/models/test_block.py
@@ -8,6 +8,7 @@ from pandas.testing import assert_frame_equal
 
 # from mage_ai.data_cleaner.column_types.constants import ColumnType
 from mage_ai.data_preparation.models.block import Block, BlockType, CallbackBlock
+from mage_ai.data_preparation.models.block.block_factory import BlockFactory
 from mage_ai.data_preparation.models.block.errors import HasDownstreamDependencies
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.data_preparation.repo_manager import get_repo_config
@@ -606,7 +607,7 @@ SELECT 1 AS id;
             upstream_block_uuids=['test_data_loader'],
         )
 
-        test_block = Block.get_block('test_data_loader', 'test_data_loader', 'data_loader')
+        test_block = BlockFactory.get_block('test_data_loader', 'test_data_loader', 'data_loader')
 
         self.assertRaises(HasDownstreamDependencies, block1.delete)
         self.assertRaises(HasDownstreamDependencies, test_block.delete)

--- a/mage_ai/tests/settings/models/test_configuration_option.py
+++ b/mage_ai/tests/settings/models/test_configuration_option.py
@@ -100,7 +100,7 @@ class ConfigurationOptionTest(AsyncDBTestCase):
             self.faker.unique.name(),
             os.path.join(self.repo_path, 'mage_platform'),
         )
-        block = DBTBlock(
+        block = DBTBlock.create(
             block_type='dbt',
             configuration=dict(file_path='dir2/mage.sql'),
             language='sql',
@@ -139,7 +139,7 @@ class ConfigurationOptionTest(AsyncDBTestCase):
                         self.faker.unique.name(),
                         os.path.join(self.repo_path, 'mage_platform'),
                     )
-                    block = DBTBlock(
+                    block = DBTBlock.create(
                         block_type='dbt',
                         configuration=dict(file_path='dir2/mage.sql'),
                         language='sql',


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Improve the performance of loading dbt blocks.
* Move Block.block_class_from_type to BlockFactory to resolve circular dependency instead of putting import statement in class method. If the import statement is inside the class method, it will indeed get executed every time the method is called. This can lead to performance overhead, especially if the method is called frequently.
* Update the `add_absolute_path` to take care of the case of old dbt block so that it doesn't always need to do direcotry scan.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested loading a pipeline with 50+ dbt blocks locally. It reduces the time from 30 seconds to instant load
- [x] Tested running dbt pipeline with dbt sql and dbt yaml block locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
