### PR TITLE
[td] Update Snowflake timeout to network_timeout

### DIFF
--- a/mage_ai/io/snowflake.py
+++ b/mage_ai/io/snowflake.py
@@ -452,7 +452,7 @@ INSERT INTO "{database}"."{schema}"."{table_name}"
         )
 
         if ConfigKey.SNOWFLAKE_TIMEOUT in config:
-            conn_kwargs['timeout'] = config[ConfigKey.SNOWFLAKE_TIMEOUT]
+            conn_kwargs['network_timeout'] = config[ConfigKey.SNOWFLAKE_TIMEOUT]
 
         if ConfigKey.SNOWFLAKE_ROLE in config:
             conn_kwargs['role'] = config[ConfigKey.SNOWFLAKE_ROLE]


### PR DESCRIPTION
The key should be `network_timeout` not `timeout`

https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#managing-connection-timeouts