### PR TITLE
[xy] Only send failure notification when pipeline run status is failed.

### DIFF
--- a/mage_ai/orchestration/pipeline_scheduler_original.py
+++ b/mage_ai/orchestration/pipeline_scheduler_original.py
@@ -284,8 +284,7 @@ class PipelineScheduler:
                     or PipelineRun.PipelineRunStatus.FAILED
                 )
                 self.pipeline_run.update(status=status)
-
-                self.on_pipeline_run_failure('Pipeline run timed out.')
+                self.on_pipeline_run_failure('Pipeline run timed out.', status=status)
             elif self.pipeline_run.any_blocks_failed() and not self.allow_blocks_to_fail:
                 self.pipeline_run.update(
                     status=PipelineRun.PipelineRunStatus.FAILED)
@@ -318,30 +317,38 @@ class PipelineScheduler:
                     self.__schedule_blocks(block_runs)
 
     @safe_db_query
-    def on_pipeline_run_failure(self, error_msg: str) -> None:
-        failed_block_runs = self.pipeline_run.failed_block_runs
-        stacktrace = None
-        for br in failed_block_runs:
-            if br.metrics:
-                message = br.metrics.get('error', {}).get('message')
-                if message:
-                    message_split = message.split('\n')
-                    # Truncate the error message if it has too many lines, set max
-                    # lines at 50
-                    if len(message_split) > 50:
-                        message_split = message_split[-50:]
-                        message_split.insert(0, '... (error truncated)')
-                    message = '\n'.join(message_split)
-                    stacktrace = f'Error for block {br.block_uuid}:\n{message}'
-                    break
-
+    def on_pipeline_run_failure(
+        self,
+        error_msg: str,
+        status=PipelineRun.PipelineRunStatus.FAILED,
+    ) -> None:
         asyncio.run(UsageStatisticLogger().pipeline_run_ended(self.pipeline_run))
-        self.notification_sender.send_pipeline_run_failure_message(
-            pipeline=self.pipeline,
-            pipeline_run=self.pipeline_run,
-            error=error_msg,
-            stacktrace=stacktrace,
-        )
+
+        if status == PipelineRun.PipelineRunStatus.FAILED:
+            # Only send notification when pipeline run status is FAILED
+            failed_block_runs = self.pipeline_run.failed_block_runs
+            stacktrace = None
+            for br in failed_block_runs:
+                if br.metrics:
+                    message = br.metrics.get('error', {}).get('message')
+                    if message:
+                        message_split = message.split('\n')
+                        # Truncate the error message if it has too many lines, set max
+                        # lines at 50
+                        if len(message_split) > 50:
+                            message_split = message_split[-50:]
+                            message_split.insert(0, '... (error truncated)')
+                        message = '\n'.join(message_split)
+                        stacktrace = f'Error for block {br.block_uuid}:\n{message}'
+                        break
+
+            self.notification_sender.send_pipeline_run_failure_message(
+                pipeline=self.pipeline,
+                pipeline_run=self.pipeline_run,
+                error=error_msg,
+                stacktrace=stacktrace,
+            )
+
         # Cancel block runs that are still in progress for the pipeline run.
         cancel_block_runs_and_jobs(self.pipeline_run, self.pipeline)
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Only send failure notification when pipeline run status is failed.

When pipeline time out and the timeout_status is CANCELLED, don't send the failure notification.

Close: https://github.com/mage-ai/mage-ai/issues/4945

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
- [x] Tested with local pipeline timeout scenario

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
