### PR TITLE
[xh]Update openai version to >= 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ kubernetes>=28.1.0
 langchain==0.1.6; python_version >= '3.8'
 langchain_community<0.0.20
 mysql-connector-python~=8.2.0
-openai>=0.27.8, <1.0.0
+openai>=1.0.0
 opentelemetry-api==1.22.0
 opentelemetry-exporter-prometheus==0.43b0
 opentelemetry-instrumentation-tornado==0.43b0

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setuptools.setup(
             'astor>=0.8.1',
             'langchain>=0.0.222',
             'langchain_community<0.0.20',
-            'openai>=0.27.8, <1.0.0',
+            'openai>=1.0.0',
         ],
         'azure': [
             'azure-eventhub==5.11.2',
@@ -170,7 +170,7 @@ setuptools.setup(
             'ldap3==2.9.1',
             'nats-py==2.6.0',
             'nkeys~=0.1.0',
-            'openai>=0.27.8, <1.0.0',
+            'openai>=1.0.0',
             'opensearch-py==2.0.0',
             'opentelemetry-api==1.22.0',
             'opentelemetry-exporter-prometheus==0.43b0',


### PR DESCRIPTION
# Description
OpenAI API got upgrade with version >= 1.0.0. [Guide](https://github.com/openai/openai-python/discussions/742). This PR changes the API call and enforce openAI version to bigger than 1.0.0.

# How Has This Been Tested?
1. Tested with Mage AI command line functions:
- `generate-block-with-description`
- `generate-pipeline-documentation`
- `generate-block-with-description`
- `generate-pipeline-with-description`
- `generate-comment-for-block`

2. unit test run `python -m unittest mage_ai/tests/ai/test_ai_functions.py`

3. Tested in Mage UI
![test](https://github.com/user-attachments/assets/df1fa8b6-aafd-435a-bc6c-a1f5ec5a120c)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993 
