### PR TITLE
Caching pipeline_project outside of loop to avoid multple lookups

### DIFF
--- a/mage_ai/data_preparation/models/block/data_integration/mixins.py
+++ b/mage_ai/data_preparation/models/block/data_integration/mixins.py
@@ -202,18 +202,29 @@ class DataIntegrationMixin:
             with open(catalog_full_path, mode='w') as f:
                 f.write(json.dumps(catalog))
 
-    def is_data_integration(self) -> bool:
+    def is_data_integration(self, pipeline_project: Project = None) -> bool:
         """
         Check if the block is a data integration block.
         If the data_integration_in_batch_pipeline feature is not enabled, return False.
 
+        Args:
+            pipeline_project (Project, optional): A cached Project value to avoid
+                looking it up many times when called inside loops. Defaults to None.
+
         Returns:
             bool: True if it's a data integration block, False otherwise.
         """
-        if not self.pipeline or not \
-                Project(self.pipeline.repo_config).is_feature_enabled(
-                    FeatureUUID.DATA_INTEGRATION_IN_BATCH_PIPELINE,
-                ):
+        if not self.pipeline:
+
+            return False
+
+        actual_project: Project = pipeline_project
+        if not actual_project:
+            actual_project = Project(self.pipeline.repo_config)
+
+        if not actual_project.is_feature_enabled(
+                        FeatureUUID.DATA_INTEGRATION_IN_BATCH_PIPELINE,
+                    ):
 
             return False
 

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -48,6 +48,7 @@ from mage_ai.data_preparation.models.constants import (
     PipelineType,
 )
 from mage_ai.data_preparation.models.pipeline import Pipeline
+from mage_ai.data_preparation.models.project import Project
 from mage_ai.data_preparation.models.triggers import (
     ScheduleInterval,
     ScheduleStatus,
@@ -989,6 +990,9 @@ class PipelineRun(PipelineRunProjectPlatformMixin, BaseModel):
         block_runs_all = []
 
         data_integration_block_uuids_mapping = {}
+
+        pipeline_project = Project(pipeline.repo_config)
+
         for block_run in self.block_runs:
             block_runs_all.append(block_run)
 
@@ -1021,7 +1025,7 @@ class PipelineRun(PipelineRunProjectPlatformMixin, BaseModel):
                 "original": 1,
             }
             """
-            if metrics and block and block.is_data_integration():
+            if metrics and block and block.is_data_integration(pipeline_project=pipeline_project):
                 original_block_uuid = metrics.get('original_block_uuid')
 
                 if original_block_uuid and metrics.get('child'):


### PR DESCRIPTION
# Description
Scheduler checks in a loop whether a block is an integration block. This instantiates Project object in each call which is quite slow and adds considerably, esp. when many blocks are in the pipeline.

The change caches the pipeline project outside of the loop. The method now takes the cached object as an optional parameter and avoids lookups.

# How Has This Been Tested?
Tested in my local project.

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993 
