### PR TITLE
[xy] Fix k8s affinity parsing.

### DIFF
--- a/mage_ai/services/k8s/config.py
+++ b/mage_ai/services/k8s/config.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from typing import Dict
 
 from kubernetes.client import (
-    V1Affinity,
     V1Container,
     V1EnvVar,
     V1LocalObjectReference,
@@ -15,8 +14,9 @@ from kubernetes.client import (
 )
 
 from mage_ai.services.k8s.constants import CONFIG_FILE, DEFAULT_NAMESPACE
+from mage_ai.services.k8s.utils import parse_affinity_config
 from mage_ai.shared.config import BaseConfig
-from mage_ai.shared.hash import camel_case_keys_to_snake_case, get_safe_value
+from mage_ai.shared.hash import get_safe_value
 
 # import traceback
 
@@ -61,8 +61,8 @@ class K8sExecutorConfig(BaseConfig):
                 executor_config.pod.get('service_account_name') or DEFAULT_SERVICE_ACCOUNT_NAME
             )
             if executor_config.pod.get('affinity'):
-                affinity = V1Affinity(
-                    **camel_case_keys_to_snake_case(executor_config.pod['affinity']))
+                # Convert the affinity to a V1Affinity object
+                affinity = parse_affinity_config(executor_config.pod['affinity'])
 
             if executor_config.pod.get('tolerations'):
                 tolerations += [V1Toleration(**e) for e in executor_config.pod['tolerations']]

--- a/mage_ai/services/k8s/utils.py
+++ b/mage_ai/services/k8s/utils.py
@@ -1,0 +1,97 @@
+from kubernetes import client
+
+
+def parse_affinity_config(affinity_config):
+    if not affinity_config:
+        return None
+
+    affinity = client.V1Affinity(
+        node_affinity=parse_node_affinity(affinity_config.get('nodeAffinity')),
+        pod_affinity=parse_pod_affinity(affinity_config.get('podAffinity')),
+        pod_anti_affinity=parse_pod_anti_affinity(affinity_config.get('podAntiAffinity'))
+    )
+    return affinity
+
+
+def parse_node_affinity(node_affinity_config):
+    if not node_affinity_config:
+        return None
+
+    required_terms = node_affinity_config.get(
+        'requiredDuringSchedulingIgnoredDuringExecution', {}).get('nodeSelectorTerms', [])
+    node_selector_terms = []
+    for term in required_terms:
+        match_expressions = [client.V1NodeSelectorRequirement(
+            key=expr.get('key'),
+            operator=expr.get('operator'),
+            values=expr.get('values')
+        ) for expr in term.get('matchExpressions', [])]
+
+        node_selector_terms.append(client.V1NodeSelectorTerm(match_expressions=match_expressions))
+
+    return client.V1NodeAffinity(
+        required_during_scheduling_ignored_during_execution=client.V1NodeSelector(
+            node_selector_terms=node_selector_terms)
+    )
+
+
+def parse_pod_affinity(pod_affinity_config):
+    if not pod_affinity_config:
+        return None
+
+    required_terms = pod_affinity_config.get('requiredDuringSchedulingIgnoredDuringExecution', [])
+    preferred_terms = pod_affinity_config.get('preferredDuringSchedulingIgnoredDuringExecution', [])
+
+    required_affinity = parse_affinity_term_list(required_terms)
+    preferred_affinity = parse_affinity_term_list(preferred_terms)
+
+    return client.V1PodAffinity(
+        required_during_scheduling_ignored_during_execution=required_affinity,
+        preferred_during_scheduling_ignored_during_execution=preferred_affinity
+    )
+
+
+def parse_pod_anti_affinity(pod_anti_affinity_config):
+    if not pod_anti_affinity_config:
+        return None
+
+    required_terms = pod_anti_affinity_config.get(
+        'requiredDuringSchedulingIgnoredDuringExecution', [])
+    preferred_terms = pod_anti_affinity_config.get(
+        'preferredDuringSchedulingIgnoredDuringExecution', [])
+
+    required_affinity = parse_affinity_term_list(required_terms)
+    preferred_affinity = parse_affinity_term_list(preferred_terms)
+
+    return client.V1PodAntiAffinity(
+        required_during_scheduling_ignored_during_execution=required_affinity,
+        preferred_during_scheduling_ignored_during_execution=preferred_affinity
+    )
+
+
+def parse_affinity_term_list(term_list):
+    if not term_list:
+        return None
+
+    affinity_term_list = []
+    for term in term_list:
+        label_selector = client.V1LabelSelector(
+            match_labels=term.get('labelSelector', {}).get('matchLabels', {}),
+            match_expressions=[client.V1LabelSelectorRequirement(
+                key=expr.get('key'),
+                operator=expr.get('operator'),
+                values=expr.get('values')
+            ) for expr in term.get('labelSelector', {}).get('matchExpressions', [])]
+        )
+
+        topology_key = term.get('topologyKey')
+
+        affinity_term_list.append(client.V1WeightedPodAffinityTerm(
+            weight=term.get('weight'),
+            pod_affinity_term=client.V1PodAffinityTerm(
+                label_selector=label_selector,
+                topology_key=topology_key
+            )
+        ))
+
+    return affinity_term_list

--- a/mage_ai/tests/services/k8s/test_job_manager.py
+++ b/mage_ai/tests/services/k8s/test_job_manager.py
@@ -7,6 +7,10 @@ from kubernetes.client import (
     V1Container,
     V1EnvFromSource,
     V1EnvVar,
+    V1NodeAffinity,
+    V1NodeSelector,
+    V1NodeSelectorRequirement,
+    V1NodeSelectorTerm,
     V1Pod,
     V1PodSpec,
     V1SecretEnvSource,
@@ -377,13 +381,12 @@ class JobManagerTests(TestCase):
 
         # Pod
         self.assertEqual(job.spec.template.spec.affinity, V1Affinity(
-            **dict(
-                node_affinity=dict(
-                    required_during_scheduling_ignored_during_execution=dict(
+                node_affinity=V1NodeAffinity(
+                    required_during_scheduling_ignored_during_execution=V1NodeSelector(
                         node_selector_terms=[
-                            dict(
+                            V1NodeSelectorTerm(
                                 match_expressions=[
-                                    dict(
+                                    V1NodeSelectorRequirement(
                                         key='kubernetes.io/os',
                                         operator='In',
                                         values=['linux']
@@ -394,7 +397,7 @@ class JobManagerTests(TestCase):
                     )
                 )
             )
-        ))
+        )
 
         self.assertEqual(job.spec.template.spec.service_account_name, 'secretaccount')
         self.assertEqual(job.spec.template.spec.image_pull_secrets,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix parsing affinity config in k8s config.
Close: https://github.com/mage-ai/mage-ai/issues/4874

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with the config
```
k8s_executor_config:
  service_account_name: mageai
  pod:
    tolerations:
    - key: "key2"
      operator: "Equal"
      value: "value2"
      effect: "NoSchedule"
    affinity:
      nodeAffinity:
        requiredDuringSchedulingIgnoredDuringExecution:
          nodeSelectorTerms:
          - matchExpressions:
            - key: kubernetes.io/os
              operator: In
              values:
              - windows
 ```
The pod is created with the correct spec
<img width="437" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/aa4da026-2169-4391-a06c-c5e07267e284">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
