### PR TITLE
Fixed error in docker command integrate-mage-airflow.mdx

### DIFF
--- a/docs/guides/integrate-mage-airflow.mdx
+++ b/docs/guides/integrate-mage-airflow.mdx
@@ -118,7 +118,7 @@ If you’re using Docker, run the following command in the `dags/` folder:
 
 ```bash
 docker run -it -p 6789:6789 -v $(pwd):/home/src \
-  /app/run_app.sh mageai/mageai mage start demo_project
+  mageai/mageai /app/run_app.sh mage start demo_project
 ```
 
 If you used pip to install Mage, run the following command in the `dags/`


### PR DESCRIPTION
# Description
There was a little mixup in using the docker command to start mage. It should work now with cut&past and no longer give an error.


# How Has This Been Tested?
On OSX the docker command works now, should work on Linux & Windows too, given that there docker command line is not different
