### PR TITLE
[xy] Only run memory usage failure check when executor type is local python

### DIFF
--- a/mage_ai/orchestration/pipeline_scheduler_original.py
+++ b/mage_ai/orchestration/pipeline_scheduler_original.py
@@ -921,7 +921,8 @@ class PipelineScheduler:
             **tags,
         )
 
-        if memory_usage and memory_usage >= MEMORY_USAGE_MAXIMUM:
+        if memory_usage and memory_usage >= MEMORY_USAGE_MAXIMUM and \
+                ExecutorFactory.get_default_executor_type() == ExecutorType.LOCAL_PYTHON:
             self.memory_usage_failure(tags=tags)
 
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Only run memory usage failure check when executor type is local python.
When using external executor, the memory usage inside the scheduler isn't related to the pipeline execution.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
