### PR TITLE
[xy] Fix logging tags for streaming pipeline run.

### DIFF
--- a/mage_ai/data_preparation/executors/streaming_pipeline_executor.py
+++ b/mage_ai/data_preparation/executors/streaming_pipeline_executor.py
@@ -84,7 +84,7 @@ class StreamingPipelineExecutor(PipelineExecutor):
         # 1. Support multiple sources and sinks
         # 2. Support flink pipeline
 
-        tags = self.build_tags(**kwargs)
+        tags = self.build_tags(pipeline_run_id=pipeline_run_id, **kwargs)
         self.logging_tags = tags
         if build_block_output_stdout:
             stdout_logger = logging.getLogger('streaming_pipeline_executor')


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix logging tags for streaming pipeline run. Include pipeline_run_id in the tags so that the logs can show in the pipeline run logs page.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with local streaming pipeline in k8s cluster
<img width="1150" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/84b6950e-584c-41eb-ae90-15689c735f29">


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
