### PR TITLE
[jk] Replace blue font with cyan in terminal

### DIFF
--- a/mage_ai/frontend/components/Terminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/index.tsx
@@ -192,8 +192,8 @@ function Terminal({
 
   const kernelOutputsUpdated: KernelOutputType[] = useMemo(() => {
     if (typeof outputs !== 'undefined') {
-      // Limit the terminal output in the UI; otherwise, typing in the terminal becomes very laggy.
-      return (outputs || []).slice(-1000);
+      // Limit the terminal output in the UI; otherwise, typing in the terminal becomes laggy.
+      return (outputs || []).slice(-2500);
     }
 
     if (!stdout) {

--- a/mage_ai/frontend/components/Terminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/index.tsx
@@ -465,7 +465,7 @@ in the context menu that appears.
               let displayElement;
               if (DATA_TYPE_TEXTLIKE.includes(dataType)) {
                 // Replace difficult-to-read blue font with cyan font
-                const dataReplacedBlueFont = data.replace('[34;', '[36;');
+                const dataReplacedBlueFont = (data || '').replace('[34;', '[36;');
                 displayElement = (
                   <Text
                     monospace

--- a/mage_ai/frontend/components/Terminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/index.tsx
@@ -464,6 +464,8 @@ in the context menu that appears.
             dataArray.forEach((data: string, idxInner: number) => {
               let displayElement;
               if (DATA_TYPE_TEXTLIKE.includes(dataType)) {
+                // Replace difficult-to-read blue font with cyan font
+                const dataReplacedBlueFont = data.replace('[34;', '[36;');
                 displayElement = (
                   <Text
                     monospace
@@ -473,7 +475,7 @@ in the context menu that appears.
                   >
                     {data && (
                       <Ansi>
-                        {data}
+                        {dataReplacedBlueFont}
                       </Ansi>
                     )}
                   </Text>

--- a/mage_ai/frontend/components/Terminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/index.tsx
@@ -33,6 +33,8 @@ import { pauseEvent } from '@utils/events';
 import { useKeyboardContext } from '@context/Keyboard';
 
 export const DEFAULT_TERMINAL_UUID = 'terminal';
+// Limit the number of lines for the terminal output; otherwise, typing in the terminal can become laggy.
+const TERMINAL_OUTPUT_LIMIT = 2500;
 
 type TerminalProps = {
   command?: string;
@@ -192,8 +194,7 @@ function Terminal({
 
   const kernelOutputsUpdated: KernelOutputType[] = useMemo(() => {
     if (typeof outputs !== 'undefined') {
-      // Limit the terminal output in the UI; otherwise, typing in the terminal becomes laggy.
-      return (outputs || []).slice(-2500);
+      return (outputs || []).slice(-TERMINAL_OUTPUT_LIMIT);
     }
 
     if (!stdout) {
@@ -204,6 +205,7 @@ function Terminal({
     const splitStdout =
       stdout
         .split('\n')
+        .slice(-TERMINAL_OUTPUT_LIMIT)
         .filter(d => !d.includes('# Mage terminal settings command'));
 
     return splitStdout.map(d => ({

--- a/mage_ai/frontend/components/Terminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/index.tsx
@@ -193,7 +193,7 @@ function Terminal({
   const kernelOutputsUpdated: KernelOutputType[] = useMemo(() => {
     if (typeof outputs !== 'undefined') {
       // Limit the terminal output in the UI; otherwise, typing in the terminal becomes very laggy.
-      return (outputs || []).slice(-1500);
+      return (outputs || []).slice(-1000);
     }
 
     if (!stdout) {

--- a/mage_ai/frontend/components/Terminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/index.tsx
@@ -192,13 +192,14 @@ function Terminal({
 
   const kernelOutputsUpdated: KernelOutputType[] = useMemo(() => {
     if (typeof outputs !== 'undefined') {
-      return outputs;
+      // Limit the terminal output in the UI; otherwise, typing in the terminal becomes very laggy.
+      return (outputs || []).slice(-1500);
     }
 
     if (!stdout) {
       return [];
     }
-    
+
     // Filter out commands to configure settings
     const splitStdout =
       stdout
@@ -517,7 +518,7 @@ in the context menu that appears.
                   <CharacterStyle
                     focusBeginning={focus && cursorIndex === 0 && idx === 0}
                     focused={
-                      focus && 
+                      focus &&
                         (cursorIndex === idx + 1 ||
                           cursorIndex >= arr.length && idx === arr.length - 1)
                     }

--- a/mage_ai/frontend/components/Terminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/index.tsx
@@ -465,7 +465,7 @@ in the context menu that appears.
               let displayElement;
               if (DATA_TYPE_TEXTLIKE.includes(dataType)) {
                 // Replace difficult-to-read blue font with cyan font
-                const dataReplacedBlueFont = (data || '').replace('[34;', '[36;');
+                const dataReplacedBlueFont = (data || '').replaceAll('[34;', '[36;');
                 displayElement = (
                   <Text
                     monospace

--- a/mage_ai/frontend/components/Terminal/useTerminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/useTerminal/index.tsx
@@ -24,10 +24,9 @@ import { cleanName, randomNameGenerator } from '@utils/string';
 import { getItems, setItems } from './storage';
 import { getUser } from '@utils/session';
 import { getWebSocket } from '@api/utils/url';
-import { keysPresentAndKeysRecent, onlyKeysPresent } from '@utils/hooks/keyboardShortcuts/utils';
+import { keysPresentAndKeysRecent } from '@utils/hooks/keyboardShortcuts/utils';
 import { pushAtIndex } from '@utils/array';
 import { useFileTabs } from '@components/PipelineDetail/FileTabs';
-import { useKeyboardContext } from '@context/Keyboard';
 
 const UUID_MAIN = 'Main Mage';
 const DEFAULT_ITEM = { selected: true, uuid: UUID_MAIN };


### PR DESCRIPTION
# Description
- The blue font in the terminal was hard to read, so this PR replaces the blue font with the more legible cyan font.
- Limit the terminal output in the UI to 2500 lines. Including more starts to hurt app performance, at least in development mode (e.g. typing in the terminal becomes very laggy to the point of being basically unusable).

# How Has This Been Tested?
- Tested locally

Before (the "notice" text has blue font):
<img width="425" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/4e2b77ff-1905-428c-97d8-a41201841d7e">

After (the "notice" text has cyan font):
<img width="435" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/c87c04e4-37a7-467a-8574-7edcefba78f6">

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
