### PR TITLE
[jk] Prevent renamed triggers in code from being duplicated

### DIFF
--- a/mage_ai/api/resources/PipelineScheduleResource.py
+++ b/mage_ai/api/resources/PipelineScheduleResource.py
@@ -403,6 +403,8 @@ class PipelineScheduleResource(DatabaseResource):
         if updated_status == ScheduleStatus.ACTIVE and self.model.status == ScheduleStatus.INACTIVE:
             payload['last_enabled_at'] = datetime.now(tz=pytz.UTC)
 
+        old_name = self.model.name
+
         resource = super().update(payload)
         updated_model = resource.model
 
@@ -424,11 +426,13 @@ class PipelineScheduleResource(DatabaseResource):
             update_only_if_exists = (
                 not pipeline.should_save_trigger_in_code_automatically()
             )
+            old_trigger_name = old_name if old_name != updated_model.name else None
 
             add_or_update_trigger_for_pipeline_and_persist(
                 trigger,
                 pipeline.uuid,
                 update_only_if_exists=update_only_if_exists,
+                old_trigger_name=old_trigger_name,
             )
 
         return self

--- a/mage_ai/data_preparation/models/triggers/__init__.py
+++ b/mage_ai/data_preparation/models/triggers/__init__.py
@@ -206,6 +206,7 @@ def add_or_update_trigger_for_pipeline_and_persist(
     trigger: Trigger,
     pipeline_uuid: str,
     update_only_if_exists: bool = False,
+    old_trigger_name: str = None,
 ) -> Dict:
     trigger_configs_by_name = get_trigger_configs_by_name(pipeline_uuid)
 
@@ -214,13 +215,14 @@ def add_or_update_trigger_for_pipeline_and_persist(
     have, so we need to set "envs" on the updated trigger if it already exists.
     Otherwise, it will get overwritten when updating the trigger in code.
     """
-    existing_trigger = trigger_configs_by_name.get(trigger.name)
+    trigger_name = trigger.name if old_trigger_name is None else old_trigger_name
+    existing_trigger = trigger_configs_by_name.get(trigger_name)
     if existing_trigger is not None:
         trigger.envs = existing_trigger.get('envs', [])
     elif update_only_if_exists:
         return None
 
-    trigger_configs_by_name[trigger.name] = trigger.to_dict()
+    trigger_configs_by_name[trigger_name] = trigger.to_dict()
     yaml_config = dict(triggers=list(trigger_configs_by_name.values()))
     content = yaml.safe_dump(yaml_config)
     trigger_file_path = get_triggers_file_path(pipeline_uuid)


### PR DESCRIPTION
# Description
- Renamed triggers saved in code (i.e. saved in `triggers.yaml` file) would update the pipeline schedule in the db, but not the trigger in the trigger config file, resulting in the original trigger being recreated. This PR fixes this so the trigger saved in code is not duplicated.
- Addresses github issue https://github.com/mage-ai/mage-ai/issues/4862

# How Has This Been Tested?
![renamed trigger in code 2](https://github.com/mage-ai/mage-ai/assets/78053898/b5c5a990-9e18-46ec-8c59-56c41a2091f8)

![renamed trigger in code 1](https://github.com/mage-ai/mage-ai/assets/78053898/1d959c30-aa47-4c09-b521-ee0a1ec7a9b7)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
