### PR TITLE
[jk] Allow files to be selected for pipeline zip import

### DIFF
--- a/mage_ai/frontend/components/FileUploader/index.tsx
+++ b/mage_ai/frontend/components/FileUploader/index.tsx
@@ -107,7 +107,7 @@ function FileUploader({
 
   return (
     <MultiFileInput
-      // @ts-ignore
+      fileSelectOnly={pipelineZip}
       onDragActiveChange={onDragActiveChange}
       setFiles={setFiles}
     >

--- a/mage_ai/frontend/components/PipelineDetail/UploadPipeline/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/UploadPipeline/index.tsx
@@ -149,7 +149,7 @@ function UploadPipeline({
           directoryPath={null} // no directory needs to be specified in case of pipeline imports
           onDragActiveChange={setIsDragActive}
           overwrite={overwritePipeline}
-          pipelineZip={true}
+          pipelineZip
           setFileUploadProgress={setFileUploadProgress}
           setUploadedFiles={(uploadedFiles) => {
             // @ts-ignore

--- a/mage_ai/frontend/oracle/elements/Inputs/MultiFileInput.tsx
+++ b/mage_ai/frontend/oracle/elements/Inputs/MultiFileInput.tsx
@@ -10,6 +10,7 @@ const DropzoneStyle = styled.div`
 
 type MultiFileInputProps = {
   children: any;
+  fileSelectOnly?: boolean;
   inputOnChange?: (e: any) => void;
   inputProps?: {
     [key: string]: number | string;
@@ -22,6 +23,7 @@ type MultiFileInputProps = {
 
 function MultiFileInput({
   children,
+  fileSelectOnly,
   inputOnChange,
   inputProps,
   onDragActiveChange,
@@ -81,8 +83,8 @@ function MultiFileInput({
       <input
         {...finalInputProps}
         // @ts-ignore
-        directory=""
-        webkitdirectory=""
+        directory={fileSelectOnly ? null : ''}
+        webkitdirectory={fileSelectOnly ? null : ''}
       />
       {children}
     </DropzoneStyle>


### PR DESCRIPTION
# Description
- Zip files were not visible or disabled in certain browsers / on Windows when using the pipeline zip importer, so this PR fixes that.

# How Has This Been Tested?
Before (zip file disabled in file uploader):
![before - zip files disabled](https://github.com/mage-ai/mage-ai/assets/78053898/f9d0a3e9-0a04-41d2-b923-4c70899e65dc)

After (zip file can be selected):
![after - zip files enabled](https://github.com/mage-ai/mage-ai/assets/78053898/db8936c2-1865-464a-8d20-f66893a88064)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
