### PR TITLE
[xy] Check type key in anyOf array objects.

### DIFF
--- a/mage_integrations/mage_integrations/destinations/base.py
+++ b/mage_integrations/mage_integrations/destinations/base.py
@@ -644,11 +644,12 @@ class Destination(ABC):
 
             if 'anyOf' in prop_k:
                 for any_of in prop_k['anyOf']:
-                    any_of_type = any_of['type']
-                    if type(any_of_type) is list:
-                        prop_types += any_of_type
-                    else:
-                        prop_types.append(any_of_type)
+                    any_of_type = any_of.get('type')
+                    if any_of_type is not None:
+                        if type(any_of_type) is list:
+                            prop_types += any_of_type
+                        else:
+                            prop_types.append(any_of_type)
 
             if COLUMN_TYPE_ARRAY not in prop_types:
                 continue


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Check type key in anyOf array objects.

Close: https://github.com/mage-ai/mage-ai/issues/4903

The MongoDB source has this schema: https://github.com/mage-ai/mage-ai/blob/master/mage_integrations/mage_integrations/sources/mongodb/tap_mongodb/sync_strategies/common.py#L259
`list_schema = {"type": "array", "items": {"anyOf": [{}]}}`

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with local mage integration pipeline


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
