### PR TITLE
Add support for user_roles when using OIDC auth

### DIFF
--- a/mage_ai/authentication/providers/oidc.py
+++ b/mage_ai/authentication/providers/oidc.py
@@ -131,4 +131,5 @@ class OidcProvider(OauthProvider, SsoProvider):
         return dict(
             email=email,
             username=userinfo_resp.get('preferred_username', email),
+            user_roles = userinfo_resp.get('user_roles'),
         )

--- a/mage_ai/authentication/providers/oidc.py
+++ b/mage_ai/authentication/providers/oidc.py
@@ -131,5 +131,5 @@ class OidcProvider(OauthProvider, SsoProvider):
         return dict(
             email=email,
             username=userinfo_resp.get('preferred_username', email),
-            user_roles = userinfo_resp.get('user_roles'),
+            user_roles=userinfo_resp.get('user_roles'),
         )

--- a/mage_ai/authentication/providers/oidc.py
+++ b/mage_ai/authentication/providers/oidc.py
@@ -131,5 +131,5 @@ class OidcProvider(OauthProvider, SsoProvider):
         return dict(
             email=email,
             username=userinfo_resp.get('preferred_username', email),
-            user_roles=userinfo_resp.get('user_roles'),
+            user_roles=userinfo_resp.get('user_roles',[]),
         )

--- a/mage_ai/authentication/providers/oidc.py
+++ b/mage_ai/authentication/providers/oidc.py
@@ -131,5 +131,5 @@ class OidcProvider(OauthProvider, SsoProvider):
         return dict(
             email=email,
             username=userinfo_resp.get('preferred_username', email),
-            user_roles=userinfo_resp.get('user_roles',[]),
+            user_roles=userinfo_resp.get('user_roles', []),
         )


### PR DESCRIPTION
OIDC auth ignores user_roles , this pr fixes reported bug #4898 

# Checklist
- [ x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
