### PR TITLE
[Enhancement] Optionally Disable Wait Timeout in ECS Config

### DIFF
--- a/docs/production/configuring-production-settings/compute-resource.mdx
+++ b/docs/production/configuring-production-settings/compute-resource.mdx
@@ -205,11 +205,11 @@ name: example_pipeline
 
 #### Extra fields
 
-| Field name              | Description                                                                                                                   | Example values              |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
-| assign_public_ip        | Whether to assign public IP to the ECS task.                                                                                  | true/false (default: true)  |
-| enable_execute_command  | Whether to [enable execute command for debugging](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html)  | true/false (default: false) |
-| wait_timeout            | The maximum wait time for the ECS task (in seoncds). The default wait timeout for the ECS task is 10 minutes.                 | 1200 (default: 600)         |
+| Field name              | Description                                                                                                                                            | Example values              |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------- |
+| assign_public_ip        | Whether to assign public IP to the ECS task.                                                                                                           | true/false (default: true)  |
+| enable_execute_command  | Whether to [enable execute command for debugging](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html)                           | true/false (default: false) |
+| wait_timeout            | The maximum wait time for the ECS task (in seoncds). The default wait timeout for the ECS task is 10 minutes. Setting to -1 will disable waiting. | 1200 (default: 600)         |
 
 Example config
 ```yaml

--- a/mage_ai/services/aws/ecs/ecs.py
+++ b/mage_ai/services/aws/ecs/ecs.py
@@ -16,7 +16,8 @@ def run_task(
     response = client.run_task(**ecs_config.get_task_config(command=command))
 
     print(json.dumps(response, indent=4, default=str))
-
+    wait_for_completion = False if ecs_config.wait_timeout == -1 else wait_for_completion
+    
     if wait_for_completion:
         arn = response['tasks'][0]['taskArn']
         waiter = client.get_waiter('tasks_stopped')

--- a/mage_ai/services/aws/ecs/ecs.py
+++ b/mage_ai/services/aws/ecs/ecs.py
@@ -17,7 +17,7 @@ def run_task(
 
     print(json.dumps(response, indent=4, default=str))
     wait_for_completion = False if ecs_config.wait_timeout == -1 else wait_for_completion
-    
+
     if wait_for_completion:
         arn = response['tasks'][0]['taskArn']
         waiter = client.get_waiter('tasks_stopped')


### PR DESCRIPTION
# Description

ECS executor configs have a setting `wait_timeout`  that tells the executor how long to wait for the task to complete before retrying. The `mage_ai.services.aws.ecs.run_task` function has been updated to check if this value is set to -1. If so, it will skip waiting for the task to complete.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

_There was no test coverage for wait functionality to update for this change. Existing tests for ECS config remain unaffected._


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
