### PR TITLE
[xy] Test kafka connection when initializing the consumer.

### DIFF
--- a/mage_ai/streaming/sources/base.py
+++ b/mage_ai/streaming/sources/base.py
@@ -22,6 +22,7 @@ class BaseSource(ABC):
         self.checkpoint_path = kwargs.get('checkpoint_path')
         self.checkpoint = self.read_checkpoint()
         self.init_client()
+        self.test_connection()
 
     @abstractmethod
     def init_client(self):

--- a/mage_ai/streaming/sources/base.py
+++ b/mage_ai/streaming/sources/base.py
@@ -3,6 +3,8 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Callable, Dict
 
+from mage_ai.shared.environments import is_test
+
 
 class SourceConsumeMethod(str, Enum):
     BATCH_READ = 'BATCH_READ'
@@ -22,7 +24,9 @@ class BaseSource(ABC):
         self.checkpoint_path = kwargs.get('checkpoint_path')
         self.checkpoint = self.read_checkpoint()
         self.init_client()
-        self.test_connection()
+        if not is_test():
+            # Not test the connection in unit tests
+            self.test_connection()
 
     @abstractmethod
     def init_client(self):

--- a/mage_ai/streaming/sources/kafka.py
+++ b/mage_ai/streaming/sources/kafka.py
@@ -256,7 +256,8 @@ class KafkaSource(BaseSource):
                 handler(message_values)
 
     def test_connection(self):
-        return True
+        self.consumer._client.check_version(timeout=5)
+        self._print('Test connectino successfully.')
 
     def __deserialize_message(self, message):
         if self.config.serde_config is None:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Test kafka connection when intiializing the consumer.
Close: https://github.com/mage-ai/mage-ai/issues/4803

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with wrong kafak broker and the exception is thrown
<img width="745" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/112efadf-f92b-471c-96cb-c4f4ae305279">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
