### PR TITLE
[jk] Default command center item

### DIFF
--- a/mage_ai/frontend/components/CommandCenter/ItemRow/constants.tsx
+++ b/mage_ai/frontend/components/CommandCenter/ItemRow/constants.tsx
@@ -32,7 +32,10 @@ export function getIcon(item: CommandCenterItemType) {
   const {
     display_settings_by_attribute: displaySettingsByAttribute,
     metadata,
-  } = item || {};
+  } = item || {
+    display_settings_by_attribute: null,
+    metadata: null,
+  };
   const iconUUID = displaySettingsByAttribute?.icon?.icon_uuid;
 
   if (iconUUID && iconUUID in AllIcons) {

--- a/mage_ai/frontend/components/CommandCenter/ItemRow/constants.tsx
+++ b/mage_ai/frontend/components/CommandCenter/ItemRow/constants.tsx
@@ -32,7 +32,7 @@ export function getIcon(item: CommandCenterItemType) {
   const {
     display_settings_by_attribute: displaySettingsByAttribute,
     metadata,
-  } = item;
+  } = item || {};
   const iconUUID = displaySettingsByAttribute?.icon?.icon_uuid;
 
   if (iconUUID && iconUUID in AllIcons) {

--- a/mage_ai/frontend/components/CommandCenter/ItemRow/index.tsx
+++ b/mage_ai/frontend/components/CommandCenter/ItemRow/index.tsx
@@ -32,7 +32,7 @@ function ItemRow({
     metadata,
     subtitle,
     title,
-  } = item;
+  } = item || {};
   const {
     description: descriptionDisplaySettings,
     subtitle: subtitleDisplaySettings,

--- a/mage_ai/frontend/components/CommandCenter/ItemRow/index.tsx
+++ b/mage_ai/frontend/components/CommandCenter/ItemRow/index.tsx
@@ -32,7 +32,13 @@ function ItemRow({
     metadata,
     subtitle,
     title,
-  } = item || {};
+  } = item || {
+    description: '',
+    display_settings_by_attribute: null,
+    metadata: null,
+    subtitle: '',
+    title: '',
+  };
   const {
     description: descriptionDisplaySettings,
     subtitle: subtitleDisplaySettings,


### PR DESCRIPTION
# Description
- Default the command center `item` variable to an object with default values to avoid type errors causing the app to crash.


# How Has This Been Tested?
- Local

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
@matrixstone 
