### PR TITLE
Add create_dataset parameter to Bigquery #5197

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,10 +62,10 @@ jobs:
         run: |
           sudo apt-get install freetds-dev
           python -m pip install --upgrade pip
+          pip install "git+https://github.com/mage-ai/sqlglot#egg=sqlglot"
           pip install -r requirements.txt
           pip install mage_integrations/
           pip install "git+https://github.com/mage-ai/singer-python.git#egg=singer-python"
-          pip install "git+https://github.com/mage-ai/sqlglot#egg=sqlglot"
       - name: Run unit tests
         run: |
           python3 -m unittest discover -s mage_ai --failfast

--- a/mage_ai/io/bigquery.py
+++ b/mage_ai/io/bigquery.py
@@ -205,6 +205,7 @@ WHERE TABLE_NAME = '{table_name}'
         unique_conflict_method: str = None,
         unique_constraints: List[str] = None,
         write_disposition: str = None,
+        create_dataset: bool = False,
         **configuration_params,
     ) -> None:
         """
@@ -225,6 +226,7 @@ WHERE TABLE_NAME = '{table_name}'
                 Defaults to `'replace'`. If `write_disposition` is specified as a keyword argument,
                 this parameter is ignored (as both define the same functionality).
             overwrite_types (Dict): The column types to be overwritten by users.
+            create_dataset (bool): If set to True, creates the dataset
             **configuration_params: Configuration parameters for export job
         """
         if table_id is None:
@@ -286,6 +288,7 @@ WHERE table_id = '{table_name}'
                             df,
                             temp_table_id,
                             overwrite_types=overwrite_types,
+                            create_dataset=create_dataset,
                             **configuration_params,
                         )
 
@@ -342,6 +345,7 @@ WHERE table_id = '{table_name}'
                         table_id,
                         overwrite_types=overwrite_types,
                         write_disposition=write_disposition,
+                        create_dataset=create_dataset,
                         **configuration_params,
                     )
 
@@ -356,6 +360,7 @@ WHERE table_id = '{table_name}'
         df: DataFrame,
         table_id: str,
         overwrite_types: Dict = None,
+        create_dataset: bool = False,
         **configuration_params,
     ):
         config = LoadJobConfig(**configuration_params)
@@ -371,7 +376,8 @@ WHERE table_id = '{table_name}'
             schema = parts[1]
             table_name = parts[2]
 
-        self.client.create_dataset(dataset=schema, exists_ok=True)
+        if schema and create_dataset:
+            self.client.create_dataset(dataset=schema, exists_ok=True)
 
         column_types = self.get_column_types(schema, table_name)
 

--- a/mage_ai/io/bigquery.py
+++ b/mage_ai/io/bigquery.py
@@ -205,7 +205,7 @@ WHERE TABLE_NAME = '{table_name}'
         unique_conflict_method: str = None,
         unique_constraints: List[str] = None,
         write_disposition: str = None,
-        create_dataset: bool = False,
+        create_dataset: bool = True,
         **configuration_params,
     ) -> None:
         """
@@ -360,7 +360,7 @@ WHERE table_id = '{table_name}'
         df: DataFrame,
         table_id: str,
         overwrite_types: Dict = None,
-        create_dataset: bool = False,
+        create_dataset: bool = True,
         **configuration_params,
     ):
         config = LoadJobConfig(**configuration_params)

--- a/mage_ai/tests/io/create_table/test_bigquery.py
+++ b/mage_ai/tests/io/create_table/test_bigquery.py
@@ -1,0 +1,68 @@
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from mage_ai.io.bigquery import BigQuery
+from mage_ai.tests.base_test import DBTestCase
+
+
+class TestTableBigQuery(DBTestCase):
+
+    @patch('google.cloud.bigquery.Client', autospec=True)
+    @patch('mage_ai.io.bigquery.BigQuery.__init__', lambda self, **kwargs: None)
+    def setUp(self, mock_client):
+        super().setUp()
+        self.bigquery_instance = BigQuery()
+        self.bigquery_instance.client = mock_client.return_value
+        self.bigquery_instance.printer = MagicMock()
+        self.bigquery_instance.client.create_dataset = MagicMock()
+        self.bigquery_instance.client.load_table_from_dataframe = MagicMock()
+
+        self.mock_df = pd.DataFrame({'column1': [1, 2], 'column2': [3, 4]})
+        self.dataset = 'test_dataset'
+        self.table_id = f"test-project.{self.dataset}.test_table"
+
+    def test_export_creates_dataset_if_flag_is_true(self):
+        self.bigquery_instance.export(self.mock_df, self.table_id, create_dataset=True)
+
+        self.bigquery_instance.client.create_dataset.assert_called_once_with(
+            dataset=self.dataset, exists_ok=True
+        )
+        self.bigquery_instance.client.load_table_from_dataframe.assert_called_once()
+
+    def test_export_does_not_create_dataset_if_flag_is_false(self):
+        self.bigquery_instance.export(self.mock_df, self.table_id, create_dataset=False)
+
+        self.bigquery_instance.client.create_dataset.assert_not_called()
+        self.bigquery_instance.client.load_table_from_dataframe.assert_called_once()
+
+    def test_export_does_not_create_dataset_if_flag_is_not_provided(self):
+        self.bigquery_instance.export(self.mock_df, self.table_id)
+
+        self.bigquery_instance.client.create_dataset.assert_not_called()
+        self.bigquery_instance.client.load_table_from_dataframe.assert_called_once()
+
+    def test_export_creates_dataset_if_flag_is_true_and_append_with_constraints(self):
+        self.bigquery_instance.export(
+            self.mock_df,
+            self.table_id,
+            create_dataset=True,
+            if_exists='append',
+            unique_constraints=['column1'],
+            unique_conflict_method='update',
+        )
+
+        self.bigquery_instance.client.create_dataset.assert_called_once_with(
+            dataset=self.dataset, exists_ok=True
+        )
+        self.bigquery_instance.client.load_table_from_dataframe.assert_called_once()
+
+    def test_export_printer_not_called_if_process_fails(self):
+        self.bigquery_instance._BigQuery__write_table = MagicMock()
+        self.bigquery_instance._BigQuery__write_table.side_effect = RuntimeError("Processing error")
+
+        with self.assertRaises(RuntimeError):
+            self.bigquery_instance.export(self.mock_df, self.table_id)
+
+        self.bigquery_instance.client.create_dataset.assert_not_called()
+        self.bigquery_instance.client.load_table_from_dataframe.assert_not_called()

--- a/mage_ai/tests/io/create_table/test_bigquery.py
+++ b/mage_ai/tests/io/create_table/test_bigquery.py
@@ -39,7 +39,9 @@ class TestTableBigQuery(DBTestCase):
     def test_export_does_not_create_dataset_if_flag_is_not_provided(self):
         self.bigquery_instance.export(self.mock_df, self.table_id)
 
-        self.bigquery_instance.client.create_dataset.assert_not_called()
+        self.bigquery_instance.client.create_dataset.assert_called_once_with(
+            dataset=self.dataset, exists_ok=True
+        )
         self.bigquery_instance.client.load_table_from_dataframe.assert_called_once()
 
     def test_export_creates_dataset_if_flag_is_true_and_append_with_constraints(self):


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
https://github.com/mage-ai/mage-ai/issues/5197

- Added a `create_dataset` parameter to the BigQuery `export` method to allow users to create a dataset if desired.
- Previously, the `__write_table` method always attempted to create a dataset.
- Now, dataset creation is controlled by the `create_dataset` parameter, which defaults to `False`.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
- [x] Tested locally and created test cases to ensure the new parameter works as expected.


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc: 
@wangxiaoyou1993
@jx2lee
<!-- Optionally mention someone to let them know about this pull request -->
