### PR TITLE
[dy] Use project uuid for workspace default permissions

### DIFF
--- a/mage_ai/data_preparation/shared/utils.py
+++ b/mage_ai/data_preparation/shared/utils.py
@@ -25,7 +25,7 @@ def get_template_vars_no_db(include_python_libraries: Dict = None) -> Dict[str, 
     try:
         from mage_ai.services.aws.secrets_manager.secrets_manager import get_secret
         kwargs['aws_secret_var'] = get_secret
-    except ImportError:
+    except Exception:
         pass
 
     try:

--- a/mage_ai/frontend/components/users/UserDetail.tsx
+++ b/mage_ai/frontend/components/users/UserDetail.tsx
@@ -402,83 +402,83 @@ function UserDetail({
     enableClickRow?: boolean,
     disableEdit?: boolean,
   ) => (
-   <Table
-      columnFlex={[null, 2, 1, 1, 6]}
-      columns={[
-        {
-          uuid: 'ID',
-        },
-        {
-          uuid: 'Entity',
-        },
-        {
-          uuid: 'Subtype',
-        },
-        {
-          uuid: 'Entity ID',
-        },
-        {
-          rightAligned: true,
-          uuid: 'Access',
-        },
-      ]}
-      onClickRow={(enableClickRow && !disableEdit)
-        ? (rowIndex: number) => {
-          const object = objectArray[rowIndex];
-          if (object && typeof window !== 'undefined') {
-            window.open(`/settings/workspace/permissions/${object?.id}`, '_blank').focus();
+    <Table
+        columnFlex={[null, 2, 1, 1, 6]}
+        columns={[
+          {
+            uuid: 'ID',
+          },
+          {
+            uuid: 'Entity',
+          },
+          {
+            uuid: 'Subtype',
+          },
+          {
+            uuid: 'Entity ID',
+          },
+          {
+            rightAligned: true,
+            uuid: 'Access',
+          },
+        ]}
+        onClickRow={(enableClickRow && !disableEdit)
+          ? (rowIndex: number) => {
+            const object = objectArray[rowIndex];
+            if (object && typeof window !== 'undefined') {
+              window.open(`/settings/workspace/permissions/${object?.id}`, '_blank').focus();
+            }
           }
+          : null
         }
-        : null
-      }
-      rows={objectArray?.map(({
-        access,
-        entity,
-        entity_id: entityID,
-        entity_name: entityName,
-        entity_type: entityType,
-        id,
-      }) => {
-        const accessDisplayNames = access ? displayNames(access) : [];
-        const accessDisplayNamesCount = accessDisplayNames?.length || 0;
+        rows={objectArray?.map(({
+          access,
+          entity,
+          entity_id: entityID,
+          entity_name: entityName,
+          entity_type: entityType,
+          id,
+        }) => {
+          const accessDisplayNames = access ? displayNames(access) : [];
+          const accessDisplayNamesCount = accessDisplayNames?.length || 0;
 
-        return [
-          <Text default key="id" monospace>
-            {id}
-          </Text>,
-          <Text key="entityName" monospace>
-            {entityName || entity}
-          </Text>,
-          <Text default key="entityType" monospace={!!entityType}>
-            {entityType || '-'}
-          </Text>,
-          <Text default key="entityID" monospace={!!entityID}>
-            {entityID || '-'}
-          </Text>,
-          <div key="access">
-            {accessDisplayNamesCount >= 1 && (
-              <FlexContainer alignItems="center" flexWrap="wrap" justifyContent="flex-end">
-                {accessDisplayNames?.map((displayName: string, idx: number) => (
-                  <div key={displayName}>
-                    <Text default monospace small>
-                      {displayName}{accessDisplayNamesCount >= 2
-                        && idx < accessDisplayNamesCount - 1
-                        && (
-                          <Text inline muted small>
-                            ,&nbsp;
-                          </Text>
-                        )
-                      }
-                    </Text>
-                  </div>
-                ))}
-              </FlexContainer>
-            )}
-          </div>,
-        ];
-      })}
-      uuid="permissions"
-    />
+          return [
+            <Text default key="id" monospace>
+              {id}
+            </Text>,
+            <Text key="entityName" monospace>
+              {entityName || entity}
+            </Text>,
+            <Text default key="entityType" monospace={!!entityType}>
+              {entityType || '-'}
+            </Text>,
+            <Text default key="entityID" monospace={!!entityID}>
+              {entityID || '-'}
+            </Text>,
+            <div key="access">
+              {accessDisplayNamesCount >= 1 && (
+                <FlexContainer alignItems="center" flexWrap="wrap" justifyContent="flex-end">
+                  {accessDisplayNames?.map((displayName: string, idx: number) => (
+                    <div key={displayName}>
+                      <Text default monospace small>
+                        {displayName}{accessDisplayNamesCount >= 2
+                          && idx < accessDisplayNamesCount - 1
+                          && (
+                            <Text inline muted small>
+                              ,&nbsp;
+                            </Text>
+                          )
+                        }
+                      </Text>
+                    </div>
+                  ))}
+                </FlexContainer>
+              )}
+            </div>,
+          ];
+        })}
+        uuid="permissions"
+      />
   ), []);
 
   const afterRoles = useMemo(() => buildTable(rolesAll), [
@@ -492,8 +492,14 @@ function UserDetail({
     roles,
   ]);
 
-  const permissionsMemo = useMemo(() => buildTablePermissions(permissions, true, (disableFields || [])?.includes(ObjectTypeEnum.PERMISSIONS)), [
+  const permissionsMemo = useMemo(
+    () => buildTablePermissions(
+      permissions,
+      true,
+      (disableFields || [])?.includes(ObjectTypeEnum.PERMISSIONS),
+    ), [
     buildTablePermissions,
+    disableFields,
     permissions,
   ]);
 

--- a/mage_ai/frontend/pages/settings/workspace/users/index.tsx
+++ b/mage_ai/frontend/pages/settings/workspace/users/index.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 
 import Button from '@oracle/elements/Button';
 import Divider from '@oracle/elements/Divider';
-import Headline from '@oracle/elements/Headline';
 import PrivateRoute from '@components/shared/PrivateRoute';
 import RoleType from '@interfaces/RoleType';
 import SettingsDashboard from '@components/settings/Dashboard';
@@ -11,21 +10,14 @@ import Spacing from '@oracle/elements/Spacing';
 import Table from '@components/shared/Table';
 import Text from '@oracle/elements/Text';
 import UserDetail from '@components/users/UserDetail';
-import UserEditForm from '@components/users/edit/Form';
 import UserType from '@interfaces/UserType';
 import api from '@api';
-import usePrevious from '@utils/usePrevious';
 import { AddUserSmileyFace } from '@oracle/icons';
 import { BreadcrumbType } from '@components/Breadcrumbs';
 import { PADDING_UNITS } from '@oracle/styles/units/spacing';
 import { SectionEnum, SectionItemEnum } from '@components/settings/Dashboard/constants';
-import { USER_PASSWORD_CURRENT_FIELD_UUID } from '@components/users/edit/Form/constants';
 import { dateFormatLong } from '@utils/date';
 import { getUser } from '@utils/session';
-import { goToWithQuery } from '@utils/routing';
-import { isEqual } from '@utils/hash';
-import { pauseEvent } from '@utils/events';
-import { queryFromUrl } from '@utils/url';
 
 function UsersListPage() {
   const router = useRouter();
@@ -37,7 +29,7 @@ function UsersListPage() {
     owner: isOwner,
   } = getUser() || {};
 
-  const { data} = api.users.list({}, {
+  const { data } = api.users.list({}, {
     revalidateOnFocus: false,
   });
   const users = useMemo(() => data?.users || [], [data?.users]);
@@ -57,7 +49,7 @@ function UsersListPage() {
     });
   } else {
     breadcrumbs[0].linkProps = {
-      href: '/settings/workspace/users'
+      href: '/settings/workspace/users',
     };
   }
 
@@ -122,7 +114,6 @@ function UsersListPage() {
               created_at: createdAt,
               email,
               first_name: firstName,
-              id,
               last_name: lastName,
               roles_display,
               roles_new,
@@ -132,7 +123,7 @@ function UsersListPage() {
               sortedRoles.sort((a: RoleType, b: RoleType) => a.id - b.id);
 
               return [
-                <Text large key="avatar" rightAligned>
+                <Text key="avatar" large rightAligned>
                   {avatar}
                 </Text>,
                 <Text key="username">
@@ -150,7 +141,7 @@ function UsersListPage() {
                 <Text default key="roles">
                   {sortedRoles.length > 0 ? sortedRoles[0].name : roles_display}
                 </Text>,
-                <Text monospace default key="created">
+                <Text default key="created" monospace>
                   {createdAt && dateFormatLong(createdAt)}
                 </Text>,
               ];

--- a/mage_ai/orchestration/db/models/oauth.py
+++ b/mage_ai/orchestration/db/models/oauth.py
@@ -1,7 +1,7 @@
 import enum
 import re
 from datetime import datetime
-from typing import Dict, List, Union
+from typing import Callable, Dict, List, Union
 
 from sqlalchemy import (
     JSON,
@@ -327,7 +327,7 @@ class Role(BaseModel):
         self,
         entity: Entity = None,
         entity_id: str = None,
-        prefix: str = None,
+        name_func: Callable[[str], str] = None,
     ) -> None:
         """
         Create default roles with associated permissions for a given entity and entity_id.
@@ -349,8 +349,8 @@ class Role(BaseModel):
         }
         for name, access in mapping.items():
             role_name = name
-            if prefix is not None:
-                role_name = f'{prefix}_{name}'
+            if name_func is not None:
+                role_name = name_func(name)
             role = self.query.filter(self.name == role_name).first()
             if not role:
                 self.create(

--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -452,12 +452,14 @@ def initialize_user_authentication(project_type: ProjectType) -> Oauth2Applicati
 
     # Create new roles on existing users. This should only need to be run once.
     if project_type == ProjectType.SUB:
+        project_uuid = get_project_uuid()
+        project_uuid_truncated = project_uuid[:8]
         Role.create_default_roles(
             entity=Entity.PROJECT,
-            entity_id=get_project_uuid(),
-            prefix=get_repo_name(),
+            entity_id=project_uuid,
+            name_func=lambda role: f'{role}_{project_uuid_truncated}',
         )
-        default_owner_role = Role.get_role(f'{get_repo_name()}_{Role.DefaultRole.OWNER}')
+        default_owner_role = Role.get_role(f'{Role.DefaultRole.OWNER}_{project_uuid_truncated}')
     else:
         Role.create_default_roles()
         default_owner_role = Role.get_role(Role.DefaultRole.OWNER)

--- a/mage_ai/settings/server.py
+++ b/mage_ai/settings/server.py
@@ -79,7 +79,7 @@ SERVER_LOGGING_TEMPLATE = os.getenv(
     '%(levelname)s:%(name)s:%(message)s',
 )
 
-INITIAL_METADATA = os.getenv('INITIAL_METADATA', '{{}}')
+INITIAL_METADATA = os.getenv('INITIAL_METADATA')
 
 DISABLE_AUTO_BROWSER_OPEN = get_bool_value(os.getenv('DISABLE_AUTO_BROWSER_OPEN', 'False'))
 

--- a/mage_ai/tests/orchestration/db/models/test_oauth.py
+++ b/mage_ai/tests/orchestration/db/models/test_oauth.py
@@ -17,7 +17,7 @@ class RoleTests(DBTestCase):
         Role.create_default_roles(
             entity=Entity.PROJECT,
             entity_id=test_entity_id,
-            prefix='test',
+            name_func=lambda x: f'test_{x}',
         )
         owner = Role.query.filter(Role.name == 'test_Owner').one_or_none()
 
@@ -29,12 +29,12 @@ class RoleTests(DBTestCase):
         Role.create_default_roles(
             entity=Entity.PROJECT,
             entity_id=test_entity_id,
-            prefix='test-2',
+            name_func=lambda x: f'test-2_{x}',
         )
         Role.create_default_roles(
             entity=Entity.PROJECT,
             entity_id=test_entity_id2,
-            prefix='test-2',
+            name_func=lambda x: f'test-2_{x}',
         )
         owner = Role.query.filter(Role.name == 'test-2_Owner').one_or_none()
 

--- a/mage_ai/tests/server/test_server.py
+++ b/mage_ai/tests/server/test_server.py
@@ -8,7 +8,7 @@ import tornado.ioloop
 
 import mage_ai.server.server as server_module
 from mage_ai.authentication.passwords import create_bcrypt_hash, generate_salt
-from mage_ai.data_preparation.repo_manager import ProjectType
+from mage_ai.data_preparation.repo_manager import ProjectType, get_project_uuid
 from mage_ai.orchestration.db.models.oauth import (
     Oauth2Application,
     Permission,
@@ -21,7 +21,6 @@ from mage_ai.server.server import (
     make_app,
     replace_base_path,
 )
-from mage_ai.settings.repo import get_repo_name
 from mage_ai.tests.base_test import AsyncDBTestCase
 
 
@@ -150,7 +149,10 @@ class ServerTests(AsyncDBTestCase):
     def test_initialize_user_authentication_subproject(self):
         initialize_user_authentication(ProjectType.SUB)
 
-        owner_role = Role.get_role(f'{get_repo_name()}_{Role.DefaultRole.OWNER}')
+        project_uuid = get_project_uuid()
+        project_uuid_truncated = project_uuid[:8]
+
+        owner_role = Role.get_role(f'{Role.DefaultRole.OWNER}_{project_uuid_truncated}')
         self.assertTrue(len(owner_role.users) > 0)
 
         owner_user = User.query.filter(User.email == 'admin@admin.com').one_or_none()
@@ -169,7 +171,9 @@ class ServerTests(AsyncDBTestCase):
         )
         initialize_user_authentication(ProjectType.SUB)
 
-        owner_role = Role.get_role(f'{get_repo_name()}_{Role.DefaultRole.OWNER}')
+        project_uuid = get_project_uuid()
+        project_uuid_truncated = project_uuid[:8]
+        owner_role = Role.get_role(f'{Role.DefaultRole.OWNER}_{project_uuid_truncated}')
         self.assertTrue(len(owner_role.users) == 0)
 
         owner_user = User.query.filter(User.email == 'admin@admin.com').one_or_none()


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

In some cases, the same project name can be used for multiple workspaces, so the permissions will be added to the same role. This PR changes the role name to use the project uuid instead. I originally used the project name to create the default roles for readability, but it has some limitations.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with subproject


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
