### PR TITLE
[jk] Only make specific files request with ArcaneLibrary

### DIFF
--- a/mage_ai/frontend/api/utils/useDelayFetch.ts
+++ b/mage_ai/frontend/api/utils/useDelayFetch.ts
@@ -10,7 +10,7 @@ export default function useDelayFetch(endpoint: (opts?: any) => any, ...argsInit
   let opts;
 
   const lastArg = argsInit?.slice(-1)?.[0];
-  if ('condition' in lastArg || 'delay' in lastArg) {
+  if ('condition' in lastArg || 'delay' in lastArg || 'pauseFetch' in lastArg) {
     args = args.slice(0, args?.length - 1);
     opts = lastArg;
   }
@@ -18,6 +18,7 @@ export default function useDelayFetch(endpoint: (opts?: any) => any, ...argsInit
   const {
     condition,
     delay,
+    pauseFetch,
   } = opts || {
     condition: undefined,
     delay: 3000,
@@ -43,17 +44,17 @@ export default function useDelayFetch(endpoint: (opts?: any) => any, ...argsInit
       }, delay);
     };
 
-    if (!ready) {
+    if (!ready && !pauseFetch) {
       getReady();
     }
-  }, [condition]);
+  }, [condition, pauseFetch]);
 
   const {
     data,
     mutate,
   } = endpoint(...(ready
     ? args
-    : [null, null, { pauseFetch: delay }]
+    : [null, null, { pauseFetch: pauseFetch || delay }]
   ));
 
   return {

--- a/mage_ai/frontend/components/Applications/PortalTerminal/index.tsx
+++ b/mage_ai/frontend/components/Applications/PortalTerminal/index.tsx
@@ -1,9 +1,3 @@
-import { useEffect, useRef, useState } from 'react';
-
-import ButtonTabs, { TabType } from '@oracle/components/Tabs/ButtonTabs';
-import Divider from '@oracle/elements/Divider';
-import FlexContainer from '@oracle/components/FlexContainer';
-import Spacing from '@oracle/elements/Spacing';
 import TripleLayout from '@components/TripleLayout';
 import useApplicationBase, { ApplicationBaseType } from '../useApplicationBase';
 import useTerminal from '@components/Terminal/useTerminal';

--- a/mage_ai/frontend/components/Files/useFileComponents.tsx
+++ b/mage_ai/frontend/components/Files/useFileComponents.tsx
@@ -33,6 +33,7 @@ import dark from '@oracle/styles/themes/dark';
 import useContextMenu from '@utils/useContextMenu';
 import useDelayFetch from '@api/utils/useDelayFetch';
 import useStatus from '@utils/models/status/useStatus';
+import { ApplicationExpansionUUIDEnum } from '@interfaces/CommandCenterType';
 import {
   Check,
   Circle,
@@ -455,6 +456,7 @@ function useFileComponents({
     exclude_dir_pattern: COMMON_EXCLUDE_DIR_PATTERNS,
   }, {
     delay: (typeof delayFetch === 'undefined' || delayFetch === null) ? 0 : delayFetch,
+    pauseFetch: uuidProp !== ApplicationExpansionUUIDEnum.ArcaneLibrary,
   });
   const filesFlatten = useMemo(() => filesFlattenData?.files  || [], [filesFlattenData]);
 


### PR DESCRIPTION
# Description
- There were unnecessary `files` requests being made when calling the `useFileComponents` hook, specifically when not using the ArcaneLibrary component specifically. If the ArcaneLibrary component wasn't being used, then we could reduce the number of `files` requests being made. This PR implements this fix.

# How Has This Been Tested?
- Confirmed `/api/files?pattern=%2F.csv%24%7C.json%24%7C.md%24%7C.py%24%7C.r%24%7C.sh%24%7C.sql%24%7C.txt%24%7C.yaml%24%7C.yml%24%2F&flatten=true&exclude_pattern=/__init__.py|metadata.yaml|interactions.yaml|.DS_Store/&exclude_dir_pattern=/compiled|__pycache__` request was only being made when opening the Arcane Library and not in other pages using the FileBrowser component.

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993 
