### PR TITLE
[jk] Add visibility into project config loading errors

### DIFF
--- a/mage_ai/frontend/components/BlockLayout/BlockLayoutItem/index.tsx
+++ b/mage_ai/frontend/components/BlockLayout/BlockLayoutItem/index.tsx
@@ -130,7 +130,7 @@ function BlockLayoutItem({
   }, [
     dataBlockLayoutItem,
     showError,
-]);
+  ]);
 
   useEffect(() => {
     if (!blockLayoutItem) {

--- a/mage_ai/frontend/components/shared/Header/index.tsx
+++ b/mage_ai/frontend/components/shared/Header/index.tsx
@@ -123,11 +123,12 @@ function Header({
   const {
     featureEnabled,
     featureUUIDs,
+    isLoadingProject,
     isLoadingUpdate,
     project: projectInit,
     rootProject,
     updateProject,
-  } = useProject();
+  } = useProject({ showError });
   const project = useMemo(() => projectProp || projectInit, [projectInit, projectProp]);
   const version = useMemo(() => versionProp || project?.version, [project, versionProp]);
   const commandCenterEnabled = useMemo(() =>
@@ -232,23 +233,18 @@ function Header({
     }
 
     breadcrumbProjects.push(crumb);
+  } else if (!isLoadingProject) {
+    breadcrumbProjects.push({
+      bold: true,
+      danger: true,
+      label: () => 'Error loading project configuration',
+    });
   }
 
-  const breadcrumbs = useMemo(() => {
-    // breadcrumbsProp || [{
-    //   bold: true,
-    //   label: () => project?.name,
-    //   linkProps: {
-    //     href: '/',
-    //     sameColorText: true,
-    //   },
-    // }]
-
-    return [
+  const breadcrumbs = useMemo(() => [
       ...breadcrumbProjects,
       ...(breadcrumbsProp || []),
-    ];
-  }, [
+    ], [
     breadcrumbProjects,
     breadcrumbsProp,
     project,

--- a/mage_ai/frontend/utils/models/project/useProject.ts
+++ b/mage_ai/frontend/utils/models/project/useProject.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useMutation } from 'react-query';
 
 import ProjectType, { FeatureUUIDEnum } from '@interfaces/ProjectType';
@@ -22,6 +22,7 @@ export type UseProjectType = {
     OPERATION_HISTORY: FeatureUUIDEnum;
   };
   fetchProjects: () => any;
+  isLoadingProject?: boolean;
   isLoadingUpdate: boolean;
   project: ProjectType;
   projectPlatformActivated?: boolean;
@@ -32,10 +33,12 @@ export type UseProjectType = {
 
 type UseProjectProps = {
   pauseFetch?: boolean;
+  showError?: (resp: { response: any }) => void;
 };
 
 function useProject({
   pauseFetch,
+  showError,
 }: UseProjectProps = {
   pauseFetch: false,
 }): UseProjectType {
@@ -44,6 +47,17 @@ function useProject({
   }, {
     pauseFetch,
   });
+  useEffect(() => {
+    if (dataProjects?.error) {
+      showError?.({
+        response: dataProjects,
+      });
+    }
+  }, [
+    dataProjects,
+    showError,
+  ]);
+
   const {
     project,
     rootProject,
@@ -92,6 +106,7 @@ function useProject({
     featureEnabled: (featureUUID: FeatureUUIDEnum): boolean => featureEnabled(project, featureUUID),
     featureUUIDs: FeatureUUIDEnum,
     fetchProjects,
+    isLoadingProject: !dataProjects,
     isLoadingUpdate,
     project,
     projectPlatformActivated: project && rootProject && project?.name !== rootProject?.name,


### PR DESCRIPTION
# Description
- If the project's header breadcrumbs were not visible, it could be indicative of an issue with the project's `metadata.yaml` configuration file. However, there wasn't any visibility into this error, so this PR displays the error in a popup and also shows `Error loading project configuration` in the header.
- May help identify issues related to this github issue: https://github.com/mage-ai/mage-ai/issues/4880

# How Has This Been Tested?
- Tested with an invalid project metadata.yaml config file:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/10ecdd3f-0649-475f-869d-41ccae259cc4)
- Tested on both single project and multi-project platform.

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
