### PR TITLE
Update integrate-mage-airflow.mdx

### DIFF
--- a/docs/guides/integrate-mage-airflow.mdx
+++ b/docs/guides/integrate-mage-airflow.mdx
@@ -57,7 +57,8 @@ If you’re using Docker, run the following command in the `dags/` folder:
 
 ```bash
 docker run -it -p 6789:6789 -v $(pwd):/home/src \
-  /app/run_app.sh mageai/mageai mage init demo_project
+  mageai/mageai /app/run_app.sh mage init demo_project
+
 ```
 
 If you used pip to install Mage, run the following command in the `dags/`


### PR DESCRIPTION
The command did not work with docker, think this fixed it.

# Description
Example did not work.


# How Has This Been Tested?
running the command did create the test project inside the dag folder
