### PR TITLE
[jk] Clear block_uuid query param when selecting new block

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -228,13 +228,24 @@ function PipelineDetailPage({
     };
   }>(null);
 
+  const qUrl = queryFromUrl();
+  const {
+    [VIEW_QUERY_PARAM]: activeSidekickView,
+    block_uuid: blockUUIDFromUrl,
+  } = qUrl;
+
   const setSelectedBlock = useCallback((block: BlockType) => {
     setSelectedBlockState(block);
     if (block && disableShortcuts) {
       setDisableShortcuts(false);
     }
     setSelectedBlockDetails(null);
-  }, [disableShortcuts]);
+    if (blockUUIDFromUrl && blockUUIDFromUrl?.split(':')?.[0] !== block?.uuid) {
+      goToWithQuery({
+        block_uuid: null,
+      });
+    }
+  }, [blockUUIDFromUrl, disableShortcuts]);
 
   const [afterHidden, setAfterHidden] =
     useState(!!get(LOCAL_STORAGE_KEY_PIPELINE_EDITOR_AFTER_HIDDEN));
@@ -578,13 +589,6 @@ function PipelineDetailPage({
     data?.pipeline?.updated_at,
     pipelineLastSaved,
   ]);
-
-  const qUrl = queryFromUrl();
-  const {
-    [VIEW_QUERY_PARAM]: activeSidekickView,
-    block_uuid: blockUUIDFromUrl,
-    // file_path: filePathFromUrl,
-  } = qUrl;
 
   function setActiveSidekickView(
     newView: ViewKeyEnum,


### PR DESCRIPTION
# Description
- Remove `block_uuid` query param when selecting/deselecting block in Pipeline Editor. The `block_uuid` query param is used to automatically select and focus a block when redirecting to the Pipeline Editor page, but if it's not removed when selecting other blocks, there can be issues with unexpected refocusing of the block with the uuid in the query param. This PR fixes this issue.

# How Has This Been Tested?
![clear block uuid query](https://github.com/mage-ai/mage-ai/assets/78053898/78738f72-3fcc-4ce3-8f5e-ccee522dde7a)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
