### PR TITLE
[jk] Differentiate current_user local storage

### DIFF
--- a/mage_ai/frontend/api/utils/AuthToken.ts
+++ b/mage_ai/frontend/api/utils/AuthToken.ts
@@ -70,7 +70,7 @@ export default class AuthToken {
   ) {
     // @ts-ignore
     ls.clear();
-    removeUser();
+    removeUser(basePath);
     removeToken(basePath);
 
     try {

--- a/mage_ai/frontend/components/Backfills/Detail/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Detail/index.tsx
@@ -86,9 +86,9 @@ function BackfillDetail({
   setErrors,
   variables,
 }: BackfillDetailProps) {
-  const isViewerRole = isViewer();
-  const displayLocalTimezone = shouldDisplayLocalTimezone();
   const router = useRouter();
+  const isViewerRole = isViewer(router?.basePath);
+  const displayLocalTimezone = shouldDisplayLocalTimezone();
   const {
     block_uuid: blockUUID,
     end_datetime: endDatetime,

--- a/mage_ai/frontend/components/Backfills/Table/index.tsx
+++ b/mage_ai/frontend/components/Backfills/Table/index.tsx
@@ -1,4 +1,5 @@
 import NextLink from 'next/link';
+import { useRouter } from 'next/router';
 
 import BackfillType, {
   BACKFILL_TYPE_DATETIME,
@@ -45,7 +46,8 @@ function BackfillsTable({
   pipeline,
   selectedRow,
 }: BackfillsTableProps) {
-  const isViewerRole = isViewer();
+  const router = useRouter();
+  const isViewerRole = isViewer(router?.basePath);
   const displayLocalTimezone = shouldDisplayLocalTimezone();
   const pipelineUUID = pipeline?.uuid;
   const timezoneTooltipProps = displayLocalTimezone ? TIMEZONE_TOOLTIP_PROPS : {};

--- a/mage_ai/frontend/components/GlobalHooks/GlobalHookDetail/index.tsx
+++ b/mage_ai/frontend/components/GlobalHooks/GlobalHookDetail/index.tsx
@@ -72,8 +72,8 @@ function GlobalHookDetail({
   uuid: globalHookUUID,
 }: GlobalHookDetailProps) {
   const displayLocalTimezone = shouldDisplayLocalTimezone();
-  const currentUser = getUser();
   const router = useRouter();
+  const currentUser = getUser(router?.basePath);
   const componentUUID = `GlobalHookDetail/${globalHookUUID}`;
   const themeContext: ThemeType = useContext(ThemeContext);
 

--- a/mage_ai/frontend/components/Orchestration/CreateSchedule/index.tsx
+++ b/mage_ai/frontend/components/Orchestration/CreateSchedule/index.tsx
@@ -80,7 +80,7 @@ function CreateSchedule({
           callback:
             (res) =>
               window.location.href =
-                `${router.basePath}/pipelines/${pipeline?.uuid}/triggers/` +
+                `${router?.basePath}/pipelines/${pipeline?.uuid}/triggers/` +
                 `${res?.pipeline_schedule?.id}?${queryString(queryFromUrl())}`,
           onErrorCallback: (response, errors) => setErrors({
             errors,

--- a/mage_ai/frontend/components/PipelineDetail/Extensions/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Extensions/index.tsx
@@ -136,7 +136,7 @@ function Extensions({
                           <img
                             alt={name}
                             height={UNIT * 3}
-                            src={`${router.basePath}/images/extensions/${uuid}/logo.png`}
+                            src={`${router?.basePath}/images/extensions/${uuid}/logo.png`}
                             width={UNIT * 3}
                           />
                         </FlexContainer>

--- a/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Runs/Table.tsx
@@ -73,7 +73,8 @@ function RetryButton({
   setShowConfirmationId: (showConfirmationId: number) => void;
   showConfirmationId: number;
 }) {
-  const isViewerRole = isViewer();
+  const router = useRouter();
+  const isViewerRole = isViewer(router?.basePath);
   const {
     id: pipelineRunId,
     pipeline_schedule_id: pipelineScheduleId,
@@ -280,7 +281,7 @@ function PipelineRunsTable({
   setErrors,
 }: PipelineRunsTableProps) {
   const router = useRouter();
-  const isViewerRole = isViewer();
+  const isViewerRole = isViewer(router?.basePath);
   const displayLocalTimezone = shouldDisplayLocalTimezone();
   const deleteButtonRefs = useRef({});
   const [cancelingRunId, setCancelingRunId] = useState<number>(null);

--- a/mage_ai/frontend/components/PipelineDetailPage/utils.ts
+++ b/mage_ai/frontend/components/PipelineDetailPage/utils.ts
@@ -11,7 +11,6 @@ import {
   SettingsWithKnobs,
 } from '@oracle/icons';
 import { PageNameEnum } from './constants';
-import { isViewer } from '@utils/session';
 
 export function buildNavigationItems(
   pageName: PageNameEnum,
@@ -97,7 +96,7 @@ export function buildNavigationItems(
     disabled: !pipelineUUID,
     id: PageNameEnum.EDIT,
     isSelected: () => PageNameEnum.EDIT === pageName,
-    label: () => isViewer() ? 'View pipeline': 'Edit pipeline',
+    label: () => 'Edit pipeline',
     linkProps: {
       as: `/pipelines/${pipelineUUID}/edit`,
       href: '/pipelines/[pipeline]/edit',

--- a/mage_ai/frontend/components/PipelineRun/Widget/index.tsx
+++ b/mage_ai/frontend/components/PipelineRun/Widget/index.tsx
@@ -116,7 +116,7 @@ function Widget({
             <Spacing px={5} py={10}>
               <FlexContainer alignItems="center" flexDirection="column">
                 <ImageStyle
-                  imageUrl={`${router.basePath}/images/blocks/grey_block.webp`}
+                  imageUrl={`${router?.basePath}/images/blocks/grey_block.webp`}
                 />
                 <Spacing mb={3} />
                 <Text large>

--- a/mage_ai/frontend/components/Sessions/SignForm/index.tsx
+++ b/mage_ai/frontend/components/Sessions/SignForm/index.tsx
@@ -56,12 +56,12 @@ function SignForm({
               user,
             },
           }) => {
-            setUser(user);
-            const basePath = router.basePath;
+            const basePath = router?.basePath;
+            setUser(user, basePath);
             AuthToken.storeToken(
               token,
               () => {
-                let url: string = `${router.basePath}/`;
+                let url: string = `${basePath}/`;
                 const query = queryFromUrl(window.location.href);
 
                 if (typeof window !== 'undefined') {
@@ -93,8 +93,8 @@ function SignForm({
 
   const create = useCallback(payload => AuthToken.logout(
     () => createRequest(payload),
-    router.basePath,
-  ), [createRequest, router.basePath]);
+    router?.basePath,
+  ), [createRequest, router?.basePath]);
 
   const { data: dataOauths } = api.oauths.list({
     redirect_uri: typeof window !== 'undefined' ? encodeURIComponent(window.location.href) : '',
@@ -254,7 +254,7 @@ function SignForm({
           px={PADDING_HORIZONTAL_UNITS}
           py={PADDING_HORIZONTAL_UNITS + 8}
         >
-          <BackgroundImageStyle src={`${router.basePath}/images/sessions/abstract.png`}>
+          <BackgroundImageStyle src={`${router?.basePath}/images/sessions/abstract.png`}>
             Sign in abstract image
           </BackgroundImageStyle>
         </Spacing>

--- a/mage_ai/frontend/components/Terminal/useTerminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/useTerminal/index.tsx
@@ -11,6 +11,7 @@ import KernelOutputType, { DataTypeEnum } from '@interfaces/KernelOutputType';
 import Spacing from '@oracle/elements/Spacing';
 import Terminal from '@components/Terminal';
 import useContextMenu from '@utils/useContextMenu';
+import useGetUser from '@utils/hooks/useGetUser';
 import { CachedItemType } from './constants';
 import { ApplicationExpansionUUIDEnum, CommandCenterStateEnum } from '@interfaces/CommandCenterType';
 import { CUSTOM_EVENT_NAME_APPLICATION_STATE_CHANGED } from '@utils/events/constants';
@@ -22,7 +23,6 @@ import { Terminal as TerminalIcon } from '@oracle/icons';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { cleanName, randomNameGenerator } from '@utils/string';
 import { getItems, setItems } from './storage';
-import { getUser } from '@utils/session';
 import { getWebSocket } from '@api/utils/url';
 import { keysPresentAndKeysRecent } from '@utils/hooks/keyboardShortcuts/utils';
 import { pushAtIndex } from '@utils/array';
@@ -48,7 +48,7 @@ export default function useTerminal({
   tabs: JSX.Element;
   terminal: JSX.Element;
 } {
-  const user = getUser() || { id: '__NO_ID__' };
+  const user = useGetUser() || { id: '__NO_ID__' };
   const token = useMemo(() => new AuthToken(), []);
   const oauthWebsocketData = useMemo(() => ({
     api_key: OAUTH2_APPLICATION_CLIENT_ID,

--- a/mage_ai/frontend/components/Triggers/Detail/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Detail/index.tsx
@@ -113,7 +113,7 @@ function TriggerDetail({
     project,
   } = useProject();
   const router = useRouter();
-  const isViewerRole = isViewer();
+  const isViewerRole = isViewer(router?.basePath);
   const displayLocalTimezone = shouldDisplayLocalTimezone();
 
   const blocksMapping =

--- a/mage_ai/frontend/components/Triggers/Table.tsx
+++ b/mage_ai/frontend/components/Triggers/Table.tsx
@@ -256,7 +256,7 @@ function TriggersTable({
       ]);
     }
 
-    if (!isViewer()) {
+    if (!isViewer(router?.basePath)) {
       columnFlex.push(...[null]);
       columns.push(...[
         {
@@ -578,7 +578,7 @@ function TriggersTable({
                   );
                 }
 
-                if (!isViewer()) {
+                if (!isViewer(router?.basePath)) {
                   rows.push(
                     <FlexContainer key={`edit_delete_buttons_${idx}`}>
                       <Button

--- a/mage_ai/frontend/components/VersionControl/GitActions.tsx
+++ b/mage_ai/frontend/components/VersionControl/GitActions.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import useWebSocket from 'react-use-websocket';
 import { useMutation } from 'react-query';
+import { useRouter } from 'next/router';
 
-import AuthToken from '@api/utils/AuthToken';
 import Button from '@oracle/elements/Button';
 import Checkbox from '@oracle/elements/Checkbox';
 import FlexContainer from '@oracle/components/FlexContainer';
@@ -22,7 +22,6 @@ import {
   PanelStyle,
   TerminalStyle,
 } from './GitActions.style';
-import { OAUTH2_APPLICATION_CLIENT_ID } from '@api/constants';
 import { getWebSocket } from '@api/utils/url';
 import { onSuccess } from '@api/utils/response';
 import { remove } from '@utils/array';
@@ -46,6 +45,7 @@ function GitActions({
   branch,
   fetchBranch,
 }: GitActionsProps) {
+  const router = useRouter();
   const [payload, setPayload] = useState<any>();
   const [confirmMessage, setConfirmMessage] = useState<string>();
   const [action, setAction] = useState<string>();
@@ -188,7 +188,7 @@ function GitActions({
     }
   }, [action, isValidating, updateStatus]);
   
-  const user = useMemo(() => getUser() || {}, []);
+  const user = useMemo(() => getUser(router?.basePath) || {}, [router?.basePath]);
   const sharedWebsocketData = useMemo(() => {
     const params = {
       term_name: user?.id ? `git_${user?.id}` : 'git',

--- a/mage_ai/frontend/components/VersionControl/Remote/index.tsx
+++ b/mage_ai/frontend/components/VersionControl/Remote/index.tsx
@@ -202,7 +202,7 @@ function Remote({
     {
       onSuccess: (response: any) => onSuccess(
         response, {
-          callback: () => window.location.href = `${router.basePath}/version-control`,
+          callback: () => window.location.href = `${router?.basePath}/version-control`,
           onErrorCallback: (response, errors) => {
             showError({
               errors,

--- a/mage_ai/frontend/components/settings/Dashboard/index.tsx
+++ b/mage_ai/frontend/components/settings/Dashboard/index.tsx
@@ -1,11 +1,11 @@
 import Dashboard from '@components/Dashboard';
 import VerticalSectionLinks from '@components/VerticalSectionLinks';
+import useGetUser from '@utils/hooks/useGetUser';
 import useProject from '@utils/models/project/useProject';
 import { BEFORE_WIDTH, BeforeStyle } from '@components/PipelineDetail/shared/index.style';
 import { BreadcrumbType } from '@components/shared/Header';
 import { SECTIONS } from './constants';
 import { UNIT } from '@oracle/styles/units/spacing';
-import { getUser } from '@utils/session';
 
 type SettingsDashboardProps = {
   after?: any;
@@ -36,7 +36,7 @@ function SettingsDashboard({
   uuidItemSelected,
   uuidWorkspaceSelected,
 }: SettingsDashboardProps) {
-  const user = getUser() || {};
+  const user = useGetUser() || {};
   const {
     projectPlatformActivated,
   } = useProject();

--- a/mage_ai/frontend/components/shared/Header/index.tsx
+++ b/mage_ai/frontend/components/shared/Header/index.tsx
@@ -81,7 +81,8 @@ function Header({
   });
 
   const themeContext = useContext(ThemeContext);
-  const userFromLocalStorage = getUser();
+  const router = useRouter();
+  const userFromLocalStorage = getUser(router?.basePath);
 
   const [commandCenterState, setCommandCenterState] = useState<CommandCenterStateEnum>(null);
   const [enableCommandCenterLoading, setEnableCommandCenterLoading] = useState<boolean>(false);
@@ -93,7 +94,6 @@ function Header({
   const menuRef = useRef(null);
   const projectRef = useRef(null);
   const refUserMenu = useRef(null);
-  const router = useRouter();
 
   const loggedIn = AuthToken.isLoggedIn();
   const {
@@ -186,7 +186,7 @@ function Header({
         .catch(() => {
           redirectToUrl('/');
         });
-    }, router.basePath);
+    }, router?.basePath);
   };
 
   const breadcrumbProjects = [];

--- a/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/router';
 
 import AddButton from '@components/shared/AddButton';
 import Badge from '@oracle/components/Badge';
@@ -116,7 +117,8 @@ function Toolbar({
   setSelectedRow,
   showDivider,
 }: ToolbarProps) {
-  const isViewerRole = isViewer();
+  const router = useRouter();
+  const isViewerRole = isViewer(router?.basePath);
   const addButtonMenuRef = useRef(null);
   const filterButtonMenuRef = useRef(null);
   const groupButtonMenuRef = useRef(null);

--- a/mage_ai/frontend/components/users/UserDetail.tsx
+++ b/mage_ai/frontend/components/users/UserDetail.tsx
@@ -83,12 +83,11 @@ function UserDetail({
   onCancel,
   slug,
 }: UserDetailPageProps) {
+  const router = useRouter();
   const {
     id: currentUserID,
     owner: isOwner,
-  } = getUser() || {};
-
-  const router = useRouter();
+  } = getUser(router?.basePath) || {};
 
   const [afterHidden, setAfterHidden] = useState(true);
   const [addingObjectType, setAddingObjectType] = useState(null);
@@ -162,12 +161,12 @@ function UserDetail({
 
             if (String(objectServer?.id) === String(currentUserID)) {
               setUser({
-                ...getUser(),
+                ...getUser(router?.basePath),
                 avatar: objectServer?.avatar,
                 first_name: objectServer?.first_name,
                 last_name: objectServer?.last_name,
                 username: objectServer?.username,
-              });
+              }, router?.basePath);
             }
 
             toast.success(

--- a/mage_ai/frontend/components/users/edit/Form/index.tsx
+++ b/mage_ai/frontend/components/users/edit/Form/index.tsx
@@ -13,6 +13,7 @@ import Text from '@oracle/elements/Text';
 import TextInput from '@oracle/elements/Inputs/TextInput';
 import UserType from '@interfaces/UserType';
 import api from '@api';
+import useGetUser from '@utils/hooks/useGetUser';
 import usePrevious from '@utils/usePrevious';
 import { ProjectTypeEnum } from '@interfaces/ProjectType';
 import {
@@ -22,7 +23,6 @@ import {
   UserFieldType,
 } from './constants';
 import { find, remove } from '@utils/array';
-import { getUser } from '@utils/session';
 import { isEmptyObject, selectKeys } from '@utils/hash';
 import { onSuccess } from '@api/utils/response';
 
@@ -56,7 +56,7 @@ function UserEditForm({
   const [profile, setProfile] = useState<UserType>(null);
   const {
     owner: isOwner,
-  } = getUser() || {};
+  } = useGetUser() || {};
 
   const { data: serverStatus } = api.statuses.list();
   const {

--- a/mage_ai/frontend/components/workspaces/Dashboard/index.tsx
+++ b/mage_ai/frontend/components/workspaces/Dashboard/index.tsx
@@ -2,10 +2,10 @@ import React, { useMemo } from 'react';
 import Dashboard from '@components/Dashboard';
 import ErrorsType from '@interfaces/ErrorsType';
 import api from '@api';
+import useGetUser from '@utils/hooks/useGetUser';
 import { BreadcrumbType } from '@components/shared/Header';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { WorkspacesPageNameEnum, buildNavigationItems } from './constants';
-import { getUser } from '@utils/session';
 
 type WorkspacesDashboardProps = {
   before?: any;
@@ -36,7 +36,7 @@ function WorkspacesDashboard({
     [dataStatus],
   );
 
-  const user = getUser() || {};
+  const user = useGetUser() || {};
 
   return (
     <Dashboard

--- a/mage_ai/frontend/interfaces/UserPropertiesType.ts
+++ b/mage_ai/frontend/interfaces/UserPropertiesType.ts
@@ -4,10 +4,13 @@ export default interface UserPropertiesType {
   id?: number | string;
 }
 
-export function buildUserProperties(userProperties: UserPropertiesType = {}) {
+export function buildUserProperties(
+  userProperties: UserPropertiesType = {},
+  basePath?: string,
+) {
   return {
     ...userProperties,
     groupId: getGroup()?.id,
-    id: getUser()?.id,
+    id: getUser(basePath)?.id,
   };
 }

--- a/mage_ai/frontend/oracle/elements/Head/index.tsx
+++ b/mage_ai/frontend/oracle/elements/Head/index.tsx
@@ -12,7 +12,7 @@ const Head = ({ children, defaultTitle = 'Mage', title }: HeadProps) => {
 
   return (
     <NextHead>
-      <link href={`${router.basePath}/favicon.ico`} rel="icon" />
+      <link href={`${router?.basePath}/favicon.ico`} rel="icon" />
 
       <title>{title ? `${title} | ${defaultTitle}` : defaultTitle}</title>
 

--- a/mage_ai/frontend/pages/manage/users/index.tsx
+++ b/mage_ai/frontend/pages/manage/users/index.tsx
@@ -23,7 +23,7 @@ import { queryFromUrl } from '@utils/url';
 function UsersListPage() {
   const router = useRouter();
   const [errors, setErrors] = useState<ErrorsType>(null);
-  const { owner: isOwner } = getUser() || {};
+  const { owner: isOwner } = getUser(router?.basePath) || {};
   const [query, setQuery] = useState<{
     add_new_user: boolean;
     user_id: number;

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1664,7 +1664,7 @@ function PipelineDetailPage({
         const { uuid } = resp.data.pipeline;
 
         if (pipelineUUID !== uuid) {
-          window.location.href = `${router.basePath}/pipelines/${uuid}/edit`;
+          window.location.href = `${router?.basePath}/pipelines/${uuid}/edit`;
         } else {
           fetchFiles();
           if (type !== pipeline?.type) {

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/settings/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/settings/index.tsx
@@ -37,7 +37,7 @@ function PipelineSettings({
               const { uuid } = resp.pipeline;
 
               if (pipelineUUID !== uuid) {
-                window.location.href = `${router.basePath}/pipelines/${uuid}/settings`;
+                window.location.href = `${router?.basePath}/pipelines/${uuid}/settings`;
               }
             }
           },

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/triggers/index.tsx
@@ -65,7 +65,7 @@ function PipelineSchedules({
   pipeline: pipelineProp,
 }: PipelineSchedulesProp) {
   const router = useRouter();
-  const isViewerRole = isViewer();
+  const isViewerRole = isViewer(router?.basePath);
   const pipelineUUID = pipelineProp.uuid;
 
   const { data } = api.pipelines.detail(pipelineUUID, {

--- a/mage_ai/frontend/pages/settings/account/profile.tsx
+++ b/mage_ai/frontend/pages/settings/account/profile.tsx
@@ -1,23 +1,14 @@
-import { useMemo } from 'react';
-
-import Panel from '@oracle/components/Panel';
 import UserDetail, { ObjectTypeEnum } from '@components/users/UserDetail';
 import PrivateRoute from '@components/shared/PrivateRoute';
 import SettingsDashboard from '@components/settings/Dashboard';
-import Spacing from '@oracle/elements/Spacing';
-import UserEditForm from '@components/users/edit/Form';
-import api from '@api';
-import { PADDING_UNITS } from '@oracle/styles/units/spacing';
+import useGetUser from '@utils/hooks/useGetUser';
 import {
   SECTION_ITEM_UUID_PROFILE,
   SECTION_UUID_ACCOUNT,
 } from '@components/settings/Dashboard/constants';
-import { getUser } from '@utils/session';
 
 function ProfilePage() {
-  const { id } = getUser() || {};
-  // const { data, mutate: fetchUser } = api.users.detail(id);
-  // const user = data?.user;
+  const { id } = useGetUser() || {};
 
   return (
     <SettingsDashboard

--- a/mage_ai/frontend/pages/settings/workspace/users/index.tsx
+++ b/mage_ai/frontend/pages/settings/workspace/users/index.tsx
@@ -27,7 +27,7 @@ function UsersListPage() {
   const {
     id: currentUserID,
     owner: isOwner,
-  } = getUser() || {};
+  } = getUser(router?.basePath) || {};
 
   const { data } = api.users.list({}, {
     revalidateOnFocus: false,

--- a/mage_ai/frontend/utils/hooks/useGetUser.ts
+++ b/mage_ai/frontend/utils/hooks/useGetUser.ts
@@ -1,0 +1,12 @@
+import { useRouter } from 'next/router';
+
+import { getUser } from '../session';
+
+function useGetUser() {
+  const router = useRouter();
+  const basePath = router?.basePath;
+
+  return getUser(basePath);
+}
+
+export default useGetUser;

--- a/mage_ai/frontend/utils/routing.ts
+++ b/mage_ai/frontend/utils/routing.ts
@@ -59,7 +59,7 @@ export function goToWithQuery(query, opts: GoToWithQueryProps = {}) {
 
   let newUrl = `${href.split('?')[0]}${qString}`;
 
-  const basePath = Router.router.basePath;
+  const basePath = Router.router?.basePath;
   if (basePath && newUrl.startsWith(basePath)) {
     newUrl = newUrl.replace(basePath, '');
   }

--- a/mage_ai/frontend/utils/session.ts
+++ b/mage_ai/frontend/utils/session.ts
@@ -67,7 +67,7 @@ export const CURRENT_GROUP_LOCAL_STORAGE_KEY: string = 'current_group';
 export const CURRENT_GROUP_MEMBERSHIP_LOCAL_STORAGE_KEY: string = 'current_group_membership';
 export const CURRENT_USER_LOCAL_STORAGE_KEY: string = 'current_user';
 
-const getCurrentUserLocalStorageKey = (basePath?: string) => (
+export const getCurrentUserLocalStorageKey = (basePath?: string) => (
   basePath
     ? `${basePath}_${CURRENT_USER_LOCAL_STORAGE_KEY}`
     : CURRENT_USER_LOCAL_STORAGE_KEY

--- a/mage_ai/frontend/utils/session.ts
+++ b/mage_ai/frontend/utils/session.ts
@@ -67,6 +67,12 @@ export const CURRENT_GROUP_LOCAL_STORAGE_KEY: string = 'current_group';
 export const CURRENT_GROUP_MEMBERSHIP_LOCAL_STORAGE_KEY: string = 'current_group_membership';
 export const CURRENT_USER_LOCAL_STORAGE_KEY: string = 'current_user';
 
+const getCurrentUserLocalStorageKey = (basePath?: string) => (
+  basePath
+    ? `${basePath}_${CURRENT_USER_LOCAL_STORAGE_KEY}`
+    : CURRENT_USER_LOCAL_STORAGE_KEY
+);
+
 export function getGroup(ctx: any = undefined): GroupType | { id?: string } | undefined {
   if (ctx) {
     const cookie = ServerCookie(ctx);
@@ -99,19 +105,19 @@ export function removeGroup() {
   ls.remove(CURRENT_GROUP_LOCAL_STORAGE_KEY);
 }
 
-export function removeUser() {
+export function removeUser(basePath?: string) {
   // @ts-ignore
-  ls.remove(CURRENT_USER_LOCAL_STORAGE_KEY);
+  ls.remove(getCurrentUserLocalStorageKey(basePath));
 }
 
-export function getUser(): UserType | undefined {
+export function getUser(basePath?: string): UserType | undefined {
   // @ts-ignore
-  return ls.get(CURRENT_USER_LOCAL_STORAGE_KEY);
+  return ls.get(getCurrentUserLocalStorageKey(basePath));
 }
 
-export function setUser(user: UserType) {
+export function setUser(user: UserType, basePath?: string) {
   // @ts-ignore
-  ls.set(CURRENT_USER_LOCAL_STORAGE_KEY, user);
+  ls.set(getCurrentUserLocalStorageKey(basePath), user);
 }
 
 export function getGroupMembership(): GroupMembershipType | undefined {
@@ -135,8 +141,8 @@ export const isLoggedIn = (ctx: NextPageContext) => {
   return !!token;
 };
 
-export function isViewer(): boolean {
-  const user = getUser() || {};
+export function isViewer(basePath?: string): boolean {
+  const user = getUser(basePath) || {};
   return user.roles === RoleValueEnum.VIEWER ||
       user.project_access === UserAccessEnum.VIEWER;
 }


### PR DESCRIPTION
# Description
- Allow user with multiple Mage accounts to sign into different clusters on the same browser at the same time.
- There was an issue with the local storage clearing user profile data for a different account when the user signed out, so this PR makes the current user local storage key unique to the Mage deployment's base path. This doesn't affect users that use a single Mage deployment on their browser.

# How Has This Been Tested?
- Used different accounts to sign into multiple Mage cluster deployments with different base paths (but same domain). Signing out of one deployment did not affect the other user profile in local storage.

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
