### PR TITLE
[jk] Fix syntax for iframe in Roadmap doc

### DIFF
--- a/docs/about/roadmap.mdx
+++ b/docs/about/roadmap.mdx
@@ -9,4 +9,12 @@ title: "Roadmap"
   Mage's 2024 Roadmap coming soon!
 </Card>
 
-<iframe class="airtable-embed" src="https://airtable.com/embed/applEuqJsK4zF5yJK/shrJctaGt4tvU27uF?backgroundColor=red&viewControls=on" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
+<iframe
+  class="airtable-embed"
+  src="https://airtable.com/embed/applEuqJsK4zF5yJK/shrJctaGt4tvU27uF?backgroundColor=red&viewControls=on"
+  frameborder="0"
+  onmousewheel=""
+  width="100%"
+  height="533"
+  style={{ background: 'transparent', border: '1px solid #ccc'}}
+></iframe>


### PR DESCRIPTION
# Description
- Fix parsing of Roadmap doc.

# How Has This Been Tested?
Doc page renders correctly:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/428dd263-a5bc-41d9-9ab5-975459f65d29)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
@thomaschung408 
