### PR TITLE
Trino iceberg and delta lake array issues fix along with issue 4895 and other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,7 @@ playwright-report/
 **/TEST_OUTPUT
 **/TEST_STATE.json
 **/TEST_CONFIG*.json
+**/TEST_*
 package-lock.json
 package.json
 yarn.lock

--- a/mage_integrations/mage_integrations/destinations/sql/utils.py
+++ b/mage_integrations/mage_integrations/destinations/sql/utils.py
@@ -132,6 +132,7 @@ def column_type_mapping(
     convert_array_column_type_func: Callable,
     number_type: str = 'DOUBLE PRECISION',
     string_type: str = 'VARCHAR',
+    array_default_item_type: str = None,
 ) -> Dict:
     mapping = {}
     for column, column_settings in schema['properties'].items():
@@ -186,6 +187,9 @@ def column_type_mapping(
             items_items = column_settings.get('items', {}).get('items', {}).get('type', [])
             if len(items_items) >= 1:
                 item_types += items_items
+
+            if array_default_item_type:
+                item_types.append(array_default_item_type)
 
             if len(item_types):
                 item_type = item_types[0]

--- a/mage_integrations/mage_integrations/destinations/trino/connectors/deltalake.py
+++ b/mage_integrations/mage_integrations/destinations/trino/connectors/deltalake.py
@@ -26,8 +26,7 @@ def convert_column_type(
 
 
 class TrinoDeltalake(TrinoConnector):
-
-    name = "delta-lake"
+    name = 'delta-lake'
 
     def column_type_mapping(self, schema: Dict) -> Dict:
         return column_type_mapping_orig(

--- a/mage_integrations/mage_integrations/destinations/trino/connectors/deltalake.py
+++ b/mage_integrations/mage_integrations/destinations/trino/connectors/deltalake.py
@@ -23,6 +23,9 @@ def convert_column_type(
 
 
 class TrinoDeltalake(TrinoConnector):
+
+    name = "delta-lake"
+
     def column_type_mapping(self, schema: Dict) -> Dict:
         return column_type_mapping_orig(
             schema,
@@ -42,4 +45,6 @@ class TrinoDeltalake(TrinoConnector):
                 value_serialized = json.dumps(value)
         else:
             value_serialized = json.dumps(value)
+
+        value_serialized = value_serialized.replace("'", "''")
         return f"CAST(JSON '{value_serialized}' AS ARRAY<{item_type_converted}>)"

--- a/mage_integrations/mage_integrations/destinations/trino/connectors/deltalake.py
+++ b/mage_integrations/mage_integrations/destinations/trino/connectors/deltalake.py
@@ -1,7 +1,10 @@
 import json
 from typing import Dict
 
-from mage_integrations.destinations.constants import COLUMN_TYPE_OBJECT
+from mage_integrations.destinations.constants import (
+    COLUMN_TYPE_OBJECT,
+    COLUMN_TYPE_STRING,
+)
 from mage_integrations.destinations.sql.utils import (
     column_type_mapping as column_type_mapping_orig,
 )
@@ -31,6 +34,7 @@ class TrinoDeltalake(TrinoConnector):
             schema,
             convert_column_type,
             lambda item_type_converted: f'ARRAY<{item_type_converted}>',
+            array_default_item_type=COLUMN_TYPE_STRING,
         )
 
     def convert_array(self, value: str, column_type_dict: Dict) -> str:

--- a/mage_integrations/mage_integrations/destinations/trino/connectors/iceberg.py
+++ b/mage_integrations/mage_integrations/destinations/trino/connectors/iceberg.py
@@ -2,7 +2,7 @@
 Trino iceberg connector
 """
 
-from .deltalake import TrinoDeltalake, convert_column_type
+from .deltalake import TrinoDeltalake, convert_column_type  # noqa: F401
 
 
 class TrinoIceberg(TrinoDeltalake):

--- a/mage_integrations/mage_integrations/destinations/trino/connectors/iceberg.py
+++ b/mage_integrations/mage_integrations/destinations/trino/connectors/iceberg.py
@@ -1,37 +1,17 @@
-from mage_integrations.destinations.constants import (
-    COLUMN_TYPE_OBJECT,
-)
-from mage_integrations.destinations.sql.utils import (
-    column_type_mapping as column_type_mapping_orig,
-    convert_column_type as convert_column_type_orig,
-)
-from mage_integrations.destinations.trino.connectors.base import TrinoConnector
-import json
-from typing import Dict
+"""
+Trino iceberg connector
+"""
+
+from .deltalake import TrinoDeltalake, convert_column_type
 
 
-def convert_column_type(
-    column_type: str,
-    column_settings: Dict,
-    **kwargs,
-) -> str:
-    if COLUMN_TYPE_OBJECT == column_type:
-        return 'VARCHAR'
+class TrinoIceberg(TrinoDeltalake):
+    """
+    As of Apr 17 2024, there is no difference between iceberg and delta-lake connectors
+    which is why we are inheriting from TrinoDeltalake.
 
-    return convert_column_type_orig(column_type, column_settings, **kwargs)
+    Any changes that are not common between iceberg and delta-lake connectors
+    should be implemented in this class.
+    """
 
-
-class TrinoIceberg(TrinoConnector):
-    def column_type_mapping(self, schema: Dict) -> Dict:
-        return column_type_mapping_orig(
-            schema,
-            convert_column_type,
-            lambda item_type_converted: f'ARRAY<{item_type_converted}>',
-        )
-
-    def convert_array(self, value: str, column_type_dict: Dict) -> str:
-        if len(value) == 0:
-            return 'NULL'
-        item_type_converted = column_type_dict['item_type_converted']
-
-        return f"CAST('{json.dumps(value)}' AS {item_type_converted})"
+    name = "iceberg"

--- a/mage_integrations/mage_integrations/destinations/trino/connectors/iceberg.py
+++ b/mage_integrations/mage_integrations/destinations/trino/connectors/iceberg.py
@@ -2,7 +2,10 @@
 Trino iceberg connector
 """
 
-from .deltalake import TrinoDeltalake, convert_column_type  # noqa: F401
+from mage_integrations.destinations.trino.connectors.deltalake import (  # noqa: F401
+    TrinoDeltalake,
+    convert_column_type,
+)
 
 
 class TrinoIceberg(TrinoDeltalake):
@@ -13,5 +16,4 @@ class TrinoIceberg(TrinoDeltalake):
     Any changes that are not common between iceberg and delta-lake connectors
     should be implemented in this class.
     """
-
-    name = "iceberg"
+    name = 'iceberg'


### PR DESCRIPTION
# Description
Issue 1 - Iceberg connector did not work with Array type fields. The issue was fixed for delta lake last month by @wangxiaoyou1993 but iceberg was still pending.

Issue 2 - Single quotes in text were not being handled by the connector causing issues with Insert commands. This PR fixes that issue

Issue 3 - Code repetition which is an anti pattern. There was no difference at all between delta lake and iceberg code so simply reusing the delta lake class makes it easy to maintain and debug.

Issue 4 - Delta lake and Iceberg default item type set as string for array fields. Fixes issue - [4895](https://github.com/mage-ai/mage-ai/issues/4895)


# How Has This Been Tested?
Test locally.
![image](https://github.com/mage-ai/mage-ai/assets/45642655/b3903dac-bd63-497e-88f2-eac3150a950c)


# Checklist
- [X ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ X] I have performed a self-review of my own code
- [ X] I have added unit tests that prove my fix is effective or that my feature works
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
