### PR TITLE
[xy] Raise ImportError when spark is not supported.

### DIFF
--- a/mage_ai/services/spark/spark.py
+++ b/mage_ai/services/spark/spark.py
@@ -119,7 +119,7 @@ def get_spark_session(spark_config: SparkConfig):
         SparkSession: The Spark session.
     """
     if not SPARK_ENABLED:
-        raise Exception('Spark is not supported in current environment.')
+        raise ImportError('Spark is not supported in current environment.')
 
     if spark_config:
         active_session = SparkSession.getActiveSession()


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Raise ImportError when spark is not supported since Spark API is only catching ImportError: https://github.com/mage-ai/mage-ai/blob/master/mage_ai/services/spark/api/base.py#L51

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested enable compute management and run a block. It succeeds running


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
