### PR TITLE
Update activemq.py

### DIFF
--- a/mage_ai/streaming/sources/activemq.py
+++ b/mage_ai/streaming/sources/activemq.py
@@ -54,7 +54,7 @@ class ActiveMQSource(BaseSource):
         self._print(f'Starting to initialize consumer for queue {queue_name}')
 
         try:
-            conn = stomp.Connection11([(connection_host, connection_port)])
+            conn = stomp.Connection11([(connection_host, connection_port)], heartbeats=(10000, 10000))
             self._print('Connecting to broker')
             conn.connect(username, password, wait=True)
             self.connection = conn


### PR DESCRIPTION
Added heartbeats every 10 seconds for the listener in the stomp connection.

# Description
Have added a heartbeat to the stomp connection :
```conn = stomp.Connection11([(connection_host, connection_port)], heartbeats=(10000, 10000))```
This fixes the issue of the listener timing out after the default connectionTtl setting of 60 seconds.
The activeMQ broker is expecting a heartbeat to make sure that the listener is alive. If none is received the connection times out after the predefined time.



# How Has This Been Tested?
The change was tested by running a streaming pipeline using the activeMQ connection.
Before this change the listener was shutting down after 60 seconds of listening. After the change the listener does not time out anymore.

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand  
- [ ] I have made corresponding changes to the documentation

cc:
@tommydangerous 