### PR TITLE
[xy] Catch yaml interpolation error.

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -524,7 +524,11 @@ class Block(DataIntegrationMixin, SparkBlock, ProjectPlatformAccessible):
             if BlockLanguage.YAML == self.language:
                 content = await self.content_async()
                 if content:
-                    text = self.interpolate_content(content)
+                    try:
+                        text = self.interpolate_content(content)
+                    except Exception:
+                        traceback.print_exc()
+                        text = content
                     settings = yaml.safe_load(text)
                     uuid = settings.get('source') or settings.get('destination')
                     mapping = grouped_templates.get(uuid) or {}

--- a/mage_ai/data_preparation/models/block/data_integration/mixins.py
+++ b/mage_ai/data_preparation/models/block/data_integration/mixins.py
@@ -29,6 +29,7 @@ from mage_ai.data_preparation.models.constants import (
     PIPELINES_FOLDER,
     BlockLanguage,
     BlockType,
+    PipelineType,
 )
 from mage_ai.data_preparation.models.project import Project
 from mage_ai.data_preparation.models.project.constants import FeatureUUID
@@ -229,7 +230,8 @@ class DataIntegrationMixin:
             return False
 
         if self.type in [BlockType.DATA_LOADER, BlockType.DATA_EXPORTER] and \
-                BlockLanguage.YAML == self.language:
+                BlockLanguage.YAML == self.language and \
+                self.pipeline.type != PipelineType.STREAMING:
 
             return True
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Catch yaml interpolation error in Pipeline API.

Close: https://github.com/mage-ai/mage-ai/issues/4998

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested by using a wrong syntax in yaml. The pipeline can still be loaded. Exception is thrown at backend. The exception is only thrown for data integration pipeline since streaming pipeline doesn't need to return interpolated metadata
<img width="652" alt="image" src="https://github.com/mage-ai/mage-ai/assets/80284865/402209b8-8968-4b7b-823f-4b6976c51396">



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
