### PR TITLE
Updated Variable Name for Cohesion

### DIFF
--- a/mage_ai/data_preparation/templates/repo/transformers/fill_in_missing_values.py
+++ b/mage_ai/data_preparation/templates/repo/transformers/fill_in_missing_values.py
@@ -13,8 +13,8 @@ def select_number_columns(df: DataFrame) -> DataFrame:
 def fill_missing_values_with_median(df: DataFrame) -> DataFrame:
     for col in df.columns:
         values = sorted(df[col].dropna().tolist())
-        median = values[math.floor(len(values) / 2)]
-        df[[col]] = df[[col]].fillna(median)
+        median_value = values[math.floor(len(values) / 2)]
+        df[[col]] = df[[col]].fillna(median_value)
     return df
 
 

--- a/mage_ai/data_preparation/templates/repo/transformers/fill_in_missing_values.py
+++ b/mage_ai/data_preparation/templates/repo/transformers/fill_in_missing_values.py
@@ -13,8 +13,8 @@ def select_number_columns(df: DataFrame) -> DataFrame:
 def fill_missing_values_with_median(df: DataFrame) -> DataFrame:
     for col in df.columns:
         values = sorted(df[col].dropna().tolist())
-        median_age = values[math.floor(len(values) / 2)]
-        df[[col]] = df[[col]].fillna(median_age)
+        median = values[math.floor(len(values) / 2)]
+        df[[col]] = df[[col]].fillna(median)
     return df
 
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
https://github.com/mage-ai/mage-ai/issues/5140

Fixed variable name `median_age` to `median_value`. Chief complaint was that the old `median_age` variable was used for iterations on all columns and not just the `Age` column. Renamed variable for clarity.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
- [x] Variable renaming should not require heavy testing or documentation changes.
- [x] Code still works as intended.


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 