### PR TITLE
[jk] Remove pipeline_runs request appearing on different pages

### DIFF
--- a/mage_ai/frontend/pages/index.tsx
+++ b/mage_ai/frontend/pages/index.tsx
@@ -19,12 +19,6 @@ const Home = () => {
   const { data: data } = api.statuses.list();
   const dataStatus = useMemo(() => data?.statuses?.[0], [data]);
 
-  const { data: dataPipelineRuns } = api.pipeline_runs.list({ _limit: 0 });
-  const pipelineRunCount = useMemo(() => dataPipelineRuns?.metadata?.count || 0, [
-    dataPipelineRuns?.metadata?.count,
-  ]);
-  const homepageRedirectPath = pipelineRunCount === 0 ? '/pipelines' : '/overview';
-
   useEffect(() => {
     if (isDemo()) {
       logUserOS();
@@ -43,19 +37,16 @@ const Home = () => {
         const manage = dataStatus?.is_instance_manager;
         let pathname = completePath;
         if (basePath === '/') {
-          pathname = manage ? '/manage' : homepageRedirectPath;
+          pathname = manage ? '/manage' : '/overview';
         }
-        if (dataPipelineRuns) {
-          router.replace(pathname);
-        }
+
+        router.replace(pathname);
       }
     }
   }, [
     basePath,
     completePath,
-    dataPipelineRuns,
     dataStatus,
-    homepageRedirectPath,
     router,
   ]);
 };


### PR DESCRIPTION
# Description
- There was an unnecessary pipeline_runs request from the `mage_ai/frontend/pages/index.tsx` file being made on most pages specifically when using the frontend production build. That pipeline_runs request was to check if the user's project had at least 1 pipeline run, and if it did not, it could mean that it was a new project and would redirect users to the Pipelines Dashboard (instead of the Overview page). Since the request could potentially affect app performance, it was removed in order to maximize app performance.
- As a result, the root page of the app no longer redirects to the Pipelines dashboard for new projects (where there are no pipeline runs yet), just the Overview dashboard, which should not affect the user experience significantly.

# How Has This Been Tested?
- Built frontend production build locally and confirmed that the unnecessary pipeline_runs request was no longer made throughout the app.

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
