### PR TITLE
[jk] Block output view option

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,6 @@ Provide instructions so we can reproduce.
 - [ ] I have added unit tests that prove my fix is effective or that my feature works
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
-- [ ] If new documentation has been added, relative paths have been added to the appropriate section of `docs/mint.json`
 
 cc:
 <!-- Optionally mention someone to let them know about this pull request -->

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import Ansi from 'ansi-to-react';
 import InnerHTML from 'dangerously-set-html-content';
 import { useMutation } from 'react-query';

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -165,8 +165,10 @@ import {
   buildBorderProps,
   buildConvertBlockMenuItems,
   calculateOffsetPercentage,
+  getCodeCollapsedUUID,
   getDownstreamBlockUuids,
   getMessagesWithType,
+  getOutputCollapsedUUID,
   getUpstreamBlockUuids,
   hasErrorOrOutput,
 } from './utils';
@@ -865,13 +867,14 @@ function CodeBlock({
     dataProviders,
   ]);
 
-  const codeCollapsedUUID = useMemo(() => (
-    `${pipelineUUID}/${blockUUID}/codeCollapsed`
-  ), [pipelineUUID, blockUUID]);
-
-  const outputCollapsedUUID = useMemo(() => (
-    `${pipelineUUID}/${blockUUID}/outputCollapsed`
-  ), [pipelineUUID, blockUUID]);
+  const codeCollapsedUUID = useMemo(
+    () => getCodeCollapsedUUID(pipelineUUID, blockUUID),
+    [pipelineUUID, blockUUID],
+  );
+  const outputCollapsedUUID = useMemo(
+    () => getOutputCollapsedUUID(pipelineUUID, blockUUID),
+    [pipelineUUID, blockUUID],
+  );
 
   useEffect(() => {
     setCodeCollapsed(get(codeCollapsedUUID, false));

--- a/mage_ai/frontend/components/CodeBlock/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/index.tsx
@@ -225,6 +225,7 @@ type CodeBlockProps = {
   hideExtraCommandButtons?: boolean;
   hideExtraConfiguration?: boolean;
   hideHeaderInteractiveInformation?: boolean;
+  hideOutputOnExecution?: boolean;
   hideRunButton?: boolean;
   interactionsMapping?: {
     [interactionUUID: string]: InteractionType;
@@ -359,6 +360,7 @@ function CodeBlock({
   hideExtraCommandButtons,
   hideExtraConfiguration,
   hideHeaderInteractiveInformation,
+  hideOutputOnExecution,
   hideRunButton,
   interactionsMapping,
   interruptKernel,
@@ -928,7 +930,7 @@ function CodeBlock({
       && !isStreamingPipeline
       && !isDataIntegration
       && BlockLanguageEnum.PYTHON === blockLanguage
-      && (PipelineTypeEnum.PYSPARK === pipeline?.type || !project?.emr_config)
+      && (PipelineTypeEnum.PYSPARK === pipeline?.type || !project?.emr_config),
     );
   }, [
     blockLanguage,
@@ -952,8 +954,8 @@ function CodeBlock({
   const runBlockAndTrack = useCallback((payload?: RunBlockAndTrackProps) => {
     if (sideBySideEnabled) {
       dispatchEventSyncColumnPositions({
-        columnIndex: scrollTogether ? 2 : 1,
         bypassOffScreen: scrollTogether,
+        columnIndex: scrollTogether ? 2 : 1,
         ...(payload?.syncColumnPositions || {
           rect: refColumn2?.current?.getBoundingClientRect(),
           y: refColumn1?.current?.getBoundingClientRect()?.y,
@@ -998,7 +1000,7 @@ function CodeBlock({
         Object.entries(interaction?.variables || {}).forEach(([
           variableUUID,
           {
-            types
+            types,
           },
         ]) => {
           if (variablesToUse && variableUUID in variablesToUse) {
@@ -1025,13 +1027,17 @@ function CodeBlock({
         || dataProviderConfig?.[CONFIG_KEY_USE_RAW_SQL]
         || [
           BlockTypeEnum.SCRATCHPAD,
-        ].includes(blockType)
+        ].includes(blockType),
     });
 
     if (!disableReset) {
       setRunCount(1 + Number(runCount));
       setRunEndTime(null);
-      setOutputCollapsed(false);
+      if (hideOutputOnExecution) {
+        setOutputCollapsed(true);
+      } else {
+        setOutputCollapsed(false);
+      }
     }
 
     if (sparkEnabled) {
@@ -1039,10 +1045,13 @@ function CodeBlock({
     }
   }, [
     blockInteractions,
+    blockType,
     content,
     dataProviderConfig,
+    dispatchEventSyncColumnPositions,
     fetchExecutionStates,
     hasDownstreamWidgets,
+    hideOutputOnExecution,
     interactionsMapping,
     isDBT,
     refColumn1,

--- a/mage_ai/frontend/components/CodeBlock/utils.ts
+++ b/mage_ai/frontend/components/CodeBlock/utils.ts
@@ -57,6 +57,16 @@ export const getDownstreamBlockUuids = (
   return downstreamBlocks;
 };
 
+export const getCodeCollapsedUUID = (
+  pipelineUUID: string,
+  blockUUID: string,
+) => `${pipelineUUID}/${blockUUID}/codeCollapsed`;
+
+export const getOutputCollapsedUUID = (
+  pipelineUUID: string,
+  blockUUID: string,
+) => `${pipelineUUID}/${blockUUID}/outputCollapsed`;
+
 export const buildConvertBlockMenuItems = (
   b: BlockType,
   blocks: BlockType[],

--- a/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/FileHeaderMenuItem.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/FileHeaderMenuItem.tsx
@@ -1,0 +1,39 @@
+import FlexContainer from '@oracle/components/FlexContainer';
+import Spacing from '@oracle/elements/Spacing';
+import Text from '@oracle/elements/Text';
+import { Check } from '@oracle/icons';
+import { ICON_SIZE_DEFAULT } from '@oracle/styles/units/icons';
+
+type FileHeaderMenuItemProps = {
+  beforeIcon?: JSX.Element;
+  checked?: boolean;
+  label: string;
+  muted?: boolean;
+};
+
+function FileHeaderMenuItem({
+  beforeIcon,
+  checked,
+  label,
+  muted,
+}: FileHeaderMenuItemProps) {
+  return (
+    <FlexContainer alignItems="center">
+      {beforeIcon
+        ? beforeIcon
+        : (checked
+          ?  <Check />
+          :  <div style={{ width: ICON_SIZE_DEFAULT }} />
+        )
+      }
+
+      <Spacing mr={1} />
+
+      <Text disabled={muted} noWrapping>
+        {label}
+      </Text>
+    </FlexContainer>
+  );
+}
+
+export default FileHeaderMenuItem;

--- a/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/index.tsx
@@ -43,6 +43,7 @@ const INDEX_COMPUTE = 4;
 type FileHeaderMenuProps = {
   cancelPipeline: () => void;
   children?: any;
+  collapseAllBlockOutputs?: (state: boolean) => void;
   createPipeline: (data: any) => void;
   executePipeline: () => void;
   hideOutputOnExecution?: boolean;
@@ -69,6 +70,7 @@ type FileHeaderMenuProps = {
 function FileHeaderMenu({
   cancelPipeline,
   children,
+  collapseAllBlockOutputs,
   createPipeline,
   executePipeline,
   hideOutputOnExecution,
@@ -240,28 +242,24 @@ function FileHeaderMenu({
       onClick: toggleHideOutputOnExecution,
       uuid: 'Hide output on execution',
     },
-    // {
-    //   label: () => (
-    //     <FileHeaderMenuItem
-    //       label="Collapse all outputs"
-    //     />
-    //   ),
-    //   onClick: () => {
-    //     // collapseAllOutputs();
-    //   },
-    //   uuid: 'Collapse all outputs',
-    // },
-    // {
-    //   label: () => (
-    //     <FileHeaderMenuItem
-    //       label="Expand all outputs"
-    //     />
-    //   ),
-    //   onClick: () => {
-    //     // expandAllOutputs();
-    //   },
-    //   uuid: 'Expand all outputs',
-    // },
+    {
+      label: () => (
+        <FileHeaderMenuItem
+          label="Collapse all outputs"
+        />
+      ),
+      onClick: () => collapseAllBlockOutputs(true),
+      uuid: 'Collapse all outputs',
+    },
+    {
+      label: () => (
+        <FileHeaderMenuItem
+          label="Expand all outputs"
+        />
+      ),
+      onClick: () => collapseAllBlockOutputs(false),
+      uuid: 'Expand all outputs',
+    },
     {
       label: () => (
         <FileHeaderMenuItem

--- a/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/index.tsx
@@ -242,24 +242,24 @@ function FileHeaderMenu({
       onClick: toggleHideOutputOnExecution,
       uuid: 'Hide output on execution',
     },
-    {
-      label: () => (
-        <FileHeaderMenuItem
-          label="Collapse all outputs"
-        />
-      ),
-      onClick: () => collapseAllBlockOutputs(true),
-      uuid: 'Collapse all outputs',
-    },
-    {
-      label: () => (
-        <FileHeaderMenuItem
-          label="Expand all outputs"
-        />
-      ),
-      onClick: () => collapseAllBlockOutputs(false),
-      uuid: 'Expand all outputs',
-    },
+    // {
+    //   label: () => (
+    //     <FileHeaderMenuItem
+    //       label="Collapse all outputs"
+    //     />
+    //   ),
+    //   onClick: () => collapseAllBlockOutputs(true),
+    //   uuid: 'Collapse all outputs',
+    // },
+    // {
+    //   label: () => (
+    //     <FileHeaderMenuItem
+    //       label="Expand all outputs"
+    //     />
+    //   ),
+    //   onClick: () => collapseAllBlockOutputs(false),
+    //   uuid: 'Expand all outputs',
+    // },
     {
       label: () => (
         <FileHeaderMenuItem

--- a/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import Button from '@oracle/elements/Button';
 import ClickOutside from '@oracle/components/ClickOutside';
 import FlexContainer from '@oracle/components/FlexContainer';
+import FileHeaderMenuItem from './FileHeaderMenuItem';
 import FlyoutMenu from '@oracle/components/FlyoutMenu';
 import KernelOutputType from '@interfaces/KernelOutputType';
 import KernelType, { KernelNameEnum } from '@interfaces/KernelType';
@@ -10,12 +11,10 @@ import PipelineType, {
   KERNEL_NAME_TO_PIPELINE_TYPE,
   PipelineTypeEnum,
 } from '@interfaces/PipelineType';
-import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
 import useKernel from '@utils/models/kernel/useKernel';
 import useProject from '@utils/models/project/useProject';
 import {
-  Check,
   LayoutSplit,
   LayoutStacked,
 } from '@oracle/icons';
@@ -39,7 +38,6 @@ import { randomNameGenerator } from '@utils/string';
 import { useKeyboardContext } from '@context/Keyboard';
 
 const NUMBER_OF_TOP_MENU_ITEMS: number = 3;
-const ICON_SIZE = 1.5 * UNIT;
 const INDEX_COMPUTE = 4;
 
 type FileHeaderMenuProps = {
@@ -47,6 +45,7 @@ type FileHeaderMenuProps = {
   children?: any;
   createPipeline: (data: any) => void;
   executePipeline: () => void;
+  hideOutputOnExecution?: boolean;
   interruptKernel: () => void;
   isPipelineExecuting: boolean;
   pipeline: PipelineType;
@@ -60,9 +59,10 @@ type FileHeaderMenuProps = {
   setMessages: (message: {
     [uuid: string]: KernelOutputType[];
   }) => void;
-  sideBySideEnabled?: boolean;
   setScrollTogether?: (prev: any) => void;
   setSideBySideEnabled?: (prev: any) => void;
+  sideBySideEnabled?: boolean;
+  toggleHideOutputOnExecution?: () => void;
   updatePipelineMetadata: (name: string, type?: string) => void;
 };
 
@@ -71,6 +71,7 @@ function FileHeaderMenu({
   children,
   createPipeline,
   executePipeline,
+  hideOutputOnExecution,
   interruptKernel,
   isPipelineExecuting,
   pipeline,
@@ -82,6 +83,7 @@ function FileHeaderMenu({
   setScrollTogether,
   setSideBySideEnabled,
   sideBySideEnabled,
+  toggleHideOutputOnExecution,
   updatePipelineMetadata,
 }: FileHeaderMenuProps) {
   const [highlightedIndex, setHighlightedIndex] = useState(null);
@@ -230,15 +232,42 @@ function FileHeaderMenu({
   const viewItems = useMemo(() => [
     {
       label: () => (
-        <FlexContainer alignItems="center">
-          <LayoutStacked success={!sideBySideEnabled} />
-
-          <Spacing mr={1} />
-
-          <Text noWrapping>
-            Show output below block
-          </Text>
-        </FlexContainer>
+        <FileHeaderMenuItem
+          checked={hideOutputOnExecution}
+          label="Hide output on execution"
+        />
+      ),
+      onClick: toggleHideOutputOnExecution,
+      uuid: 'Hide output on execution',
+    },
+    // {
+    //   label: () => (
+    //     <FileHeaderMenuItem
+    //       label="Collapse all outputs"
+    //     />
+    //   ),
+    //   onClick: () => {
+    //     // collapseAllOutputs();
+    //   },
+    //   uuid: 'Collapse all outputs',
+    // },
+    // {
+    //   label: () => (
+    //     <FileHeaderMenuItem
+    //       label="Expand all outputs"
+    //     />
+    //   ),
+    //   onClick: () => {
+    //     // expandAllOutputs();
+    //   },
+    //   uuid: 'Expand all outputs',
+    // },
+    {
+      label: () => (
+        <FileHeaderMenuItem
+          beforeIcon={<LayoutStacked success={!sideBySideEnabled} />}
+          label="Show output below block"
+        />
       ),
       onClick: () => {
         setSideBySideEnabled(false);
@@ -247,15 +276,10 @@ function FileHeaderMenu({
     },
     {
       label: () => (
-        <FlexContainer alignItems="center">
-          <LayoutSplit success={sideBySideEnabled} />
-
-          <Spacing mr={1} />
-
-          <Text noWrapping>
-            Show output next to code (beta)
-          </Text>
-        </FlexContainer>
+        <FileHeaderMenuItem
+          beforeIcon={<LayoutSplit success={sideBySideEnabled} />}
+          label="Show output next to code (beta)"
+        />
       ),
       onClick: () => {
         setSideBySideEnabled(true);
@@ -265,24 +289,22 @@ function FileHeaderMenu({
     {
       disabled: !sideBySideEnabled,
       label: () => (
-        <FlexContainer alignItems="center">
-          {scrollTogether ? <Check /> : <div style={{ width: ICON_SIZE}} />}
-
-          <Spacing mr={1} />
-
-          <Text disabled={!sideBySideEnabled} noWrapping>
-            Scroll output alongside code (beta)
-          </Text>
-        </FlexContainer>
+        <FileHeaderMenuItem
+          checked={scrollTogether}
+          label="Scroll output alongside code (beta)"
+          muted={!sideBySideEnabled}
+        />
       ),
       onClick: () => setScrollTogether(!scrollTogether),
       uuid: 'Scroll output alongside code',
     },
   ], [
+    hideOutputOnExecution,
     scrollTogether,
     setScrollTogether,
     setSideBySideEnabled,
     sideBySideEnabled,
+    toggleHideOutputOnExecution,
   ]);
 
   const computeItems = useMemo(() => {

--- a/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/FileHeaderMenu/index.tsx
@@ -6,7 +6,6 @@ import FlexContainer from '@oracle/components/FlexContainer';
 import FileHeaderMenuItem from './FileHeaderMenuItem';
 import FlyoutMenu from '@oracle/components/FlyoutMenu';
 import KernelOutputType from '@interfaces/KernelOutputType';
-import KernelType, { KernelNameEnum } from '@interfaces/KernelType';
 import PipelineType, {
   KERNEL_NAME_TO_PIPELINE_TYPE,
   PipelineTypeEnum,
@@ -18,6 +17,7 @@ import {
   LayoutSplit,
   LayoutStacked,
 } from '@oracle/icons';
+import { KernelNameEnum } from '@interfaces/KernelType';
 import {
   KEY_CODE_NUMBERS_TO_NUMBER,
   KEY_CODE_NUMBER_0,
@@ -31,7 +31,6 @@ import {
   KEY_CODE_ARROW_RIGHT,
 } from '@utils/hooks/keyboardShortcuts/constants';
 import { SHARED_FILE_HEADER_BUTTON_PROPS } from './constants';
-import { UNIT } from '@oracle/styles/units/spacing';
 import { ViewKeyEnum } from '@components/Sidekick/constants';
 import { isMac } from '@utils/os';
 import { randomNameGenerator } from '@utils/string';

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -132,6 +132,7 @@ type PipelineDetailProps = {
   files: FileType[];
   globalDataProducts?: GlobalDataProductType[];
   globalVariables: PipelineVariableType[];
+  hideOutputOnExecution?: boolean;
   hiddenBlocks: {
     [uuid: string]: BlockType;
   };
@@ -229,6 +230,7 @@ function PipelineDetail({
   files,
   globalDataProducts,
   globalVariables,
+  hideOutputOnExecution,
   hiddenBlocks,
   interactionsMapping,
   interruptKernel,
@@ -1027,6 +1029,7 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
           fetchFileTree={fetchFileTree}
           fetchPipeline={fetchPipeline}
           globalDataProducts={globalDataProducts}
+          hideOutputOnExecution={hideOutputOnExecution}
           hideRunButton={isStreaming || isMarkdown || (isIntegration && isTransformer)}
           interactionsMapping={interactionsMapping}
           interruptKernel={interruptKernel}
@@ -1123,6 +1126,7 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
     fetchFileTree,
     fetchPipeline,
     globalDataProducts,
+    hideOutputOnExecution,
     hiddenBlocks,
     interactionsMapping,
     interruptKernel,

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -103,6 +103,7 @@ import {
   LOCAL_STORAGE_KEY_PIPELINE_EDIT_HIDDEN_BLOCKS,
   LOCAL_STORAGE_KEY_PIPELINE_EDITOR_SIDE_BY_SIDE_ENABLED,
   LOCAL_STORAGE_KEY_PIPELINE_EDITOR_SIDE_BY_SIDE_SCROLL_TOGETHER,
+  LOCAL_STORAGE_KEY_HIDE_BLOCK_OUTPUT_ON_EXECUTION,
 } from '@storage/constants';
 import {
   LOCAL_STORAGE_KEY_PIPELINE_EDITOR_AFTER_HIDDEN,
@@ -475,6 +476,18 @@ function PipelineDetailPage({
     setScrollTogether,
     setSideBySideEnabledState,
   ]);
+
+  const [hideBlockOutputOnExecution, setHideBlockOutputOnExecution] = useState<boolean>(
+    get(LOCAL_STORAGE_KEY_HIDE_BLOCK_OUTPUT_ON_EXECUTION, false),
+  );
+  const toggleHideBlockOutputOnExecution = useCallback(() => {
+    const hideBlockOutputOnExecutionUpdated = !hideBlockOutputOnExecution;
+    setHideBlockOutputOnExecution(hideBlockOutputOnExecutionUpdated);
+    set(
+      LOCAL_STORAGE_KEY_HIDE_BLOCK_OUTPUT_ON_EXECUTION,
+      hideBlockOutputOnExecutionUpdated,
+    );
+  }, [hideBlockOutputOnExecution]);
 
   const dispatchEventChanged = useCallback(() => {
     const evt = new CustomEvent(CUSTOM_EVENT_CODE_BLOCK_CHANGED, {
@@ -3090,6 +3103,7 @@ function PipelineDetailPage({
       files={files}
       globalDataProducts={globalDataProducts}
       globalVariables={globalVariables}
+      hideOutputOnExecution={hideBlockOutputOnExecution}
       // @ts-ignore
       hiddenBlocks={hiddenBlocks}
       interactionsMapping={interactionsMapping}
@@ -3155,6 +3169,7 @@ function PipelineDetailPage({
     files,
     globalDataProducts,
     globalVariables,
+    hideBlockOutputOnExecution,
     hiddenBlocks,
     interactionsMapping,
     interruptKernel,
@@ -3199,6 +3214,7 @@ function PipelineDetailPage({
           cancelPipeline={cancelPipeline}
           createPipeline={createPipeline}
           executePipeline={executePipeline}
+          hideOutputOnExecution={hideBlockOutputOnExecution}
           interruptKernel={interruptKernel}
           isPipelineExecuting={isPipelineExecuting}
           pipeline={pipeline}
@@ -3210,6 +3226,7 @@ function PipelineDetailPage({
           setScrollTogether={setScrollTogether}
           setSideBySideEnabled={setSideBySideEnabled}
           sideBySideEnabled={sideBySideEnabled}
+          toggleHideOutputOnExecution={toggleHideBlockOutputOnExecution}
           updatePipelineMetadata={updatePipelineMetadata}
         />
       );
@@ -3218,6 +3235,7 @@ function PipelineDetailPage({
     cancelPipeline,
     createPipeline,
     executePipeline,
+    hideBlockOutputOnExecution,
     interruptKernel,
     isPipelineExecuting,
     page,
@@ -3229,6 +3247,7 @@ function PipelineDetailPage({
     setScrollTogether,
     setSideBySideEnabled,
     sideBySideEnabled,
+    toggleHideBlockOutputOnExecution,
     updatePipelineMetadata,
   ]);
 

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1619,24 +1619,24 @@ function PipelineDetailPage({
     };
   }, [blocks]);
 
-  const collapseAllBlockOutputs = useCallback((state: boolean = true) => {
-    if (blocksInNotebook.some(({ uuid: blockUUID }) =>
-      get(getOutputCollapsedUUID(pipelineUUID, blockUUID), false) !== state,
-    )) {
-      const blocksThatNeedToRefreshUpdated = {};
-      blocksInNotebook.forEach(({ type: blockType, uuid: blockUUID }) => {
-        set(getOutputCollapsedUUID(pipelineUUID, blockUUID), state);
-        if (!blocksThatNeedToRefreshUpdated[blockType]) {
-          blocksThatNeedToRefreshUpdated[blockType] = {};
-        }
-        blocksThatNeedToRefreshUpdated[blockType][blockUUID] = Number(new Date());
-      });
-      setBlocksThatNeedToRefresh((prev: any) => ({
-        ...prev,
-        ...blocksThatNeedToRefreshUpdated,
-      }));
-    }
-  }, [blocksInNotebook, pipelineUUID]);
+  // const collapseAllBlockOutputs = useCallback((state: boolean = true) => {
+  //   if (blocksInNotebook.some(({ uuid: blockUUID }) =>
+  //     get(getOutputCollapsedUUID(pipelineUUID, blockUUID), false) !== state,
+  //   )) {
+  //     const blocksThatNeedToRefreshUpdated = {};
+  //     blocksInNotebook.forEach(({ type: blockType, uuid: blockUUID }) => {
+  //       set(getOutputCollapsedUUID(pipelineUUID, blockUUID), state);
+  //       if (!blocksThatNeedToRefreshUpdated[blockType]) {
+  //         blocksThatNeedToRefreshUpdated[blockType] = {};
+  //       }
+  //       blocksThatNeedToRefreshUpdated[blockType][blockUUID] = Number(new Date());
+  //     });
+  //     setBlocksThatNeedToRefresh((prev: any) => ({
+  //       ...prev,
+  //       ...blocksThatNeedToRefreshUpdated,
+  //     }));
+  //   }
+  // }, [blocksInNotebook, pipelineUUID]);
 
   const updatePipelineMetadata =
     useCallback((name: string, type?: PipelineTypeEnum) => savePipelineContent({
@@ -3232,7 +3232,6 @@ function PipelineDetailPage({
       return (
         <FileHeaderMenu
           cancelPipeline={cancelPipeline}
-          collapseAllBlockOutputs={collapseAllBlockOutputs}
           createPipeline={createPipeline}
           executePipeline={executePipeline}
           hideOutputOnExecution={hideBlockOutputOnExecution}
@@ -3254,7 +3253,6 @@ function PipelineDetailPage({
     }
   }, [
     cancelPipeline,
-    collapseAllBlockOutputs,
     createPipeline,
     executePipeline,
     hideBlockOutputOnExecution,

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1623,16 +1623,18 @@ function PipelineDetailPage({
     if (blocksInNotebook.some(({ uuid: blockUUID }) =>
       get(getOutputCollapsedUUID(pipelineUUID, blockUUID), false) !== state,
     )) {
+      const blocksThatNeedToRefreshUpdated = {};
       blocksInNotebook.forEach(({ type: blockType, uuid: blockUUID }) => {
         set(getOutputCollapsedUUID(pipelineUUID, blockUUID), state);
-        setBlocksThatNeedToRefresh((prev: any) => ({
-          ...prev,
-          [blockType]: {
-            ...prev?.[blockType],
-            [blockUUID]: Number(new Date()),
-          },
-        }));
+        if (!blocksThatNeedToRefreshUpdated[blockType]) {
+          blocksThatNeedToRefreshUpdated[blockType] = {};
+        }
+        blocksThatNeedToRefreshUpdated[blockType][blockUUID] = Number(new Date());
       });
+      setBlocksThatNeedToRefresh((prev: any) => ({
+        ...prev,
+        ...blocksThatNeedToRefreshUpdated,
+      }));
     }
   }, [blocksInNotebook, pipelineUUID]);
 

--- a/mage_ai/frontend/storage/constants.ts
+++ b/mage_ai/frontend/storage/constants.ts
@@ -22,3 +22,4 @@ export const LOCAL_STORAGE_KEY_INCLUDE_SERVER_TIME_SECONDS =
 
 export const LOCAL_STORAGE_KEY_PIPELINE_EDITOR_SIDE_BY_SIDE_ENABLED = 'pipeline_editor_side_by_side_enabled';
 export const LOCAL_STORAGE_KEY_PIPELINE_EDITOR_SIDE_BY_SIDE_SCROLL_TOGETHER = 'pipeline_editor_side_by_side_scroll_together';
+export const LOCAL_STORAGE_KEY_HIDE_BLOCK_OUTPUT_ON_EXECUTION = 'hide_block_output_on_execution';


### PR DESCRIPTION
# Description
- Add "View" menu item in Pipeline Editor for hiding block output after block is executed, which can avoid rendering excessive block output 

# How Has This Been Tested?
![hide block output on execute](https://github.com/mage-ai/mage-ai/assets/78053898/29d20902-09db-44ee-ac66-fd0178674bba)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
