### PR TITLE
[dy] Add prune option for fetch

### DIFF
--- a/mage_ai/api/resources/GitBranchResource.py
+++ b/mage_ai/api/resources/GitBranchResource.py
@@ -187,6 +187,13 @@ class GitBranchResource(GenericResource):
         action_payload = payload.get('action_payload', dict())
         action_remote = action_payload.get('remote', None)
         action_branch = action_payload.get('branch', None)
+        action_arg = action_payload.get('arg', None)
+
+        # Eventually we would want to give the user the ability to pass in multiple
+        # arguments to the action, but for now we will just pass in a single argument.
+        action_kwargs = dict()
+        if action_arg:
+            action_kwargs[action_arg] = True
 
         files = payload.get('files', None)
         message = payload.get('message', None)
@@ -239,6 +246,7 @@ class GitBranchResource(GenericResource):
                             action_branch,
                             token,
                             config_overwrite=config_overwrite,
+                            **action_kwargs,
                         )
                         if custom_progress.other_lines:
                             lines = custom_progress.other_lines
@@ -269,6 +277,7 @@ class GitBranchResource(GenericResource):
                                 action_branch,
                                 token,
                                 config_overwrite=config_overwrite,
+                                **action_kwargs,
                             )
                         else:
                             custom_progress = api.fetch(
@@ -276,6 +285,7 @@ class GitBranchResource(GenericResource):
                                 url,
                                 token,
                                 config_overwrite=config_overwrite,
+                                **action_kwargs,
                             )
 
                         if custom_progress and custom_progress.other_lines:
@@ -304,6 +314,7 @@ class GitBranchResource(GenericResource):
                             url,
                             token,
                             config_overwrite=config_overwrite,
+                            **action_kwargs,
                         )
 
                         if custom_progress and custom_progress.other_lines:
@@ -337,6 +348,7 @@ class GitBranchResource(GenericResource):
                                 action_branch,
                                 token,
                                 config_overwrite=config_overwrite,
+                                **action_kwargs,
                             )
                         else:
                             self.model[
@@ -357,6 +369,7 @@ class GitBranchResource(GenericResource):
                             url,
                             token,
                             config_overwrite=config_overwrite,
+                            **action_kwargs,
                         )
                     else:
                         self.model[

--- a/mage_ai/data_preparation/git/api.py
+++ b/mage_ai/data_preparation/git/api.py
@@ -37,6 +37,7 @@ def switch_branch(
     token: str,
     config_overwrite: Dict = None,
     user: User = None,
+    **kwargs,
 ):
     from mage_ai.data_preparation.git import Git
     provider = get_provider_from_remote_url(remote_url)
@@ -67,6 +68,7 @@ def fetch(
     token: str,
     user: User = None,
     config_overwrite: Dict = None,
+    **kwargs,
 ):
     """
     Returns:
@@ -89,7 +91,7 @@ def fetch(
     remote.set_url(url)
 
     try:
-        remote.fetch(progress=custom_progress)
+        remote.fetch(progress=custom_progress, **kwargs)
     except Exception as err:
         raise err
     finally:
@@ -109,6 +111,7 @@ def pull(
     token: str,
     user: User = None,
     config_overwrite: Dict = None,
+    **kwargs,
 ):
     """
     Returns:
@@ -190,6 +193,7 @@ def push(
     token: str,
     user: User = None,
     config_overwrite: Dict = None,
+    **kwargs,
 ):
     """
     Returns:
@@ -218,6 +222,7 @@ def reset_hard(
     token: str,
     user: User = None,
     config_overwrite: Dict = None,
+    **kwargs,
 ) -> None:
     from mage_ai.data_preparation.git import Git
 
@@ -248,6 +253,7 @@ def clone(
     token: str,
     user: User = None,
     config_overwrite: Dict = None,
+    **kwargs,
 ) -> None:
     from mage_ai.data_preparation.git import Git
 

--- a/mage_ai/frontend/components/VersionControl/Remote/index.tsx
+++ b/mage_ai/frontend/components/VersionControl/Remote/index.tsx
@@ -27,6 +27,7 @@ import {
   ACTION_PULL,
   ACTION_RESET,
   ACTION_RESET_HARD,
+  ADDITIONAL_ARGUMENTS,
 } from '../constants';
 import {
   Add,
@@ -78,6 +79,7 @@ function Remote({
   const [actionError, setActionError] = useState<string>(null);
   const [actionName, setActionName] = useState<string>(null);
   const [actionProgress, setActionProgress] = useState<string>(null);
+  const [actionArgument, setActionArgument] = useState<string>(null);
   const [editRepoPathActive, setEditRepoPathActive] = useState<boolean>(false);
   const [remoteNameActive, setRemoteNameActive] = useState<string>(null);
   const [remoteNameNew, setRemoteNameNew] = useState<string>('');
@@ -620,7 +622,7 @@ function Remote({
                   ))}
                 </Select>
                 
-                {![ACTION_FETCH, ACTION_CLONE].includes(actionName) && (
+                {[ACTION_PULL, ACTION_RESET_HARD].includes(actionName) && (
                   <Spacing ml={1}>
                     <Select
                       beforeIcon={<Branch />}
@@ -633,6 +635,23 @@ function Remote({
                       {branches?.map(({ name }) => (
                         <option key={name} value={name}>
                           {name}
+                        </option>
+                      ))}
+                    </Select>
+                  </Spacing>
+                )}
+
+                {ADDITIONAL_ARGUMENTS[actionName] && (
+                  <Spacing ml={1}>
+                    <Select
+                      label="Additional argument"
+                      monospace
+                      onChange={e => setActionArgument(e.target.value)}
+                      value={actionArgument || ''}
+                    >
+                      {ADDITIONAL_ARGUMENTS[actionName]?.map((name) => (
+                        <option key={name} value={name}>
+                          {capitalizeRemoveUnderscoreLower(name)}
                         </option>
                       ))}
                     </Select>
@@ -711,6 +730,7 @@ function Remote({
                       actionGitBranch({
                         git_custom_branch: {
                           action_payload: {
+                            arg: actionArgument,
                             branch: actionBranchName,
                             remote: actionRemoteName,
                           },

--- a/mage_ai/frontend/components/VersionControl/constants.ts
+++ b/mage_ai/frontend/components/VersionControl/constants.ts
@@ -10,6 +10,10 @@ export const ACTION_REBASE = 'rebase';
 export const ACTION_RESET = 'reset';
 export const ACTION_RESET_HARD = 'reset --hard';
 
+export const ADDITIONAL_ARGUMENTS = {
+  [ACTION_FETCH]: ['prune'],
+};
+
 export const LOCAL_STORAGE_GIT_REMOTE_NAME = 'git_remote_name';
 export const LOCAL_STORAGE_GIT_REPOSITORY_NAME = 'git_repository_name';
 

--- a/mage_ai/frontend/components/VersionControl/index.tsx
+++ b/mage_ai/frontend/components/VersionControl/index.tsx
@@ -82,9 +82,7 @@ function VersionControl() {
     }
   }, [q]);
 
-  const { data: dataBranches, mutate: fetchBranches } = api.git_custom_branches.list({
-    include_remote_branches: 1,
-  });
+  const { data: dataBranches, mutate: fetchBranches } = api.git_custom_branches.list();
   const branches: GitBranchType[] = useMemo(() => dataBranches?.git_custom_branches, [dataBranches]);
 
   useEffect(() => {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Being able to prune the remote is useful when we want to delete references to deleted branches. This PR adds the ability to select a "prune" option when performing a fetch operation.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested with github repository


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
