### PR TITLE
[dy] Fix slack notifications with stacktrace

### DIFF
--- a/docs/integrations/observability/alerting-discord.mdx
+++ b/docs/integrations/observability/alerting-discord.mdx
@@ -101,16 +101,16 @@ You can customize the message template for `success`, `failure`, `passed_sla` sc
 you can specify the sentence on `summary` and the `title`.
 
 To interpolate variables in the message template, you can use `{variable_name}` syntax.
-Hare are the supported variables:
+Here are the supported variables:
 1. `execution_time`
 1. `pipeline_run_url`
 1. `pipeline_schedule_id`
 1. `pipeline_schedule_name`
 1. `pipeline_uuid`
 1. `error`
-  * available only for the `failure` message template
+    * available only for the `failure` message template
 1. `stacktrace`
-  * available only for the `failure` message template
+    * available only for the `failure` message template
 
 For `pipeline_run_url`, the default host is `http://localhost:6789`. You can specify `MAGE_PUBLIC_HOST` to be
 the host url you want to use in the notification messages.

--- a/docs/integrations/observability/alerting-discord.mdx
+++ b/docs/integrations/observability/alerting-discord.mdx
@@ -100,9 +100,17 @@ notification_config:
 You can customize the message template for `success`, `failure`, `passed_sla` scenarios. For each message template,
 you can specify the sentence on `summary` and the `title`.
 
-To interpolate variables in the messaget template, you can use `{variable_name}` syntax.
-Hare are the supported variables: `error`, `execution_time`, `pipeline_run_url`, `pipeline_schedule_id`,
-`pipeline_schedule_name`, `pipeline_uuid`.
+To interpolate variables in the message template, you can use `{variable_name}` syntax.
+Hare are the supported variables:
+1. `execution_time`
+1. `pipeline_run_url`
+1. `pipeline_schedule_id`
+1. `pipeline_schedule_name`
+1. `pipeline_uuid`
+1. `error`
+  * available only for the `failure` message template
+1. `stacktrace`
+  * available only for the `failure` message template
 
 For `pipeline_run_url`, the default host is `http://localhost:6789`. You can specify `MAGE_PUBLIC_HOST` to be
 the host url you want to use in the notification messages.

--- a/docs/integrations/observability/alerting-email.mdx
+++ b/docs/integrations/observability/alerting-email.mdx
@@ -89,16 +89,16 @@ you can specify `title` and either `summary` or `details`.
 * If you specify the `details`, the `details` will be used as your email body
 
 To interpolate variables in the message template, you can use `{variable_name}` syntax.
-Hare are the supported variables:
+Here are the supported variables:
 1. `execution_time`
 1. `pipeline_run_url`
 1. `pipeline_schedule_id`
 1. `pipeline_schedule_name`
 1. `pipeline_uuid`
 1. `error`
-  * available only for the `failure` message template
+    * available only for the `failure` message template
 1. `stacktrace`
-  * available only for the `failure` message template
+    * available only for the `failure` message template
 
 For `pipeline_run_url`, the default host is `http://localhost:6789`. You can specify `MAGE_PUBLIC_HOST` to be
 the host url you want to use in the notification messages.

--- a/docs/integrations/observability/alerting-email.mdx
+++ b/docs/integrations/observability/alerting-email.mdx
@@ -88,9 +88,17 @@ you can specify `title` and either `summary` or `details`.
 * If you specify the `summary`, the email body will be your `summary` + the url of the pipeline run page
 * If you specify the `details`, the `details` will be used as your email body
 
-To interpolate variables in the messaget template, you can use `{variable_name}` syntax.
-Hare are the supported variables: `error`, `execution_time`, `pipeline_run_url`, `pipeline_schedule_id`,
-`pipeline_schedule_name`, `pipeline_uuid`.
+To interpolate variables in the message template, you can use `{variable_name}` syntax.
+Hare are the supported variables:
+1. `execution_time`
+1. `pipeline_run_url`
+1. `pipeline_schedule_id`
+1. `pipeline_schedule_name`
+1. `pipeline_uuid`
+1. `error`
+  * available only for the `failure` message template
+1. `stacktrace`
+  * available only for the `failure` message template
 
 For `pipeline_run_url`, the default host is `http://localhost:6789`. You can specify `MAGE_PUBLIC_HOST` to be
 the host url you want to use in the notification messages.

--- a/docs/integrations/observability/alerting-slack.mdx
+++ b/docs/integrations/observability/alerting-slack.mdx
@@ -99,9 +99,17 @@ you can specify either `summary` or `details`.
 * If you specify the `summary`, the slack message will be your `summary` + the url of the pipeline run page
 * If you specify the `details`, the `details` will be used as your slack message directly
 
-To interpolate variables in the messaget template, you can use `{variable_name}` syntax.
-Hare are the supported variables: `error`, `execution_time`, `pipeline_run_url`, `pipeline_schedule_id`,
-`pipeline_schedule_name`, `pipeline_uuid`.
+To interpolate variables in the message template, you can use `{variable_name}` syntax.
+Hare are the supported variables:
+1. `execution_time`
+1. `pipeline_run_url`
+1. `pipeline_schedule_id`
+1. `pipeline_schedule_name`
+1. `pipeline_uuid`
+1. `error`
+  * available only for the `failure` message template
+1. `stacktrace`
+  * available only for the `failure` message template
 
 For `pipeline_run_url`, the default host is `http://localhost:6789`. You can specify `MAGE_PUBLIC_HOST` to be
 the host url you want to use in the notification messages.

--- a/docs/integrations/observability/alerting-slack.mdx
+++ b/docs/integrations/observability/alerting-slack.mdx
@@ -100,16 +100,16 @@ you can specify either `summary` or `details`.
 * If you specify the `details`, the `details` will be used as your slack message directly
 
 To interpolate variables in the message template, you can use `{variable_name}` syntax.
-Hare are the supported variables:
+Here are the supported variables:
 1. `execution_time`
 1. `pipeline_run_url`
 1. `pipeline_schedule_id`
 1. `pipeline_schedule_name`
 1. `pipeline_uuid`
 1. `error`
-  * available only for the `failure` message template
+    * available only for the `failure` message template
 1. `stacktrace`
-  * available only for the `failure` message template
+    * available only for the `failure` message template
 
 For `pipeline_run_url`, the default host is `http://localhost:6789`. You can specify `MAGE_PUBLIC_HOST` to be
 the host url you want to use in the notification messages.

--- a/docs/integrations/observability/alerting-telegram.mdx
+++ b/docs/integrations/observability/alerting-telegram.mdx
@@ -105,9 +105,17 @@ notification_config:
 You can customize the message template for `success`, `failure`, `passed_sla` scenarios. For each message template,
 you can specify the sentence on `summary` and the `title`.
 
-To interpolate variables in the messaget template, you can use `{variable_name}` syntax.
-Hare are the supported variables: `error`, `execution_time`, `pipeline_run_url`, `pipeline_schedule_id`,
-`pipeline_schedule_name`, `pipeline_uuid`.
+To interpolate variables in the message template, you can use `{variable_name}` syntax.
+Hare are the supported variables:
+1. `execution_time`
+1. `pipeline_run_url`
+1. `pipeline_schedule_id`
+1. `pipeline_schedule_name`
+1. `pipeline_uuid`
+1. `error`
+  * available only for the `failure` message template
+1. `stacktrace`
+  * available only for the `failure` message template
 
 For `pipeline_run_url`, the default host is `http://localhost:6789`. You can specify `MAGE_PUBLIC_HOST` to be
 the host url you want to use in the notification messages.

--- a/docs/integrations/observability/alerting-telegram.mdx
+++ b/docs/integrations/observability/alerting-telegram.mdx
@@ -106,16 +106,16 @@ You can customize the message template for `success`, `failure`, `passed_sla` sc
 you can specify the sentence on `summary` and the `title`.
 
 To interpolate variables in the message template, you can use `{variable_name}` syntax.
-Hare are the supported variables:
+Here are the supported variables:
 1. `execution_time`
 1. `pipeline_run_url`
 1. `pipeline_schedule_id`
 1. `pipeline_schedule_name`
 1. `pipeline_uuid`
 1. `error`
-  * available only for the `failure` message template
+    * available only for the `failure` message template
 1. `stacktrace`
-  * available only for the `failure` message template
+    * available only for the `failure` message template
 
 For `pipeline_run_url`, the default host is `http://localhost:6789`. You can specify `MAGE_PUBLIC_HOST` to be
 the host url you want to use in the notification messages.

--- a/mage_ai/api/monitors/BaseMonitor.py
+++ b/mage_ai/api/monitors/BaseMonitor.py
@@ -24,8 +24,6 @@ class BaseMonitor:
         if self.error.type:
             data['type'] = self.error.type
 
-        loop = asyncio.get_event_loop()
-
         kwargs = dict(
             resource=self.resource,
             **extract(
@@ -48,6 +46,7 @@ class BaseMonitor:
             ),
         )
 
+        loop = asyncio.get_event_loop()
         if loop is not None:
             loop.create_task(
                 UsageStatisticLogger().error(

--- a/mage_ai/orchestration/notification/sender.py
+++ b/mage_ai/orchestration/notification/sender.py
@@ -108,6 +108,7 @@ class NotificationSender:
         pipeline,
         pipeline_run,
         error: str = None,
+        stacktrace: str = None,
         summary: str = None,
     ) -> None:
         if AlertOn.PIPELINE_RUN_FAILURE in self.config.alert_on:
@@ -122,6 +123,7 @@ class NotificationSender:
                 pipeline_run,
                 error=error,
                 message_template=message_template,
+                stacktrace=stacktrace,
                 summary=summary,
             )
 
@@ -145,6 +147,7 @@ class NotificationSender:
         pipeline,
         pipeline_run,
         error: str = None,
+        stacktrace: str = None,
     ):
         if text is None or pipeline is None or pipeline_run is None:
             return text
@@ -155,6 +158,7 @@ class NotificationSender:
             pipeline_schedule_id=pipeline_run.pipeline_schedule.id,
             pipeline_schedule_name=pipeline_run.pipeline_schedule.name,
             pipeline_uuid=pipeline.uuid,
+            stacktrace=stacktrace,
         )
 
     def __send_pipeline_run_message(
@@ -164,6 +168,7 @@ class NotificationSender:
         pipeline_run,
         error: str = None,
         message_template: MessageTemplate = None,
+        stacktrace: str = None,
         summary: str = None,
     ):
         """Shared method to send pipeline run message of multiple types (success, failure, etc.).
@@ -207,18 +212,21 @@ class NotificationSender:
                 pipeline,
                 pipeline_run,
                 error=error,
+                stacktrace=stacktrace,
             ),
             summary=self.__interpolate_vars(
                 summary or default_summary,
                 pipeline,
                 pipeline_run,
                 error=error,
+                stacktrace=stacktrace,
             ),
             details=self.__interpolate_vars(
                 details or default_details,
                 pipeline,
                 pipeline_run,
                 error=error,
+                stacktrace=stacktrace,
             ),
         )
 

--- a/mage_ai/orchestration/pipeline_scheduler_original.py
+++ b/mage_ai/orchestration/pipeline_scheduler_original.py
@@ -320,18 +320,20 @@ class PipelineScheduler:
     @safe_db_query
     def on_pipeline_run_failure(self, error_msg: str) -> None:
         failed_block_runs = self.pipeline_run.failed_block_runs
+        error = None
         for br in failed_block_runs:
             if br.metrics:
                 message = br.metrics.get('error', {}).get('message')
                 if message:
-                    error_msg += f'\nError for block {br.block_uuid}:\n{message}'
+                    error = f'\nError for block {br.block_uuid}:\n{message}'
                     break
 
         asyncio.run(UsageStatisticLogger().pipeline_run_ended(self.pipeline_run))
         self.notification_sender.send_pipeline_run_failure_message(
             pipeline=self.pipeline,
             pipeline_run=self.pipeline_run,
-            error=error_msg,
+            message=error_msg,
+            error=error,
         )
         # Cancel block runs that are still in progress for the pipeline run.
         cancel_block_runs_and_jobs(self.pipeline_run, self.pipeline)

--- a/mage_ai/orchestration/pipeline_scheduler_original.py
+++ b/mage_ai/orchestration/pipeline_scheduler_original.py
@@ -327,7 +327,7 @@ class PipelineScheduler:
                 if message:
                     message_split = message.split('\n')
                     # Truncate the error message if it has too many lines, set max
-                    # liens at 50
+                    # lines at 50
                     if len(message_split) > 50:
                         message_split = message_split[-50:]
                         message_split.insert(0, '... (error truncated)')

--- a/mage_ai/services/slack/slack.py
+++ b/mage_ai/services/slack/slack.py
@@ -2,7 +2,10 @@ import json
 
 import requests
 
+from mage_ai.server.logger import Logger
 from mage_ai.services.slack.config import SlackConfig
+
+logger = Logger().new_server_logger(__name__)
 
 
 def send_slack_message(config: SlackConfig, message: str, title: str = None) -> None:
@@ -21,7 +24,13 @@ def send_slack_message(config: SlackConfig, message: str, title: str = None) -> 
         ]
     }
 
-    requests.post(
+    response = requests.post(
         config.webhook_url,
         json.dumps(payload),
     )
+
+    try:
+        if response is not None:
+            response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        logger.exception('Failed to send slack message')

--- a/mage_ai/tests/orchestration/test_pipeline_scheduler.py
+++ b/mage_ai/tests/orchestration/test_pipeline_scheduler.py
@@ -396,6 +396,7 @@ class PipelineSchedulerTests(DBTestCase):
                 error=f'Failed blocks: {block_runs[0].block_uuid}.',
                 pipeline=scheduler.pipeline,
                 pipeline_run=pipeline_run,
+                stacktrace=None,
             )
 
     def test_schedule_with_block_failures(self):
@@ -419,6 +420,7 @@ class PipelineSchedulerTests(DBTestCase):
                 error=f'Failed blocks: {block_runs[0].block_uuid}.',
                 pipeline=scheduler.pipeline,
                 pipeline_run=pipeline_run,
+                stacktrace=None,
             )
 
     @patch('mage_ai.orchestration.pipeline_scheduler_original.run_pipeline')


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

The slack notifications were not being sent out properly when the stack trace was included in the error message. I also think it's a good idea to include the stack trace as an additional parameter `stacktrace` instead of including it with the existing `error` parameter. I also truncate the error message if it has too many lines in case the clients can't handle it.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with slack webhooks


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
