### PR TITLE
[jk] Fix max concurrent runs value for backfill

### DIFF
--- a/mage_ai/frontend/components/Backfills/Edit/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Edit/index.tsx
@@ -383,9 +383,11 @@ function BackfillEdit({
         monospace
         onChange={(e) => {
           e.preventDefault();
+          const updatedPipelineRunLimit = e.target.value;
+          const invalidPipelineRunLimit = updatedPipelineRunLimit < 0 || updatedPipelineRunLimit === '';
           setSettings(s => ({
             ...s,
-            pipeline_run_limit: e.target.value,
+            pipeline_run_limit: invalidPipelineRunLimit ? null : updatedPipelineRunLimit,
           }));
         }}
         type="number"


### PR DESCRIPTION
# Description
- When editing a backfill, if user entered a value for "Max concurrent runs" but then deleted it and didn't enter anything else, there would be a `ValueError: invalid literal for int() with base 10: ''` error with the scheduler, causing the backfill to be stuck in the `initial` status. This PR fixes this.


# How Has This Been Tested?
- Locally


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
