### PR TITLE
Add pipeline_schedule_description variable to notification sender

### DIFF
--- a/docs/integrations/observability/alerting-discord.mdx
+++ b/docs/integrations/observability/alerting-discord.mdx
@@ -106,6 +106,7 @@ Here are the supported variables:
 1. `pipeline_run_url`
 1. `pipeline_schedule_id`
 1. `pipeline_schedule_name`
+1. `pipeline_schedule_description`
 1. `pipeline_uuid`
 1. `error`
     * available only for the `failure` message template

--- a/docs/integrations/observability/alerting-email.mdx
+++ b/docs/integrations/observability/alerting-email.mdx
@@ -94,6 +94,7 @@ Here are the supported variables:
 1. `pipeline_run_url`
 1. `pipeline_schedule_id`
 1. `pipeline_schedule_name`
+1. `pipeline_schedule_description`
 1. `pipeline_uuid`
 1. `error`
     * available only for the `failure` message template

--- a/docs/integrations/observability/alerting-slack.mdx
+++ b/docs/integrations/observability/alerting-slack.mdx
@@ -105,6 +105,7 @@ Here are the supported variables:
 1. `pipeline_run_url`
 1. `pipeline_schedule_id`
 1. `pipeline_schedule_name`
+1. `pipeline_schedule_description`
 1. `pipeline_uuid`
 1. `error`
     * available only for the `failure` message template

--- a/docs/integrations/observability/alerting-telegram.mdx
+++ b/docs/integrations/observability/alerting-telegram.mdx
@@ -111,6 +111,7 @@ Here are the supported variables:
 1. `pipeline_run_url`
 1. `pipeline_schedule_id`
 1. `pipeline_schedule_name`
+1. `pipeline_schedule_description`
 1. `pipeline_uuid`
 1. `error`
     * available only for the `failure` message template

--- a/mage_ai/orchestration/notification/sender.py
+++ b/mage_ai/orchestration/notification/sender.py
@@ -179,6 +179,7 @@ class NotificationSender:
             pipeline_run_url=self.__pipeline_run_url(pipeline, pipeline_run),
             pipeline_schedule_id=pipeline_run.pipeline_schedule.id,
             pipeline_schedule_name=pipeline_run.pipeline_schedule.name,
+            pipeline_schedule_description=pipeline_run.pipeline_schedule.description,
             pipeline_uuid=pipeline.uuid,
             stacktrace=stacktrace,
         )


### PR DESCRIPTION
# Description

1) Motivation: It is helpful to be able to interpolate `PipelineSchedule.description` attribute in notification messages
2) Problem: Currently there is no way to interpolate `PipelineSchedule.description` attribute
3) Solution: Include a `pipeline_schedule_description` var that interpolates from `PipelineSchedule.description`

# How Has This Been Tested?

Locally Ran `scripts/dev.sh` with the following notification config in project metadata.yaml (send notifications to slack)
```yaml
notification_config:
  alert_on:
  - trigger_success
  - trigger_failure
  - trigger_passed_sla
  slack_config:
    <<YOUR_SLACK_URL>>
  message_templates:
    success:
      details: |
        > Run Status: `Success ✅`
        > Environment: `{{ env_var('ENV') }}`
        > Pipeline UUID: `{pipeline_uuid}`
        > Pipeline Schedule ID: `{pipeline_schedule_id}`
        > Pipeline Schedule Name: `{pipeline_schedule_name}`
        > Pipeline Schedule Description: `{pipeline_schedule_description}`
        > Pipeline Run URL: `{pipeline_run_url}`
        > Execution Time: `{execution_time}`
    failure:
      details: |
        > Run Status: `Failure ❌`
        > Environment: `{{ env_var('ENV') }}`
        > Pipeline UUID: `{pipeline_uuid}`
        > Pipeline Schedule ID: `{pipeline_schedule_id}`
        > Pipeline Schedule Name: `{pipeline_schedule_name}`
        > Pipeline Schedule Description: `{pipeline_schedule_description}`
        > Pipeline Run URL: `{pipeline_run_url}?status=failed`
        > Execution Time: `{execution_time}`
    passed_sla:
      details: |
        > Run Status: `SLA Exceeded ⌛`
        > Environment: `{{ env_var('ENV') }}`
        > Pipeline UUID: `{pipeline_uuid}`
        > Pipeline Schedule ID: `{pipeline_schedule_id}`
        > Pipeline Schedule Name: `{pipeline_schedule_name}`
        > Pipeline Schedule Description: `{pipeline_schedule_description}`
        > Pipeline Run URL: `{pipeline_run_url}`
        > Execution Time: `{execution_time}`
```

Results:
<img width="704" alt="Screenshot 2024-05-27 at 17 48 00" src="https://github.com/mage-ai/mage-ai/assets/37792010/60beff60-020e-439a-98ee-f1a9481637b4">

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993 
