### PR TITLE
[jk] Cancel unsaved modified file dialogue

### DIFF
--- a/mage_ai/frontend/components/Files/useFileComponents.tsx
+++ b/mage_ai/frontend/components/Files/useFileComponents.tsx
@@ -316,6 +316,10 @@ function useFileComponents({
       && (typeof window === 'undefined'
         || !window.confirm(`${filePath} has unsaved changes, are you sure you want to close this file?`)));
 
+    if (fps?.length > 0) {
+      return;
+    }
+
     const indexes = filePaths?.map((filePath) => openFilePaths?.findIndex((fp: string) => fp === filePath));
     indexes.sort();
     let idx = indexes?.find((index, i) => i >= 1 && index > indexes[i - 1] + 1);
@@ -355,9 +359,11 @@ function useFileComponents({
     }
   }, [
     filesTouched,
-    selectedFilePath,
+    openFilePaths,
     setContentByFilePath,
+    setFilesTouched,
     setOpenFilePaths,
+    setSelectedFilePath,
     status,
   ]);
 

--- a/mage_ai/frontend/components/PipelineDetail/FileTabs/Tab.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/FileTabs/Tab.tsx
@@ -161,31 +161,26 @@ function FileTab({
             <>
               <Spacing mr={2} />
 
-              <Tooltip
-                label="Close"
-                size={null}
-                widthFitContent
+              <Link
+                autoHeight
+                block
+                noHoverUnderline
+                noOutline
+                onClick={(e) => {
+                  pauseEvent(e);
+                  onClickTabClose?.(filePath);
+                }}
+                preventDefault
+                title="Close"
               >
-                <Link
-                  autoHeight
-                  block
-                  noHoverUnderline
-                  noOutline
-                  onClick={(e) => {
-                    pauseEvent(e);
-                    onClickTabClose?.(filePath);
-                  }}
-                  preventDefault
-                >
-                  {(focused || selected) && (
-                    <Close
-                      muted={!selected}
-                      size={ICON_SIZE}
-                    />
-                  )}
-                  {!focused && !selected && <div style={{ width: ICON_SIZE }} />}
-                </Link>
-              </Tooltip>
+                {(focused || selected) && (
+                  <Close
+                    muted={!selected}
+                    size={ICON_SIZE}
+                  />
+                )}
+                {!focused && !selected && <div style={{ width: ICON_SIZE }} />}
+              </Link>
             </>
           )}
         </FlexContainer>


### PR DESCRIPTION
# Description
- When clicking `Cancel` in the confirmation dialogue for closing an unsaved, modified file in the File Editor, user would expect the unsaved file to remain open so they could save it, but the file was closing instead, causing unsaved changes to be lost. This PR fixes this so that clicking `Cancel` behaves as expected.
- Addresses github issue https://github.com/mage-ai/mage-ai/issues/4882
- Also fix blocked "Close" button tooltip in file tab.

# How Has This Been Tested?
Before (clicking cancel closes the file without allowing user to save changes):
![before - close unsaved file](https://github.com/mage-ai/mage-ai/assets/78053898/f2b2eaaf-2a5d-435e-85e6-5d376632e341)

After (clicking cancel keeps the file open as expected):
![after - close unsaved file](https://github.com/mage-ai/mage-ai/assets/78053898/32205b7d-ed2d-40b6-af0d-149f28d0115a)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
