### PR TITLE
[xy] Fix api trigger token comparison.

### DIFF
--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -358,11 +358,12 @@ class PipelineSchedule(PipelineScheduleProjectPlatformMixin, BaseModel):
                     existing_trigger.sla != kwargs.get('sla'),
                     existing_trigger.start_time != kwargs.get('start_time'),
                     existing_trigger.status != kwargs.get('status'),
-                    existing_trigger.token != kwargs.get('token'),
+                    existing_trigger.token != kwargs.get('token') and kwargs.get('token'),
+                    existing_trigger.token is None,
                     existing_trigger.variables != kwargs.get('variables'),
                 ]):
-                    if existing_trigger.token is None and kwargs.get('token') is None:
-                        kwargs['token'] = uuid.uuid4().hex
+                    if kwargs.get('token') is None:
+                        kwargs['token'] = existing_trigger.token or uuid.uuid4().hex
                     existing_trigger.update(**kwargs)
             else:
                 if kwargs.get('token') is None:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Close: https://github.com/mage-ai/mage-ai/issues/5157

When comparing the token in trigger config with the database object
* If the existing trigger database object's token is None, create the token with uuid.uuid4().hex
* If the token in the trigger config is not None and it's not same with the trigger database object's token, update the db object's token

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally with API trigger with and without specifying token in trigger config 


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
