### PR TITLE
Bugfix/okta authorization url discovery

### DIFF
--- a/mage_ai/authentication/providers/okta.py
+++ b/mage_ai/authentication/providers/okta.py
@@ -1,32 +1,28 @@
-import urllib.parse
-import uuid
-from typing import Awaitable, Dict
-
-import aiohttp
-from aiohttp import BasicAuth
+from urllib.parse import unquote, urlparse
 
 from mage_ai.authentication.oauth.constants import ProviderName
-from mage_ai.authentication.providers.oauth import OauthProvider
-from mage_ai.authentication.providers.sso import SsoProvider
-from mage_ai.authentication.providers.utils import get_base_url
+from mage_ai.authentication.providers.oidc import OidcProvider
 from mage_ai.settings import get_settings_value
 from mage_ai.settings.keys import OKTA_CLIENT_ID, OKTA_CLIENT_SECRET, OKTA_DOMAIN_URL
 
 
-class OktaProvider(SsoProvider, OauthProvider):
+class OktaProvider(OidcProvider): # Okta configuration uses OIDC so we can just subclass the OidcProvider
     provider = ProviderName.OKTA
 
     def __init__(self):
         self.hostname = get_settings_value(OKTA_DOMAIN_URL)
         self.client_id = get_settings_value(OKTA_CLIENT_ID)
         self.client_secret = get_settings_value(OKTA_CLIENT_SECRET)
+        self.parsed_url = urlparse(unquote(self.hostname))
+        if not self.parsed_url.scheme:
+            self.parsed_url = urlparse(unquote(f"https://{self.hostname}"))
         self.__validate()
 
-        if not self.hostname.startswith('https'):
-            self.hostname = f'https://{self.hostname}'
+        self.discovery_url = f"https://{self.parsed_url.netloc}/.well-known/openid-configuration"
+        self.discover()
 
     def __validate(self):
-        if not self.hostname:
+        if not self.parsed_url.netloc:
             raise Exception(
                 'Okta hostname is empty. '
                 'Make sure the OKTA_DOMAIN_URL environment variable is set.')
@@ -38,67 +34,3 @@ class OktaProvider(SsoProvider, OauthProvider):
             raise Exception(
                 'Okta client secret is empty. '
                 'Make sure the OKTA_CLIENT_SECRET environment variable is set.')
-
-    def get_auth_url_response(self, redirect_uri: str = None, **kwargs) -> Dict:
-        base_url = get_base_url(redirect_uri)
-        redirect_uri_query = dict(
-            provider=self.provider,
-            redirect_uri=redirect_uri,
-        )
-        query = dict(
-            client_id=self.client_id,
-            redirect_uri=urllib.parse.quote_plus(
-                f'{base_url}/oauth',
-            ),
-            response_mode='query',
-            response_type='code',
-            scope='openid email profile',
-            state=uuid.uuid4().hex,
-        )
-        query_strings = []
-        for k, v in query.items():
-            query_strings.append(f'{k}={v}')
-
-        return dict(
-            url=f"{self.hostname}/oauth2/default/v1/authorize?{'&'.join(query_strings)}",
-            redirect_query_params=redirect_uri_query,
-        )
-
-    async def get_access_token_response(self, code: str, **kwargs) -> Awaitable[Dict]:
-        base_url = get_base_url(kwargs.get('redirect_uri'))
-        data = dict()
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                f'{self.hostname}/oauth2/default/v1/token',
-                headers={
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                },
-                data=dict(
-                    grant_type='authorization_code',
-                    code=code,
-                    redirect_uri=f'{base_url}/oauth',
-                ),
-                auth=BasicAuth(self.client_id, self.client_secret),
-                timeout=20,
-            ) as response:
-                data = await response.json()
-
-        return data
-
-    async def get_user_info(self, access_token: str = None, **kwargs) -> Awaitable[Dict]:
-        if access_token is None:
-            raise Exception('Access token is required to fetch user info.')
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
-                f'{self.hostname}/oauth2/default/v1/userinfo',
-                headers={
-                    'Authorization': f'Bearer {access_token}'
-                },
-                timeout=10,
-            ) as response:
-                userinfo_resp = await response.json()
-
-        return dict(
-            email=userinfo_resp.get('email'),
-            username=userinfo_resp.get('sub'),
-        )

--- a/mage_ai/authentication/providers/okta.py
+++ b/mage_ai/authentication/providers/okta.py
@@ -6,7 +6,9 @@ from mage_ai.settings import get_settings_value
 from mage_ai.settings.keys import OKTA_CLIENT_ID, OKTA_CLIENT_SECRET, OKTA_DOMAIN_URL
 
 
-class OktaProvider(OidcProvider): # Okta configuration uses OIDC so we can just subclass the OidcProvider
+class OktaProvider(
+    OidcProvider
+):  # Okta configuration uses OIDC so we can just subclass the OidcProvider
     provider = ProviderName.OKTA
 
     def __init__(self):
@@ -18,19 +20,24 @@ class OktaProvider(OidcProvider): # Okta configuration uses OIDC so we can just 
             self.parsed_url = urlparse(unquote(f"https://{self.hostname}"))
         self.__validate()
 
-        self.discovery_url = f"https://{self.parsed_url.netloc}/.well-known/openid-configuration"
+        self.discovery_url = (
+            f"https://{self.parsed_url.netloc}/.well-known/openid-configuration"
+        )
         self.discover()
 
     def __validate(self):
         if not self.parsed_url.netloc:
-            raise Exception(
-                'Okta hostname is empty. '
-                'Make sure the OKTA_DOMAIN_URL environment variable is set.')
+            raise ValueError(
+                "Okta hostname is empty. "
+                "Make sure the OKTA_DOMAIN_URL environment variable is set."
+            )
         if not self.client_id:
-            raise Exception(
-                'Okta client id is empty. '
-                'Make sure the OKTA_CLIENT_ID environment variable is set.')
+            raise ValueError(
+                "Okta client id is empty. "
+                "Make sure the OKTA_CLIENT_ID environment variable is set."
+            )
         if not self.client_secret:
-            raise Exception(
-                'Okta client secret is empty. '
-                'Make sure the OKTA_CLIENT_SECRET environment variable is set.')
+            raise ValueError(
+                "Okta client secret is empty. "
+                "Make sure the OKTA_CLIENT_SECRET environment variable is set."
+            )

--- a/mage_ai/authentication/providers/okta.py
+++ b/mage_ai/authentication/providers/okta.py
@@ -17,27 +17,27 @@ class OktaProvider(
         self.client_secret = get_settings_value(OKTA_CLIENT_SECRET)
         self.parsed_url = urlparse(unquote(self.hostname))
         if not self.parsed_url.scheme:
-            self.parsed_url = urlparse(unquote(f"https://{self.hostname}"))
+            self.parsed_url = urlparse(unquote(f'https://{self.hostname}'))
         self.__validate()
 
         self.discovery_url = (
-            f"https://{self.parsed_url.netloc}/.well-known/openid-configuration"
+            f'https://{self.parsed_url.netloc}/.well-known/openid-configuration'
         )
         self.discover()
 
     def __validate(self):
         if not self.parsed_url.netloc:
             raise ValueError(
-                "Okta hostname is empty. "
-                "Make sure the OKTA_DOMAIN_URL environment variable is set."
+                'Okta hostname is empty. '
+                'Make sure the OKTA_DOMAIN_URL environment variable is set.'
             )
         if not self.client_id:
             raise ValueError(
-                "Okta client id is empty. "
-                "Make sure the OKTA_CLIENT_ID environment variable is set."
+                'Okta client id is empty. '
+                'Make sure the OKTA_CLIENT_ID environment variable is set.'
             )
         if not self.client_secret:
             raise ValueError(
-                "Okta client secret is empty. "
-                "Make sure the OKTA_CLIENT_SECRET environment variable is set."
+                'Okta client secret is empty. '
+                'Make sure the OKTA_CLIENT_SECRET environment variable is set.'
             )

--- a/mage_ai/data_preparation/models/block/integration/__init__.py
+++ b/mage_ai/data_preparation/models/block/integration/__init__.py
@@ -155,7 +155,7 @@ class IntegrationBlock(Block):
                 proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
                 for line in proc.stdout:
-                    f.write(line.decode()),
+                    f.write(line.decode())
                     print_log_from_line(
                         line,
                         config=config,

--- a/mage_ai/tests/authentication/providers/test_okta.py
+++ b/mage_ai/tests/authentication/providers/test_okta.py
@@ -5,18 +5,18 @@ from unittest.mock import patch
 from mage_ai.authentication.providers.okta import OktaProvider
 
 test_parameters = [
-    ("https://samples.auth0.com", "test-client-id", "test-client-secret"),
-    ("samples.auth0.com", "test-client-id", "test-client-secret"),
-    ("", "test-client-id", "test-client-secret"),
-    ("samples.auth0.com", "", ""),
+    ('https://samples.auth0.com', 'test-client-id', 'test-client-secret'),
+    ('samples.auth0.com', 'test-client-id', 'test-client-secret'),
+    ('', 'test-client-id', 'test-client-secret'),
+    ('samples.auth0.com', '', ''),
 ]
 
 
 class OktaProviderTest(unittest.TestCase):
     def setUp(self):
-        self.authorization_endpoint = "https://samples.auth0.com/authorize"
-        self.token_endpoint = "https://samples.auth0.com/oauth/token"
-        self.userinfo_endpoint = "https://samples.auth0.com/userinfo"
+        self.authorization_endpoint = 'https://samples.auth0.com/authorize'
+        self.token_endpoint = 'https://samples.auth0.com/oauth/token'
+        self.userinfo_endpoint = 'https://samples.auth0.com/userinfo'
 
     def test_okta_provider_initialization(self):
         for url, id, secret in test_parameters:

--- a/mage_ai/tests/authentication/providers/test_okta.py
+++ b/mage_ai/tests/authentication/providers/test_okta.py
@@ -1,0 +1,35 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from mage_ai.authentication.providers.okta import OktaProvider
+
+test_parameters = [
+    ("https://samples.auth0.com", "test-client-id", "test-client-secret"),
+    ("samples.auth0.com", "test-client-id", "test-client-secret"),
+    ("", "test-client-id", "test-client-secret"),
+    ("samples.auth0.com", "", "")
+]
+
+class OktaProviderTest(unittest.TestCase):
+    def setUp(self):
+        self.authorization_endpoint = "https://samples.auth0.com/authorize"
+        self.token_endpoint = "https://samples.auth0.com/oauth/token"
+        self.userinfo_endpoint = "https://samples.auth0.com/userinfo"
+
+    def test_okta_provider_initialization(self):
+        for url, id, secret in test_parameters:
+            with self.subTest():
+                with patch.dict(os.environ, dict(
+                    OKTA_DOMAIN_URL=url,
+                    OKTA_CLIENT_ID=id,
+                    OKTA_CLIENT_SECRET=secret
+                )):
+                    if not all([url, id]):
+                        with self.assertRaises(Exception):
+                            provider = OktaProvider()
+                    else:
+                        provider = OktaProvider()
+                        self.assertEqual(provider.authorization_endpoint, self.authorization_endpoint)
+                        self.assertEqual(provider.token_endpoint, self.token_endpoint)
+                        self.assertEqual(provider.userinfo_endpoint, self.userinfo_endpoint)

--- a/mage_ai/tests/authentication/providers/test_okta.py
+++ b/mage_ai/tests/authentication/providers/test_okta.py
@@ -8,8 +8,9 @@ test_parameters = [
     ("https://samples.auth0.com", "test-client-id", "test-client-secret"),
     ("samples.auth0.com", "test-client-id", "test-client-secret"),
     ("", "test-client-id", "test-client-secret"),
-    ("samples.auth0.com", "", "")
+    ("samples.auth0.com", "", ""),
 ]
+
 
 class OktaProviderTest(unittest.TestCase):
     def setUp(self):
@@ -20,16 +21,23 @@ class OktaProviderTest(unittest.TestCase):
     def test_okta_provider_initialization(self):
         for url, id, secret in test_parameters:
             with self.subTest():
-                with patch.dict(os.environ, dict(
-                    OKTA_DOMAIN_URL=url,
-                    OKTA_CLIENT_ID=id,
-                    OKTA_CLIENT_SECRET=secret
-                )):
+                with patch.dict(
+                    os.environ,
+                    dict(
+                        OKTA_DOMAIN_URL=url,
+                        OKTA_CLIENT_ID=id,
+                        OKTA_CLIENT_SECRET=secret,
+                    ),
+                ):
                     if not all([url, id]):
-                        with self.assertRaises(Exception):
+                        with self.assertRaises(ValueError):
                             provider = OktaProvider()
                     else:
                         provider = OktaProvider()
-                        self.assertEqual(provider.authorization_endpoint, self.authorization_endpoint)
+                        self.assertEqual(
+                            provider.authorization_endpoint, self.authorization_endpoint
+                        )
                         self.assertEqual(provider.token_endpoint, self.token_endpoint)
-                        self.assertEqual(provider.userinfo_endpoint, self.userinfo_endpoint)
+                        self.assertEqual(
+                            provider.userinfo_endpoint, self.userinfo_endpoint
+                        )


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fixes: #4808 
Rewrote `mage_ai.authentication.providers.OktaProvider` as a subclass of `mage_ai.authentication.providers.OidcProvider`.  This change preserves backwards compatability while fixing issue with hardcoded authorization server url.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Added test case to try different combinations of Okta environment variables to ensure initialization and url discovery works.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
