### PR TITLE
[jk] Bugfix - Dependency tree layout

### DIFF
--- a/mage_ai/frontend/components/DependencyGraph/BlockNode/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/BlockNode/index.tsx
@@ -8,9 +8,7 @@ import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
 import PipelineType from '@interfaces/PipelineType';
 import Spacing from '@oracle/elements/Spacing';
-import Spinner from '@oracle/components/Spinner';
 import Text from '@oracle/elements/Text';
-import dark from '@oracle/styles/themes/dark';
 import {
   CircleWithArrowUp,
   CubeWithArrowDown,

--- a/mage_ai/frontend/components/DependencyGraph/BlockNode/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/BlockNode/index.tsx
@@ -138,7 +138,7 @@ function BlockNode({
     color,
     runtime: runtimeFromBlock,
     type,
-  } = block;
+  } = block || {};
   const {
     accent,
     accentLight,

--- a/mage_ai/frontend/components/DependencyGraph/BlockNode/utils.ts
+++ b/mage_ai/frontend/components/DependencyGraph/BlockNode/utils.ts
@@ -41,7 +41,7 @@ const BADGE_SPACING_HORIZONTAL = 4;
 const BADGE_SPACING_VERTICAL = 4;
 
 export function blockTagsText(block: BlockType): string {
-  const tags = buildTags(block);
+  const tags = buildTags(block || {});
 
   if (tags?.length >= 1) {
     return tags?.map(({ title }) => title).join(', ') || '';

--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -2153,7 +2153,7 @@ function DependencyGraph({
           nodes={nodes}
           onNodeLinkCheck={(event, from, to) => !edges.some(e => e.from === from.id && e.to === to.id)}
           onZoomChange={z => {
-            const zFinal = Math.max(z, 0.05)
+            const zFinal = Math.max(z, 0.05);
             setZoom?.(zFinal);
             setZoomLevel(zFinal);
           }}

--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -673,7 +673,7 @@ function DependencyGraph({
       }
     }
 
-    const disabled = blockEditing?.uuid === block.uuid;
+    const disabled = blockEditing?.uuid === block?.uuid;
     if (!disabled) {
       if (blockEditing) {
         onClickWhenEditingUpstreamBlocks(block);
@@ -2129,7 +2129,7 @@ function DependencyGraph({
                         blocksWithSameDownstreamBlocks={blocksWithSameDownstreamBlocks}
                         callbackBlocks={callbackBlocksByBlockUUID?.[block?.uuid]}
                         conditionalBlocks={conditionalBlocksByBlockUUID?.[block?.uuid]}
-                        disabled={blockEditing?.uuid === block.uuid}
+                        disabled={blockEditing?.uuid === block?.uuid}
                         downstreamBlocks={downstreamBlocks}
                         extensionBlocks={extensionBlocksByBlockUUID?.[block?.uuid]}
                         hasFailed={hasFailed}
@@ -2139,7 +2139,7 @@ function DependencyGraph({
                         isInProgress={isInProgressFinal}
                         isQueued={isQueued}
                         isSuccessful={isSuccessful}
-                        key={block.uuid}
+                        key={block?.uuid}
                         pipeline={pipeline}
                         selected={selected}
                         selectedBlock={selectedBlock}

--- a/mage_ai/frontend/components/DependencyGraph/utils.ts
+++ b/mage_ai/frontend/components/DependencyGraph/utils.ts
@@ -349,7 +349,7 @@ export function buildNodesEdgesPorts({
         return downstreamKey === initalDownstreamKey;
       });
     }
-    if ((downstreamBlocks?.length >= 2 && upstreamBlocks?.length < 2) || sameDownstreamBlocksGroup) {
+    if (downstreamBlocks?.length >= 2 && (upstreamBlocks?.length < 2 || sameDownstreamBlocksGroup)) {
       // Only group these blocks if their downstream is identical
       // or at least 2 of them have downstreams that match exactly (subgroup).
       const counts = {};

--- a/mage_ai/frontend/components/DependencyGraph/utils.ts
+++ b/mage_ai/frontend/components/DependencyGraph/utils.ts
@@ -340,6 +340,11 @@ export function buildNodesEdgesPorts({
     } = info;
 
     let sameDownstreamBlocksGroup = false;
+    /*
+     * We need to make sure certain block groupings only happen when there aren't
+     * additional block connections that can break the rendering of the layout
+     * in the dependency graph.
+     */
     if (upstreamBlocks?.length > 1) {
       const initalDownstreamKey = getBlocksKey(upstreamBlocks?.[0]?.downstream_blocks);
       const upstreamsHaveSameDownstreams = upstreamBlocks?.every(({


### PR DESCRIPTION
# Description
- There was a "Layout Error: TypeError: Cannot read properties of null (reading 'p')" preventing the dependency tree in the Pipeline Editor from rendering when block dependencies were added in certain scenarios (e.g. downstream connection added to a block two levels down in a block grouping within a grouping)
- Example of what could cause the dependency tree rendering issue (among other combinations):
<img width="1442" alt="dep tree block groupings" src="https://github.com/mage-ai/mage-ai/assets/78053898/d675429c-9fff-4ad2-aebb-0a2709524e63">

# How Has This Been Tested?
- Confirmed dep tree would render properly even with downstream connections that previously prevented the dep tree from rendering, such as:
<img width="1455" alt="image" src="https://github.com/mage-ai/mage-ai/assets/78053898/a8e63f41-4c52-4b4d-9d79-165e27054bfe">

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
