### PR TITLE
[xy] Support alerts and limited retries in streaming pipeline.

### DIFF
--- a/mage_ai/data_preparation/models/block/extension/utils.py
+++ b/mage_ai/data_preparation/models/block/extension/utils.py
@@ -45,4 +45,5 @@ def handle_run_tests(
             global_vars=global_vars,
             logger=logger,
             logging_tags=logging_tags,
+            update_status=False,
         )

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -673,6 +673,7 @@ class Pipeline:
         analyze_outputs: bool = False,
         build_block_output_stdout: Callable[..., object] = None,
         global_vars=None,
+        retry_config=None,
         run_sensors: bool = True,
         run_tests: bool = True,
         update_status: bool = True,
@@ -689,6 +690,7 @@ class Pipeline:
             StreamingPipelineExecutor(self).execute(
                 build_block_output_stdout=build_block_output_stdout,
                 global_vars=global_vars,
+                retry_config=retry_config,
             )
         else:
             root_blocks = []

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -62,6 +62,8 @@ from mage_ai.data_preparation.shared.utils import get_template_vars
 from mage_ai.data_preparation.templates.utils import copy_template_directory
 from mage_ai.data_preparation.variable_manager import VariableManager
 from mage_ai.orchestration.constants import Entity
+from mage_ai.orchestration.notification.config import NotificationConfig
+from mage_ai.orchestration.notification.sender import NotificationSender
 from mage_ai.settings.platform import build_repo_path_for_all_projects
 from mage_ai.settings.platform.constants import project_platform_activated
 from mage_ai.settings.repo import get_repo_path
@@ -727,6 +729,16 @@ class Pipeline:
         with open(self.catalog_config_path) as f:
             config = json.load(f)
         return config
+
+    def get_notification_sender(self):
+        return NotificationSender(
+            NotificationConfig.load(
+                config=merge_dict(
+                    self.repo_config.notification_config,
+                    self.notification_config,
+                ),
+            ),
+        )
 
     def load_config_from_yaml(self):
         catalog = None

--- a/mage_ai/server/websocket_server.py
+++ b/mage_ai/server/websocket_server.py
@@ -116,6 +116,7 @@ def run_pipeline(
         pipeline.execute_sync(
             global_vars=global_vars,
             build_block_output_stdout=build_block_output_stdout,
+            retry_config=dict(),
             run_sensors=False,
         )
         add_pipeline_message(


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Support alerts and limited retries in streaming pipeline.
Close: https://github.com/mage-ai/mage-ai/issues/4840
Close: https://github.com/mage-ai/mage-ai/issues/4842

When retry_config is set in streaming pipeline's metadata.yaml at pipeline level, only retry the streaming pipeline with limited times and send alerts when pipeline fails.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with streaming pipeline with error locally

retry config
<img width="373" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/cec3697b-8efd-4a05-8cfd-861bec4a4bfb">

retry logs
<img width="944" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/07fc6a60-0f98-4d54-9349-1fcf34fbb33b">

alerts
<img width="538" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/fefe0aeb-968b-4468-a9de-e7716293b0dc">


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
