### PR TITLE
[xy] Delay initializing the queue.

### DIFF
--- a/mage_ai/orchestration/job_manager.py
+++ b/mage_ai/orchestration/job_manager.py
@@ -13,7 +13,16 @@ class JobType(str, Enum):
 
 class JobManager:
     def __init__(self):
-        self.queue = QueueFactory.get_queue()
+        self._queue = None
+
+    @property
+    def queue(self):
+        # Delay initalizing the queue with multiprocessing to prevent the
+        # error of staring a new process before the current process has finished
+        # its bootstrapping phase.
+        if self._queue is None:
+            self._queue = QueueFactory.get_queue()
+        return self._queue
 
     def add_job(
         self,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Delay initializing the queue.

Fix this error when installing Mage via pip
```
    raise RuntimeError('''
RuntimeError:
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.

        To fix this issue, refer to the "Safe importing of main module"
        section in https://docs.python.org/3/library/multiprocessing.html
```

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally by installing Mage branch via pip and starting Mage


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
