### PR TITLE
[jk] Add specific lodash dependency version

### DIFF
--- a/mage_ai/frontend/package.json
+++ b/mage_ai/frontend/package.json
@@ -115,6 +115,8 @@
     "@storybook/addon-links": "^7.4.2",
     "@storybook/nextjs": "^7.4.2",
     "@storybook/react": "^7.4.2",
+    "@types/lodash": "4.14.112",
+    "@types/lodash-es": "4.14.2",
     "@types/node": "17.0.34",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.0.4",


### PR DESCRIPTION
# Description
- There was a Next build error related to lodash types:
```
./node_modules/@types/lodash/common/object.d.ts:1026:46
Type error: '?' expected.

  1024 |     type GetFieldTypeOfArrayLikeByKey<T extends unknown[], K> =
  1025 |         K extends number ? T[K]
> 1026 |         : K extends `${infer N extends number}` ? T[N]
       |                                              ^
  1027 |         : K extends keyof T ? T[K] : undefined;
  1028 | 
  1029 |     type GetFieldTypeOfStringByKey<T extends string, K> =
```
- This PR specifies versions for `@types/lodash` and `@types/lodash-es` to avoid the type error during the frontend build.

# How Has This Been Tested?
- Created successful build locally without the lodash type error.

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
