### PR TITLE
[xy] Refresh block run statuses before fetching crashed block runs.

### DIFF
--- a/mage_ai/orchestration/pipeline_scheduler_original.py
+++ b/mage_ai/orchestration/pipeline_scheduler_original.py
@@ -830,6 +830,8 @@ class PipelineScheduler:
         Returns:
             List[BlockRun]: A list of crashed block runs.
         """
+        for b in self.pipeline_run.block_runs:
+            b.refresh()
         running_or_queued_block_runs = [b for b in self.pipeline_run.block_runs if b.status in [
             BlockRun.BlockRunStatus.RUNNING,
             BlockRun.BlockRunStatus.QUEUED,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Refresh block run statuses before fetching crashed block runs.

This prevents block runs keep being restarted  (especially when there're a lot of dynamic child blocks)

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with 400 dynamic child blocks


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
