### PR TITLE
Added repo_path to block kwargs and os.environ, improves multi-project feature

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -3572,6 +3572,12 @@ class Block(
         global_vars['pipeline_uuid'] = self.pipeline_uuid
         global_vars['block_uuid'] = self.uuid
 
+        # Add repo_path to global_vars
+        if self.pipeline and self.pipeline.repo_path:
+            global_vars['repo_path'] = self.pipeline.repo_path
+            # Setting value in os.environ is local to python subprocess
+            os.environ['MAGE_RUNTIME__REPO_PATH'] = self.pipeline.repo_path
+
         if dynamic_block_index is not None:
             global_vars['dynamic_block_index'] = dynamic_block_index
 


### PR DESCRIPTION
# Description
In multi-project the get_repo_path() in the settings lib returns the active project repo path.
This makes it hard to read config files using generic code.
Having the repo path in kwargs makes it easy to use that in blocks.
Having it in os.environ local to python subprocesses, allows libraries to access this. This works with local executors. A different solution may be appropriate for spark and cloud executors.

# How Has This Been Tested?
Tested in our local multi-project codebase.


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993 