### PR TITLE
[xy] Exclude dropped columns from the postgres schema discovery query.

### DIFF
--- a/mage_integrations/mage_integrations/sources/postgresql/__init__.py
+++ b/mage_integrations/mage_integrations/sources/postgresql/__init__.py
@@ -96,6 +96,7 @@ class PostgreSQL(Source):
         * attnum: stores the attribute number (column number) within the table or composite type.
             It serves as the ordinal position of the attribute within the table.
         * attnotnull: stores information about whether an attribute allows NULL values or not.
+        * attisdropped: whether the attribute has been dropped (removed) from the table.
 
         pg_attrdef: stores default values for table columns.
         * adbin:  stores the binary representation of the default value expression. It contains the
@@ -145,6 +146,7 @@ LEFT JOIN
         AND pg_attribute.attnum = pg_attrdef.adnum
 WHERE
   pg_attribute.attnum > -1
+    AND pg_attribute.attisdropped = 'f'
     AND pg_class.relkind IN ('r', 'v', 'm', 'f')
     AND nspname = '{schema}'
         """


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Exclude dropped columns from the postgres schema discovery query.

Dropped columns are not removed from the pg_attribute table. The column name becomes "........pg.dropped.n........" in the pg_attribute table. Update the query to filter out the dropped columns with the attisdropped field.



# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested in local postgres database


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
