### PR TITLE
Update integrate-mage-airflow.mdx

### DIFF
--- a/docs/guides/integrate-mage-airflow.mdx
+++ b/docs/guides/integrate-mage-airflow.mdx
@@ -117,7 +117,8 @@ If you’re using Docker, run the following command in the `dags/` folder:
 
 ```bash
 docker run -it -p 6789:6789 -v $(pwd):/home/src \
-  /app/run_app.sh mageai/mageai mage start demo_project
+  mageai/mageai /app/run_app.sh mage start demo_project
+
 ```
 
 If you used pip to install Mage, run the following command in the `dags/`


### PR DESCRIPTION
Error in docker command, fixed now it works

# Description
Docker command did not work, now it executes

# How Has This Been Tested?
On OSX, presume that the command will work on windows 