### PR TITLE
[jk] Replace Block reference with BlockFactory

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -3473,12 +3473,13 @@ df = get_variable('{self.pipeline.uuid}', '{self.uuid}', 'df')
 
             cache = BlockCache()
             if detach:
+                from mage_ai.data_preparation.models.block.block_factory import BlockFactory
                 """"
                 New block added to pipeline, so it must be added to the block cache.
                 Old block no longer in pipeline, so it must be removed from block cache.
                 """
                 cache.add_pipeline(self, self.pipeline)
-                old_block = self.get_block(
+                old_block = BlockFactory.get_block(
                     old_uuid,
                     old_uuid,
                     self.type,

--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -3473,7 +3473,9 @@ df = get_variable('{self.pipeline.uuid}', '{self.uuid}', 'df')
 
             cache = BlockCache()
             if detach:
-                from mage_ai.data_preparation.models.block.block_factory import BlockFactory
+                from mage_ai.data_preparation.models.block.block_factory import (
+                    BlockFactory,
+                )
                 """"
                 New block added to pipeline, so it must be added to the block cache.
                 Old block no longer in pipeline, so it must be removed from block cache.


### PR DESCRIPTION
# Description
- Fix `Block object has no attribute 'get_block'` error when detaching block.

# How Has This Been Tested?
![detach block](https://github.com/mage-ai/mage-ai/assets/78053898/2e6b66c5-f734-4dc1-ae7b-62459fd6d7fd)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
