### PR TITLE
[jk] Configure dbt v2 yaml block and other dbt code block improvements

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -37,11 +37,7 @@ import CodeEditor, {
 } from '@components/CodeEditor';
 import CodeOutput from './CodeOutput';
 import CommandButtons, { CommandButtonsSharedProps } from './CommandButtons';
-import ConfigurationOptionType, {
-  ConfigurationTypeEnum,
-  OptionTypeEnum,
-  ResourceTypeEnum,
-} from '@interfaces/ConfigurationOptionType';
+import ConfigurationOptionType from '@interfaces/ConfigurationOptionType';
 import DataIntegrationBlock from './DataIntegrationBlock';
 import DataProviderType, {
   DataProviderEnum,

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -420,7 +420,12 @@ function CodeBlock({
   } = useProject();
   const { status } = useStatus();
 
-  const codeBlockV2 = useMemo(() => featureEnabled?.(featureUUIDs.CODE_BLOCK_V2), [
+  /*
+   * Currently, only the dbt blocks are using V2 of the code block.
+   * Change "featureUUIDs.DBT_V2" for the featureEnabled property below
+   * to "featureUUIDs.CODE_BLOCK_V2" when all block types are using V2.
+   */
+  const codeBlockV2 = useMemo(() => featureEnabled?.(featureUUIDs.DBT_V2), [
     featureEnabled,
     featureUUIDs,
   ]);

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -173,7 +173,7 @@ import {
 import { capitalize, pluralize } from '@utils/string';
 import { convertValueToVariableDataType } from '@utils/models/interaction';
 import { executeCode } from '@components/CodeEditor/keyboard_shortcuts/shortcuts';
-import { find, indexBy, sum } from '@utils/array';
+import { find, indexBy, sum, uniqueArray } from '@utils/array';
 import { get, set } from '@storage/localStorage';
 import { getModelName } from '@utils/models/dbt';
 import { initializeContentAndMessages } from '@components/PipelineDetail/utils';
@@ -788,9 +788,15 @@ function CodeBlock({
     dbtProjects,
   ]);
 
-  const dbtProfileTargets = useMemo(() => {
-    return (dbtProfileData || [])?.reduce((acc, { targets }) => acc.concat(targets || []), []);
-  }, [dbtProfileData]);
+  const dbtProfileTargets = useMemo(() =>
+    uniqueArray(
+      (dbtProfileData || [])?.reduce(
+        (acc, { targets }) => acc.concat(targets || []),
+        [],
+      ),
+    ),
+    [dbtProfileData],
+  );
 
   const dbtProfileTarget = useMemo(() => dataProviderConfig[CONFIG_KEY_DBT_PROFILE_TARGET], [
     dataProviderConfig,

--- a/mage_ai/frontend/components/CodeBlockV2/dbt/Configuration/index.tsx
+++ b/mage_ai/frontend/components/CodeBlockV2/dbt/Configuration/index.tsx
@@ -16,6 +16,7 @@ import {
   CONFIG_KEY_LIMIT,
 } from '@interfaces/ChartBlockType';
 import { PADDING_UNITS } from '@oracle/styles/units/spacing';
+import { SHARED_SETUP_ROW_PROPS } from '../constants';
 import { pluralize } from '@utils/string';
 import { sortByKey } from '@utils/array';
 
@@ -109,6 +110,7 @@ function Configuration({
   const inputProject = useMemo(() => {
     let key = 'selectInput';
     let opts = {
+      compact: true,
       monospace: true,
       onChange: e => setAttributes(prev => ({
         ...prev,
@@ -152,6 +154,7 @@ function Configuration({
   const inputProfile = useMemo(() => {
     let key = 'selectInput';
     let opts = {
+      compact: true,
       monospace: true,
       onChange: e => setAttributes(prev => ({
         ...prev,
@@ -198,6 +201,7 @@ function Configuration({
   const inputTarget = useMemo(() => {
     let key = 'selectInput';
     let opts = {
+      compact: true,
       monospace: true,
       onChange: e => setAttributes(prev => ({
         ...prev,
@@ -244,8 +248,7 @@ function Configuration({
         title="Configuration"
       >
         <SetupSectionRow
-          title="Project"
-          invalid={!attributes?.configuration?.[CONFIG_KEY_DBT_PROJECT_NAME]}
+          {...SHARED_SETUP_ROW_PROPS}
           description={(
             <Spacing mt={1}>
               <FlexContainer alignItems="center">
@@ -261,28 +264,29 @@ function Configuration({
 
                 <Spacing mr={1} />
 
-                <Text muted inline small>
+                <Text inline muted small>
                   Manually enter the full path from the root directory of the current project,
-                  to the dbt project directory that contains the <Text muted inline monospace small>
+                  to the dbt project directory that contains the <Text inline monospace muted small>
                     dbt_project.yml
                   </Text> file.
                   Interpolate environment variables, runtime variables, etc.
                   using the following syntax:
-                  <Text muted inline monospace small>
+                  <Text inline monospace muted small>
                     {'{{ env_var(\'NAME\') }}'}
-                  </Text> or <Text muted inline monospace small>
+                  </Text> or <Text inline monospace muted small>
                     {'{{ variables(\'NAME\') }}'}
                   </Text>
                 </Text>
               </FlexContainer>
             </Spacing>
           )}
+          invalid={!attributes?.configuration?.[CONFIG_KEY_DBT_PROJECT_NAME]}
+          title="Project"
           {...inputProject}
         />
 
         <SetupSectionRow
-          title="Profile"
-          invalid={!attributes?.configuration?.[CONFIG_KEY_DBT_PROFILES_FILE_PATH]}
+          {...SHARED_SETUP_ROW_PROPS}
           description={(
             <Spacing mt={1}>
               <FlexContainer alignItems="center">
@@ -298,31 +302,32 @@ function Configuration({
 
                 <Spacing mr={1} />
 
-                <Text muted inline small>
-                  Manually enter the full path with the filename <Text muted inline monospace small>
+                <Text inline muted small>
+                  Manually enter the full path with the filename <Text inline monospace muted small>
                     profiles.yml
                   </Text>
                   from the root directory of the current project,
-                  to the dbt project directory that contains the <Text muted inline monospace small>
+                  to the dbt project directory that contains the <Text inline monospace muted small>
                     profiles.yml
                   </Text> file.
                   Interpolate environment variables, runtime variables, etc.
                   using the following syntax:
-                  <Text muted inline monospace small>
+                  <Text inline monospace muted small>
                     {'{{ env_var(\'NAME\') }}'}
-                  </Text> or <Text muted inline monospace small>
+                  </Text> or <Text inline monospace muted small>
                     {'{{ variables(\'NAME\') }}'}
                   </Text>
                 </Text>
               </FlexContainer>
             </Spacing>
           )}
+          invalid={!attributes?.configuration?.[CONFIG_KEY_DBT_PROFILES_FILE_PATH]}
+          title="Profile"
           {...inputProfile}
         />
 
         <SetupSectionRow
-          title="Target"
-          invalid={!attributes?.configuration?.[CONFIG_KEY_DBT_PROFILE_TARGET]}
+          {...SHARED_SETUP_ROW_PROPS}
           description={(
             <Spacing mt={1}>
               <FlexContainer alignItems="center">
@@ -338,28 +343,31 @@ function Configuration({
 
                 <Spacing mr={1} />
 
-                <Text muted inline small>
-                  Manually enter the target name from the <Text muted inline monospace small>
+                <Text inline muted small>
+                  Manually enter the target name from the <Text inline monospace muted small>
                     dbt_project.yml
                   </Text> file.
                   Interpolate environment variables, runtime variables, etc.
                   using the following syntax:
-                  <Text muted inline monospace small>
+                  <Text inline monospace muted small>
                     {'{{ env_var(\'NAME\') }}'}
-                  </Text> or <Text muted inline monospace small>
+                  </Text> or <Text inline monospace muted small>
                     {'{{ variables(\'NAME\') }}'}
                   </Text>
                 </Text>
               </FlexContainer>
             </Spacing>
           )}
+          invalid={!attributes?.configuration?.[CONFIG_KEY_DBT_PROFILE_TARGET]}
+          title="Target"
           {...inputTarget}
         />
 
         <SetupSectionRow
-          title="Preview query result limit"
+          {...SHARED_SETUP_ROW_PROPS}
           description="Limit the number of rows that are fetched when compiling and previewing."
           textInput={{
+            compact: true,
             fullWidth: true,
             monospace: true,
             onChange: e => setAttributes(prev => ({
@@ -369,10 +377,11 @@ function Configuration({
                 [CONFIG_KEY_LIMIT]: e.target.value,
               },
             })),
-            type: 'number',
             placeholder: 'e.g. 1000',
+            type: 'number',
             value: attributes?.configuration?.[CONFIG_KEY_LIMIT],
           }}
+          title="Preview query result limit"
         />
       </SetupSection>
 

--- a/mage_ai/frontend/components/CodeBlockV2/dbt/Configuration/index.tsx
+++ b/mage_ai/frontend/components/CodeBlockV2/dbt/Configuration/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import BlockType from '@interfaces/BlockType';
+import BlockType, { BlockLanguageEnum } from '@interfaces/BlockType';
 import Button from '@oracle/elements/Button';
 import Checkbox from '@oracle/elements/Checkbox';
 import ConfigurationOptionType from '@interfaces/ConfigurationOptionType';
@@ -10,13 +10,15 @@ import SetupSection, { SetupSectionRow } from '@components/shared/SetupSection';
 import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
 import {
+  CONFIG_KEY_DBT,
+  CONFIG_KEY_DBT_COMMAND,
   CONFIG_KEY_DBT_PROFILES_FILE_PATH,
   CONFIG_KEY_DBT_PROFILE_TARGET,
   CONFIG_KEY_DBT_PROJECT_NAME,
   CONFIG_KEY_LIMIT,
 } from '@interfaces/ChartBlockType';
 import { PADDING_UNITS } from '@oracle/styles/units/spacing';
-import { SHARED_SETUP_ROW_PROPS } from '../constants';
+import { SHARED_INPUT_PROPS, SHARED_SETUP_ROW_PROPS } from '../constants';
 import { pluralize } from '@utils/string';
 import { sortByKey } from '@utils/array';
 
@@ -110,8 +112,7 @@ function Configuration({
   const inputProject = useMemo(() => {
     let key = 'selectInput';
     let opts = {
-      compact: true,
-      monospace: true,
+      ...SHARED_INPUT_PROPS,
       onChange: e => setAttributes(prev => ({
         ...prev,
         configuration: {
@@ -154,8 +155,7 @@ function Configuration({
   const inputProfile = useMemo(() => {
     let key = 'selectInput';
     let opts = {
-      compact: true,
-      monospace: true,
+      ...SHARED_INPUT_PROPS,
       onChange: e => setAttributes(prev => ({
         ...prev,
         configuration: {
@@ -201,8 +201,7 @@ function Configuration({
   const inputTarget = useMemo(() => {
     let key = 'selectInput';
     let opts = {
-      compact: true,
-      monospace: true,
+      ...SHARED_INPUT_PROPS,
       onChange: e => setAttributes(prev => ({
         ...prev,
         configuration: {
@@ -367,9 +366,8 @@ function Configuration({
           {...SHARED_SETUP_ROW_PROPS}
           description="Limit the number of rows that are fetched when compiling and previewing."
           textInput={{
-            compact: true,
+            ...SHARED_INPUT_PROPS,
             fullWidth: true,
-            monospace: true,
             onChange: e => setAttributes(prev => ({
               ...prev,
               configuration: {
@@ -383,6 +381,30 @@ function Configuration({
           }}
           title="Preview query result limit"
         />
+
+        {BlockLanguageEnum.YAML === block?.language && (
+          <SetupSectionRow
+            {...SHARED_SETUP_ROW_PROPS}
+            description="Enter which dbt command to run."
+            textInput={{
+              ...SHARED_INPUT_PROPS,
+              fullWidth: true,
+              onChange: e => setAttributes(prev => ({
+                ...prev,
+                configuration: {
+                  ...(prev?.configuration || {}),
+                  [CONFIG_KEY_DBT]: {
+                    ...(prev?.configuration || {})?.[CONFIG_KEY_DBT],
+                    [CONFIG_KEY_DBT_COMMAND]: e.target.value,
+                  },
+                },
+              })),
+              placeholder: 'e.g. run, seed',
+              value: attributes?.configuration?.[CONFIG_KEY_DBT]?.[CONFIG_KEY_DBT_COMMAND],
+            }}
+            title="dbt command"
+          />
+        )}
       </SetupSection>
 
       <Spacing mt={PADDING_UNITS}>

--- a/mage_ai/frontend/components/CodeBlockV2/dbt/constants.tsx
+++ b/mage_ai/frontend/components/CodeBlockV2/dbt/constants.tsx
@@ -6,6 +6,10 @@ export const SHARED_SETUP_ROW_PROPS = {
   inputFlex: 1,
   large: false,
 };
+export const SHARED_INPUT_PROPS = {
+  compact: true,
+  monospace: true,
+};
 
 export enum HeaderTabEnum {
   CODE = 'code',

--- a/mage_ai/frontend/components/CodeBlockV2/dbt/constants.tsx
+++ b/mage_ai/frontend/components/CodeBlockV2/dbt/constants.tsx
@@ -1,6 +1,11 @@
 import BlockType from '@interfaces/BlockType';
-import { AlertTriangle, Code, NavDashboard, SettingsWithKnobs, TreeWithArrowsUp } from '@oracle/icons';
+import { AlertTriangle } from '@oracle/icons';
 import { validate } from './utils';
+
+export const SHARED_SETUP_ROW_PROPS = {
+  inputFlex: 1,
+  large: false,
+};
 
 export enum HeaderTabEnum {
   CODE = 'code',

--- a/mage_ai/frontend/components/CodeBlockV2/useCodeBlockComponents.tsx
+++ b/mage_ai/frontend/components/CodeBlockV2/useCodeBlockComponents.tsx
@@ -73,14 +73,23 @@ export default function useCodeBlockComponents({
     project,
   } = useProject();
 
-  const enabled = useMemo(() => [
-    PipelineTypeEnum.PYTHON,
-    PipelineTypeEnum.PYSPARK,
-  ].includes(pipeline?.type) && featureEnabled?.(featureUUIDs?.CODE_BLOCK_V2), [
-    featureEnabled,
-    featureUUIDs,
-    pipeline,
-  ]);
+  const enabled = useMemo(() =>
+    [
+      PipelineTypeEnum.PYTHON,
+      PipelineTypeEnum.PYSPARK,
+    ].includes(pipeline?.type)
+      /*
+       * Replace "featureUUIDs?.DBT_V2" with "featureUUIDs?.CODE_BLOCK_V2" when all
+       * block types (not just dbt blocks) are supported by V2 of the code block.
+       * Also update the codeBlockV2 variable in the CodeBlock component file.
+       */
+      && featureEnabled?.(featureUUIDs?.DBT_V2),
+    [
+      featureEnabled,
+      featureUUIDs,
+      pipeline,
+    ],
+  );
 
   const {
     type,

--- a/mage_ai/frontend/components/settings/workspace/Preferences.tsx
+++ b/mage_ai/frontend/components/settings/workspace/Preferences.tsx
@@ -255,7 +255,7 @@ function Preferences({
           </Spacing>
 
           {Object.entries(ignoreKeys(projectAttributes?.features, [
-            {/*FeatureUUIDEnum.GLOBAL_HOOKS,*/}
+            FeatureUUIDEnum.CODE_BLOCK_V2,
           ]) || {}).map(([k, v], idx) => {
             const overrideFromRootProject = projectPlatformActivated
               && !rootProjectUse

--- a/mage_ai/frontend/components/shared/SetupSection/SetupSectionRow.tsx
+++ b/mage_ai/frontend/components/shared/SetupSection/SetupSectionRow.tsx
@@ -12,6 +12,7 @@ import { ICON_SIZE } from '@components/shared/index.style';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 
 interface InputType {
+  compact?: boolean;
   fullWidth?: boolean;
   monospace?: boolean;
   multiline?: boolean;
@@ -24,6 +25,7 @@ interface InputType {
 type SetupSectionRowProps = {
   children?: any;
   description?: any | string;
+  inputFlex?: number;
   invalid?: boolean;
   large?: boolean;
   selectInput?: InputType & {
@@ -44,6 +46,7 @@ type SetupSectionRowProps = {
 function SetupSectionRow({
   children,
   description,
+  inputFlex = 3,
   invalid,
   large = true,
   selectInput,
@@ -109,7 +112,7 @@ function SetupSectionRow({
           {description && typeof description !== 'string' && description}
         </FlexContainer>
 
-        <Flex flex={3} justifyContent="flex-end">
+        <Flex flex={inputFlex} justifyContent="flex-end">
           {children}
 
           {textInputMemo}

--- a/mage_ai/frontend/tests/base.ts
+++ b/mage_ai/frontend/tests/base.ts
@@ -7,7 +7,10 @@ export const test = base.extend<{
   settingFeaturesToDisable: TSettingFeaturesToDisable,
 }>({
   failOnClientError: true,
-  settingFeaturesToDisable: { [FeatureUUIDEnum.LOCAL_TIMEZONE]: true },
+  settingFeaturesToDisable: {
+    [FeatureUUIDEnum.CODE_BLOCK_V2]: true,
+    [FeatureUUIDEnum.LOCAL_TIMEZONE]: true,
+  },
   // eslint-disable-next-line sort-keys
   page: async ({ page, failOnClientError, settingFeaturesToDisable }, use) => {
     const pageErrors: Error[] = [];

--- a/mage_ai/frontend/tsconfig.json
+++ b/mage_ai/frontend/tsconfig.json
@@ -33,7 +33,7 @@
         "utils/*"
       ]
     },
-    "target": "es5",
+    "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/mage_ai/frontend/utils/array.ts
+++ b/mage_ai/frontend/utils/array.ts
@@ -144,7 +144,7 @@ export function splitIntoChunks(arr, numChunks) {
 }
 
 export function uniqueArray(arrArg) {
-  return arrArg.filter((elem, pos, arr) => arr.c(elem) === pos);
+  return [...new Set(arrArg)];
 }
 
 export function unique(arrArg, compare) {


### PR DESCRIPTION
# Description
- Allow dbt command in dbt v2 code block to be configurable.
- Remove duplicate "targets" appearing in select dropdown in dbt v1 code block header
- Since dbt blocks are the only block type using the v2 code block, remove the `Code block v2` project setting and only use `Dbt v2` project setting to avoid confusion. Otherwise, users may not know how to switch between dbt code block v1 and v2.
- Update typescript configuration (tsconfig.json) from es5 to es6 (typescript errors were appearing for correct es6 syntax).

# How Has This Been Tested?
- Tested locally
- Rebuilt frontend production build without issues

- dbt command input added to dbt yaml block config:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/286aa80b-96ea-4b21-a002-27f9e9e987e6)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
