### PR TITLE
[xy] Fix downloading xlsx file.

### DIFF
--- a/mage_ai/server/api/downloads.py
+++ b/mage_ai/server/api/downloads.py
@@ -114,7 +114,10 @@ class ApiResourceDownloadHandler(BaseHandler):
     # file pointer points to either a singular file or a temporary zip
     def get_file_pointer(self, file_list, relative_file_list):
         if len(file_list) == 1:
-            return open(file_list[0])
+            if file_list[0].endswith('.xlsx'):  # Check if it's an XLSX file
+                return open(file_list[0], 'rb')  # Open in binary mode for XLSX
+            else:
+                return open(file_list[0])
         return self.zip_files(file_list, relative_file_list)
 
     # creates a temporary zip and returns the (open) file pointer


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix downloading xlsx file.

Got the error when downloading xlsx
```
Error fetching file filename.xlsx.
'utf-8' codec can't decode byte 0x8f in position 22: invalid start byte
```

Update the file open mode to `rb` for xlsx file to fix the issue

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested downloading xlsx file locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
