### PR TITLE
Reload libraries when running blocks from edit pipeline

### DIFF
--- a/mage_ai/autocomplete/utils.py
+++ b/mage_ai/autocomplete/utils.py
@@ -60,6 +60,7 @@ def extract_all_imports(file_content, ignore_nesting=False):
         r'import [\w.]+',
         r'from [\w.]+ import [\w.]+ as [\w.]+',
         r'from [\w.]+ import [\w.]+',
+        r'from [\w.]+ import \(',
     ]
     regexes = []
 

--- a/mage_ai/autocomplete/utils.py
+++ b/mage_ai/autocomplete/utils.py
@@ -1,11 +1,12 @@
-from functools import reduce
-from mage_ai.shared.utils import files_in_path
-import aiofiles
 import importlib
 import os
 import pathlib
 import re
+from functools import reduce
 
+import aiofiles
+
+from mage_ai.shared.utils import files_in_path
 
 root_path = '/'.join(str(pathlib.Path(__file__).parent.resolve()).split('/')[:-2])
 
@@ -27,7 +28,7 @@ def add_file(acc, path):
 
     def __should_include(file_name):
         tup = os.path.splitext(file_name)
-        if (len(tup) >= 2):
+        if len(tup) >= 2:
             file_extension = tup[1]
             return file_extension in FILE_EXTENSIONS_TO_INCLUDE
 
@@ -90,7 +91,7 @@ async def build_file_content_mapping(paths, files):
         module_name = '.'.join(parts).replace('.py', '')
 
         if '__init__.py' == parts[-1]:
-            path_sub = '/'.join(parts[:len(parts) - 1])
+            path_sub = '/'.join(parts[: len(parts) - 1])
             files += [fn for fn in reduce(add_file, [path_sub], []) if fn != file_name]
             module_name = module_name.replace('.__init__', '')
 
@@ -102,10 +103,12 @@ async def build_file_content_mapping(paths, files):
                     importlib.import_module(module_name),
                     class_name,
                 )
-                methods_for_class[class_name] = list(filter(
-                    lambda x: not re.match('^_', x),
-                    dir(klass),
-                ))
+                methods_for_class[class_name] = list(
+                    filter(
+                        lambda x: not re.match('^_', x),
+                        dir(klass),
+                    )
+                )
             except ImportError as err:
                 print(err)
 

--- a/mage_ai/server/websocket_server.py
+++ b/mage_ai/server/websocket_server.py
@@ -418,11 +418,11 @@ class WebSocketServer(tornado.websocket.WebSocketHandler):
         if is_disable_pipeline_edit_access():
             custom_code = block.content
 
-        reload_all_repo_modules(custom_code)
-
         code = custom_code
 
         client = self.init_kernel_client(kernel_name)
+
+        reload_all_repo_modules(custom_code, client)
 
         value = dict(
             block_type=block_type or block.type,

--- a/mage_ai/utils/code.py
+++ b/mage_ai/utils/code.py
@@ -13,7 +13,7 @@ def reload_all_repo_modules(content: str, client: KernelClient) -> None:
     project_name = parts[-1]
     root_parts = get_repo_path(root_project=True).split('/')
     if len(root_parts) < len(parts):
-        project_name = '.'.join(parts[len(root_parts) - 1 :])
+        project_name = '.'.join(parts[len(root_parts) - 1:])
 
     for line in extract_all_imports(content):
         if f'import {project_name}' not in line and f'from {project_name}' not in line:
@@ -46,34 +46,40 @@ def extract_decorated_function(code: str, decorated_function_name: str) -> Tuple
     number_of_lines = len(lines)
 
     for idx, line in enumerate(lines):
-        if line and \
-                span_current_start is not None and \
-                span_current_def is not None:
+        if line and span_current_start is not None and span_current_def is not None:
 
             if line.startswith('@') or line.startswith('def '):
-                spans.append((
-                    span_current_start,
-                    idx - 1,
-                ))
+                spans.append(
+                    (
+                        span_current_start,
+                        idx - 1,
+                    )
+                )
                 span_current_start = None
                 span_current_def = None
 
-        if line and \
-                span_current_start is not None and \
-                span_current_def is None and \
-                line.startswith('def '):
+        if (
+            line
+            and span_current_start is not None
+            and span_current_def is None
+            and line.startswith('def ')
+        ):
 
             span_current_def = idx
 
-        if line and \
-                span_current_start is None and \
-                line.startswith(f'@{decorated_function_name}'):
+        if (
+            line
+            and span_current_start is None
+            and line.startswith(f'@{decorated_function_name}')
+        ):
 
             span_current_start = idx
 
-        if span_current_start is not None and \
-                span_current_def is not None and \
-                idx == number_of_lines - 1:
+        if (
+            span_current_start is not None
+            and span_current_def is not None
+            and idx == number_of_lines - 1
+        ):
 
             spans.append((span_current_start, idx))
 

--- a/mage_ai/utils/code.py
+++ b/mage_ai/utils/code.py
@@ -9,11 +9,8 @@ from mage_ai.settings.repo import get_repo_path
 
 
 def reload_all_repo_modules(content: str, client: KernelClient) -> None:
-    parts = get_repo_path().split('/')
+    parts = get_repo_path(root_project=True).split('/')
     project_name = parts[-1]
-    root_parts = get_repo_path(root_project=True).split('/')
-    if len(root_parts) < len(parts):
-        project_name = '.'.join(parts[len(root_parts) - 1:])
 
     for line in extract_all_imports(content):
         if f'import {project_name}' not in line and f'from {project_name}' not in line:


### PR DESCRIPTION
# Description
In our local development, utility code changes are not effective automatically when working with the editor.
Instead kernel restart or manual importlib.reload helps.
In a slack chat I learnt from @tommydangerous, this is not the intended way.
[https://app.slack.com/client/T03GK6PEQP6/C03HTTWFEKE/1713014196.350109](https://app.slack.com/client/T03GK6PEQP6/C03HTTWFEKE/1713014196.350109)

I looked at the code that was referenced by Tommy and applied a few changes. This seems to work in our local dev env.
Changes:
- look for root project name, helps w multiprojects
- run importlib.reload in kernel via client

# How Has This Been Tested?
- [X] Tested in our local dev.
- [] Not tested in other bigger, cloud, etc systems.
Also could not reproduce original issue on demo.mage.ai


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
@tommydangerous