### PR TITLE
Remove leading whitespace from Telegram notification message (Issue #4877)

### DIFF
--- a/mage_ai/data_preparation/templates/repo/transformers/fill_in_missing_values.py
+++ b/mage_ai/data_preparation/templates/repo/transformers/fill_in_missing_values.py
@@ -13,8 +13,8 @@ def select_number_columns(df: DataFrame) -> DataFrame:
 def fill_missing_values_with_median(df: DataFrame) -> DataFrame:
     for col in df.columns:
         values = sorted(df[col].dropna().tolist())
-        median = values[math.floor(len(values) / 2)]
-        df[[col]] = df[[col]].fillna(median)
+        median_value = values[math.floor(len(values) / 2)]
+        df[[col]] = df[[col]].fillna(median_value)
     return df
 
 

--- a/mage_ai/data_preparation/templates/repo/transformers/fill_in_missing_values.py
+++ b/mage_ai/data_preparation/templates/repo/transformers/fill_in_missing_values.py
@@ -13,8 +13,8 @@ def select_number_columns(df: DataFrame) -> DataFrame:
 def fill_missing_values_with_median(df: DataFrame) -> DataFrame:
     for col in df.columns:
         values = sorted(df[col].dropna().tolist())
-        median_age = values[math.floor(len(values) / 2)]
-        df[[col]] = df[[col]].fillna(median_age)
+        median = values[math.floor(len(values) / 2)]
+        df[[col]] = df[[col]].fillna(median)
     return df
 
 

--- a/mage_ai/services/telegram/telegram.py
+++ b/mage_ai/services/telegram/telegram.py
@@ -4,12 +4,10 @@ from mage_ai.services.telegram.config import TelegramConfig
 
 
 def send_telegram_message(config: TelegramConfig, message: str, title: str) -> None:
-    summary = """
-    <b>{title}</b>
-
-
-    {message}
-    """.format(title=title, message=message)
+    summary = (
+        "<b>{title}</b>\n\n"
+        "{message}"
+    ).format(title=title, message=message)
 
     payload = {
         "text": summary,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Close: https://github.com/mage-ai/mage-ai/issues/4877
Whitespace in front of the content messages. Used code provided by the issue reporter to fix.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Ran old telegram trigger after setting up a telegram bot
![image](https://github.com/mage-ai/mage-ai/assets/79187097/d497b971-52cb-4459-bb51-7a2939fd92a0)
- [x] Put new code in and ran changes to test if fixed.
![image](https://github.com/mage-ai/mage-ai/assets/79187097/42723dd6-d1c8-43d3-8e55-59d9d9641b38)

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@csharplus @wangxiaoyou1993 