### PR TITLE
[xy] Fix spark dataframe read error.

### DIFF
--- a/mage_ai/data_preparation/models/variable.py
+++ b/mage_ai/data_preparation/models/variable.py
@@ -282,7 +282,9 @@ class Variable:
         else:
             self.__write_json(data)
 
-        self.write_metadata()
+        if self.variable_type != VariableType.SPARK_DATAFRAME:
+            # Not write json file in spark data directory to avoid read error
+            self.write_metadata()
 
     async def write_data_async(self, data: Any) -> None:
         """
@@ -315,7 +317,9 @@ class Variable:
         else:
             await self.__write_json_async(data)
 
-        self.write_metadata()
+        if self.variable_type != VariableType.SPARK_DATAFRAME:
+            # Not write json file in spark data directory to avoid read error
+            self.write_metadata()
 
     def write_metadata(self) -> None:
         """


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix spark dataframe read error.
Do not write json file in spark data directory to avoid read error
```
java.lang.RuntimeException: file:/home/src/mage_data/.../output_0/type.json is not a Parquet file. 
Expected magic number at tail, but found [109, 101, 34, 125]
```
# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with local spark docker image

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
