### PR TITLE
update deltalake to version 0.17.4 to fix build fail

### DIFF
--- a/mage_integrations/requirements.txt
+++ b/mage_integrations/requirements.txt
@@ -3,7 +3,7 @@ azure-storage-blob==12.14.1
 backoff
 clickhouse_sqlalchemy~=0.2.4
 couchbase==4.1.1
-deltalake==0.17.2
+deltalake==0.17.4
 elasticsearch==8.9.0
 facebook_business==17.0.2
 gnupg==2.3.1


### PR DESCRIPTION
# Description
1) Issue: docker build for custom mage-ai image fails due to `deltalake==0.17.2` in `mage-ai/mage_integrations/requirements.txt`
2) Solution: Update to `deltalake==0.17.4`
3) Related to previous commit by @tommydangerous commit SHA: `03c7f12ab70af7e3d72fbbb252d3d9efcf0241d4`

(Note: not sure if this is an isolated issue that only I face from building my own custom mage-ai image. Do close this PR if this issue is not reproducible in the master)

# How Has This Been Tested?
- Locally tested that docker build for mage-ai image is resolved

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993 @tommydangerous 
