### PR TITLE
relax pytz version requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ polars>=0.18.0, <0.19.2
 protobuf~=4.21.12
 pyarrow==14.0.1
 python-dateutil==2.8.2
-pytz==2022.2.1
+pytz>=2022.2.1
 pyyaml~=6.0
 redis~=5.0.1
 requests~=2.31.0


### PR DESCRIPTION
given the bleow requirements.txt in a mage project:
> mage-ai[mysql]
> dlt

it bails with:
> ERROR: Cannot install -r requirements.txt (line 2), None, dlt==0.4.9 and mage-ai because these package versions have conflicting dependencies.
>The conflict is caused by:
>    mage-ai 0.9.70 depends on pytz==2022.2
>    great-expectations 0.18.12 depends on pytz>=2021.3
>    dlt 0.4.9 depends on pytz>=2022.6
>    mage-ai 0.9.70 depends on pytz==2022.2
>    great-expectations 0.18.12 depends on pytz>=2021.3
>...
>    dlt 0.2.7 depends on pytz>=2022.6
>    mage-ai 0.9.70 depends on pytz==2022.2
>    great-expectations 0.18.12 depends on pytz>=2021.3
>
> To fix this you could try to:
> 1. loosen the range of package versions you've specified
> 2. remove package versions to allow pip attempt to solve the dependency conflict
>
> ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
> dlt

relaxing the pytz requirements to allow anything greater than 2022.2.1 fixes things.

# Description
While trying to try out mage-ai with dlt, mage never starts up because of above issues with pytz.


# How Has This Been Tested?
- [x] pip3 install -r requirments.txt with the mage deps pointing at my local repo


# Checklist
- [] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation