### PR TITLE
Escaping Backslashes when interpolating code content

### DIFF
--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -228,7 +228,7 @@ def add_execution_code(
     variables: Optional[Dict] = None,
     widget: bool = False,
 ) -> str:
-    escaped_code = code.replace("'''", '"""')
+    escaped_code = code.replace("'''", '"""').replace("\\", "\\\\")
 
     run_settings_json = json.dumps(run_settings or {})
 


### PR DESCRIPTION
# Description
Problem:
Runtime crashes occurred due to improper escaping of backslashes in raw string patterns used in code blocks, exemplified by:

```
foo = re.match(r'[A-Z]+(\d+)', segments[2])
```

This resulted in errors such as:

```
server-1  | KeyError: '\\d'
```

The root cause was traced back to insufficient backslash escaping in the escaped_code variable during dynamic string operations.

# Key Changes:
- Enhanced Backslash Escaping: Updated the escaping mechanism to ensure correct handling of backslashes in dynamically evaluated strings. This change doubles backslashes in escaped_code, preventing runtime errors during regex operations. The adjustment specifically affects the __interpolate_code_content method, where re.sub() is utilized for string replacements.

# How to Test:
- Reproduce the Error: Before applying the changes, insert a raw string with an unescaped backslash in any Mage code block and execute it to observe the crash.
- Verify the Fix: After implementing the changes, rerun the same block. The absence of the previous KeyError confirms the correction.

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993 
@dy46 
@tommydangerous 
