### PR TITLE
[xy] Not show locals in CLI exception.

### DIFF
--- a/mage_ai/cli/main.py
+++ b/mage_ai/cli/main.py
@@ -22,6 +22,7 @@ class OrderCommands(TyperGroup):
 
 app = typer.Typer(
     cls=OrderCommands,
+    pretty_exceptions_show_locals=False,
 )
 
 # Defaults


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Not show locals in CLI exception.

When there's an exception connecting to database, the password might be shown in the exception's local values. This PR 
fixes that.

Reference: https://typer.tiangolo.com/tutorial/exceptions/#disable-local-variables-for-security

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested by specifying a wrong db connection url. Local values are not shown.
<img width="603" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/2d905eab-0c88-4120-ad76-dbb69b88f323">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
