### PR TITLE
[jk] Hide header actions on sign-in page

### DIFF
--- a/mage_ai/frontend/components/ServerTimeDropdown/index.tsx
+++ b/mage_ai/frontend/components/ServerTimeDropdown/index.tsx
@@ -36,11 +36,13 @@ import { useError } from '@context/Error';
 const DISPLAYED_TIME_ZONES = [TimeZoneEnum.UTC, TimeZoneEnum.LOCAL];
 
 type ServerTimeDropdownProps = {
+  disabled?: boolean;
   disableTimezoneToggle?: boolean;
   projectName: string;
 };
 
 function ServerTimeDropdown({
+  disabled,
   disableTimezoneToggle,
   projectName,
 }: ServerTimeDropdownProps) {
@@ -150,7 +152,7 @@ function ServerTimeDropdown({
       <div style={{ position: 'relative' }}>
         <ServerTimeButton
           active={showDropdown}
-          disabled={isSmallBreakpoint}
+          disabled={isSmallBreakpoint || disabled}
           mountedCallback={setDropdownPosition}
           onClick={handleButtonClick}
           time={times.get(defaultTimeZone)}

--- a/mage_ai/frontend/components/shared/Header/index.tsx
+++ b/mage_ai/frontend/components/shared/Header/index.tsx
@@ -63,6 +63,7 @@ export type MenuItemType = {
 
 export type HeaderProps = {
   breadcrumbs?: BreadcrumbType[];
+  hideActions?: boolean;
   menuItems?: MenuItemType[];
   project?: ProjectType;
   version?: string;
@@ -70,6 +71,7 @@ export type HeaderProps = {
 
 function Header({
   breadcrumbs: breadcrumbsProp,
+  hideActions,
   menuItems,
   project: projectProp,
   version: versionProp,
@@ -233,7 +235,7 @@ function Header({
     }
 
     breadcrumbProjects.push(crumb);
-  } else if (!isLoadingProject) {
+  } else if (!isLoadingProject && !hideActions) {
     breadcrumbProjects.push({
       bold: true,
       danger: true,
@@ -321,23 +323,25 @@ function Header({
     design,
   ]);
 
-  const userDropdown: FlyoutMenuItemType[] = [
-    {
-      label: () => 'Settings',
-      linkProps: {
-        href: '/settings/workspace/preferences',
+  const userDropdown: FlyoutMenuItemType[] = hideActions
+    ? []
+    : [
+      {
+        label: () => 'Settings',
+        linkProps: {
+          href: '/settings/workspace/preferences',
+        },
+        uuid: 'user_settings',
       },
-      uuid: 'user_settings',
-    },
-    {
-      label: () => 'Launch command center',
-      onClick: (e) => {
-        pauseEvent(e);
-        launchCommandCenterWrapper();
+      {
+        label: () => 'Launch command center',
+        onClick: (e) => {
+          pauseEvent(e);
+          launchCommandCenterWrapper();
+        },
+        uuid: 'Launch command center',
       },
-      uuid: 'Launch command center',
-    },
-  ];
+    ];
 
   if (REQUIRE_USER_AUTHENTICATION()) {
     userDropdown.push(
@@ -468,7 +472,7 @@ function Header({
             />
           </Flex>
 
-          {!!project && (
+          {(!!project && !hideActions) && (
             <Flex flex={1} alignItems="center" justifyContent="center">
               <Spacing ml={PADDING_UNITS} />
 
@@ -596,6 +600,7 @@ function Header({
             <Spacing ml={1}>
               <ServerTimeDropdown
                 disableTimezoneToggle={projectPlatformOverrideFeaturesEnabled}
+                disabled={hideActions}
                 projectName={project?.name}
               />
             </Spacing>

--- a/mage_ai/frontend/pages/sign-in.tsx
+++ b/mage_ai/frontend/pages/sign-in.tsx
@@ -3,7 +3,12 @@ import SignForm from '@components/Sessions/SignForm';
 
 function SignInPage() {
   return (
-    <BasePage title="Sign in">
+    <BasePage
+      headerProps={{
+        hideActions: true,
+      }}
+      title="Sign in"
+    >
       <SignForm
         title="👋 Sign in"
       />


### PR DESCRIPTION
# Description
- Certain components in the Header were visible or actions able to be performed on the Sign In page, which would not work due to the user not being signed in. This PR hides these actions/components in the Header to avoid confusion.

# How Has This Been Tested?
- Tested locally
- Confirmed when user is not logged in, they cannot go to project settings from the Sign-in page UI, launch the command center, or adjust timezone settings.

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
