### PR TITLE
[xy] Fix dangling process when reloading webserver.

### DIFF
--- a/mage_ai/orchestration/queue/process_queue.py
+++ b/mage_ai/orchestration/queue/process_queue.py
@@ -306,10 +306,11 @@ def poll_job_and_execute(
         job_dict: The shared job dictionary.
 
     """
+    pid = os.getpid()
     workers = []
     while True:
         workers = [w for w in workers if w.is_alive()]
-        print(f'Worker pool size: {len(workers)}')
+        print(f'[Process {pid}] Worker pool size: {len(workers)}')
         if not workers and queue.empty():
             break
         while not queue.empty():

--- a/mage_ai/server/scheduler_manager.py
+++ b/mage_ai/server/scheduler_manager.py
@@ -101,6 +101,8 @@ class SchedulerManager:
         logger.info('Stop scheduler.')
         if self.is_alive:
             self.scheduler_process.terminate()
+            if job_manager is not None:
+                job_manager.stop()
             self.scheduler_process = None
             self.status = self.SchedulerStatus.STOPPED
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix dangling process when reloading webserver.
When tornado server is reloaded, in addition to stop the scheduler, we should also kill the running jobs so that there're no duplicate jobs running.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally. Before the fix, there're duplicate logs of "Worker pool size" from different processes after reloading the web server. After the fix, there're only logs from the single process, which is the expected behavior.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`

cc:
<!-- Optionally mention someone to let them know about this pull request -->
