### PR TITLE
Add trim reformat action to transformer block

### DIFF
--- a/docs/design/blocks/transformer-blocks.mdx
+++ b/docs/design/blocks/transformer-blocks.mdx
@@ -309,6 +309,7 @@ Reformats values in column based on requested action. The currently supported re
     | "-  3.42032 CAD" | -3.42032       |                                                 |
     | "Rs - 100000.23" | -100000.23     | Negation after symbol is supported              |
 - Convert string to datetime (`reformat = 'date_time_conversion'`): Converts a string value representing a datetime to a `pandas.Timestamp` object if correctly formatted, else converts to `None`.
+- Trim whitespace (`reformat = 'trim'`): Removes leading and trailing whitespace from text columns.
 
 **Example**:
 ```python
@@ -328,6 +329,7 @@ build_transformer_action(
     - `'caps_standardization'` - standardize capitalization
     - `'currency_to_num'` - convert currency string to number
     - `'date_format_conversion'` - convert datetime string to `pandas.Timestamp`
+    - `'trim'` - remove leading and trailing whitespace from text columns
   - `capitalization` (optional): Specifies the capitalization strategy to use when standardizing capitalization. This argument is ignored unless `reformat = "caps_standardization"`. Options are `['lowercase', 'uppercase']`.
 
 ## Column Removal Actions

--- a/docs/guides/blocks/transformer-blocks.mdx
+++ b/docs/guides/blocks/transformer-blocks.mdx
@@ -489,6 +489,7 @@ Reformats values in column based on requested action. The currently supported re
     | "-  3.42032 CAD" | -3.42032       |                                                 |
     | "Rs - 100000.23" | -100000.23     | Negation after symbol is supported              |
 - Convert string to datetime (`reformat = 'date_time_conversion'`): Converts a string value representing a datetime to a `pandas.Timestamp` object if correctly formatted, else converts to `None`.
+- Trim whitespace (`reformat = 'trim'`): Removes leading and trailing whitespace from text columns.
 
 **Example**:
 ```python
@@ -508,6 +509,7 @@ build_transformer_action(
     - `'caps_standardization'` - standardize capitalization
     - `'currency_to_num'` - convert currency string to number
     - `'date_format_conversion'` - convert datetime string to `pandas.Timestamp`
+    - `'trim'` - remove leading and trailing whitespace from text columns
   - `capitalization` (optional): Specifies the capitalization strategy to use when standardizing capitalization. This argument is ignored unless `reformat = "caps_standardization"`. Options are `['lowercase', 'uppercase']`.
 
 ## Column Removal Actions

--- a/mage_ai/data_cleaner/transformer_actions/column.py
+++ b/mage_ai/data_cleaner/transformer_actions/column.py
@@ -119,7 +119,8 @@ def impute(df, action, **kwargs):
                 mode = df[column].mode().iloc[0]
                 if dtype == ColumnType.LIST:
                     df[column] = df[column].apply(
-                        lambda element: element if element not in [None, np.nan] else mode
+                        lambda element, mode=mode: element if element not in [
+                            None, np.nan] else mode
                     )
                 else:
                     df[columns] = df[columns].fillna(mode)

--- a/mage_ai/data_cleaner/transformer_actions/column.py
+++ b/mage_ai/data_cleaner/transformer_actions/column.py
@@ -184,7 +184,6 @@ def reformat(df, action, **kwargs):
     columns = action['action_arguments']
     options = action['action_options']
     reformat_action = options['reformat']
-    df.loc[:, columns] = df[columns].replace(r'^\s*$', np.nan, regex=True)
 
     if reformat_action == 'caps_standardization':
         capitalization = options['capitalization']
@@ -193,6 +192,8 @@ def reformat(df, action, **kwargs):
                 df.loc[:, column] = df[columns][column].str.upper()
             else:
                 df.loc[:, column] = df[columns][column].str.lower()
+        # Convert empty strings to NaN for this action
+        df.loc[:, columns] = df[columns].replace(r'^\s*$', np.nan, regex=True)
     elif reformat_action == 'currency_to_num':
         for column in generate_string_cols(df, columns):
             clean_col = df[column].replace(CURRENCY_SYMBOLS, '', regex=True)
@@ -222,6 +223,9 @@ def reformat(df, action, **kwargs):
     elif reformat_action == 'trim':
         for column in columns:
             df[column] = df[column].str.strip()
+    else:
+        # Apply NaN replacement only for other actions
+        df.loc[:, columns] = df[columns].replace(r'^\s*$', np.nan, regex=True)
 
     return df
 

--- a/mage_ai/data_cleaner/transformer_actions/column.py
+++ b/mage_ai/data_cleaner/transformer_actions/column.py
@@ -1,3 +1,8 @@
+import logging
+
+import numpy as np
+import pandas as pd
+
 from mage_ai.data_cleaner.column_types.column_type_detector import find_syntax_errors
 from mage_ai.data_cleaner.column_types.constants import NUMBER_TYPES, ColumnType
 from mage_ai.data_cleaner.estimators.outlier_removal import OutlierRemover
@@ -15,11 +20,10 @@ from mage_ai.data_cleaner.transformer_actions.helpers import (
     get_time_window_str,
 )
 from mage_ai.data_cleaner.transformer_actions.udf.base import execute_udf
-from mage_ai.data_cleaner.transformer_actions.utils import clean_column_name, generate_string_cols
-import logging
-import pandas as pd
-import numpy as np
-
+from mage_ai.data_cleaner.transformer_actions.utils import (
+    clean_column_name,
+    generate_string_cols,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -215,6 +219,9 @@ def reformat(df, action, **kwargs):
             df.loc[:, column] = pd.to_datetime(
                 clean_col, infer_datetime_format=True, errors='coerce'
             )
+    elif reformat_action == 'trim':
+        for column in columns:
+            df[column] = df[column].str.strip()
 
     return df
 

--- a/mage_ai/tests/data_cleaner/transformer_actions/test_trim_transformer.py
+++ b/mage_ai/tests/data_cleaner/transformer_actions/test_trim_transformer.py
@@ -1,0 +1,161 @@
+import unittest
+
+import pandas as pd
+
+from mage_ai.data_cleaner.transformer_actions.base import BaseAction
+from mage_ai.data_cleaner.transformer_actions.constants import ActionType, Axis
+from mage_ai.data_cleaner.transformer_actions.utils import build_transformer_action
+
+
+class TestTrimTransformer(unittest.TestCase):
+    def test_basic_trimming(self):
+        df = pd.DataFrame({
+            'category': ['  A  ', '  B  ', '  C  ', '  D  ']
+        })
+
+        expected_output = pd.DataFrame({
+            'category': ['A', 'B', 'C', 'D']
+        })
+
+        action = build_transformer_action(
+            df,
+            action_type=ActionType.REFORMAT,
+            arguments=['category'],
+            axis=Axis.COLUMN,
+            options={'reformat': 'trim'}
+        )
+
+        output = BaseAction(action).execute(df)
+
+        pd.testing.assert_frame_equal(output, expected_output)
+        print("Test 1 (Basic Trimming): Passed")
+
+    def test_no_trimming_needed(self):
+        df = pd.DataFrame({
+            'category': ['A', 'B', 'C', 'D']
+        })
+
+        expected_output = df.copy()
+
+        action = build_transformer_action(
+            df,
+            action_type=ActionType.REFORMAT,
+            arguments=['category'],
+            axis=Axis.COLUMN,
+            options={'reformat': 'trim'}
+        )
+
+        output = BaseAction(action).execute(df)
+
+        pd.testing.assert_frame_equal(output, expected_output)
+        print("Test 2 (No Trimming Needed): Passed")
+
+    def test_mixed_content(self):
+        df = pd.DataFrame({
+            'category': ['  A  ', 'B', '  C', 'D  ']
+        })
+
+        expected_output = pd.DataFrame({
+            'category': ['A', 'B', 'C', 'D']
+        })
+
+        action = build_transformer_action(
+            df,
+            action_type=ActionType.REFORMAT,
+            arguments=['category'],
+            axis=Axis.COLUMN,
+            options={'reformat': 'trim'}
+        )
+
+        output = BaseAction(action).execute(df)
+
+        pd.testing.assert_frame_equal(output, expected_output)
+        print("Test 3 (Mixed Content): Passed")
+
+    def test_multiple_columns(self):
+        df = pd.DataFrame({
+            'category': ['  A  ', '  B  ', '  C  ', '  D  '],
+            'subcategory': ['  X  ', 'Y  ', '  Z', ' W ']
+        })
+
+        expected_output = pd.DataFrame({
+            'category': ['A', 'B', 'C', 'D'],
+            'subcategory': ['X', 'Y', 'Z', 'W']
+        })
+
+        action = build_transformer_action(
+            df,
+            action_type=ActionType.REFORMAT,
+            arguments=['category', 'subcategory'],
+            axis=Axis.COLUMN,
+            options={'reformat': 'trim'}
+        )
+
+        output = BaseAction(action).execute(df)
+
+        pd.testing.assert_frame_equal(output, expected_output)
+        print("Test 4 (Multiple Columns): Passed")
+
+    def test_empty_strings(self):
+        df = pd.DataFrame({
+            'category': ['  ', '  B  ', '  ', '  D  ']
+        })
+
+        expected_output = pd.DataFrame({
+            'category': ['', 'B', '', 'D']
+        })
+
+        action = build_transformer_action(
+            df,
+            action_type=ActionType.REFORMAT,
+            arguments=['category'],
+            axis=Axis.COLUMN,
+            options={'reformat': 'trim'}
+        )
+
+        output = BaseAction(action).execute(df)
+
+        pd.testing.assert_frame_equal(output, expected_output)
+        print("Test 5 (Empty Strings): Passed")
+
+    def test_no_columns_to_trim(self):
+        df = pd.DataFrame({
+            'category': ['  A  ', '  B  ', '  C  ', '  D  ']
+        })
+
+        expected_output = df.copy()
+
+        action = build_transformer_action(
+            df,
+            action_type=ActionType.REFORMAT,
+            arguments=[],
+            axis=Axis.COLUMN,
+            options={'reformat': 'trim'}
+        )
+
+        output = BaseAction(action).execute(df)
+
+        pd.testing.assert_frame_equal(output, expected_output)
+        print("Test 6 (No Columns to Trim): Passed")
+
+    def test_column_not_found(self):
+        df = pd.DataFrame({
+            'category': ['  A  ', '  B  ', '  C  ', '  D  ']
+        })
+
+        with self.assertRaises(KeyError):
+            action = build_transformer_action(
+                df,
+                action_type=ActionType.REFORMAT,
+                arguments=['nonexistent_column'],
+                axis=Axis.COLUMN,
+                options={'reformat': 'trim'}
+            )
+
+            BaseAction(action).execute(df)
+
+        print("Test 7 (Column Not Found): Passed")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This PR adds a new `trim` reformat action to the Python transformer block, which removes leading and trailing whitespace from specified text columns. My motivation for this PR is to start contributing to the Mage project!

No additional dependencies are required for this change.
<img width="796" alt="image" src="https://github.com/user-attachments/assets/0142f3cc-0828-48d3-b8b0-9b27f0bdf471">

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Specific unit tests for the `trim` action.
  - [x]  Basic trimming functionality
  - [x] Values that don't need to be trimmed
  - [x] Some values with trailing & leading spaces, some without
  - [x] Multiple columns with values that need trimming
  - [x] Empty strings (remains an empty string, not NaN)
  - [x] No columns to trim
  - [x] Column not found
- [x] ./scripts/server/test.sh which ran those unit tests.


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc: @wangxiaoyou1993 @johnson-mage 
<!-- Optionally mention someone to let them know about this pull request -->

