### PR TITLE
[jk] Triggers table UI fixes

### DIFF
--- a/mage_ai/frontend/components/Triggers/Table.tsx
+++ b/mage_ai/frontend/components/Triggers/Table.tsx
@@ -522,7 +522,7 @@ function TriggersTable({
                   {...getRunStatusTextProps(lastPipelineRunStatus)}
                   key={`latest_run_status_${idx}`}
                 >
-                  {lastPipelineRunStatus || 'N/A'}
+                  {lastPipelineRunStatus || '—'}
                 </Text>,
                 <Text default key={`trigger_run_count_${idx}`} monospace>
                   {pipelineRunsCount || '0'}

--- a/mage_ai/frontend/components/Triggers/Table.tsx
+++ b/mage_ai/frontend/components/Triggers/Table.tsx
@@ -481,6 +481,8 @@ function TriggersTable({
                 <Text
                   default
                   key={`trigger_description_${idx}`}
+                  title={description}
+                  width={UNIT * 35}
                 >
                   {description}
                 </Text>,

--- a/mage_ai/frontend/components/Triggers/Table.tsx
+++ b/mage_ai/frontend/components/Triggers/Table.tsx
@@ -192,7 +192,7 @@ function TriggersTable({
     ]);
   }
 
-  columnFlex.push(...[1, 2]);
+  columnFlex.push(...[2, 1]);
   columns.push(...[
     {
       uuid: 'Name',
@@ -482,7 +482,7 @@ function TriggersTable({
                   default
                   key={`trigger_description_${idx}`}
                   title={description}
-                  width={UNIT * 35}
+                  width={UNIT * 40}
                 >
                   {description}
                 </Text>,

--- a/mage_ai/frontend/components/Triggers/Table.tsx
+++ b/mage_ai/frontend/components/Triggers/Table.tsx
@@ -168,34 +168,70 @@ function TriggersTable({
   const columns = [];
 
   if (!disableActions) {
-    columnFlex.push(...[null, null, null]);
+    columnFlex.push(...[null]);
     columns.push(...[
       {
         uuid: 'Active',
       },
-      {
-        uuid: 'Type',
-      },
+    ]);
+  }
+
+  columnFlex.push(...[1]);
+  columns.push(...[
+    {
+      uuid: 'Name',
+    },
+  ]);
+
+  if (!disableActions) {
+    columnFlex.push(...[null]);
+    columns.push(...[
       {
         center: true,
         uuid: 'Logs',
       },
     ]);
-  }
 
-  if (projectPlatformActivated) {
-    columnFlex.push(...[null]);
+    if (projectPlatformActivated) {
+      columnFlex.push(...[null]);
+      columns.push(...[
+        {
+          uuid: 'Project',
+        },
+      ]);
+    }
+
+    if (includePipelineColumn) {
+      columnFlex.push(...[1]);
+      columns.push(...[
+        {
+          uuid: 'Pipeline',
+        },
+      ]);
+    }
+
+    columnFlex.push(...[null, null]);
     columns.push(...[
       {
-        uuid: 'Project',
+        uuid: 'Type',
+      },
+      {
+        uuid: 'Frequency',
       },
     ]);
   }
 
-  columnFlex.push(...[2, 1]);
+  columnFlex.push(...[1, 1,  null, null]);
   columns.push(...[
     {
-      uuid: 'Name',
+      uuid: 'Latest status',
+    },
+    {
+      ...timezoneTooltipProps,
+      uuid: 'Next run date',
+    },
+    {
+      uuid: 'Runs',
     },
     {
       uuid: 'Description',
@@ -203,48 +239,32 @@ function TriggersTable({
   ]);
 
   if (!disableActions) {
-    columnFlex.push(...[null]);
-    columns.push({
-      uuid: 'Frequency',
-    });
-  }
-
-  columnFlex.push(...[1, 1,  null]);
-  columns.push(...[
-    {
-      ...timezoneTooltipProps,
-      uuid: 'Next run date',
-    },
-    {
-      uuid: 'Latest status',
-    },
-    {
-      uuid: 'Runs',
-    },
-  ]);
-
-  if (!disableActions) {
     columnFlex.push(...[1]);
-    columns.push({
-      uuid: 'Tags',
-    });
-  }
+    columns.push(...[
+      {
+        uuid: 'Tags',
+      },
+    ]);
 
-  if (!disableActions && !isViewer()) {
-    columnFlex.push(...[null]);
-    columns.push({
-      label: () => '',
-      uuid: 'edit/delete',
-    });
-  }
+    if (includeCreatedAtColumn) {
+      columnFlex.push(...[null]);
+      columns.push(...[
+        {
+          ...timezoneTooltipProps,
+          uuid: 'Created at',
+        },
+      ]);
+    }
 
-  if (!disableActions && includePipelineColumn) {
-    columns.splice(2, 0, { uuid: 'Pipeline' });
-    columnFlex.splice(2, 0, 1);
-  }
-  if (!disableActions && includeCreatedAtColumn) {
-    columns.splice(5, 0, { ...timezoneTooltipProps, uuid: 'Created at' });
-    columnFlex.splice(5, 0, null);
+    if (!isViewer()) {
+      columnFlex.push(...[null]);
+      columns.push(...[
+        {
+          label: () => '',
+          uuid: 'edit/delete',
+        },
+      ]);
+    }
   }
 
   const [showDisableTriggerModal, hideDisableTriggerModal] = useModal(({
@@ -401,42 +421,6 @@ function TriggersTable({
                       />
                     </div>
                   </Tooltip>,
-                  <Text
-                    default
-                    key={`trigger_type_${idx}`}
-                    monospace
-                  >
-                    {SCHEDULE_TYPE_TO_LABEL[pipelineSchedule.schedule_type]?.()}
-                  </Text>,
-                ]);
-
-                rows.push(
-                  <Button
-                    default
-                    iconOnly
-                    key={`logs_button_${idx}`}
-                    noBackground
-                    onClick={() => router.push(
-                      `/pipelines/${finalPipelineUUID}/logs?pipeline_schedule_id[]=${id}`,
-                    )}
-                  >
-                    <Logs default size={ICON_SIZE_SMALL} />
-                  </Button>,
-                );
-
-                if (projectPlatformActivated) {
-                  rows.push(...[
-                    <Text
-                      default
-                      key={`project_${idx}`}
-                      monospace
-                    >
-                      {repoPath?.replace(statusProject?.repo_path_root || '', '')?.slice(1)}
-                    </Text>,
-                  ]);
-                }
-
-                rows.push(...[
                   <FlexContainer
                     alignItems="center"
                     key={`trigger_name_${idx}`}
@@ -477,29 +461,69 @@ function TriggersTable({
                 ]);
               }
 
-              rows.push(...[
-                <Text
-                  default
-                  key={`trigger_description_${idx}`}
-                  title={description}
-                  width={UNIT * 40}
-                >
-                  {description}
-                </Text>,
-              ]);
-
               if (!disableActions) {
                 rows.push(
+                  <Button
+                    default
+                    iconOnly
+                    key={`logs_button_${idx}`}
+                    noBackground
+                    onClick={() => router.push(
+                      `/pipelines/${finalPipelineUUID}/logs?pipeline_schedule_id[]=${id}`,
+                    )}
+                  >
+                    <Logs default size={ICON_SIZE_SMALL} />
+                  </Button>,
+                );
+
+                if (projectPlatformActivated) {
+                  rows.push(...[
+                    <Text
+                      default
+                      key={`project_${idx}`}
+                      monospace
+                    >
+                      {repoPath?.replace(statusProject?.repo_path_root || '', '')?.slice(1)}
+                    </Text>,
+                  ]);
+                }
+
+                if (includePipelineColumn) {
+                  rows.push(
+                    <Text
+                      default
+                      key={`pipeline_name_${idx}`}
+                      monospace
+                    >
+                      {finalPipelineUUID}
+                    </Text>,
+                  );
+                }
+
+                rows.push(...[
+                  <Text
+                    default
+                    key={`trigger_type_${idx}`}
+                    monospace
+                  >
+                    {SCHEDULE_TYPE_TO_LABEL[pipelineSchedule.schedule_type]?.()}
+                  </Text>,
                   <Text default key={`trigger_frequency_${idx}`} monospace>
                     {(displayLocalTimezone && isCustomInterval)
                       ? convertUtcCronExpressionToLocalTimezone(scheduleInterval)
                       : scheduleInterval
                     }
                   </Text>,
-                );
+                ]);
               }
 
               rows.push(...[
+                <Text
+                  {...getRunStatusTextProps(lastPipelineRunStatus)}
+                  key={`latest_run_status_${idx}`}
+                >
+                  {lastPipelineRunStatus || '—'}
+                </Text>,
                 <Text
                   key={`trigger_next_run_date_${idx}`}
                   monospace
@@ -518,14 +542,16 @@ function TriggersTable({
                     )
                   }
                 </Text>,
-                <Text
-                  {...getRunStatusTextProps(lastPipelineRunStatus)}
-                  key={`latest_run_status_${idx}`}
-                >
-                  {lastPipelineRunStatus || '—'}
-                </Text>,
                 <Text default key={`trigger_run_count_${idx}`} monospace>
                   {pipelineRunsCount || '0'}
+                </Text>,
+                <Text
+                  default
+                  key={`trigger_description_${idx}`}
+                  title={description}
+                  width={UNIT * 40}
+                >
+                  {description}
                 </Text>,
               ]);
 
@@ -537,85 +563,70 @@ function TriggersTable({
                     />
                   </div>,
                 );
-              }
 
-              if (!disableActions && !isViewer()) {
-                rows.push(
-                  <FlexContainer key={`edit_delete_buttons_${idx}`}>
-                    <Button
+                if (includeCreatedAtColumn) {
+                  rows.push(
+                    <Text
                       default
-                      iconOnly
-                      noBackground
-                      onClick={() => router.push(`/pipelines/${finalPipelineUUID}/triggers/${id}/edit`)}
-                      title="Edit"
+                      key={`created_at_${idx}`}
+                      monospace
+                      small
+                      title={createdAt ? utcStringToElapsedTime(createdAt) : null}
                     >
-                      <Edit default size={ICON_SIZE_SMALL} />
-                    </Button>
-                    <Spacing mr={1} />
-                    <Button
-                      default
-                      iconOnly
-                      noBackground
-                      onClick={() => {
-                        setDeleteConfirmationOpenIdx(id);
-                        setConfirmDialogueTopOffset(deleteButtonRefs.current[id]?.current?.offsetTop || 0);
-                        setConfirmDialogueLeftOffset(deleteButtonRefs.current[id]?.current?.offsetLeft || 0);
-                      }}
-                      ref={deleteButtonRefs.current[id]}
-                      title="Delete"
-                    >
-                      <Trash default size={ICON_SIZE_SMALL} />
-                    </Button>
-                    <ClickOutside
-                      onClickOutside={() => setDeleteConfirmationOpenIdx(null)}
-                      open={deleteConfirmationOpenIdx === id}
-                    >
-                      <PopupMenu
-                        danger
-                        left={(confirmDialogueLeftOffset || 0) - DELETE_CONFIRM_LEFT_OFFSET_DIFF}
-                        onCancel={() => setDeleteConfirmationOpenIdx(null)}
+                      {datetimeInLocalTimezone(createdAt?.slice(0, 19), displayLocalTimezone)}
+                    </Text>,
+                  );
+                }
+
+                if (!isViewer()) {
+                  rows.push(
+                    <FlexContainer key={`edit_delete_buttons_${idx}`}>
+                      <Button
+                        default
+                        iconOnly
+                        noBackground
+                        onClick={() => router.push(`/pipelines/${finalPipelineUUID}/triggers/${id}/edit`)}
+                        title="Edit"
+                      >
+                        <Edit default size={ICON_SIZE_SMALL} />
+                      </Button>
+                      <Spacing mr={1} />
+                      <Button
+                        default
+                        iconOnly
+                        noBackground
                         onClick={() => {
-                          setDeleteConfirmationOpenIdx(null);
-                          deletePipelineTrigger(id);
+                          setDeleteConfirmationOpenIdx(id);
+                          setConfirmDialogueTopOffset(deleteButtonRefs.current[id]?.current?.offsetTop || 0);
+                          setConfirmDialogueLeftOffset(deleteButtonRefs.current[id]?.current?.offsetLeft || 0);
                         }}
-                        title={`Are you sure you want to delete the trigger ${name}?`}
-                        top={(confirmDialogueTopOffset || 0)
-                          - (idx <= 1 ? DELETE_CONFIRM_TOP_OFFSET_DIFF_FIRST : DELETE_CONFIRM_TOP_OFFSET_DIFF)
-                        }
-                        width={DELETE_CONFIRM_WIDTH}
-                      />
-                    </ClickOutside>
-                  </FlexContainer>,
-                );
-              }
-
-              if (!disableActions && includePipelineColumn) {
-                rows.splice(
-                  2,
-                  0,
-                  <Text
-                    default
-                    key={`pipeline_name_${idx}`}
-                    monospace
-                  >
-                    {finalPipelineUUID}
-                  </Text>,
-                );
-              }
-              if (!disableActions && includeCreatedAtColumn) {
-                rows.splice(
-                  5,
-                  0,
-                  <Text
-                    default
-                    key={`created_at_${idx}`}
-                    monospace
-                    small
-                    title={createdAt ? utcStringToElapsedTime(createdAt) : null}
-                  >
-                    {datetimeInLocalTimezone(createdAt?.slice(0, 19), displayLocalTimezone)}
-                  </Text>,
-                );
+                        ref={deleteButtonRefs.current[id]}
+                        title="Delete"
+                      >
+                        <Trash default size={ICON_SIZE_SMALL} />
+                      </Button>
+                      <ClickOutside
+                        onClickOutside={() => setDeleteConfirmationOpenIdx(null)}
+                        open={deleteConfirmationOpenIdx === id}
+                      >
+                        <PopupMenu
+                          danger
+                          left={(confirmDialogueLeftOffset || 0) - DELETE_CONFIRM_LEFT_OFFSET_DIFF}
+                          onCancel={() => setDeleteConfirmationOpenIdx(null)}
+                          onClick={() => {
+                            setDeleteConfirmationOpenIdx(null);
+                            deletePipelineTrigger(id);
+                          }}
+                          title={`Are you sure you want to delete the trigger ${name}?`}
+                          top={(confirmDialogueTopOffset || 0)
+                            - (idx <= 1 ? DELETE_CONFIRM_TOP_OFFSET_DIFF_FIRST : DELETE_CONFIRM_TOP_OFFSET_DIFF)
+                          }
+                          width={DELETE_CONFIRM_WIDTH}
+                        />
+                      </ClickOutside>
+                    </FlexContainer>,
+                  );
+                }
               }
 
               return rows;

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -493,6 +493,7 @@ function PipelineSchedules({
               <>
                 <TriggersTable
                   fetchPipelineSchedules={fetchPipelineSchedules}
+                  includeCreatedAtColumn
                   pipeline={pipeline}
                   pipelineSchedules={pipelineSchedules}
                   pipelineTriggersByName={pipelineTriggersByName}

--- a/mage_ai/frontend/pages/triggers/index.tsx
+++ b/mage_ai/frontend/pages/triggers/index.tsx
@@ -72,7 +72,7 @@ function TriggerListPage() {
     >
       <Spacing mx={2} my={1}>
         <FlexContainer alignItems="center">
-          <Text bold default large>Sort runs by:</Text>
+          <Text bold default large>Sort by:</Text>
           <Spacing mr={1} />
           <Select
             compact

--- a/mage_ai/frontend/pages/triggers/index.tsx
+++ b/mage_ai/frontend/pages/triggers/index.tsx
@@ -8,6 +8,7 @@ import PrivateRoute from '@components/shared/PrivateRoute';
 import ProjectType, { FeatureUUIDEnum } from '@interfaces/ProjectType';
 import Select from '@oracle/elements/Inputs/Select';
 import Spacing from '@oracle/elements/Spacing';
+import Spinner from '@oracle/components/Spinner';
 import Text from '@oracle/elements/Text';
 import TriggersTable from '@components/Triggers/Table';
 import api from '@api';
@@ -99,34 +100,43 @@ function TriggerListPage() {
         </FlexContainer>
       </Spacing>
 
-      <TriggersTable
-        fetchPipelineSchedules={fetchPipelineSchedules}
-        highlightRowOnHover
-        includeCreatedAtColumn
-        includePipelineColumn
-        pipelineSchedules={pipelineSchedules}
-        setErrors={setErrors}
-        stickyHeader
-      />
+      {!dataPipelineSchedules
+        ?
+          <Spacing m={2}>
+            <Spinner inverted large />
+          </Spacing>
+        :
+          <>
+            <TriggersTable
+              fetchPipelineSchedules={fetchPipelineSchedules}
+              highlightRowOnHover
+              includeCreatedAtColumn
+              includePipelineColumn
+              pipelineSchedules={pipelineSchedules}
+              setErrors={setErrors}
+              stickyHeader
+            />
 
-      <Spacing p={2}>
-        <Paginate
-          maxPages={9}
-          onUpdate={(p) => {
-            const newPage = Number(p);
-            const updatedQuery = {
-              ...q,
-              page: newPage >= 0 ? newPage : 0,
-            };
-            router.push(
-              '/triggers',
-              `/triggers?${queryString(updatedQuery)}`,
-            );
-          }}
-          page={Number(page)}
-          totalPages={Math.ceil(totalSchedules / ROW_LIMIT)}
-        />
-      </Spacing>
+            <Spacing p={2}>
+              <Paginate
+                maxPages={9}
+                onUpdate={(p) => {
+                  const newPage = Number(p);
+                  const updatedQuery = {
+                    ...q,
+                    page: newPage >= 0 ? newPage : 0,
+                  };
+                  router.push(
+                    '/triggers',
+                    `/triggers?${queryString(updatedQuery)}`,
+                  );
+                }}
+                page={Number(page)}
+                totalPages={Math.ceil(totalSchedules / ROW_LIMIT)}
+              />
+            </Spacing>
+          </>
+      }
     </Dashboard>
   );
 }


### PR DESCRIPTION
# Description
- Improve Triggers table column order.
- Fix `Description` column widths for very long descriptions.
- Fix typo for "Sort runs by" text on project-wide Triggers page (these are triggers, not runs).
- Change "N/A" to a simple "-" in `Latest status` column for improved differentiation from status text.
- Show spinner on project-wide Triggers page when pipeline schedules are loading (table previously showed "No triggers available" text when pipeline schedules were loading).

# How Has This Been Tested?
- Confirmed fixes locally

Old Triggers table column order:
<img width="2056" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/20fbb4db-5068-4112-bf8a-cefb889a50a1">

Updated Triggers table column order:
<img width="2056" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/8e820204-730e-4869-856b-3e9f1a9b8502">

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
