### PR TITLE
Add configuration parameters to V1JobSpec in k8s executor

### DIFF
--- a/docs/production/configuring-production-settings/compute-resource.mdx
+++ b/docs/production/configuring-production-settings/compute-resource.mdx
@@ -107,7 +107,7 @@ in this project. Example config:
   ```
   Please make sure the [GPU driver](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/#using-device-plugins)
   is installed and run on your nodes to use the GPUs.
-* To futher customize the container config of the kubernetes executor, you can sepcify the `container_config` in the k8s executor config. Here is the example:
+* To further customize the container config of the kubernetes executor, you can sepcify the `container_config` or `job_config` in the k8s executor config. Here is the example:
   ```yaml
   k8s_executor_config:
     container_config:
@@ -115,6 +115,10 @@ in this project. Example config:
       env:
       - name: USER_CODE_PATH
         value: /home/src/k8s_project
+    job_config:
+      active_deadline_seconds: 120
+      backoff_limit: 3
+      ttl_seconds_after_finished: 86400
   ```
 3. You can configure the job template by using the `K8S_CONFIG_FILE` environment variable, which should point to the configuration file. Here is the format for the Kubernetes configuration template:
 

--- a/mage_ai/services/k8s/config.py
+++ b/mage_ai/services/k8s/config.py
@@ -12,7 +12,7 @@ from kubernetes.client import (
     V1ResourceRequirements,
     V1Toleration,
     V1Volume,
-    V1VolumeMount
+    V1VolumeMount,
 )
 
 from mage_ai.services.k8s.constants import CONFIG_FILE, DEFAULT_NAMESPACE

--- a/mage_ai/services/k8s/config.py
+++ b/mage_ai/services/k8s/config.py
@@ -11,6 +11,8 @@ from kubernetes.client import (
     V1Toleration,
     V1Volume,
     V1VolumeMount,
+    V1JobSpec,
+    V1PodTemplateSpec
 )
 
 from mage_ai.services.k8s.constants import CONFIG_FILE, DEFAULT_NAMESPACE
@@ -43,8 +45,10 @@ class K8sExecutorConfig(BaseConfig):
     metadata: Dict = None
     container: Dict = None
     pod: Dict = None
+    job: Dict = None
     # parsed k8s objects
     pod_config: V1PodSpec = None
+    job_config: V1JobSpec = None
     meta: V1ObjectMeta = None
 
     @classmethod
@@ -119,6 +123,25 @@ class K8sExecutorConfig(BaseConfig):
             tolerations=tolerations,
             volumes=volumes,
         )
+
+        active_deadline_seconds = None
+        backoff_limit = 0
+        ttl_seconds_after_finished = None
+
+        if executor_config.job:
+            active_deadline_seconds = executor_config.job.get('active_deadline_seconds')
+            backoff_limit = executor_config.job.get('backoff_limit')
+            ttl_seconds_after_finished = executor_config.job.get('ttl_seconds_after_finished')
+
+        executor_config.job_config = V1JobSpec(
+            active_deadline_seconds=active_deadline_seconds,
+            backoff_limit=backoff_limit,
+            ttl_seconds_after_finished=ttl_seconds_after_finished,
+            template=V1PodTemplateSpec(
+                spec=executor_config.pod_config
+            )
+        )
+
         return executor_config
 
     @classmethod

--- a/mage_ai/services/k8s/config.py
+++ b/mage_ai/services/k8s/config.py
@@ -4,15 +4,15 @@ from typing import Dict
 from kubernetes.client import (
     V1Container,
     V1EnvVar,
+    V1JobSpec,
     V1LocalObjectReference,
     V1ObjectMeta,
     V1PodSpec,
+    V1PodTemplateSpec,
     V1ResourceRequirements,
     V1Toleration,
     V1Volume,
-    V1VolumeMount,
-    V1JobSpec,
-    V1PodTemplateSpec
+    V1VolumeMount
 )
 
 from mage_ai.services.k8s.constants import CONFIG_FILE, DEFAULT_NAMESPACE

--- a/mage_ai/services/k8s/job_manager.py
+++ b/mage_ai/services/k8s/job_manager.py
@@ -138,9 +138,10 @@ class JobManager():
 
         # Create the specification of deployment
         spec = client.V1JobSpec(template=template,
-                                active_deadline_seconds=k8s_config.job_config.active_deadline_seconds,
-                                backoff_limit=k8s_config.job_config.backoff_limit,
-                                ttl_seconds_after_finished=k8s_config.job_config.ttl_seconds_after_finished)
+            active_deadline_seconds=k8s_config.job_config.active_deadline_seconds,
+            backoff_limit=k8s_config.job_config.backoff_limit,
+            ttl_seconds_after_finished=k8s_config.job_config.ttl_seconds_after_finished)
+
         # Instantiate the job object
         job = client.V1Job(
             api_version=self.api_version,

--- a/mage_ai/services/k8s/job_manager.py
+++ b/mage_ai/services/k8s/job_manager.py
@@ -137,7 +137,8 @@ class JobManager():
         )
 
         # Create the specification of deployment
-        spec = client.V1JobSpec(template=template,
+        spec = client.V1JobSpec(
+            template=template,
             active_deadline_seconds=k8s_config.job_config.active_deadline_seconds,
             backoff_limit=k8s_config.job_config.backoff_limit,
             ttl_seconds_after_finished=k8s_config.job_config.ttl_seconds_after_finished)

--- a/mage_ai/services/k8s/job_manager.py
+++ b/mage_ai/services/k8s/job_manager.py
@@ -137,7 +137,10 @@ class JobManager():
         )
 
         # Create the specification of deployment
-        spec = client.V1JobSpec(template=template, backoff_limit=0)
+        spec = client.V1JobSpec(template=template,
+                                active_deadline_seconds=k8s_config.job_config.active_deadline_seconds,
+                                backoff_limit=k8s_config.job_config.backoff_limit,
+                                ttl_seconds_after_finished=k8s_config.job_config.ttl_seconds_after_finished)
         # Instantiate the job object
         job = client.V1Job(
             api_version=self.api_version,

--- a/mage_ai/tests/services/k8s/test_job_manager.py
+++ b/mage_ai/tests/services/k8s/test_job_manager.py
@@ -7,6 +7,7 @@ from kubernetes.client import (
     V1Container,
     V1EnvFromSource,
     V1EnvVar,
+    V1JobSpec,
     V1NodeAffinity,
     V1NodeSelector,
     V1NodeSelectorRequirement,
@@ -14,8 +15,7 @@ from kubernetes.client import (
     V1Pod,
     V1PodSpec,
     V1SecretEnvSource,
-    V1Toleration,
-    V1JobSpec
+    V1Toleration
 )
 
 from mage_ai.services.k8s.config import K8sExecutorConfig

--- a/mage_ai/tests/services/k8s/test_job_manager.py
+++ b/mage_ai/tests/services/k8s/test_job_manager.py
@@ -15,7 +15,7 @@ from kubernetes.client import (
     V1Pod,
     V1PodSpec,
     V1SecretEnvSource,
-    V1Toleration
+    V1Toleration,
 )
 
 from mage_ai.services.k8s.config import K8sExecutorConfig

--- a/mage_ai/tests/services/k8s/test_job_manager.py
+++ b/mage_ai/tests/services/k8s/test_job_manager.py
@@ -365,7 +365,7 @@ class JobManagerTests(TestCase):
             },
             'job': {
                 'active_deadline_seconds': 0,
-                'backoff_limit': 0,
+                'backoff_limit': 3,
                 'ttl_seconds_after_finished': 100
             }
         }
@@ -440,6 +440,11 @@ class JobManagerTests(TestCase):
                 name='data-pvc',
             )
         )
+
+        # Job
+        self.assertEqual(job.spec.active_deadline_seconds, 0)
+        self.assertEqual(job.spec.backoff_limit, 3)
+        self.assertEqual(job.spec.ttl_seconds_after_finished, 100)
 
     @patch('mage_ai.services.k8s.job_manager.client')
     @patch('mage_ai.services.k8s.job_manager.config')


### PR DESCRIPTION
# Description
Simple pass parameters to V1JobSpec in JobManager.create_job_object


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Fix current unit tests
- [x] Add job spec assert in test_create_job_object_with_config_file


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->