### PR TITLE
[jk] Avoid N dbt config option requests for N blocks on Pipeline Editor

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -217,6 +217,7 @@ type CodeBlockProps = {
   cursorHeight2?: number;
   cursorHeight3?: number;
   dataProviders?: DataProviderType[];
+  dbtConfigurationOptions?: ConfigurationOptionType[]
   defaultValue?: string;
   disableDrag?: boolean;
   disableShortcuts?: boolean;
@@ -348,6 +349,7 @@ function CodeBlock({
   cursorHeight2,
   cursorHeight3,
   dataProviders,
+  dbtConfigurationOptions,
   defaultValue = '',
   deleteBlock,
   disableDrag,
@@ -755,19 +757,8 @@ function CodeBlock({
     drop: (item: BlockType) => onDrop?.(block, item),
   }), [block]);
 
-  const { data: dataConfigurationOptions } = api.configuration_options.pipelines.list(isDBT ? pipelineUUID : null, {
-    configuration_type: ConfigurationTypeEnum.DBT,
-    option_type: OptionTypeEnum.PROJECTS,
-    resource_type: ResourceTypeEnum.Block,
-    resource_uuid: BlockLanguageEnum.SQL === blockLanguage ? blockUUID : null,
-  }, {
-    revalidateOnFocus: false,
-  });
-  const configurationOptions: ConfigurationOptionType[] =
-    useMemo(() => dataConfigurationOptions?.configuration_options, [dataConfigurationOptions]);
-
-  const dbtProjects = useMemo(() => indexBy(configurationOptions || [], ({ uuid }) => uuid), [
-    configurationOptions,
+  const dbtProjects = useMemo(() => indexBy(dbtConfigurationOptions || [], ({ uuid }) => uuid), [
+    dbtConfigurationOptions,
   ]);
 
   const dbtProjectName =
@@ -776,7 +767,7 @@ function CodeBlock({
     ]);
 
   const dbtProfileData = useMemo(() => {
-    if (!configurationOptions) {
+    if (!dbtConfigurationOptions) {
       return [
         dbtProjects[dbtProjectName] || {
           target: null,
@@ -785,13 +776,13 @@ function CodeBlock({
       ];
     }
 
-    const configOpts = configurationOptions?.length === 1
-      ? configurationOptions?.[0]
-      : configurationOptions?.find(({ uuid }) => dbtProjectName === uuid);
+    const configOpts = dbtConfigurationOptions?.length === 1
+      ? dbtConfigurationOptions?.[0]
+      : dbtConfigurationOptions?.find(({ uuid }) => dbtProjectName === uuid);
 
     return configOpts?.option?.profiles || [];
   }, [
-    configurationOptions,
+    dbtConfigurationOptions,
     dbtProjectName,
     dbtProjects,
   ]);
@@ -1388,6 +1379,7 @@ function CodeBlock({
     blocks,
     codeCollapsed,
     content,
+    dbtConfigurationOptions,
     deleteBlock: deleteBlockCallback,
     disableShortcuts,
     executionState,

--- a/mage_ai/frontend/components/CodeBlockV2/constants.ts
+++ b/mage_ai/frontend/components/CodeBlockV2/constants.ts
@@ -1,4 +1,5 @@
 import BlockType from '@interfaces/BlockType';
+import ConfigurationOptionType from '@interfaces/ConfigurationOptionType';
 import ErrorsType from '@interfaces/ErrorsType';
 import KernelOutputType, { ExecutionStateEnum } from '@interfaces/KernelOutputType';
 import KeyboardShortcutType from '@interfaces/KeyboardShortcutType';
@@ -76,6 +77,7 @@ export type UseCodeBlockComponentProps = {
   blocks?: BlockType[];
   codeCollapsed?: boolean;
   content?: string;
+  dbtConfigurationOptions?: ConfigurationOptionType[];
   deleteBlock?: (block: BlockType) => void,
   disableShortcuts?: boolean;
   executionState?: ExecutionStateEnum;

--- a/mage_ai/frontend/components/CodeBlockV2/dbt/Configuration/index.tsx
+++ b/mage_ai/frontend/components/CodeBlockV2/dbt/Configuration/index.tsx
@@ -1,13 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import BlockType, { BlockLanguageEnum } from '@interfaces/BlockType';
+import BlockType from '@interfaces/BlockType';
 import Button from '@oracle/elements/Button';
 import Checkbox from '@oracle/elements/Checkbox';
-import ConfigurationOptionType, {
-  ConfigurationTypeEnum,
-  OptionTypeEnum,
-  ResourceTypeEnum,
-} from '@interfaces/ConfigurationOptionType';
+import ConfigurationOptionType from '@interfaces/ConfigurationOptionType';
 import FlexContainer from '@oracle/components/FlexContainer';
 import PipelineType from '@interfaces/PipelineType';
 import SetupSection, { SetupSectionRow } from '@components/shared/SetupSection';

--- a/mage_ai/frontend/components/CodeBlockV2/dbt/Configuration/index.tsx
+++ b/mage_ai/frontend/components/CodeBlockV2/dbt/Configuration/index.tsx
@@ -13,84 +13,68 @@ import PipelineType from '@interfaces/PipelineType';
 import SetupSection, { SetupSectionRow } from '@components/shared/SetupSection';
 import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
-import api from '@api';
 import {
-  CONFIG_KEY_DBT,
-  CONFIG_KEY_DBT_COMMAND,
   CONFIG_KEY_DBT_PROFILES_FILE_PATH,
   CONFIG_KEY_DBT_PROFILE_TARGET,
   CONFIG_KEY_DBT_PROJECT_NAME,
   CONFIG_KEY_LIMIT,
 } from '@interfaces/ChartBlockType';
-import { Info } from '@oracle/icons';
-import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
+import { PADDING_UNITS } from '@oracle/styles/units/spacing';
 import { pluralize } from '@utils/string';
 import { sortByKey } from '@utils/array';
 
 type ConfigurationProps = {
   block: BlockType;
+  dbtConfigurationOptions: ConfigurationOptionType[];
   pipeline: PipelineType;
   savePipelineContent: (payload?: {
     block?: BlockType;
     pipeline?: PipelineType;
   }) => Promise<any>;
-}
+};
 
 function Configuration({
   block,
+  dbtConfigurationOptions,
   pipeline,
   savePipelineContent,
 }: ConfigurationProps) {
   const [attributes, setAttributes] = useState(block);
   const [attributesManuallyEnter, setAttributesManuallyEnter] = useState({});
 
-  const {
-    data: dataConfigurationOptions,
-  } = api.configuration_options.pipelines.list(pipeline?.uuid,
-    {
-      configuration_type: ConfigurationTypeEnum.DBT,
-      option_type: OptionTypeEnum.PROJECTS,
-      resource_type: ResourceTypeEnum.Block,
-      resource_uuid: BlockLanguageEnum.SQL === block?.language ? block?.uuid : null,
-    }, {
-      revalidateOnFocus: false,
-    });
-  const configurationOptions: ConfigurationOptionType[] =
-    useMemo(() => dataConfigurationOptions?.configuration_options, [dataConfigurationOptions]);
-
-  const project = useMemo(() => configurationOptions?.find(({
+  const project = useMemo(() => dbtConfigurationOptions?.find(({
     option,
   }) => attributes?.configuration?.[CONFIG_KEY_DBT_PROJECT_NAME] === option?.project?.uuid)?.option, [
     attributes,
-    configurationOptions,
+    dbtConfigurationOptions,
   ]);
-  const projects = useMemo(() => sortByKey(configurationOptions || [], ({ project }) => project?.uuid)?.map(({
+  const projects = useMemo(() => sortByKey(dbtConfigurationOptions || [], ({ project }) => project?.uuid)?.map(({
     option,
-  }) => option?.project), [configurationOptions]);
+  }) => option?.project), [dbtConfigurationOptions]);
 
   const profiles = useMemo(() => project?.profiles || [], [
     project,
   ]);
-  const profilesAll = useMemo(() => configurationOptions?.reduce((acc, { option }) => acc.concat(option?.profiles || []), []), [
-    projects
-  ]);
+  const profilesAll = useMemo(
+    () => dbtConfigurationOptions?.reduce((acc, { option }) => acc.concat(option?.profiles || []), []),
+    [dbtConfigurationOptions],
+  );
 
   const profile = useMemo(() => profiles?.find(({
     full_path: uuid,
   }) => uuid === attributes?.configuration?.[CONFIG_KEY_DBT_PROFILES_FILE_PATH]), [
     attributes,
     profiles,
-  ])
+  ]);
 
   const targets = useMemo(() => profile?.targets || [], [profile]);
-  const targetsAll = useMemo(() => configurationOptions?.reduce((acc, { option }) => acc.concat(
+  const targetsAll = useMemo(() => dbtConfigurationOptions?.reduce((acc, { option }) => acc.concat(
     option?.profiles?.reduce((acc2, pro) => acc2.concat(pro.targets), []) || [],
-  ), []), [
-    projects
-  ]);
-  const target = useMemo(() => targets?.find(targetName => attributes?.configuration?.[CONFIG_KEY_DBT_PROFILE_TARGET] === targetName), [
-    targets,
-  ]);
+  ), []), [dbtConfigurationOptions]);
+  const target = useMemo(
+    () => targets?.find(targetName => attributes?.configuration?.[CONFIG_KEY_DBT_PROFILE_TARGET] === targetName),
+    [attributes?.configuration, targets],
+  );
 
   useEffect(() => {
     const projectNamePath = attributes?.configuration?.[CONFIG_KEY_DBT_PROJECT_NAME];
@@ -162,11 +146,10 @@ function Configuration({
 
     return {
       [key]: opts,
-    }
+    };
   }, [
     attributes,
     attributesManuallyEnter,
-    configurationOptions,
     projects,
   ]);
 
@@ -209,11 +192,10 @@ function Configuration({
 
     return {
       [key]: opts,
-    }
+    };
   }, [
     attributes,
     attributesManuallyEnter,
-    configurationOptions,
     profiles,
   ]);
 
@@ -253,11 +235,10 @@ function Configuration({
 
     return {
       [key]: opts,
-    }
+    };
   }, [
     attributes,
     attributesManuallyEnter,
-    configurationOptions,
     targets,
   ]);
 

--- a/mage_ai/frontend/components/CodeBlockV2/dbt/useCodeBlockProps.tsx
+++ b/mage_ai/frontend/components/CodeBlockV2/dbt/useCodeBlockProps.tsx
@@ -1,5 +1,4 @@
 import * as osPath from 'path';
-import { useCallback } from 'react';
 
 import BlockType, { BlockTypeEnum, BlockLanguageEnum, StatusTypeEnum } from '@interfaces/BlockType';
 import Circle from '@oracle/elements/Circle';
@@ -8,15 +7,10 @@ import FlexContainer from '@oracle/components/FlexContainer';
 import KeyboardTextGroup from '@oracle/elements/KeyboardTextGroup';
 import Lineage from './Lineage';
 import Spacing from '@oracle/elements/Spacing';
-import Spinner from '@oracle/components/Spinner';
 import Text from '@oracle/elements/Text';
 import { AddonBlockTypeEnum } from '@interfaces/AddonBlockOptionType';
 import {
-  AISparkle,
-  AlertTriangle,
   Alphabet,
-  ArrowsAdjustingFrameSquare,
-  BatchPipeline,
   BatchSquaresStacked,
   BlocksCombined,
   Callback,
@@ -26,7 +20,6 @@ import {
   ChevronUp,
   Close,
   Conditional,
-  Copy,
   DocumentIcon,
   Edit,
   Filter,
@@ -34,10 +27,8 @@ import {
   LayoutSplit,
   LayoutStacked,
   Monitor,
-  PauseV2,
   PlayButtonFilled,
   PowerUps,
-  Save,
   SettingsWithKnobs,
   Trash,
   TreeWithArrowsDown,
@@ -45,7 +36,6 @@ import {
   VisibleEye,
 } from '@oracle/icons';
 import { ButtonUUIDEnum, UseCodeBlockPropsReturnType, UseCodeBlockPropsType } from '../constants';
-import { ExecutionStateEnum } from '@interfaces/KernelOutputType';
 import { HeaderTabEnum, buildHeaderTabs, buildOutputTabs } from './constants';
 import { ICON_SIZE, MENU_ICON_SIZE } from '../Header/index.style';
 import {
@@ -59,7 +49,6 @@ import {
 } from '@utils/hooks/keyboardShortcuts/constants';
 import { KeyTextsPostitionEnum } from '@oracle/elements/Button/KeyboardShortcutButton';
 import { TabType } from '@oracle/components/Tabs/ButtonTabs';
-import { UNIT } from '@oracle/styles/units/spacing';
 import { ViewKeyEnum } from '@components/Sidekick/constants';
 import { validate } from './utils';
 import { executeCode } from '@components/CodeEditor/keyboard_shortcuts/shortcuts';
@@ -77,6 +66,7 @@ export default function useCodeBlockProps({
   allowCodeBlockShortcuts,
   block,
   codeCollapsed,
+  dbtConfigurationOptions,
   deleteBlock,
   disableShortcuts,
   executionState,
@@ -154,7 +144,7 @@ export default function useCodeBlockProps({
     }
 
     return true;
-  };
+  }
 
   const headerTabs = buildHeaderTabs({
     block,
@@ -638,6 +628,7 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
         return (
           <Configuration
             block={block}
+            dbtConfigurationOptions={dbtConfigurationOptions}
             pipeline={pipeline}
             savePipelineContent={savePipelineContent}
           />
@@ -645,7 +636,7 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
       // } else if (HeaderTabEnum.OVERVIEW === tab?.uuid) {
       //   return;
       } else if (HeaderTabEnum.LINEAGE === tab?.uuid) {
-        return <Lineage block={block} />
+        return <Lineage block={block} />;
       }
 
       return defaultContent;

--- a/mage_ai/frontend/components/CodeBlockV2/useCodeBlockComponents.tsx
+++ b/mage_ai/frontend/components/CodeBlockV2/useCodeBlockComponents.tsx
@@ -271,6 +271,7 @@ export default function useCodeBlockComponents({
     blocks,
     codeBlockProps,
     collapsed,
+    enabled,
     errorMessages,
     executionState,
     isHidden,

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -461,9 +461,10 @@ function PipelineDetail({
         configuration_type: ConfigurationTypeEnum.DBT,
         option_type: OptionTypeEnum.PROJECTS,
         resource_type: ResourceTypeEnum.Block,
-        resource_uuid: BlockLanguageEnum.SQL === selectedBlock?.language
-          ? selectedBlock?.uuid
-          : null,
+        resource_uuid: (BlockLanguageEnum.SQL === selectedBlock?.language
+          && BlockTypeEnum.DBT === selectedBlock?.type)
+            ? selectedBlock?.uuid
+            : null,
       }, {
         revalidateOnFocus: false,
       },

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -455,22 +455,22 @@ function PipelineDetail({
       dataBlockTemplates,
     ]);
 
-    const { data: dataDbtConfigurationOptions } = api.configuration_options.pipelines.list(
-      hasDbtBlock ? pipeline?.uuid : null,
-      {
-        configuration_type: ConfigurationTypeEnum.DBT,
-        option_type: OptionTypeEnum.PROJECTS,
-        resource_type: ResourceTypeEnum.Block,
-        resource_uuid: (BlockLanguageEnum.SQL === selectedBlock?.language
-          && BlockTypeEnum.DBT === selectedBlock?.type)
-            ? selectedBlock?.uuid
-            : null,
-      }, {
-        revalidateOnFocus: false,
-      },
-    );
-    const dbtConfigurationOptions: ConfigurationOptionType[] =
-      useMemo(() => dataDbtConfigurationOptions?.configuration_options, [dataDbtConfigurationOptions]);
+  const { data: dataDbtConfigurationOptions } = api.configuration_options.pipelines.list(
+    (hasDbtBlock && selectedBlock) ? pipeline?.uuid : null,
+    {
+      configuration_type: ConfigurationTypeEnum.DBT,
+      option_type: OptionTypeEnum.PROJECTS,
+      resource_type: ResourceTypeEnum.Block,
+      resource_uuid: (BlockLanguageEnum.SQL === selectedBlock?.language
+        && BlockTypeEnum.DBT === selectedBlock?.type)
+          ? selectedBlock?.uuid
+          : null,
+    }, {
+      revalidateOnFocus: false,
+    },
+  );
+  const dbtConfigurationOptions: ConfigurationOptionType[] =
+    useMemo(() => dataDbtConfigurationOptions?.configuration_options, [dataDbtConfigurationOptions]);
 
   const addNewBlock = useCallback((newBlock: BlockRequestPayloadType, newBlockIndex?: number) => {
       const block = blocks[blocks.length - 1];

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import NextLink from 'next/link';
 import React, {
   createRef,
@@ -23,12 +22,17 @@ import BlockType, {
   SetEditingBlockType,
 } from '@interfaces/BlockType';
 import ClickOutside from '@oracle/components/ClickOutside';
-import CodeBlock, { DEFAULT_SQL_CONFIG_KEY_LIMIT } from '@components/CodeBlock';
-import ColumnScroller, { StartDataType } from './ColumnScroller';
+import CodeBlock from '@components/CodeBlock';
+import ColumnScroller from './ColumnScroller';
+import ConfigurationOptionType, {
+  ConfigurationTypeEnum,
+  OptionTypeEnum,
+  ResourceTypeEnum,
+} from '@interfaces/ConfigurationOptionType';
 import DataProviderType from '@interfaces/DataProviderType';
 import ErrorsType from '@interfaces/ErrorsType';
 import FileSelectorPopup from '@components/FileSelectorPopup';
-import FileType, { BlockFolderNameEnum, FileExtensionEnum } from '@interfaces/FileType';
+import FileType from '@interfaces/FileType';
 import GlobalDataProductType from '@interfaces/GlobalDataProductType';
 import IntegrationPipeline from '@components/IntegrationPipeline';
 import InteractionType from '@interfaces/InteractionType';
@@ -85,14 +89,12 @@ import { SIDE_BY_SIDE_VERTICAL_PADDING } from '@components/CodeBlock/index.style
 import { ViewKeyEnum } from '@components/Sidekick/constants';
 import { addClassNames, removeClassNames } from '@utils/elements';
 import { addScratchpadNote, addSqlBlockNote } from '@components/PipelineDetail/AddNewBlocks/utils';
-import { addUnderscores, randomNameGenerator, removeExtensionFromFilename } from '@utils/string';
 import { buildBlockRefKey, buildBlockFromFilePath } from './utils';
 import { getUpstreamBlockUuids } from '@components/CodeBlock/utils';
 import { isInputElement } from '@context/shared/utils';
 import { onlyKeysPresent } from '@utils/hooks/keyboardShortcuts/utils';
 import { onSuccess } from '@api/utils/response';
-import { groupBy, pushAtIndex, range, removeAtIndex } from '@utils/array';
-import { removeRootFromFilePath } from '@components/FileBrowser/utils';
+import { pushAtIndex, removeAtIndex } from '@utils/array';
 import { selectKeys } from '@utils/hash';
 import { useKeyboardContext } from '@context/Keyboard';
 import { useWindowSize } from '@utils/sizes';
@@ -303,6 +305,7 @@ function PipelineDetail({
 
   const isIntegration = useMemo(() => PipelineTypeEnum.INTEGRATION === pipeline?.type, [pipeline]);
   const isStreaming = useMemo(() => PipelineTypeEnum.STREAMING === pipeline?.type, [pipeline]);
+  const hasDbtBlock = useMemo(() => blocks?.some(({ type }) => BlockTypeEnum.DBT === type), [blocks]);
 
   const blocksFiltered =
     useMemo(() => blocks.filter(({ type }) => !isIntegration || BlockTypeEnum.TRANSFORMER === type), [
@@ -451,6 +454,22 @@ function PipelineDetail({
     useMemo(() => dataBlockTemplates?.block_templates || [], [
       dataBlockTemplates,
     ]);
+
+    const { data: dataDbtConfigurationOptions } = api.configuration_options.pipelines.list(
+      hasDbtBlock ? pipeline?.uuid : null,
+      {
+        configuration_type: ConfigurationTypeEnum.DBT,
+        option_type: OptionTypeEnum.PROJECTS,
+        resource_type: ResourceTypeEnum.Block,
+        resource_uuid: BlockLanguageEnum.SQL === selectedBlock?.language
+          ? selectedBlock?.uuid
+          : null,
+      }, {
+        revalidateOnFocus: false,
+      },
+    );
+    const dbtConfigurationOptions: ConfigurationOptionType[] =
+      useMemo(() => dataDbtConfigurationOptions?.configuration_options, [dataDbtConfigurationOptions]);
 
   const addNewBlock = useCallback((newBlock: BlockRequestPayloadType, newBlockIndex?: number) => {
       const block = blocks[blocks.length - 1];
@@ -998,6 +1017,7 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
           cursorHeight2={cursorHeight2}
           cursorHeight3={cursorHeight3}
           dataProviders={dataProviders}
+          dbtConfigurationOptions={dbtConfigurationOptions}
           defaultValue={block.content}
           deleteBlock={deleteBlockCallbackMemo}
           disableShortcuts={disableShortcuts}

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -456,15 +456,16 @@ function PipelineDetail({
     ]);
 
   const { data: dataDbtConfigurationOptions } = api.configuration_options.pipelines.list(
-    (hasDbtBlock && selectedBlock) ? pipeline?.uuid : null,
+    hasDbtBlock ? pipeline?.uuid : null,
     {
       configuration_type: ConfigurationTypeEnum.DBT,
       option_type: OptionTypeEnum.PROJECTS,
       resource_type: ResourceTypeEnum.Block,
-      resource_uuid: (BlockLanguageEnum.SQL === selectedBlock?.language
-        && BlockTypeEnum.DBT === selectedBlock?.type)
-          ? selectedBlock?.uuid
-          : null,
+      // Leaving out the resource_uuid query param in order to minimize # of requests made
+      // resource_uuid: (BlockLanguageEnum.SQL === selectedBlock?.language
+      //   && BlockTypeEnum.DBT === selectedBlock?.type)
+      //     ? selectedBlock?.uuid
+      //     : null,
     }, {
       revalidateOnFocus: false,
     },


### PR DESCRIPTION
# Description
- The Pipeline Editor page was making a `configuration_options` request for each dbt block in the pipeline upon initial load (e.g. 50 dbt blocks would make 50 requests). This PR mitigates the number of requests made by making a single `configuration_options` request upon initial load.

# How Has This Been Tested?
Load pipeline with dbt blocks (2 sql and 1 yaml):
![load dbt pipeline](https://github.com/mage-ai/mage-ai/assets/78053898/0bdce3c3-213d-43da-8961-00cbaabc0edf)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
@wangxiaoyou1993 
