### PR TITLE
[td] Upgrade deltalake because of Docker image build error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -124,7 +124,7 @@ dbt-trino==1.7.1
 attrs==17.4.0
 backoff
 clickhouse_sqlalchemy
-deltalake==0.17.2
+deltalake==0.17.4
 facebook_business==17.0.2
 gnupg==2.3.1
 google-analytics-data==0.14.2


### PR DESCRIPTION
```
#20 377.6   Downloading psycopg2_binary-2.9.3-cp310-cp310-manylinux_2_24_aarch64.whl (3.4 MB)
#20 377.9      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.4/3.4 MB 17.8 MB/s eta 0:00:00
#20 378.0 Collecting terminaltables==3.1.10
#20 378.0   Downloading terminaltables-3.1.10-py2.py3-none-any.whl (15 kB)
#20 378.6 Collecting google-cloud-storage==2.5.0
#20 378.6   Downloading google_cloud_storage-2.5.0-py2.py3-none-any.whl (106 kB)
#20 378.6      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 107.0/107.0 kB 18.6 MB/s eta 0:00:00
#20 378.8 Collecting google-analytics-data==0.14.2
#20 378.9   Downloading google_analytics_data-0.14.2-py2.py3-none-any.whl (108 kB)
#20 378.9      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 108.2/108.2 kB 18.9 MB/s eta 0:00:00
#20 379.6 Collecting mysql-connector-python~=8.2.0
#20 379.6   Downloading mysql_connector_python-8.2.0-cp310-cp310-manylinux_2_17_aarch64.whl (31.1 MB)
#20 381.5      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 31.1/31.1 MB 17.1 MB/s eta 0:00:00
#20 382.3 Collecting deltalake==0.17.2
#20 382.3   Downloading deltalake-0.17.2-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (24.2 MB)
#20 385.3      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╸        19.9/24.2 MB 4.3 MB/s eta 0:00:02
#20 385.5 ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise, examine the package contents carefully; someone may have tampered with them.
#20 385.5     deltalake==0.17.2 from https://files.pythonhosted.org/packages/38/1d/50d51ebe5c1770ab1d27bae382e7cb78ed38c17c4d35c35191c2d60de7b9/deltalake-0.17.2-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (from mage-integrations):
#20 385.5         Expected sha256 8058346784749da06032dc7ccc35b0c35c1e6410ac0d93e0bf300160f8658285
#20 385.5              Got        67c4ae7ec453d1556d2140c91473cea0c823157fb2e24a6f3bc0a565fac01bad
#20 385.5 
#20 386.6 
#20 386.6 [notice] A new release of pip is available: 23.0.1 -> 24.0
#20 386.6 [notice] To update, run: pip install --upgrade pip
#20 ERROR: process "/bin/bash -o pipefail -c pip3 install --no-cache-dir \"git+[https://github.com/wbond/oscrypto.git@d5f3437ed24257895ae1edd9e503cfb352e635a8\](https://github.com/wbond/oscrypto.git@d5f3437ed24257895ae1edd9e503cfb352e635a8/)" &&   pip3 install --no-cache-dir \"git+https://github.com/dremio-hub/arrow-flight-client-examples.git#egg=dremio-flight&subdirectory=python/dremio-flight\" &&   pip3 install --no-cache-dir \"git+https://github.com/mage-ai/singer-python.git#egg=singer-python\" &&   pip3 install --no-cache-dir \"git+https://github.com/mage-ai/dbt-mysql.git#egg=dbt-mysql\" &&   pip3 install --no-cache-dir \"git+https://github.com/mage-ai/dbt-synapse.git#egg=dbt-synapse\" &&   pip3 install --no-cache-dir \"git+https://github.com/mage-ai/sqlglot#egg=sqlglot\" &&   if [ -z \"$FEATURE_BRANCH\" ] || [ \"$FEATURE_BRANCH\" = \"null\" ]; then   pip3 install --no-cache-dir \"git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations&subdirectory=mage_integrations\";   else   pip3 install --no-cache-dir \"git+https://github.com/mage-ai/mage-ai.git@$FEATURE_BRANCH#egg=mage-integrations&subdirectory=mage_integrations\";   fi" did not complete successfully: exit code: 1
------
 > [linux/arm64 5/9] RUN   pip3 install --no-cache-dir "git+https://github.com/wbond/oscrypto.git@d5f3437ed24257895ae1edd9e503cfb352e635a8" &&   pip3 install --no-cache-dir "git+https://github.com/dremio-hub/arrow-flight-client-examples.git#egg=dremio-flight&subdirectory=python/dremio-flight" &&   pip3 install --no-cache-dir "git+https://github.com/mage-ai/singer-python.git#egg=singer-python" &&   pip3 install --no-cache-dir "git+https://github.com/mage-ai/dbt-mysql.git#egg=dbt-mysql" &&   pip3 install --no-cache-dir "git+https://github.com/mage-ai/dbt-synapse.git#egg=dbt-synapse" &&   pip3 install --no-cache-dir "git+https://github.com/mage-ai/sqlglot#egg=sqlglot" &&   if [ -z "master" ] || [ "master" = "null" ]; then   pip3 install --no-cache-dir "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations&subdirectory=mage_integrations";   else   pip3 install --no-cache-dir "git+https://github.com/mage-ai/mage-ai.git@master#egg=mage-integrations&subdirectory=mage_integrations";   fi:
382.3   Downloading deltalake-0.17.2-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (24.2 MB)

385.5 ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise, examine the package contents carefully; someone may have tampered with them.
385.5     deltalake==0.17.2 from https://files.pythonhosted.org/packages/38/1d/50d51ebe5c1770ab1d27bae382e7cb78ed38c17c4d35c35191c2d60de7b9/deltalake-0.17.2-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (from mage-integrations):
385.5         Expected sha256 8058346784749da06032dc7ccc35b0c35c1e6410ac0d93e0bf300160f8658285
385.5              Got        67c4ae7ec453d1556d2140c91473cea0c823157fb2e24a6f3bc0a565fac01bad
385.5 
386.6 
Notice: 386.6 [notice] A new release of pip is available: 23.0.1 -> 24.0
Notice: 386.6 [notice] To update, run: pip install --upgrade pip
```