### PR TITLE
[xh]Create streaming oracle destination

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -302,6 +302,7 @@
                 "streaming/destinations/mssql",
                 "streaming/destinations/mysql",
                 "streaming/destinations/opensearch",
+                "streaming/destinations/oracledb",
                 "streaming/destinations/postgres",
                 "streaming/destinations/rabbitmq",
                 "streaming/destinations/redshift",

--- a/docs/streaming/destinations/oracledb.mdx
+++ b/docs/streaming/destinations/oracledb.mdx
@@ -1,0 +1,30 @@
+---
+title: "Oracle Database"
+---
+
+## Basic config
+
+```yaml
+connector_type: oracledb
+user: your_user_name
+password: your_user_password
+host: host_name
+port: port_number
+table: exported_table_name
+service_name: exported_service_name
+```
+
+* `user`: Ther user account in Oracle Database to export data with.
+* `password`: password of the user account.
+* `host`: Oracle Database host name.
+* `port`: Oracle Database port number.
+* `table`: Table name to export.
+* `service_name`: Oracle Database service name.
+
+## Optional fields
+
+```yaml
+mode: mode_to_export
+```
+
+* `mode`: Export mode. Available values: `thin`, `thick`.

--- a/mage_ai/data_preparation/templates/data_exporters/streaming/oracledb.yaml
+++ b/mage_ai/data_preparation/templates/data_exporters/streaming/oracledb.yaml
@@ -1,0 +1,8 @@
+connector_type: oracledb
+user: 'test'
+password: '123456'
+host: 'host_name'
+port: 1521
+table: 'exported_table'
+service_name: 'service_name'
+mode: 'thin'

--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/utils.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/utils.tsx
@@ -61,6 +61,7 @@ const getDataSourceTypes = (
         DataSourceTypeEnum.MSSQL,
         DataSourceTypeEnum.MYSQL,
         DataSourceTypeEnum.OPENSEARCH,
+        DataSourceTypeEnum.ORACLEDB,
         DataSourceTypeEnum.POSTGRES,
         DataSourceTypeEnum.RABBITMQ,
         DataSourceTypeEnum.REDSHIFT,

--- a/mage_ai/streaming/sinks/oracledb.py
+++ b/mage_ai/streaming/sinks/oracledb.py
@@ -1,0 +1,57 @@
+import json
+import time
+from dataclasses import dataclass
+from typing import Dict, List
+
+import pandas as pd
+
+from mage_ai.io.base import ExportWritePolicy
+from mage_ai.io.oracledb import OracleDB
+from mage_ai.shared.config import BaseConfig
+from mage_ai.streaming.sinks.base import BaseSink
+
+
+@dataclass
+class OracleDbConfig(BaseConfig):
+    user: str
+    password: int
+    host: str
+    port: int
+    table: str
+    service_name: str
+    verbose: bool = False
+    mode: str = 'thin'
+
+
+class OracleDbSink(BaseSink):
+    config_class = OracleDbConfig
+
+    def init_client(self):
+        self.oracledb_client = OracleDB(
+            user=self.config.user,
+            password=self.config.password,
+            host=self.config.host,
+            port=self.config.port,
+            service_name=self.config.service_name,
+            verbose=self.config.verbose,
+            mode=self.config.mode,
+        )
+        self.oracledb_client.open()
+
+    def write(self, message: Dict):
+        self.batch_write([message])
+
+    def batch_write(self, messages: List[Dict]):
+        if not messages:
+            return
+        self._print(
+            f'Batch ingest {len(messages)} records, time={time.time()}. Sample: {messages[0]}')
+        # Convert string formated dictionary array to array of dictionaries.
+        # To be used for dataframe creation.
+        dictionary_messages = [json.loads(doc_string) for doc_string in messages]
+        df = pd.DataFrame(dictionary_messages)
+        self.oracledb_client.export(
+            df,
+            self.config.table,
+            if_exists=ExportWritePolicy.APPEND,
+        )

--- a/mage_ai/streaming/sinks/sink_factory.py
+++ b/mage_ai/streaming/sinks/sink_factory.py
@@ -59,6 +59,10 @@ class SinkFactory:
             from mage_ai.streaming.sinks.opensearch import OpenSearchSink
 
             return OpenSearchSink(config, **kwargs)
+        elif connector_type == SinkType.ORACLEDB:
+            from mage_ai.streaming.sinks.oracledb import OracleDbSink
+
+            return OracleDbSink(config, **kwargs)
         elif connector_type == SinkType.POSTGRES:
             from mage_ai.streaming.sinks.postgres import PostgresSink
 

--- a/mage_ai/tests/streaming/sinks/test_oracledb.py
+++ b/mage_ai/tests/streaming/sinks/test_oracledb.py
@@ -1,0 +1,38 @@
+from unittest.mock import patch
+
+from mage_ai.streaming.sinks.oracledb import OracleDbSink
+from mage_ai.tests.base_test import TestCase
+
+
+class OracleDbTests(TestCase):
+    def test_init(self):
+        with patch.object(OracleDbSink, 'init_client') as mock_init_client:
+            OracleDbSink(dict(
+                connector_type='oracledb',
+                user='test',
+                password='123456',
+                host='oracle-test',
+                port=1521,
+                table='test_table',
+                service_name='test_service',
+                mode='thin',
+            ))
+            mock_init_client.assert_called_once()
+
+    def test_init_invalid_config(self):
+        with patch.object(OracleDbSink, 'init_client') as mock_init_client:
+            with self.assertRaises(Exception) as context:
+                OracleDbSink(dict(
+                    connector_type='oracledb',
+                    user='test',
+                    password='123456',
+                    host='oracle-test',
+                    port=1521,
+                    table='test_table',
+                    mode='thin',
+                ))
+            self.assertTrue(
+                '__init__() missing 1 required positional argument: \'service_name\''
+                in str(context.exception),
+            )
+            self.assertEqual(mock_init_client.call_count, 0)


### PR DESCRIPTION
# Description
Follow this issue request: https://github.com/mage-ai/mage-ai/issues/4666 to create oracle destination for streaming pipeline.


# How Has This Been Tested?
Mage UI:
Created streaming pipeline with source: RabbitMQ, transformer and OracleDB destination.

UI to select OracleDB destination
![sink_ui](https://github.com/mage-ai/mage-ai/assets/5386254/b5fb30ea-97a2-4b82-b26c-250f6afb4354)

Successfully exported data into Oracle:
![streamed_output](https://github.com/mage-ai/mage-ai/assets/5386254/047fd02f-a0be-466c-bbfd-401aaa42621b)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993 
