### PR TITLE
[jk] Add "Last run failed" filter to Pipeline Runs table

### DIFF
--- a/mage_ai/data_preparation/models/constants.py
+++ b/mage_ai/data_preparation/models/constants.py
@@ -24,6 +24,8 @@ PREFERENCES_FILE = '.preferences.yaml'
 REPO_CONFIG_FILE = 'metadata.yaml'
 VARIABLE_DIR = '.variables'
 
+PIPELINE_RUN_STATUS_LAST_RUN_FAILED = 'last_run_failed'
+
 
 class AIMode(str, Enum):
     OPEN_AI = 'open_ai'

--- a/mage_ai/frontend/interfaces/PipelineRunType.ts
+++ b/mage_ai/frontend/interfaces/PipelineRunType.ts
@@ -3,7 +3,21 @@ import { ScheduleTypeEnum } from './PipelineScheduleType';
 
 export const RunStatus = RunStatusEnum;
 
+// This is a pipeline run status filter used for fetching the latest (most
+// recently created) failed pipeline run for each grouping of pipeline
+// runs with the same execution date and pipeline schedule ID.
+export const LAST_RUN_FAILED_STATUS = 'last_run_failed';
+
 export const PIPELINE_RUN_STATUSES = [
+  RunStatus.FAILED,
+  LAST_RUN_FAILED_STATUS,
+  RunStatus.COMPLETED,
+  RunStatus.RUNNING,
+  RunStatus.CANCELLED,
+  RunStatus.INITIAL,
+];
+
+export const PIPELINE_RUN_STATUSES_NO_LAST_RUN_FAILED = [
   RunStatus.FAILED,
   RunStatus.COMPLETED,
   RunStatus.RUNNING,
@@ -29,6 +43,7 @@ export const RUN_STATUS_TO_LABEL = {
   [RunStatus.COMPLETED]: 'Done',
   [RunStatus.FAILED]: 'Failed',
   [RunStatus.INITIAL]: 'Ready',
+  [LAST_RUN_FAILED_STATUS]: 'Last run failed',
   [RunStatus.RUNNING]: 'Running',
 };
 

--- a/mage_ai/frontend/pages/pipeline-runs/index.tsx
+++ b/mage_ai/frontend/pages/pipeline-runs/index.tsx
@@ -13,7 +13,7 @@ import TagType from '@interfaces/TagType';
 import Toolbar from '@components/shared/Table/Toolbar';
 import api from '@api';
 import {
-  PIPELINE_RUN_STATUSES,
+  PIPELINE_RUN_STATUSES_NO_LAST_RUN_FAILED,
   PipelineRunFilterQueryEnum,
   PipelineRunReqQueryParamsType,
   RUN_STATUS_TO_LABEL,
@@ -77,7 +77,7 @@ function RunListPage() {
       filterOptions={{
         pipeline_tag: tags.map(({ uuid }) => uuid),
         pipeline_uuid: pipelineUUIDs,
-        status: PIPELINE_RUN_STATUSES,
+        status: PIPELINE_RUN_STATUSES_NO_LAST_RUN_FAILED,
       }}
       filterValueLabelMapping={{
         pipeline_tag: tags.reduce((acc, { uuid }) => ({

--- a/mage_ai/frontend/pages/triggers/index.tsx
+++ b/mage_ai/frontend/pages/triggers/index.tsx
@@ -71,7 +71,7 @@ function TriggerListPage() {
     >
       <Spacing mx={2} my={1}>
         <FlexContainer alignItems="center">
-          <Text bold default large>Sort runs by:</Text>
+          <Text bold default large>Sort by:</Text>
           <Spacing mr={1} />
           <Select
             compact


### PR DESCRIPTION
# Description
- Add a "Last run failed" filter to the Pipeline Runs Tables on pages where the filter is a dropdown (not where the filter is a toggle menu and multiple filters can be applied, such as on the project-wide Pipeline Runs page). The "Last run failed" filter displays failed pipeline runs that are the last pipeline run retry (or runs without any retries). This can be helpful if the user does not want to see failed pipeline runs that have already been retried successfully.

# How Has This Been Tested?
- [ ] Added unit test
- [ ] Tested locally (see gif below):


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
