### PR TITLE
[jk] Backfills table improvements

### DIFF
--- a/mage_ai/api/policies/BackfillPolicy.py
+++ b/mage_ai/api/policies/BackfillPolicy.py
@@ -32,6 +32,7 @@ BackfillPolicy.allow_actions([
 
 BackfillPolicy.allow_read([
     'pipeline_run_dates',
+    'run_status_counts',
     'total_run_count',
 ] + BackfillPresenter.default_attributes, scopes=[
     OauthScope.CLIENT_PRIVATE,

--- a/mage_ai/api/presenters/BackfillPresenter.py
+++ b/mage_ai/api/presenters/BackfillPresenter.py
@@ -49,6 +49,7 @@ class BackfillPresenter(BasePresenter):
         ):
             pipeline_run_dates = preview_run_dates(self.model)
             data['total_run_count'] = len(pipeline_run_dates)
+            data['run_status_counts'] = self.model.pipeline_run_status_counts
             if include_preview_runs:
                 start_idx = offset
                 end_idx = start_idx + limit

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -98,6 +98,7 @@ function BackfillDetail({
     name: modelName,
     pipeline_run_dates: pipelineRunDates,
     start_datetime: startDatetime,
+    started_at: startedAt,
     status,
     total_run_count: totalRunCount,
     variables: modelVariablesInit = {},
@@ -578,65 +579,61 @@ function BackfillDetail({
               </>
             )}
 
-            {!isViewerRole &&
-              <>
-                {status === RunStatus.COMPLETED
-                  ?
-                    <Text bold default large>
-                      Filter runs by status:
-                    </Text>
-                  :
-                    <Button
-                      linkProps={{
-                        as: `/pipelines/${pipelineUUID}/backfills/${modelID}/edit`,
-                        href: '/pipelines/[pipeline]/backfills/[...slug]',
-                      }}
-                      noHoverUnderline
-                      outline
-                      sameColorAsText
-                    >
-                      Edit backfill
-                    </Button>
-                }
-
-                <Spacing mr={PADDING_UNITS} />
-              </>
+            {(!isViewerRole && !startedAt) &&
+              <Button
+                linkProps={{
+                  as: `/pipelines/${pipelineUUID}/backfills/${modelID}/edit`,
+                  href: '/pipelines/[pipeline]/backfills/[...slug]',
+                }}
+                noHoverUnderline
+                outline
+                sameColorAsText
+                title="Backfills can no longer be edited once they've been started."
+              >
+                Edit backfill
+              </Button>
             }
 
             {!showPreviewRuns &&
-              <Select
-                compact
-                defaultColor
-                onChange={e => {
-                  e.preventDefault();
-                  const updatedStatus = e.target.value;
-                  if (updatedStatus === 'all') {
-                    router.push(
-                      '/pipelines/[pipeline]/backfills/[...slug]',
-                      `/pipelines/${pipelineUUID}/backfills/${modelID}`,
-                    );
-                  } else {
-                    goToWithQuery(
-                      {
-                        page: 0,
-                        status: e.target.value,
-                      },
-                    );
-                  }
-                }}
-                paddingRight={UNIT * 4}
-                placeholder="Select run status"
-                value={q?.status || 'all'}
-              >
-                <option key="all_statuses" value="all">
-                  All statuses
-                </option>
-                {PIPELINE_RUN_STATUSES.map(status => (
-                  <option key={status} value={status}>
-                    {RUN_STATUS_TO_LABEL[status]}
+              <>
+                <Text bold default large>
+                  Filter runs by status:
+                </Text>
+                <Spacing mr={PADDING_UNITS} />
+                <Select
+                  compact
+                  defaultColor
+                  onChange={e => {
+                    e.preventDefault();
+                    const updatedStatus = e.target.value;
+                    if (updatedStatus === 'all') {
+                      router.push(
+                        '/pipelines/[pipeline]/backfills/[...slug]',
+                        `/pipelines/${pipelineUUID}/backfills/${modelID}`,
+                      );
+                    } else {
+                      goToWithQuery(
+                        {
+                          page: 0,
+                          status: e.target.value,
+                        },
+                      );
+                    }
+                  }}
+                  paddingRight={UNIT * 4}
+                  placeholder="Select run status"
+                  value={q?.status || 'all'}
+                >
+                  <option key="all_statuses" value="all">
+                    All statuses
                   </option>
-                ))}
-              </Select>
+                  {PIPELINE_RUN_STATUSES.map(status => (
+                    <option key={status} value={status}>
+                      {RUN_STATUS_TO_LABEL[status]}
+                    </option>
+                  ))}
+                </Select>
+              </>
             }
           </FlexContainer>
         )}

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -588,7 +588,7 @@ function BackfillDetail({
                 noHoverUnderline
                 outline
                 sameColorAsText
-                title="Backfills can no longer be edited once they've been started."
+                title="Backfills cannot be edited once they've been started."
               >
                 Edit backfill
               </Button>

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -31,6 +31,7 @@ import Spacing from '@oracle/elements/Spacing';
 import Spinner from '@oracle/components/Spinner';
 import Table from '@components/shared/Table';
 import Text from '@oracle/elements/Text';
+import Tooltip from '@oracle/components/Tooltip';
 import api from '@api';
 import buildTableSidekick, { TABS } from '@components/PipelineRun/shared/buildTableSidekick';
 import {
@@ -44,6 +45,7 @@ import {
   Switch,
 } from '@oracle/icons';
 import { BeforeStyle } from '@components/PipelineDetail/shared/index.style';
+import { ICON_SIZE_DEFAULT } from '@oracle/styles/units/icons';
 import {
   PADDING_UNITS,
   UNIT,
@@ -51,7 +53,6 @@ import {
 } from '@oracle/styles/units/spacing';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
 import { capitalize } from '@utils/string';
-import { datetimeInLocalTimezone } from '@utils/date';
 import { displayLocalOrUtcTime } from '@components/Triggers/utils';
 import {
   getFormattedVariable,
@@ -202,6 +203,7 @@ function BackfillDetail({
     selectedRun,
     setErrors,
     showPreviewRuns,
+    status,
     totalRuns,
   ]);
 
@@ -371,6 +373,13 @@ function BackfillDetail({
             <Text default>
               Total runs
             </Text>
+            <Spacing mr={1} />
+            <Tooltip
+              default
+              label="This count does not include retries."
+              size={ICON_SIZE_DEFAULT}
+              widthFitContent
+            />
           </FlexContainer>,
           <Text
             key="total_runs"

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -164,6 +164,7 @@ function BackfillDetail({
             : 'No runs available'
           }
           fetchPipelineRuns={fetchPipelineRuns}
+          hidePipelineColumn
           onClickRow={(rowIndex: number) => setSelectedRun((prev) => {
             const run = pipelineRuns[rowIndex];
 

--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -250,7 +250,7 @@ function BackfillsTable({
             <FlexContainer key={`edit_delete_backfill_${idx}`}>
               <Button
                 default
-                disabled={status === RunStatus.COMPLETED}
+                disabled={!!startedAt}
                 iconOnly
                 key={`${idx}_edit_button`}
                 linkProps={{

--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -52,7 +52,7 @@ function BackfillsTable({
     pipelineUUID,
   });
 
-  const columnFlex = [null, 1, 1, null, 1, 1, null, null, null, null];
+  const columnFlex = [null, 1, 1, null, null, null, null, null, null, 1, 1, null, null, null, null];
   const columns: ColumnType[] = [
     {
       uuid: 'Status',
@@ -65,7 +65,22 @@ function BackfillsTable({
       uuid: 'Backfill',
     },
     {
-      uuid: 'Runs',
+      uuid: 'Ready',
+    },
+    {
+      uuid: 'Running',
+    },
+    {
+      uuid: 'Cancelled',
+    },
+    {
+      uuid: 'Completed',
+    },
+    {
+      uuid: 'Failed',
+    },
+    {
+      uuid: 'Total runs',
     },
     {
       ...timezoneTooltipProps,
@@ -106,6 +121,7 @@ function BackfillsTable({
         interval_type: intervalType,
         interval_units: intervalUnits,
         name,
+        run_status_counts: runStatusCounts = {},
         start_datetime: startDatetime,
         started_at: startedAt,
         status,
@@ -138,7 +154,48 @@ function BackfillsTable({
             )}
             {!(startDatetime && endDatetime) && <>&#8212;</>}
           </Text>,
-          <Text default key={`runs_${idx}`} monospace>{totalRunCount || 0}</Text>,
+          <Text
+            default
+            key={`ready_${idx}`}
+            monospace
+          >
+            {runStatusCounts[RunStatus.INITIAL] || 0}
+          </Text>,
+          <Text
+            default
+            info={runStatusCounts[RunStatus.RUNNING] > 0}
+            key={`running_${idx}`}
+            monospace
+          >
+            {runStatusCounts[RunStatus.RUNNING] || 0}
+          </Text>,
+          <Text
+            default
+            key={`cancelled_${idx}`}
+            monospace
+            warning={runStatusCounts[RunStatus.CANCELLED] > 0}
+          >
+            {runStatusCounts[RunStatus.CANCELLED] || 0}
+          </Text>,
+          <Text
+            default
+            key={`completed_${idx}`}
+            monospace
+            success={runStatusCounts[RunStatus.COMPLETED] > 0}
+          >
+            {runStatusCounts[RunStatus.COMPLETED] || 0}
+          </Text>,
+          <Text
+            danger={runStatusCounts[RunStatus.FAILED] > 0}
+            default
+            key={`failed_${idx}`}
+            monospace
+          >
+            {runStatusCounts[RunStatus.FAILED] || 0}
+          </Text>,
+          <Text bold default key={`total_runs_${idx}`} monospace>
+            {totalRunCount || 0}
+          </Text>,
           <Text
             default
             key={`started_at_${idx}`}
@@ -165,7 +222,7 @@ function BackfillsTable({
           </Text>,
           <Text
             default
-            key={`interval_type_${idx}`}
+            key={`interval_${idx}`}
             monospace
           >
             {intervalType || <>&#8212;</>}

--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -52,7 +52,7 @@ function BackfillsTable({
     pipelineUUID,
   });
 
-  const columnFlex = [null, 1, null, null, null, 1, 1, null];
+  const columnFlex = [null, 1, 1, null, 1, 1, null, null];
   const columns: ColumnType[] = [
     {
       uuid: 'Status',
@@ -61,14 +61,11 @@ function BackfillsTable({
       uuid: 'Name',
     },
     {
-      uuid: 'Type',
+      ...timezoneTooltipProps,
+      uuid: 'Backfill',
     },
     {
       uuid: 'Runs',
-    },
-    {
-      ...timezoneTooltipProps,
-      uuid: 'Backfill',
     },
     {
       ...timezoneTooltipProps,
@@ -77,6 +74,9 @@ function BackfillsTable({
     {
       ...timezoneTooltipProps,
       uuid: 'Completed at',
+    },
+    {
+      uuid: 'Type',
     },
   ];
   if (!isViewerRole) {
@@ -106,25 +106,21 @@ function BackfillsTable({
         const arr = [
           <Text
             {...getRunStatusTextProps(status)}
-            key="status"
+            key={`status_${idx}`}
           >
             {status || 'inactive'}
           </Text>,
           <NextLink
             as={`/pipelines/${pipelineUUID}/backfills/${id}`}
             href={'/pipelines/[pipeline]/backfills/[...slug]'}
-            key="name"
+            key={`name_${idx}`}
             passHref
           >
             <Link bold sameColorAsText>
               {name}
             </Link>
           </NextLink>,
-          <Text default key="type" monospace>
-            {blockUUID ? BACKFILL_TYPE_CODE : BACKFILL_TYPE_DATETIME}
-          </Text>,
-          <Text default key="runs" monospace>{totalRunCount || 0}</Text>,
-          <Text default key="backfill" monospace small>
+          <Text default key={`backfill_${idx}`} monospace small>
             {(startDatetime && endDatetime) && (
               <>
                 {displayLocalOrUtcTime(startDatetime, displayLocalTimezone)}
@@ -134,9 +130,10 @@ function BackfillsTable({
             )}
             {!(startDatetime && endDatetime) && <>&#8212;</>}
           </Text>,
+          <Text default key={`runs_${idx}`} monospace>{totalRunCount || 0}</Text>,
           <Text
             default
-            key="started_at"
+            key={`started_at_${idx}`}
             monospace
             small
             title={startedAt ? utcStringToElapsedTime(startedAt) : null}
@@ -148,7 +145,7 @@ function BackfillsTable({
           </Text>,
           <Text
             default
-            key="completed_at"
+            key={`completed_at_${idx}`}
             monospace
             small
             title={completedAt ? utcStringToElapsedTime(completedAt) : null}
@@ -157,6 +154,9 @@ function BackfillsTable({
               ? displayLocalOrUtcTime(completedAt, displayLocalTimezone)
               : <>&#8212;</>
             }
+          </Text>,
+          <Text default key={`type_${idx}`} monospace>
+            {blockUUID ? BACKFILL_TYPE_CODE : BACKFILL_TYPE_DATETIME}
           </Text>,
         ];
         if (!isViewerRole) {

--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -23,6 +23,11 @@ import { isViewer } from '@utils/session';
 import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
 import { utcStringToElapsedTime } from '@utils/date';
 
+const SHARED_COLUMN_TEXT_PROPS = {
+  default: true,
+  monospace: true,
+};
+
 type BackfillsTableProps = {
   fetchBackfills: () => void;
   pipeline: {
@@ -144,7 +149,11 @@ function BackfillsTable({
               {name}
             </Link>
           </NextLink>,
-          <Text default key={`backfill_${idx}`} monospace small>
+          <Text
+            {...SHARED_COLUMN_TEXT_PROPS}
+            key={`backfill_${idx}`}
+            small
+          >
             {(startDatetime && endDatetime) && (
               <>
                 {displayLocalOrUtcTime(startDatetime, displayLocalTimezone)}
@@ -155,51 +164,49 @@ function BackfillsTable({
             {!(startDatetime && endDatetime) && <>&#8212;</>}
           </Text>,
           <Text
-            default
+            {...SHARED_COLUMN_TEXT_PROPS}
             key={`ready_${idx}`}
-            monospace
           >
             {runStatusCounts[RunStatus.INITIAL] || 0}
           </Text>,
           <Text
-            default
+            {...SHARED_COLUMN_TEXT_PROPS}
             info={runStatusCounts[RunStatus.RUNNING] > 0}
             key={`running_${idx}`}
-            monospace
           >
             {runStatusCounts[RunStatus.RUNNING] || 0}
           </Text>,
           <Text
-            default
+            {...SHARED_COLUMN_TEXT_PROPS}
             key={`cancelled_${idx}`}
-            monospace
             warning={runStatusCounts[RunStatus.CANCELLED] > 0}
           >
             {runStatusCounts[RunStatus.CANCELLED] || 0}
           </Text>,
           <Text
-            default
+            {...SHARED_COLUMN_TEXT_PROPS}
             key={`completed_${idx}`}
-            monospace
             success={runStatusCounts[RunStatus.COMPLETED] > 0}
           >
             {runStatusCounts[RunStatus.COMPLETED] || 0}
           </Text>,
           <Text
+            {...SHARED_COLUMN_TEXT_PROPS}
             danger={runStatusCounts[RunStatus.FAILED] > 0}
-            default
             key={`failed_${idx}`}
-            monospace
           >
             {runStatusCounts[RunStatus.FAILED] || 0}
           </Text>,
-          <Text bold default key={`total_runs_${idx}`} monospace>
+          <Text
+            {...SHARED_COLUMN_TEXT_PROPS}
+            bold
+            key={`total_runs_${idx}`}
+          >
             {totalRunCount || 0}
           </Text>,
           <Text
-            default
+            {...SHARED_COLUMN_TEXT_PROPS}
             key={`started_at_${idx}`}
-            monospace
             small
             title={startedAt ? utcStringToElapsedTime(startedAt) : null}
           >
@@ -209,9 +216,8 @@ function BackfillsTable({
             }
           </Text>,
           <Text
-            default
+            {...SHARED_COLUMN_TEXT_PROPS}
             key={`completed_at_${idx}`}
-            monospace
             small
             title={completedAt ? utcStringToElapsedTime(completedAt) : null}
           >
@@ -221,20 +227,21 @@ function BackfillsTable({
             }
           </Text>,
           <Text
-            default
+            {...SHARED_COLUMN_TEXT_PROPS}
             key={`interval_${idx}`}
-            monospace
           >
             {intervalType || <>&#8212;</>}
           </Text>,
           <Text
-            default
+            {...SHARED_COLUMN_TEXT_PROPS}
             key={`interval_units_${idx}`}
-            monospace
           >
             {intervalUnits || <>&#8212;</>}
           </Text>,
-          <Text default key={`type_${idx}`} monospace>
+          <Text
+            {...SHARED_COLUMN_TEXT_PROPS}
+            key={`type_${idx}`}
+          >
             {blockUUID ? BACKFILL_TYPE_CODE : BACKFILL_TYPE_DATETIME}
           </Text>,
         ];

--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -52,7 +52,7 @@ function BackfillsTable({
     pipelineUUID,
   });
 
-  const columnFlex = [null, 1, 1, null, 1, 1, null, null];
+  const columnFlex = [null, 1, 1, null, 1, 1, null, null, null, null];
   const columns: ColumnType[] = [
     {
       uuid: 'Status',
@@ -76,6 +76,12 @@ function BackfillsTable({
       uuid: 'Completed at',
     },
     {
+      uuid: 'Interval',
+    },
+    {
+      uuid: 'Interval units',
+    },
+    {
       uuid: 'Type',
     },
   ];
@@ -97,6 +103,8 @@ function BackfillsTable({
         completed_at: completedAt,
         end_datetime: endDatetime,
         id,
+        interval_type: intervalType,
+        interval_units: intervalUnits,
         name,
         start_datetime: startDatetime,
         started_at: startedAt,
@@ -154,6 +162,20 @@ function BackfillsTable({
               ? displayLocalOrUtcTime(completedAt, displayLocalTimezone)
               : <>&#8212;</>
             }
+          </Text>,
+          <Text
+            default
+            key={`interval_type_${idx}`}
+            monospace
+          >
+            {intervalType || <>&#8212;</>}
+          </Text>,
+          <Text
+            default
+            key={`interval_units_${idx}`}
+            monospace
+          >
+            {intervalUnits || <>&#8212;</>}
           </Text>,
           <Text default key={`type_${idx}`} monospace>
             {blockUUID ? BACKFILL_TYPE_CODE : BACKFILL_TYPE_DATETIME}

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -270,6 +270,7 @@ type PipelineRunsTableProps = {
   disableRowSelect?: boolean;
   emptyMessage?: string;
   fetchPipelineRuns?: () => void;
+  hidePipelineColumn?: boolean;
   hideTriggerColumn?: boolean;
   includePipelineTags?: boolean;
   onClickRow?: (rowIndex: number) => void;
@@ -289,6 +290,7 @@ function PipelineRunsTable({
   disableRowSelect,
   emptyMessage = 'No runs available',
   fetchPipelineRuns,
+  hidePipelineColumn,
   hideTriggerColumn,
   includePipelineTags,
   onClickRow,
@@ -406,7 +408,7 @@ function PipelineRunsTable({
   }, [getRunRowIndex, selectedRun]);
 
   const timezoneTooltipProps = displayLocalTimezone ? TIMEZONE_TOOLTIP_PROPS : {};
-  const columnFlex = [null, null, null, null, 1];
+  const columnFlex = [null, null, null, null];
   const columns: ColumnType[] = [
     {
       uuid: 'Status',
@@ -422,10 +424,14 @@ function PipelineRunsTable({
     {
       uuid: 'Block runs',
     },
-    {
-      uuid: 'Pipeline',
-    },
   ];
+
+  if (!hidePipelineColumn) {
+    columnFlex.push(1);
+    columns.push({
+      uuid: 'Pipeline',
+    });
+  }
 
   if (!hideTriggerColumn) {
     columnFlex.push(1);
@@ -621,10 +627,15 @@ function PipelineRunsTable({
                       {`${completedBlockRunsCount} / ${blockRunsCount}`}
                     </Link>
                   </NextLink>,
-                  <Text default key="row_pipeline_uuid" monospace muted>
-                    {pipelineUUID}
-                  </Text>,
                 ];
+
+                if (!hidePipelineColumn) {
+                  arr.push(
+                    <Text default key="row_pipeline_uuid" monospace muted>
+                      {pipelineUUID}
+                    </Text>,
+                  );
+                }
 
                 if (!hideTriggerColumn) {
                   arr.push(
@@ -732,10 +743,15 @@ function PipelineRunsTable({
                       {disabled ? '' : `${completedBlockRunsCount} / ${blockRunsCount}`}
                     </Link>
                   </NextLink>,
-                  <Text default key="row_pipeline_uuid" monospace>
-                    {pipelineUUID}
-                  </Text>,
                 ];
+
+                if (!hidePipelineColumn) {
+                  arr.push(
+                    <Text default key="row_pipeline_uuid" monospace>
+                      {pipelineUUID}
+                    </Text>,
+                  );
+                }
 
                 if (!hideTriggerColumn) {
                   arr.push(

--- a/mage_ai/frontend/components/Triggers/Detail/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Detail/index.tsx
@@ -179,6 +179,7 @@ function TriggerDetail({
       <>
         <PipelineRunsTable
           fetchPipelineRuns={fetchPipelineRuns}
+          hideTriggerColumn
           onClickRow={(rowIndex: number) => setSelectedRun((prev) => {
             const run = pipelineRuns[rowIndex];
 

--- a/mage_ai/frontend/interfaces/BackfillType.ts
+++ b/mage_ai/frontend/interfaces/BackfillType.ts
@@ -51,6 +51,9 @@ export default interface BackfillType {
   pipeline_run_dates?: PipelineRunDateType[];
   pipeline_schedule_id?: number;
   pipeline_uuid: string;
+  run_status_counts?: {
+    [key in RunStatus]: number;
+  };
   settings?: BackfillSettingsType;
   start_datetime?: string;
   started_at?: string;

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/backfills/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/backfills/index.tsx
@@ -18,7 +18,6 @@ import api from '@api';
 import { Add } from '@oracle/icons';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
-import { goToWithQuery } from '@utils/routing';
 import { onSuccess } from '@api/utils/response';
 import { queryFromUrl } from '@utils/url';
 import { randomNameGenerator } from '@utils/string';

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -6,7 +6,6 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from math import ceil
 from statistics import stdev
-import time
 from typing import DefaultDict, Dict, List
 
 import dateutil.parser
@@ -24,9 +23,6 @@ from sqlalchemy import (
     String,
     Table,
     Text,
-    and_,
-    desc,
-    func,
     or_,
 )
 from sqlalchemy.orm import joinedload, relationship, validates

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -1917,7 +1917,7 @@ class Backfill(BaseModel):
     @property
     def pipeline_run_status_counts(self) -> Dict:
         status_counts = dict()
-        execution_dates_added = dict()
+        execution_dates_counted = set()
 
         # Sort the pipeline runs by id in reverse order so the first pipeline run
         # checked is the latest pipeline run created for a given execution date.
@@ -1929,8 +1929,8 @@ class Backfill(BaseModel):
 
         for pr in pipeline_runs_sorted:
             # Only count a pipeline run once per execution date
-            if pr.execution_date not in execution_dates_added:
+            if pr.execution_date not in execution_dates_counted:
                 status_counts[pr.status] = (status_counts.get(pr.status) or 0) + 1
-                execution_dates_added[pr.execution_date] = True
+                execution_dates_counted.add(pr.execution_date)
 
         return status_counts

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -1913,3 +1913,24 @@ class Backfill(BaseModel):
                 Backfill.pipeline_schedule_id.in_(pipeline_schedule_ids),
             )
         return []
+
+    @property
+    def pipeline_run_status_counts(self) -> Dict:
+        status_counts = dict()
+        execution_dates_added = dict()
+
+        # Sort the pipeline runs by id in reverse order so the first pipeline run
+        # checked is the latest pipeline run created for a given execution date.
+        pipeline_runs_sorted = sorted(
+            self.pipeline_runs,
+            key=lambda pr: (pr.execution_date, pr.id),
+            reverse=True,
+        )
+
+        for pr in pipeline_runs_sorted:
+            # Only count a pipeline run once per execution date
+            if pr.execution_date not in execution_dates_added:
+                status_counts[pr.status] = (status_counts.get(pr.status) or 0) + 1
+                execution_dates_added[pr.execution_date] = True
+
+        return status_counts

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -1920,33 +1920,6 @@ class Backfill(BaseModel):
 
     @property
     def pipeline_run_status_counts(self) -> Dict:
-        # Method 1 with query
-        # start1 = time.time()
-        # latest_pipeline_runs = PipelineRun.select(
-        #     PipelineRun,
-        #     func.row_number()
-        #         .over(
-        #             partition_by=PipelineRun.execution_date,
-        #             order_by=desc(PipelineRun.id))
-        #         .label('row_number')
-        # ).where(PipelineRun.backfill_id == self.id).cte(name='latest_pipeline_runs')
-        # query = (PipelineRun.select(
-        #         PipelineRun.status,
-        #         func.count(PipelineRun.status).over(partition_by=PipelineRun.status).label('count'),
-        #     )
-        #     .distinct()
-        #     .join(latest_pipeline_runs, and_(
-        #         PipelineRun.id == latest_pipeline_runs.c.id,
-        #         latest_pipeline_runs.c.row_number == 1,
-        #     ))
-        # )
-        # results = query.all()
-        # status_counts2 = dict(results)
-        # end1 = time.time()
-        # print('+========DB QUERY time elapsed:', end1 - start1)
-
-        # Method 2 using given self.pipeline_runs
-        start2 = time.time()
         status_counts = dict()
         execution_dates_counted = set()
 
@@ -1963,9 +1936,5 @@ class Backfill(BaseModel):
             if pr.execution_date not in execution_dates_counted:
                 status_counts[pr.status] = (status_counts.get(pr.status) or 0) + 1
                 execution_dates_counted.add(pr.execution_date)
-        end2 = time.time()
-        print('+========SORT AND ITERATE time elapsed:', end2 - start2)
-
-        print('----------------------------------------------')
 
         return status_counts


### PR DESCRIPTION
# Description
- Prevent user from being able to edit backfill once backfill has started. It can be confusing if the user edits a backfill's interval type/units after a backfill has started, since it would not affect the number of associated pipeline runs created.
- Add status count (i.e. `Ready`, `Running`, `Cancelled`, `Completed`, and `Failed`) columns for all statuses.
- Rearrange columns to better display most relevant data.

# How Has This Been Tested?
Before:
<img width="2056" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/d0368ea8-442f-4080-af51-4cdaa4fef4b2">

After:
<img width="2056" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/e15cc151-6784-4cc6-aca0-28b28e1b81d9">


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
