### PR TITLE
[jk] Improve visibility of variable/secret names

### DIFF
--- a/mage_ai/frontend/components/Sidekick/GlobalVariables/Secrets.tsx
+++ b/mage_ai/frontend/components/Sidekick/GlobalVariables/Secrets.tsx
@@ -200,7 +200,7 @@ function Secrets({
                   </KeyboardShortcutButton>
                 </CellStyle>
               </Col>
-              <Col md={4}>
+              <Col md={5}>
                 <CellStyle>
                   <TextInput
                     borderless
@@ -219,7 +219,7 @@ function Secrets({
                   />
                 </CellStyle>
               </Col>
-              <Col md={7}>
+              <Col md={6}>
                 <CellStyle>
                   <TextInput
                     borderless

--- a/mage_ai/frontend/components/Sidekick/GlobalVariables/VariableRow.tsx
+++ b/mage_ai/frontend/components/Sidekick/GlobalVariables/VariableRow.tsx
@@ -162,7 +162,7 @@ function VariableRow({
             </KeyboardShortcutButton>
           </CellStyle>
         </Col>
-        <Col md={obfuscate ? 7 : 4}>
+        <Col md={obfuscate ? 9 : 4}>
           {(edit && !disableKeyEdit) ? (
             <CellStyle>
               <TextInput
@@ -184,13 +184,19 @@ function VariableRow({
             </CellStyle>
           ) : (
             <CellStyle>
-              <Text color={LIME_DARK} monospace small textOverflow>
+              <Text
+                color={LIME_DARK}
+                monospace
+                small
+                textOverflow={!obfuscate}
+                title={uuid}
+              >
                 {uuid}
               </Text>
             </CellStyle>
           )}
         </Col>
-        <Col md={obfuscate ? 4 : 7}>
+        <Col md={obfuscate ? 2 : 7}>
           {edit ? (
             <CellStyle>
               <TextInput
@@ -214,10 +220,14 @@ function VariableRow({
             <CellStyle>
               {obfuscate ? (
                 <Text monospace small>
-                  ********
+                  {showActions ? '*' : '*******'}
                 </Text>
               ) : (
-                <Text monospace small>
+                <Text
+                  monospace
+                  small
+                  title={value.toString()}
+                >
                   {value.toString()}
                 </Text>
               )}

--- a/mage_ai/frontend/components/Sidekick/GlobalVariables/VariableRow.tsx
+++ b/mage_ai/frontend/components/Sidekick/GlobalVariables/VariableRow.tsx
@@ -188,7 +188,6 @@ function VariableRow({
                 color={LIME_DARK}
                 monospace
                 small
-                textOverflow={!obfuscate}
                 title={uuid}
               >
                 {uuid}


### PR DESCRIPTION
# Description
- Long secret and variable names in the Sidekick of the Pipeline Editor were getting cut off with no way to read them if the clipboard was blocked. This PR makes the variable/secret names fully visible, also adding tooltips, even if there is no access to the browser's clipboard.
- Addresses https://github.com/mage-ai/mage-ai/issues/5066

# How Has This Been Tested?
Before:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/86612dfd-5171-421c-a278-0a3fe917843e)
![image](https://github.com/mage-ai/mage-ai/assets/78053898/e2fee119-eb82-4c00-abc5-2ab622214cd9)

After:
![image](https://github.com/mage-ai/mage-ai/assets/78053898/bc820069-5045-415d-b433-b999faebde67)
![image](https://github.com/mage-ai/mage-ai/assets/78053898/8f2f4a7d-1c47-45c0-890a-73215e4aea40)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
