### PR TITLE
[jk] Bugfix pipeline tag cache

### DIFF
--- a/mage_ai/cache/tag.py
+++ b/mage_ai/cache/tag.py
@@ -144,6 +144,9 @@ class TagCache(BaseCache):
 
         mapping[key][KEY_FOR_PIPELINES] = pipelines_dict
 
+        if not pipelines_dict and mapping[key].keys() == set([KEY_FOR_PIPELINES]):
+            mapping.pop(key, None)
+
         self.set(self.cache_key, mapping)
 
     async def initialize_cache_for_all_objects(self) -> None:

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -1051,6 +1051,7 @@ class Pipeline:
         old_uuid = None
         blocks_to_remove_from_cache = []
         block_uuids_to_add_to_cache = []
+        tags_to_remove_from_cache = []
         should_update_block_cache = False
         should_update_tag_cache = False
 
@@ -1103,6 +1104,10 @@ class Pipeline:
             old_tags = self.tags or []
 
             if sorted(new_tags) != sorted(old_tags):
+                tags_diff = set(old_tags).symmetric_difference(set(new_tags))
+                for tag in tags_diff:
+                    if tag in old_tags:
+                        tags_to_remove_from_cache.append(tag)
                 self.tags = new_tags
                 should_save = True
                 should_update_tag_cache = True
@@ -1356,6 +1361,8 @@ class Pipeline:
 
             cache = await TagCache.initialize_cache()
 
+            for tag_uuid in tags_to_remove_from_cache:
+                cache.remove_pipeline(tag_uuid, self.uuid, self.repo_path)
             for tag_uuid in self.tags:
                 if old_uuid:
                     cache.remove_pipeline(tag_uuid, old_uuid, self.repo_path)

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -904,11 +904,13 @@ function PipelineListPage() {
       onClickFilterDefaults={() => {
         setFilters({});
         setSearchTextState('');
-        goToWithQuery({
-          [MetaQueryEnum.LIMIT]: query?.[MetaQueryEnum.LIMIT] || ROW_LIMIT,
-          [PipelineQueryEnum.SEARCH]: '',
-        }, {
-          replaceParams: true,
+        fetchPipelines?.().then(() => {
+          goToWithQuery({
+            [MetaQueryEnum.LIMIT]: query?.[MetaQueryEnum.LIMIT] || ROW_LIMIT,
+            [PipelineQueryEnum.SEARCH]: '',
+          }, {
+            replaceParams: true,
+          });
         });
       }}
       onFilterApply={(query, updatedQuery) => {
@@ -930,6 +932,7 @@ function PipelineListPage() {
   ), [
     clonePipeline,
     deletePipeline,
+    fetchPipelines,
     groupByQuery,
     isLoadingClone,
     isLoadingCreate,


### PR DESCRIPTION
# Description
- Remove pipeline tag from filter dropdown on Pipelines Dashboard if that tag is no longer used by any pipelines.
- Update tag cache when removing tags from a pipeline (previously the tag cache was not getting updated in this scenario).

# How Has This Been Tested?
Tag is removed from pipeline filters after the only pipeline using it is deleted:
![unused tag](https://github.com/mage-ai/mage-ai/assets/78053898/5644c085-df1d-4888-8347-5ee786a7cae5)

The pipelines dashboard reflects a pipeline's updated tags after removing one of its tags:
![pipeline tags updated when removed](https://github.com/mage-ai/mage-ai/assets/78053898/270b67a4-9feb-4cfd-98f7-4c0d7ef16e96)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
