### PR TITLE
[jk] Disallow numbers as first character of block names

### DIFF
--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -1308,7 +1308,9 @@ class Pipeline:
                         file_path = (configuration.get('file_source') or {}).get('path')
                         if file_path:
                             # Check for block name with period to avoid replacing a directory name
-                            new_file_path = file_path.replace(f'{block.name}.', f'{name}.')
+                            new_file_path = file_path.replace(
+                                f'{clean_name(block.name)}.', f'{clean_name(name)}.'
+                            )
                             configuration['file_source']['path'] = new_file_path
                             block_update_payload['configuration'] = configuration
                         blocks_to_remove_from_cache.append(block.to_dict())

--- a/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.style.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.style.tsx
@@ -38,6 +38,7 @@ export const HeaderStyle = styled.div<{
 `;
 
 export const RowStyle = styled.div<{
+  columnFlex?: boolean;
   display?: string;
   lightBackground?: boolean;
   paddingVerticalAddition?: number;
@@ -54,6 +55,11 @@ export const RowStyle = styled.div<{
     padding-bottom: ${1 * UNIT + (props?.paddingVerticalAddition || 0)}px;
     padding-left: ${PADDING_UNITS * UNIT}px;
     padding-top: ${1 * UNIT + (props?.paddingVerticalAddition || 0)}px;
+  `}
+
+  ${({ columnFlex }) => columnFlex && `
+    display: flex;
+    flex-direction: column;
   `}
 
   ${props => props.lightBackground && `

--- a/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
@@ -15,7 +15,7 @@ import BlockType, {
 import Button from '@oracle/elements/Button';
 import CodeBlock from '@components/CodeBlock';
 import Flex from '@oracle/components/Flex';
-import FlexContainer from '@oracle/components/FlexContainer';
+import FlexContainer, { JUSTIFY_SPACE_BETWEEN_PROPS } from '@oracle/components/FlexContainer';
 import KeyboardShortcutButton from '@oracle/elements/Button/KeyboardShortcutButton';
 import LLMType, { LLMUseCaseEnum } from '@interfaces/LLMType';
 import PipelineType, { PipelineTypeEnum } from '@interfaces/PipelineType';
@@ -44,7 +44,7 @@ import {
   PADDING_UNITS,
   UNIT,
 } from '@oracle/styles/units/spacing';
-import { capitalize } from '@utils/string';
+import { capitalize, startsWithNumber } from '@utils/string';
 import { onSuccess } from '@api/utils/response';
 import { useError } from '@context/Error';
 
@@ -130,6 +130,10 @@ function ConfigureBlock({
 
   const isCustomBlock = useMemo(() => BlockTypeEnum.CUSTOM === block?.type, [block]);
   const isMarkdown = useMemo(() => BlockTypeEnum.MARKDOWN === block?.type, [block]);
+  const blockNameStartsWithNumber = useMemo(() =>
+    !!blockAttributes?.name && startsWithNumber(blockAttributes?.name || ''),
+    [blockAttributes?.name],
+  );
 
   // @ts-ignore
   const blockActionObject = useMemo(() => block?.block_action_object, [block]);
@@ -351,26 +355,34 @@ function ConfigureBlock({
         </RowStyle>
       )}
 
-      <RowStyle>
-        <Text default>
-          Name
-        </Text>
+      <RowStyle columnFlex>
+        <FlexContainer {...JUSTIFY_SPACE_BETWEEN_PROPS} fullWidth>
+          <Text default>
+            Name
+          </Text>
 
-        <TextInput
-          alignRight
-          fullWidth
-          noBackground
-          noBorder
-          // @ts-ignore
-          onChange={e => setBlockAttributes(prev => ({
-            ...prev,
-            name: e.target.value,
-          }))}
-          paddingVertical={UNIT}
-          placeholder="Block name..."
-          ref={refTextInput}
-          value={blockAttributes?.name || ''}
-        />
+          <TextInput
+            alignRight
+            fullWidth
+            noBackground
+            noBorder
+            // @ts-ignore
+            onChange={e => setBlockAttributes(prev => ({
+              ...prev,
+              name: e.target.value,
+            }))}
+            paddingVertical={UNIT}
+            placeholder="Block name..."
+            ref={refTextInput}
+            value={blockAttributes?.name || ''}
+          />
+        </FlexContainer>
+
+        {blockNameStartsWithNumber && (
+          <Text bold warning>
+            Note: Numbers are not allowed as the first character of block name.
+          </Text>
+        )}
       </RowStyle>
 
       <RowStyle>
@@ -560,7 +572,7 @@ function ConfigureBlock({
           <KeyboardShortcutButton
             bold
             centerText
-            disabled={isLoadingCreateLLM}
+            disabled={isLoadingCreateLLM || blockNameStartsWithNumber}
             onClick={handleOnSave}
             primary
             tabIndex={0}

--- a/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/ConfigureBlock/index.tsx
@@ -92,6 +92,11 @@ function ConfigureBlock({
     type: block?.type,
   });
 
+  const blockNameStartsWithNumber = useMemo(() =>
+    !!blockAttributes?.name && startsWithNumber(blockAttributes?.name || ''),
+    [blockAttributes?.name],
+  );
+
   const handleOnSave = useCallback(() => {
     onSave({
       ...blockAttributes,
@@ -107,7 +112,10 @@ function ConfigureBlock({
         onClose();
       } else if (event.key === KEY_ENTER) {
         const buttonText = event.target.innerText;
-        if (!buttonText.startsWith('Save and') && buttonText !== 'Cancel') {
+        if (!buttonText.startsWith('Save and')
+          && buttonText !== 'Cancel'
+          && !blockNameStartsWithNumber
+        ) {
           handleOnSave();
         }
       }
@@ -118,7 +126,7 @@ function ConfigureBlock({
     return () => {
       document?.removeEventListener('keydown', handleKeyDown);
     };
-  }, [handleOnSave, onClose]);
+  }, [blockNameStartsWithNumber, handleOnSave, onClose]);
 
   useEffect(() => {
     refTextInput?.current?.focus();
@@ -130,10 +138,6 @@ function ConfigureBlock({
 
   const isCustomBlock = useMemo(() => BlockTypeEnum.CUSTOM === block?.type, [block]);
   const isMarkdown = useMemo(() => BlockTypeEnum.MARKDOWN === block?.type, [block]);
-  const blockNameStartsWithNumber = useMemo(() =>
-    !!blockAttributes?.name && startsWithNumber(blockAttributes?.name || ''),
-    [blockAttributes?.name],
-  );
 
   // @ts-ignore
   const blockActionObject = useMemo(() => block?.block_action_object, [block]);
@@ -380,7 +384,7 @@ function ConfigureBlock({
 
         {blockNameStartsWithNumber && (
           <Text bold warning>
-            Note: Numbers are not allowed as the first character of block name.
+            Note: Numbers are not allowed as the first character of a block name.
           </Text>
         )}
       </RowStyle>

--- a/mage_ai/frontend/utils/string.ts
+++ b/mage_ai/frontend/utils/string.ts
@@ -275,8 +275,12 @@ export function isNumeric(str) {
   return !isNaN(str);
 }
 
-export function isInteger(str) {
+export function isInteger(str: string) {
   return Number.isInteger(Number(str));
+}
+
+export function startsWithNumber(str: string) {
+  return isInteger(str.charAt(0));
 }
 
 export function extractNumber(text) {


### PR DESCRIPTION
# Description
- Using a number as the first character of a block name could cause confusion because the block uuid replaces the number with `letter_n`. For example, if a block was named `1example_block`, its block uuid would be `letter_1example_block`. In order to make the block naming consistent with the block uuids, this PR does not allow numbers to be used as the first character of a block name in the UI. If the user enters a number as the first char, the "Save" button gets disabled and warning appears.

# How Has This Been Tested?
![block name first char](https://github.com/mage-ai/mage-ai/assets/78053898/ebcb99af-2a7c-4b55-8c69-3db446ccf008)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
