### PR TITLE
[xy] Catch pipeline error in scheduler.

### DIFF
--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -935,7 +935,10 @@ class PipelineRun(PipelineRunProjectPlatformMixin, BaseModel):
 
     @property
     def pipeline_tags(self):
-        pipeline_config = Pipeline.get_config(self.pipeline_uuid)
+        try:
+            pipeline_config = Pipeline.get_config(self.pipeline_uuid)
+        except Exception:
+            pipeline_config = dict()
 
         return pipeline_config.get('tags') if pipeline_config is not None else []
 

--- a/mage_ai/orchestration/pipeline_scheduler_original.py
+++ b/mage_ai/orchestration/pipeline_scheduler_original.py
@@ -1681,7 +1681,11 @@ def gen_pipeline_with_schedules_single_project(
     # Iterate through pipeline schedules by pipeline to handle pipeline run limits for
     # each pipeline.
     for pipeline_uuid, active_schedules in pipeline_schedules_by_pipeline.items():
-        pipeline = Pipeline.get(pipeline_uuid)
+        try:
+            pipeline = Pipeline.get(pipeline_uuid)
+        except Exception as e:
+            print(f'Error fetching pipeline {pipeline_uuid}: {e}')
+            continue
         yield pipeline_uuid, pipeline, active_schedules
 
 
@@ -1742,11 +1746,15 @@ def gen_pipeline_with_schedules_project_platform(
     for pair in pipeline_schedules_by_pipeline_by_repo_path.items():
         repo_path, pipeline_schedules_by_pipeline = pair
         for pipeline_uuid, active_schedules in pipeline_schedules_by_pipeline.items():
-            pipeline = get_pipeline_from_platform(
-                pipeline_uuid,
-                repo_path=repo_path,
-                mapping=pipeline_schedule_repo_paths_to_repo_path_mapping,
-            )
+            try:
+                pipeline = get_pipeline_from_platform(
+                    pipeline_uuid,
+                    repo_path=repo_path,
+                    mapping=pipeline_schedule_repo_paths_to_repo_path_mapping,
+                )
+            except Exception as e:
+                print(f'Error fetching pipeline {pipeline_uuid}: {e}')
+                continue
             yield pipeline_uuid, pipeline, active_schedules
 
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Currently, if one pipeline's metadata.yaml is invalid, the whole scheduler gets crashed.
Catch pipeline error in scheduler to avoid scheduler crash.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally by manually updating a pipeline's metadata.yaml to be invalid
<img width="566" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/bc1e91da-e0de-4171-86dd-63fb0cf40bae">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
