### PR TITLE
[xy] Support interpolating trigger name in k8s job name.

### DIFF
--- a/mage_ai/data_preparation/executors/k8s_block_executor.py
+++ b/mage_ai/data_preparation/executors/k8s_block_executor.py
@@ -10,6 +10,7 @@ from mage_ai.services.k8s.config import K8sExecutorConfig
 from mage_ai.services.k8s.constants import DEFAULT_NAMESPACE
 from mage_ai.services.k8s.job_manager import JobManager as K8sJobManager
 from mage_ai.shared.hash import merge_dict
+from mage_ai.shared.utils import clean_name
 
 
 class K8sBlockExecutor(BlockExecutor):
@@ -72,6 +73,7 @@ class K8sBlockExecutor(BlockExecutor):
         if '{trigger_name}' in job_name_prefix:
             block_run = BlockRun.query.get(block_run_id)
             trigger = block_run.pipeline_run.pipeline_schedule
-            job_name_prefix = job_name_prefix.format(trigger_name=trigger.name)
+            job_name_prefix = job_name_prefix.format(
+                trigger_name=clean_name(trigger.name).replace('_', '-'))
 
         return job_name_prefix

--- a/mage_ai/data_preparation/executors/k8s_block_executor.py
+++ b/mage_ai/data_preparation/executors/k8s_block_executor.py
@@ -4,6 +4,8 @@ from jinja2 import Template
 
 from mage_ai.data_preparation.executors.block_executor import BlockExecutor
 from mage_ai.data_preparation.shared.utils import get_template_vars
+from mage_ai.orchestration.db import safe_db_query
+from mage_ai.orchestration.db.models.schedules import BlockRun
 from mage_ai.services.k8s.config import K8sExecutorConfig
 from mage_ai.services.k8s.constants import DEFAULT_NAMESPACE
 from mage_ai.services.k8s.job_manager import JobManager as K8sJobManager
@@ -15,10 +17,13 @@ class K8sBlockExecutor(BlockExecutor):
 
     def __init__(self, pipeline, block_uuid: str, execution_partition: str = None, **kwargs):
         super().__init__(pipeline, block_uuid, execution_partition=execution_partition)
-        self.executor_config = self.pipeline.repo_config.k8s_executor_config or dict()
+        self.executor_config_dict = self.pipeline.repo_config.k8s_executor_config or dict()
         if self.block.executor_config is not None:
-            self.executor_config = merge_dict(self.executor_config, self.block.executor_config)
-        self.executor_config = K8sExecutorConfig.load(config=self.executor_config)
+            self.executor_config_dict = merge_dict(
+                self.executor_config_dict,
+                self.block.executor_config,
+            )
+        self.executor_config = K8sExecutorConfig.load(config=self.executor_config_dict)
 
     def _execute(
         self,
@@ -26,10 +31,7 @@ class K8sBlockExecutor(BlockExecutor):
         global_vars: Dict = None,
         **kwargs,
     ) -> None:
-        if not self.executor_config.job_name_prefix:
-            job_name_prefix = 'data-prep'
-        else:
-            job_name_prefix = self.executor_config.job_name_prefix
+        job_name_prefix = self._get_job_name_prefix(block_run_id)
 
         if self.executor_config.namespace:
             namespace = Template(self.executor_config.namespace).render(
@@ -54,3 +56,22 @@ class K8sBlockExecutor(BlockExecutor):
             cmd,
             k8s_config=self.executor_config,
         )
+
+    @safe_db_query
+    def _get_job_name_prefix(
+        self,
+        block_run_id,
+    ):
+        if not self.executor_config.job_name_prefix:
+            job_name_prefix = 'data-prep'
+        else:
+            job_name_prefix = self.executor_config.job_name_prefix
+        if not block_run_id:
+            return job_name_prefix
+
+        if '{trigger_name}' in job_name_prefix:
+            block_run = BlockRun.query.get(block_run_id)
+            trigger = block_run.pipeline_run.pipeline_schedule
+            job_name_prefix = job_name_prefix.format(trigger_name=trigger.name)
+
+        return job_name_prefix

--- a/mage_ai/data_preparation/executors/k8s_pipeline_executor.py
+++ b/mage_ai/data_preparation/executors/k8s_pipeline_executor.py
@@ -6,6 +6,8 @@ from jinja2 import Template
 from mage_ai.data_preparation.executors.pipeline_executor import PipelineExecutor
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.data_preparation.shared.utils import get_template_vars
+from mage_ai.orchestration.db import safe_db_query
+from mage_ai.orchestration.db.models.schedules import PipelineRun
 from mage_ai.services.k8s.config import K8sExecutorConfig
 from mage_ai.services.k8s.constants import DEFAULT_NAMESPACE
 from mage_ai.services.k8s.job_manager import JobManager as K8sJobManager
@@ -15,10 +17,13 @@ from mage_ai.shared.hash import merge_dict
 class K8sPipelineExecutor(PipelineExecutor):
     def __init__(self, pipeline: Pipeline, execution_partition: str = None):
         super().__init__(pipeline, execution_partition=execution_partition)
-        self.executor_config = self.pipeline.repo_config.k8s_executor_config or dict()
+        self.executor_config_dict = self.pipeline.repo_config.k8s_executor_config or dict()
         if self.pipeline.executor_config is not None:
-            self.executor_config = merge_dict(self.executor_config, self.pipeline.executor_config)
-        self.executor_config = K8sExecutorConfig.load(config=self.executor_config)
+            self.executor_config_dict = merge_dict(
+                self.executor_config_dict,
+                self.pipeline.executor_config,
+            )
+        self.executor_config = K8sExecutorConfig.load(config=self.executor_config_dict)
 
     def cancel(
         self,
@@ -63,10 +68,7 @@ class K8sPipelineExecutor(PipelineExecutor):
     ) -> K8sJobManager:
         if global_vars is None:
             global_vars = dict()
-        if not self.executor_config.job_name_prefix:
-            job_name_prefix = 'data-prep'
-        else:
-            job_name_prefix = self.executor_config.job_name_prefix
+        job_name_prefix = self._get_job_name_prefix(pipeline_run_id)
 
         if self.executor_config.namespace:
 
@@ -83,3 +85,22 @@ class K8sPipelineExecutor(PipelineExecutor):
             logging_tags=kwargs.get('tags', dict()),
             namespace=namespace,
         )
+
+    @safe_db_query
+    def _get_job_name_prefix(
+        self,
+        pipeline_run_id,
+    ):
+        if not self.executor_config.job_name_prefix:
+            job_name_prefix = 'data-prep'
+        else:
+            job_name_prefix = self.executor_config.job_name_prefix
+        if not pipeline_run_id:
+            return job_name_prefix
+
+        if '{trigger_name}' in job_name_prefix:
+            pipeline_run = PipelineRun.query.get(pipeline_run_id)
+            trigger = pipeline_run.pipeline_schedule
+            job_name_prefix = job_name_prefix.format(trigger_name=trigger.name)
+
+        return job_name_prefix

--- a/mage_ai/data_preparation/executors/k8s_pipeline_executor.py
+++ b/mage_ai/data_preparation/executors/k8s_pipeline_executor.py
@@ -12,6 +12,7 @@ from mage_ai.services.k8s.config import K8sExecutorConfig
 from mage_ai.services.k8s.constants import DEFAULT_NAMESPACE
 from mage_ai.services.k8s.job_manager import JobManager as K8sJobManager
 from mage_ai.shared.hash import merge_dict
+from mage_ai.shared.utils import clean_name
 
 
 class K8sPipelineExecutor(PipelineExecutor):
@@ -101,6 +102,7 @@ class K8sPipelineExecutor(PipelineExecutor):
         if '{trigger_name}' in job_name_prefix:
             pipeline_run = PipelineRun.query.get(pipeline_run_id)
             trigger = pipeline_run.pipeline_schedule
-            job_name_prefix = job_name_prefix.format(trigger_name=trigger.name)
+            job_name_prefix = job_name_prefix.format(
+                trigger_name=clean_name(trigger.name).replace('_', '-'))
 
         return job_name_prefix


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Support interpolating trigger name in k8s job name by using `{trigger_name}` in the k8s executor config's `job_name_prefix` field.

Close: https://github.com/mage-ai/mage-ai/issues/4910

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with local k8s job
<img width="397" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/37d408b8-6242-4365-9734-5280e58e4f7d">

<img width="240" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/a301586a-f391-4e64-aed9-1a89504afa5d">


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
