### PR TITLE
[jk] Include base path when loading favicon

### DIFF
--- a/mage_ai/frontend/oracle/elements/Head/index.tsx
+++ b/mage_ai/frontend/oracle/elements/Head/index.tsx
@@ -1,4 +1,5 @@
 import NextHead from 'next/head';
+import { useRouter } from 'next/router';
 
 type HeadProps = {
   children?: any;
@@ -6,14 +7,18 @@ type HeadProps = {
   title?: string;
 };
 
-const Head = ({ children, defaultTitle = 'Mage', title }: HeadProps) => (
-  <NextHead>
-    <link href="/favicon.ico" rel="icon" />
+const Head = ({ children, defaultTitle = 'Mage', title }: HeadProps) => {
+  const router = useRouter();
 
-    <title>{title ? `${title} | ${defaultTitle}` : defaultTitle}</title>
+  return (
+    <NextHead>
+      <link href={`${router.basePath}/favicon.ico`} rel="icon" />
 
-    {children}
-  </NextHead>
-);
+      <title>{title ? `${title} | ${defaultTitle}` : defaultTitle}</title>
+
+      {children}
+    </NextHead>
+  );
+};
 
 export default Head;


### PR DESCRIPTION
# Description
- The Mage website icon (`favicon.ico`) wasn't loading properly (e.g. in the browser tab), so this PR fixes the base path issue associated with it.

# How Has This Been Tested?
- Tested locally

Before (note the lack of Mage icon in the browser tab):
![image](https://github.com/user-attachments/assets/ca81138d-b96d-4630-a3b3-c68e37c59c00)

After:
![image](https://github.com/user-attachments/assets/5a121987-b20d-4589-be4e-74be384443c7)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
