### PR TITLE
[jk] V2 Canvas entry points

### DIFF
--- a/mage_ai/api/presenters/PipelinePresenter.py
+++ b/mage_ai/api/presenters/PipelinePresenter.py
@@ -17,6 +17,7 @@ class PipelinePresenter(BasePresenter):
         'created_at',
         'data_integration',
         'description',
+        'execution_framework',
         'executor_config',
         'executor_count',
         'executor_type',
@@ -101,7 +102,7 @@ class PipelinePresenter(BasePresenter):
         elif constants.UPDATE == display_format:
             data = self.model.to_dict(include_extensions=include_extensions)
         else:
-            data = self.model.to_dict()
+            data = self.model.to_dict(include_execution_framework=True)
             if self.model.history:
                 data.update(history=[h.to_dict() for h in self.model.history])
 

--- a/mage_ai/cache/utils.py
+++ b/mage_ai/cache/utils.py
@@ -6,6 +6,7 @@ from mage_ai.shared.hash import extract, merge_dict
 PIPELINE_KEYS = [
     'created_at',
     'description',
+    'execution_framework',
     'name',
     'tags',
     'type',

--- a/mage_ai/frontend/components/PipelineDetail/utils.ts
+++ b/mage_ai/frontend/components/PipelineDetail/utils.ts
@@ -94,7 +94,6 @@ export function prepareOutputsForDisplay(outputs: OutputType[]) {
       });
     }
   });
-  console.log('outputsFinal', outputsFinal);
 
   if (DataTypeEnum.TEXT_PLAIN === outputType) {
     return outputsFinal;

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -1138,7 +1138,24 @@ function PipelineListPage() {
         ref={refTable}
         renderRightClickMenuItems={(rowIndex: number) => {
           const selectedPipeline = pipelinesInner[rowIndex];
-          const rightClickMenuItems = [
+
+          return [
+            {
+              label: () => 'Open pipeline',
+              onClick: () => {
+                if (selectedPipeline?.execution_framework === PipelineExecutionFrameworkUUIDEnum.RAG) {
+                  router.push(
+                    `/v2/pipelines/${snakeToHyphens(selectedPipeline?.uuid)}/${snakeToHyphens(selectedPipeline?.execution_framework)}`,
+                  );
+                } else {
+                  router.push(
+                    '/pipelines/[pipeline]/edit',
+                    `/pipelines/${pipelinesInner[rowIndex].uuid}/edit`,
+                  );
+                }
+              },
+              uuid: 'open_pipeline',
+            },
             {
               label: () => 'Edit description',
               onClick: () =>
@@ -1230,20 +1247,6 @@ function PipelineListPage() {
               uuid: 'delete',
             },
           ];
-
-          if (selectedPipeline?.execution_framework === PipelineExecutionFrameworkUUIDEnum.RAG) {
-            rightClickMenuItems.unshift({
-              label: () => 'Go to RAG pipeline canvas',
-              onClick: () => {
-                router.push(
-                  `/v2/pipelines/${snakeToHyphens(selectedPipeline?.uuid)}/${snakeToHyphens(selectedPipeline?.execution_framework)}`,
-                );
-              },
-              uuid: 'rag_pipeline_canvas',
-            });
-          }
-
-          return rightClickMenuItems;
         }}
         rightClickMenuHeight={36 * 7}
         rightClickMenuWidth={UNIT * 30}

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -1121,16 +1121,21 @@ function PipelineListPage() {
           })
         }
         onDoubleClickRow={(rowIndex: number) => {
-          router.push(
-            '/pipelines/[pipeline]/edit',
-            `/pipelines/${pipelinesInner[rowIndex].uuid}/edit`,
-          );
+          if (selectedPipeline?.execution_framework === PipelineExecutionFrameworkUUIDEnum.RAG) {
+            router.push(
+              `/v2/pipelines/${snakeToHyphens(selectedPipeline?.uuid)}/${snakeToHyphens(selectedPipeline?.execution_framework)}`,
+            );
+          } else {
+            router.push(
+              '/pipelines/[pipeline]/edit',
+              `/pipelines/${pipelinesInner[rowIndex].uuid}/edit`,
+            );
+          }
         }}
         ref={refTable}
         renderRightClickMenuItems={(rowIndex: number) => {
           const selectedPipeline = pipelinesInner[rowIndex];
-
-          return [
+          const rightClickMenuItems = [
             {
               label: () => 'Edit description',
               onClick: () =>
@@ -1222,6 +1227,20 @@ function PipelineListPage() {
               uuid: 'delete',
             },
           ];
+
+          if (selectedPipeline?.execution_framework === PipelineExecutionFrameworkUUIDEnum.RAG) {
+            rightClickMenuItems.unshift({
+              label: () => 'Go to RAG pipeline canvas',
+              onClick: () => {
+                router.push(
+                  `/v2/pipelines/${snakeToHyphens(selectedPipeline?.uuid)}/${snakeToHyphens(selectedPipeline?.execution_framework)}`,
+                );
+              },
+              uuid: 'rag_pipeline_canvas',
+            });
+          }
+
+          return rightClickMenuItems;
         }}
         rightClickMenuHeight={36 * 7}
         rightClickMenuWidth={UNIT * 30}

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -1124,6 +1124,7 @@ function PipelineListPage() {
           })
         }
         onDoubleClickRow={(rowIndex: number) => {
+          const selectedPipeline = pipelinesInner[rowIndex];
           if (selectedPipeline?.execution_framework === PipelineExecutionFrameworkUUIDEnum.RAG) {
             router.push(
               `/v2/pipelines/${snakeToHyphens(selectedPipeline?.uuid)}/${snakeToHyphens(selectedPipeline?.execution_framework)}`,
@@ -1131,7 +1132,7 @@ function PipelineListPage() {
           } else {
             router.push(
               '/pipelines/[pipeline]/edit',
-              `/pipelines/${pipelinesInner[rowIndex].uuid}/edit`,
+              `/pipelines/${selectedPipeline?.uuid}/edit`,
             );
           }
         }}
@@ -1150,7 +1151,7 @@ function PipelineListPage() {
                 } else {
                   router.push(
                     '/pipelines/[pipeline]/edit',
-                    `/pipelines/${pipelinesInner[rowIndex].uuid}/edit`,
+                    `/pipelines/${selectedPipeline?.uuid}/edit`,
                   );
                 }
               },

--- a/mage_ai/frontend/pages/pipelines/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/index.tsx
@@ -3,7 +3,10 @@ import { snakeToHyphens } from '@utils/url';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { MutateFunction, useMutation } from 'react-query';
 import { useRouter } from 'next/router';
-import { PipelineExecutionFrameworkUUIDEnum } from '@interfaces/PipelineExecutionFramework/types';
+import {
+  FRAMEWORK_NAME_MAPPING,
+  PipelineExecutionFrameworkUUIDEnum,
+} from '@interfaces/PipelineExecutionFramework/types';
 import AIControlPanel from '@components/AI/ControlPanel';
 import BrowseTemplates from '@components/CustomTemplates/BrowseTemplates';
 import Button from '@oracle/elements/Button';
@@ -1250,6 +1253,7 @@ function PipelineListPage() {
             blocks,
             created_at: createdAt,
             description,
+            execution_framework: executionFramework,
             schedules,
             tags,
             type,
@@ -1313,7 +1317,10 @@ function PipelineListPage() {
               {description}
             </Text>,
             <Text bold={isInvalid} danger={isInvalid} key={`pipeline_type_${idx}`}>
-              {isInvalid ? capitalize(PIPELINE_TYPE_INVALID) : PIPELINE_TYPE_LABEL_MAPPING[type]}
+              {isInvalid
+                ? capitalize(PIPELINE_TYPE_INVALID)
+                : (executionFramework ? FRAMEWORK_NAME_MAPPING[executionFramework] : PIPELINE_TYPE_LABEL_MAPPING[type])
+              }
             </Text>,
             <Text
               key={`pipeline_updated_at_${idx}`}


### PR DESCRIPTION
# Description
- Add ways for user to go back to RAG pipeline canvas page after creating RAG pipeline (e.g. if they navigate away from the canvas back to the main dashboard).
- To go to the v2 canvas, users can do one of the following from the Pipelines Dashboard:
1. Double-click a RAG pipeline (double-clicking a non-RAG pipeline will still go to the Pipeline Editor).
2. Right-click a RAG pipeline and select "Open pipeline" from the context menu.

# How Has This Been Tested?
![image](https://github.com/user-attachments/assets/baafd0c1-90bd-49b2-9dd1-398fce57795c)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
@MageKai 
