### PR TITLE
[xy] Kill all jobs on scheduler crash.

### DIFF
--- a/mage_ai/orchestration/job_manager.py
+++ b/mage_ai/orchestration/job_manager.py
@@ -86,6 +86,12 @@ class JobManager:
         job_id = self.__job_id(JobType.INTEGRATION_STREAM, id)
         return self.queue.kill_job(job_id)
 
+    def start(self):
+        self.queue.start()
+
+    def stop(self):
+        self.queue.stop()
+
     def __job_id(self, job_type: JobType, uid: Union[str, int]):
         return f'{job_type}_{uid}'
 

--- a/mage_ai/orchestration/queue/celery_queue.py
+++ b/mage_ai/orchestration/queue/celery_queue.py
@@ -1,6 +1,7 @@
+from typing import Callable
+
 from mage_ai.orchestration.queue.config import QueueConfig
 from mage_ai.orchestration.queue.queue import Queue
-from typing import Callable
 
 
 class CeleryQueue(Queue):
@@ -26,4 +27,10 @@ class CeleryQueue(Queue):
         return False
 
     def kill_job(self, job_id: str):
+        pass
+
+    def start(self):
+        pass
+
+    def stop(self):
         pass

--- a/mage_ai/orchestration/queue/queue.py
+++ b/mage_ai/orchestration/queue/queue.py
@@ -19,5 +19,13 @@ class Queue(ABC):
     def kill_job(self, job_id: str):
         pass
 
+    @abstractmethod
+    def start(self):
+        pass
+
+    @abstractmethod
+    def stop(self):
+        pass
+
     def _print(self, msg):
         print(f'[{self.__class__.__name__}] {msg}')

--- a/mage_ai/server/scheduler_manager.py
+++ b/mage_ai/server/scheduler_manager.py
@@ -9,6 +9,7 @@ import sentry_sdk
 
 from mage_ai.orchestration.db.database_manager import database_manager
 from mage_ai.orchestration.db.process import create_process
+from mage_ai.orchestration.job_manager import job_manager
 from mage_ai.server.logger import Logger
 from mage_ai.services.newrelic import initialize_new_relic
 from mage_ai.settings import (
@@ -47,8 +48,12 @@ def run_scheduler():
     )
 
     try:
+        if job_manager is not None:
+            job_manager.start()
         LoopTimeTrigger().start()
     except Exception as e:
+        if job_manager is not None:
+            job_manager.stop()
         logger.exception('Failed to run scheduler.')
         raise e
 

--- a/mage_ai/tests/orchestration/queue/test_process_queue.py
+++ b/mage_ai/tests/orchestration/queue/test_process_queue.py
@@ -13,6 +13,7 @@ class ProcessQueueTests(TestCase):
     def setUp(self):
         queue_config = QueueConfig.load(config=dict(concurrency=100))
         self.queue = ProcessQueue(queue_config=queue_config)
+        self.queue.start()
 
     def test_init(self):
         self.assertEqual(self.queue.size, 100)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Kill all jobs on scheduler crash so that the scheduler can successfully restart.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally by forcing the scheduler to crash with an exception and running a streaming pipeline. The scheduler can automatically restart on crash


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
