### PR TITLE
[xy] Fix extracting table name from INSERT statement in SQL block.

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -14,7 +14,7 @@ from inspect import Parameter, isfunction, signature
 from logging import Logger
 from pathlib import Path
 from queue import Queue
-from typing import Any, Callable, Dict, Generator, List, Set, Tuple, Union
+from typing import Any, Callable, Dict, Generator, List, Optional, Set, Tuple, Union
 
 import inflection
 import pandas as pd
@@ -680,31 +680,15 @@ class Block(DataIntegrationMixin, SparkBlock, ProjectPlatformAccessible):
         return table_name
 
     @property
-    def full_table_name(self) -> str:
+    def full_table_name(self) -> Optional[str]:
         from mage_ai.data_preparation.models.block.sql.utils.shared import (
-            extract_create_statement_table_name,
-            extract_insert_statement_table_names,
-            extract_update_statement_table_names,
+            extract_full_table_name,
         )
 
-        if not self.content:
-            return None
-
-        table_name = extract_create_statement_table_name(self.content)
-        if table_name:
-            return table_name
-
-        matches = extract_insert_statement_table_names(self.content)
-        if len(matches) == 0:
-            matches = extract_update_statement_table_names(self.content)
-
-        if len(matches) == 0:
-            return None
-
-        return matches[len(matches) - 1]
+        return extract_full_table_name(self.content)
 
     @classmethod
-    def after_create(self, block: 'Block', **kwargs) -> None:
+    def after_create(cls, block: 'Block', **kwargs) -> None:
         widget = kwargs.get('widget')
         pipeline = kwargs.get('pipeline')
         if pipeline is not None:

--- a/mage_ai/tests/data_preparation/models/block/sql/utils/test_shared.py
+++ b/mage_ai/tests/data_preparation/models/block/sql/utils/test_shared.py
@@ -55,7 +55,7 @@ class SQLBlockSharedUtilsTest(DBTestCase):
         self.assertEqual(extract_create_statement_table_name(text), expected_result)
 
     def test_extract_insert_statement_table_names(self):
-        # Test case 1: Basic test with one INSERT statement
+        # Test case 1: Basic test with one INSERT statement and remove comment
         text = """
         -- This is a comment
         INSERT INTO table_name
@@ -77,6 +77,31 @@ class SQLBlockSharedUtilsTest(DBTestCase):
         SELECT * FROM table_name;
         """
         expected_result = []
+        self.assertEqual(extract_insert_statement_table_names(text), expected_result)
+
+        # Test case 4: Multiple INSERT statements
+        text = """
+            INSERT INTO table1 VALUES (1, 'John');
+            INSERT INTO table2 VALUES (2, 'Jane');
+            """
+        expected_result = ["table1", "table2"]
+        self.assertEqual(extract_insert_statement_table_names(text), expected_result)
+
+        # Test case 5: IGNORE INSERT statement
+        text = "INSERT IGNORE INTO table3 VALUES (3, 'Alice');"
+        expected_result = ["table3"]
+        self.assertEqual(extract_insert_statement_table_names(text), expected_result)
+
+        # Test case 6: case insensitivity
+        text = "insert into TABLE5 values (5, 'Eve');"
+        expected_result = ["TABLE5"]
+        self.assertEqual(extract_insert_statement_table_names(text), expected_result)
+
+        # Test case 7: Multiple spaces
+        text = """
+        INSERT   INTO   table_name VALUES (1, 'John');
+        """
+        expected_result = ['table_name']
         self.assertEqual(extract_insert_statement_table_names(text), expected_result)
 
     def test_extract_drop_statement_table_names(self):


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix extracting table name from INSERT statement in SQL block.
* When using env variable in the SQL block, the table name is not extracted correctly.
* When using `INSERT IGNORE INTO` syntax in MySQL SQL block, the table name is not extracted correctly.
* When putting multiple spaces between INSERT and INTO, the table name is not extracted correctly.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with sql block
```sql
INSERT IGNORE INTO {{ env_var("default_fact_schema") }}.test_table(
    columnA,
    columnB
)
SELECT
    columnA,
    columnB
FROM {{ env_var("default_stage_schema") }}.stage_table as s;
```


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
