### PR TITLE
Update ads_insights_age_and_gender.json

### DIFF
--- a/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/ads_insights_age_and_gender.json
+++ b/mage_integrations/mage_integrations/sources/facebook_ads/tap_facebook/schemas/ads_insights_age_and_gender.json
@@ -320,8 +320,8 @@
     "age": {
       "type": [
         "null",
-        "integer",
-        "string"
+        "string",
+        "integer"
       ]
     },
     "gender": {


### PR DESCRIPTION
# Description
 This data in facebook stream **ads_insights_age_and_gender** comes as age range i.e. 18-24, 25-30 etc.. rather than an integer value. If we change the order of the types and bring string above integer, i think it make sense and should sort casting the error that i am getting with trino.

# How Has This Been Tested?
Locally

- [ ] Test A
- [ ] Test B


# Checklist
- [X ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
