### PR TITLE
[jk] Fix filters from being reset when items fetched

### DIFF
--- a/mage_ai/frontend/pages/pipeline-runs/index.tsx
+++ b/mage_ai/frontend/pages/pipeline-runs/index.tsx
@@ -95,7 +95,7 @@ function RunListPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   ), [
     // The "query" dependency is intentionally excluded to avoid the filters
-    // being reset everytime pipeline runs are fetched.
+    // being reset every time pipeline runs are fetched.
     pipelineUUIDs,
     router,
     tags,

--- a/mage_ai/frontend/pages/pipeline-runs/index.tsx
+++ b/mage_ai/frontend/pages/pipeline-runs/index.tsx
@@ -28,11 +28,11 @@ function RunListPage() {
   const [errors, setErrors] = useState<ErrorsType>(null);
   const q = queryFromUrl();
   const page = q?.page ? q.page : 0;
-  const query = filterQuery(q, [
+  const query = useMemo(() => filterQuery(q, [
     PipelineRunFilterQueryEnum.PIPELINE_UUID,
     PipelineRunFilterQueryEnum.STATUS,
     PipelineRunFilterQueryEnum.TAG,
-  ]);
+  ]), [q]);
 
   const { data: dataProjects } = api.projects.list();
   const project: ProjectType = useMemo(() => dataProjects?.projects?.[0], [dataProjects]);
@@ -75,8 +75,8 @@ function RunListPage() {
   const toolbarEl = useMemo(() => (
     <Toolbar
       filterOptions={{
-        pipeline_uuid: pipelineUUIDs,
         pipeline_tag: tags.map(({ uuid }) => uuid),
+        pipeline_uuid: pipelineUUIDs,
         status: PIPELINE_RUN_STATUSES,
       }}
       filterValueLabelMapping={{
@@ -92,7 +92,14 @@ function RunListPage() {
       query={query}
       resetPageOnFilterApply
     />
-  ), [pipelineUUIDs, query, router, tags]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  ), [
+    // The "query" dependency is intentionally excluded to avoid the filters
+    // being reset everytime pipeline runs are fetched.
+    pipelineUUIDs,
+    router,
+    tags,
+  ]);
 
   return (
     <Dashboard

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -118,12 +118,12 @@ function PipelineSchedules({
   const globalVariables = dataGlobalVariables?.variables;
 
   const q = queryFromUrl();
-  const query = filterQuery(q, [
+  const query = useMemo(() => filterQuery(q, [
     PipelineScheduleFilterQueryEnum.INTERVAL,
     PipelineScheduleFilterQueryEnum.STATUS,
     PipelineScheduleFilterQueryEnum.TAG,
     PipelineScheduleFilterQueryEnum.TYPE,
-  ]);
+  ]), [q]);
   const apiFilterQuery = getPipelineScheduleApiFilterQuery(query);
   const page = q?.page ? q.page : 0;
   const {
@@ -413,7 +413,10 @@ function PipelineSchedules({
     >
       {newTriggerFromInteractionsButtonMemo}
     </Toolbar>
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   ), [
+    // The "query" dependency is intentionally excluded to avoid the filters
+    // being reset everytime pipeline triggers are fetched.
     createNewSchedule,
     isCreateDisabled,
     isLoadingCreateNewSchedule,
@@ -421,7 +424,6 @@ function PipelineSchedules({
     isViewerRole,
     newTriggerFromInteractionsButtonMemo,
     pipelineUUID,
-    query,
     router,
     showModal,
     tags,

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -416,7 +416,7 @@ function PipelineSchedules({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   ), [
     // The "query" dependency is intentionally excluded to avoid the filters
-    // being reset everytime pipeline triggers are fetched.
+    // being reset every time pipeline triggers are fetched.
     createNewSchedule,
     isCreateDisabled,
     isLoadingCreateNewSchedule,


### PR DESCRIPTION
# Description
- The filters toggles on the `/pipeline-runs` and `/pipelines/[pipeline_uuid]/triggers` were being reset unexpectedly due to the filter component getting re-rendered with stale data every time a certain resource was being fetched. This PR fixes this issue.

# How Has This Been Tested?
- Tested locally

Before (filters periodically reset):
![Before - filters periodically reset](https://github.com/mage-ai/mage-ai/assets/78053898/4a78609b-dd03-4199-9876-f6303bc2166e)

After (filter state persists):
![After - filters not reset](https://github.com/mage-ai/mage-ai/assets/78053898/d7410b79-0482-4558-9ff1-8523ebcb2419)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
