### PR TITLE
[dy] Cast ambiguous columns to strings

### DIFF
--- a/mage_ai/data_preparation/models/utils.py
+++ b/mage_ai/data_preparation/models/utils.py
@@ -19,6 +19,13 @@ STRING_SERIALIZABLE_COLUMN_TYPES = set([
     'ObjectId',
 ])
 
+AMBIGUOUS_COLUMN_TYPES = set([
+    'mixed-integer',
+    'mixed',
+    'complex',
+    'unknown-array',
+])
+
 CAST_TYPE_COLUMN_TYPES = set([
     'Int64',
     'int64',

--- a/mage_ai/data_preparation/models/utils.py
+++ b/mage_ai/data_preparation/models/utils.py
@@ -21,7 +21,6 @@ STRING_SERIALIZABLE_COLUMN_TYPES = set([
 
 AMBIGUOUS_COLUMN_TYPES = set([
     'mixed-integer',
-    'mixed',
     'complex',
     'unknown-array',
 ])

--- a/mage_ai/data_preparation/models/variable.py
+++ b/mage_ai/data_preparation/models/variable.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List
 import numpy as np
 import pandas as pd
 import polars as pl
-from pandas.api.types import is_object_dtype
+from pandas.api.types import infer_dtype, is_object_dtype
 from pandas.core.indexes.range import RangeIndex
 
 from mage_ai.data_cleaner.shared.utils import is_geo_dataframe, is_spark_dataframe
@@ -18,6 +18,7 @@ from mage_ai.data_preparation.models.constants import (
     VARIABLE_DIR,
 )
 from mage_ai.data_preparation.models.utils import (  # dask_from_pandas,
+    AMBIGUOUS_COLUMN_TYPES,
     STRING_SERIALIZABLE_COLUMN_TYPES,
     apply_transform_pandas,
     cast_column_types,
@@ -579,8 +580,12 @@ class Variable:
                 series_non_null = df_col.dropna()
                 if len(series_non_null) > 0:
                     coltype = type(series_non_null.iloc[0])
+                    coltype_inferred = infer_dtype(series_non_null)
                     if is_object_dtype(series_non_null.dtype):
-                        if coltype.__name__ in STRING_SERIALIZABLE_COLUMN_TYPES:
+                        if (
+                            coltype.__name__ in STRING_SERIALIZABLE_COLUMN_TYPES
+                            or coltype_inferred in AMBIGUOUS_COLUMN_TYPES
+                        ):
                             cast_coltype = str
                         else:
                             cast_coltype = coltype

--- a/mage_ai/data_preparation/models/variable.py
+++ b/mage_ai/data_preparation/models/variable.py
@@ -579,12 +579,17 @@ class Variable:
             else:
                 series_non_null = df_col.dropna()
                 if len(series_non_null) > 0:
-                    coltype = type(series_non_null.iloc[0])
+                    sample_element = series_non_null.iloc[0]
+                    coltype = type(sample_element)
                     coltype_inferred = infer_dtype(series_non_null)
                     if is_object_dtype(series_non_null.dtype):
-                        if (
-                            coltype.__name__ in STRING_SERIALIZABLE_COLUMN_TYPES
-                            or coltype_inferred in AMBIGUOUS_COLUMN_TYPES
+                        if coltype.__name__ in STRING_SERIALIZABLE_COLUMN_TYPES:
+                            cast_coltype = str
+                        # If the column is a "primitive" type, i.e. int/bool/etc and there is
+                        # a mix of types in the column, cast to string
+                        elif (
+                            not hasattr(sample_element, '__dict__')
+                            and coltype_inferred in AMBIGUOUS_COLUMN_TYPES
                         ):
                             cast_coltype = str
                         else:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

In issue https://github.com/mage-ai/mage-ai/issues/4682, the `__write_parquet` method is failing when there is a mix of string and integer values in a column. If we just cast the column to string, then the `__write_parquet` method should work properly.

@wangxiaoyou1993 let me know if this makes sense. I'm not sure what the best solution is here.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with mixed columns


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
