### PR TITLE
[jk] Cookie session updates

### DIFF
--- a/mage_ai/frontend/api/cleaner/utils/token.ts
+++ b/mage_ai/frontend/api/cleaner/utils/token.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import Cookies from 'js-cookie';
 
 import {

--- a/mage_ai/frontend/api/cleaner/utils/token.ts
+++ b/mage_ai/frontend/api/cleaner/utils/token.ts
@@ -14,7 +14,7 @@ export const PATH: string = COOKIE_PATH;
 export const SHARED_OPTS: any = SHARED_COOKIE_PROPERTIES;
 
 export function getToken(): string | undefined {
-  return Cookies.get(COOKIE_KEY, SHARED_OPTS);
+  return Cookies.get(COOKIE_KEY);
 }
 
 export function removeToken() {

--- a/mage_ai/frontend/api/utils/AuthToken.ts
+++ b/mage_ai/frontend/api/utils/AuthToken.ts
@@ -1,6 +1,7 @@
 import jwtDecode from 'jwt-decode';
 import ls from 'local-storage';
 
+import { COOKIE_PATH } from '@utils/cookies/constants';
 import { getToken, removeToken, setToken } from './token';
 import { removeUser } from '@utils/session';
 import { redirectToUrl } from '@utils/url';
@@ -52,18 +53,25 @@ export default class AuthToken {
     return authToken.isValid;
   }
 
-  static async storeToken(token: string, callback: any = null) {
-    setToken(token);
+  static async storeToken(
+    token: string,
+    callback: any = null,
+    basePath: string = COOKIE_PATH,
+  ) {
+    setToken(token, basePath);
     if (callback) {
       await callback();
     }
   }
 
-  static async logout(callback: any = null) {
+  static async logout(
+    callback: any = null,
+    basePath: string = COOKIE_PATH,
+  ) {
     // @ts-ignore
     ls.clear();
     removeUser();
-    removeToken();
+    removeToken(basePath);
 
     try {
       if (callback) {

--- a/mage_ai/frontend/api/utils/token.ts
+++ b/mage_ai/frontend/api/utils/token.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import Cookies from 'js-cookie';
 
 import {

--- a/mage_ai/frontend/api/utils/token.ts
+++ b/mage_ai/frontend/api/utils/token.ts
@@ -14,13 +14,30 @@ export const PATH: string = COOKIE_PATH;
 export const SHARED_OPTS: any = SHARED_COOKIE_PROPERTIES;
 
 export function getToken(): string | undefined {
-  return Cookies.get(COOKIE_KEY, SHARED_OPTS);
+  return Cookies.get(COOKIE_KEY);
 }
 
-export function removeToken() {
-  Cookies.remove(COOKIE_KEY, SHARED_OPTS);
+export function removeToken(basePath?: string) {
+  Cookies.remove(
+    COOKIE_KEY,
+    {
+      ...SHARED_OPTS,
+      path: basePath || PATH,
+    },
+  );
 }
 
-export function setToken(token: string) {
-  Cookies.set(COOKIE_KEY, token, { ...SHARED_OPTS, expires: 30 });
+export function setToken(
+  token: string,
+  basePath?: string,
+) {
+  Cookies.set(
+    COOKIE_KEY,
+    token,
+    {
+      ...SHARED_OPTS,
+      expires: 30,
+      path: basePath || PATH,
+    },
+  );
 }

--- a/mage_ai/frontend/components/Sessions/SignForm/index.tsx
+++ b/mage_ai/frontend/components/Sessions/SignForm/index.tsx
@@ -57,26 +57,31 @@ function SignForm({
             },
           }) => {
             setUser(user);
-            AuthToken.storeToken(token, () => {
-              let url: string = `${router.basePath}/`;
-              const query = queryFromUrl(window.location.href);
+            const basePath = router.basePath;
+            AuthToken.storeToken(
+              token,
+              () => {
+                let url: string = `${router.basePath}/`;
+                const query = queryFromUrl(window.location.href);
 
-              if (typeof window !== 'undefined') {
-                const qs = queryString(
-                  ignoreKeys(
-                    query,
-                    ['redirect_url', 'access_token', 'provider'],
-                  ),
-                );
-                if (query.redirect_url) {
-                  url = `${query.redirect_url}?${qs}`;
+                if (typeof window !== 'undefined') {
+                  const qs = queryString(
+                    ignoreKeys(
+                      query,
+                      ['redirect_url', 'access_token', 'provider'],
+                    ),
+                  );
+                  if (query.redirect_url) {
+                    url = `${query.redirect_url}?${qs}`;
+                  }
+
+                  window.location.href = url;
+                } else {
+                  router.push(url);
                 }
-
-                window.location.href = url;
-              } else {
-                router.push(url);
-              }
-            });
+              },
+              basePath,
+            );
           },
           onErrorCallback: ({ error }) => {
             setError(error);
@@ -86,9 +91,10 @@ function SignForm({
     },
   );
 
-  const create = useCallback(payload => AuthToken.logout(() => createRequest(payload)), [
-    createRequest,
-  ]);
+  const create = useCallback(payload => AuthToken.logout(
+    () => createRequest(payload),
+    router.basePath,
+  ), [createRequest, router.basePath]);
 
   const { data: dataOauths } = api.oauths.list({
     redirect_uri: typeof window !== 'undefined' ? encodeURIComponent(window.location.href) : '',

--- a/mage_ai/frontend/components/shared/Header/index.tsx
+++ b/mage_ai/frontend/components/shared/Header/index.tsx
@@ -186,7 +186,7 @@ function Header({
         .catch(() => {
           redirectToUrl('/');
         });
-    });
+    }, router.basePath);
   };
 
   const breadcrumbProjects = [];

--- a/mage_ai/frontend/mana/themes/utils.ts
+++ b/mage_ai/frontend/mana/themes/utils.ts
@@ -18,7 +18,7 @@ function getThemeSettingsCache(ctx?: any): ThemeSettingsType {
       themeSettings = cookie[KEY];
     }
   } else {
-    themeSettings = Cookies.get(KEY, SHARED_OPTS);
+    themeSettings = Cookies.get(KEY);
   }
 
   if (typeof themeSettings === 'string') {

--- a/mage_ai/frontend/oracle/styles/themes/utils.ts
+++ b/mage_ai/frontend/oracle/styles/themes/utils.ts
@@ -17,7 +17,7 @@ export function getCurrentTheme(ctx: any, invertedTheme = 1) {
     const cookie = ServerCookie(ctx);
     currentTheme = cookie[LOCAL_STORAGE_KEY_THEME];
   } else {
-    currentTheme = Cookies.get(LOCAL_STORAGE_KEY_THEME, SHARED_OPTS);
+    currentTheme = Cookies.get(LOCAL_STORAGE_KEY_THEME);
   }
 
   if (Number(currentTheme) === invertedTheme) {
@@ -47,7 +47,7 @@ export function setCurrentTheme(theme) {
 }
 
 export function toggleTheme() {
-  const currentTheme = Cookies.get(LOCAL_STORAGE_KEY_THEME, SHARED_OPTS);
+  const currentTheme = Cookies.get(LOCAL_STORAGE_KEY_THEME);
 
   return setCurrentTheme(
     Number(currentTheme) === LOCAL_STORAGE_KEY_THEME_DARK || currentTheme === null

--- a/mage_ai/frontend/package.json
+++ b/mage_ai/frontend/package.json
@@ -115,6 +115,7 @@
     "@storybook/addon-links": "^7.4.2",
     "@storybook/nextjs": "^7.4.2",
     "@storybook/react": "^7.4.2",
+    "@types/js-cookie": "^3.0.6",
     "@types/lodash": "4.14.112",
     "@types/lodash-es": "4.14.2",
     "@types/node": "17.0.34",

--- a/mage_ai/frontend/pages/_app.tsx
+++ b/mage_ai/frontend/pages/_app.tsx
@@ -195,13 +195,11 @@ function MyApp(props: MyAppProps & AppProps) {
 
   const val = Cookies.get(
     REQUIRE_USER_AUTHENTICATION_COOKIE_KEY,
-    REQUIRE_USER_AUTHENTICATION_COOKIE_PROPERTIES,
   );
   const noValue = typeof val === 'undefined' || val === null || !REQUIRE_USER_AUTHENTICATION();
 
   const valPermissions = Cookies.get(
     REQUIRE_USER_PERMISSIONS_COOKIE_KEY,
-    REQUIRE_USER_PERMISSIONS_COOKIE_PROPERTIES,
   );
   const noValuePermissions =
     typeof valPermissions === 'undefined' || valPermissions === null || !REQUIRE_USER_PERMISSIONS();
@@ -224,7 +222,7 @@ function MyApp(props: MyAppProps & AppProps) {
     ) {
       Cookies.set(
         REQUIRE_USER_AUTHENTICATION_COOKIE_KEY,
-        requireUserAuthentication,
+        String(requireUserAuthentication),
         REQUIRE_USER_AUTHENTICATION_COOKIE_PROPERTIES,
       );
     }
@@ -236,7 +234,7 @@ function MyApp(props: MyAppProps & AppProps) {
     ) {
       Cookies.set(
         REQUIRE_USER_PERMISSIONS_COOKIE_KEY,
-        requireUserPermissions,
+        String(requireUserPermissions),
         REQUIRE_USER_PERMISSIONS_COOKIE_PROPERTIES,
       );
     }

--- a/mage_ai/frontend/pages/_document.tsx
+++ b/mage_ai/frontend/pages/_document.tsx
@@ -38,7 +38,7 @@ export default class MyDocument extends Document {
 
   render() {
     return (
-      <Html lang='en'>
+      <Html lang="en">
         <Head>
           <script
             dangerouslySetInnerHTML={{

--- a/mage_ai/frontend/utils/cookies/constants.ts
+++ b/mage_ai/frontend/utils/cookies/constants.ts
@@ -1,9 +1,13 @@
+import { isProduction } from '@utils/environment';
+
 export const COOKIE_DOMAIN: string = typeof window === 'undefined' ? null : window.location.hostname;
 export const COOKIE_PATH: string = '/';
 
 export const SHARED_COOKIE_PROPERTIES: any = {
   domain: COOKIE_DOMAIN,
   path: COOKIE_PATH,
+  sameSite: 'Strict',
+  secure: isProduction(),
 };
 
 export const COOKIE_KEY_INITIAL_AS_PATH = 'initial_as_path';

--- a/mage_ai/frontend/utils/cookies/utils.ts
+++ b/mage_ai/frontend/utils/cookies/utils.ts
@@ -6,7 +6,6 @@ import {
   COOKIE_KEY_NOTIFICATION_TEMPLATE,
   COOKIE_KEY_NOTIFICATION_UUID,
   COOKIE_KEY_REF,
-  SHARED_COOKIE_PROPERTIES,
 } from './constants';
 
 export function getTrackingCookies() {
@@ -18,6 +17,6 @@ export function getTrackingCookies() {
     [COOKIE_KEY_REF, 'referringURL'],
   ].reduce((acc, [cookieKey, trackingKey]) => ({
     ...acc,
-    [trackingKey]: Cookies.get(cookieKey, SHARED_COOKIE_PROPERTIES),
+    [trackingKey]: Cookies.get(cookieKey),
   }), {});
 }

--- a/mage_ai/frontend/utils/session.ts
+++ b/mage_ai/frontend/utils/session.ts
@@ -33,7 +33,6 @@ export const REQUIRE_USER_AUTHENTICATION = (ctx: any = null) => {
   } else {
     val = Cookies.get(
       REQUIRE_USER_AUTHENTICATION_COOKIE_KEY,
-      REQUIRE_USER_AUTHENTICATION_COOKIE_PROPERTIES,
     );
   }
 
@@ -53,7 +52,6 @@ export const REQUIRE_USER_PERMISSIONS = (ctx: any = null) => {
   } else {
     val = Cookies.get(
       REQUIRE_USER_PERMISSIONS_COOKIE_KEY,
-      REQUIRE_USER_PERMISSIONS_COOKIE_PROPERTIES,
     );
   }
 
@@ -81,7 +79,7 @@ export function getGroup(ctx: any = undefined): GroupType | { id?: string } | un
 
   // @ts-ignore
   const group = ls.get(CURRENT_GROUP_LOCAL_STORAGE_KEY);
-  const groupId = Cookies.get(CURRENT_GROUP_ID_COOKIE_KEY, SHARED_OPTS);
+  const groupId = Cookies.get(CURRENT_GROUP_ID_COOKIE_KEY);
 
   if (group && groupId) {
     return group;

--- a/mage_ai/frontend/yarn.lock
+++ b/mage_ai/frontend/yarn.lock
@@ -3603,6 +3603,11 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/js-cookie@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-3.0.6.tgz#a04ca19e877687bd449f5ad37d33b104b71fdf95"
+  integrity sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==
+
 "@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"


### PR DESCRIPTION
# Description
- Store oauth cookie based on base path so if user has multiple clusters open on the same domain but different base paths, they can be logged into all of them at the same time.
- Remove second argument from the `Cookies.get` method call, since it only requires 1 argument.
- Set `SameSite` and `Secure` attributes on oauth_token cookie.
- Note that there may still be some conflicting behavior due to shared local storage, for example if user is logged in as admin role in one cluster and viewer role in another cluster (to be resolved in separate PR).

# How Has This Been Tested?
- Tested logging into multiple clusters with different base paths at the same time (was not logged out of one after logging into the other as happened previously):
![multiple sessions](https://github.com/user-attachments/assets/b30c3149-3334-407d-a98b-5d49047d5d1a)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
