### PR TITLE
[jk] Update condition for cookie secure property

### DIFF
--- a/mage_ai/frontend/utils/cookies/constants.ts
+++ b/mage_ai/frontend/utils/cookies/constants.ts
@@ -1,4 +1,4 @@
-import { isProduction } from '@utils/environment';
+import { isSecureProtocol } from '@utils/environment';
 
 export const COOKIE_DOMAIN: string = typeof window === 'undefined' ? null : window.location.hostname;
 export const COOKIE_PATH: string = '/';
@@ -7,7 +7,7 @@ export const SHARED_COOKIE_PROPERTIES: any = {
   domain: COOKIE_DOMAIN,
   path: COOKIE_PATH,
   sameSite: 'Strict',
-  secure: isProduction(),
+  secure: isSecureProtocol(),
 };
 
 export const COOKIE_KEY_INITIAL_AS_PATH = 'initial_as_path';

--- a/mage_ai/frontend/utils/environment.ts
+++ b/mage_ai/frontend/utils/environment.ts
@@ -2,6 +2,13 @@ export function isProduction() {
   return typeof process !== 'undefined' && process.env.NODE_ENV === 'production';
 }
 
+export function isSecureProtocol() {
+  if (typeof window !== 'undefined') {
+    return window.location.protocol === 'https:';
+  }
+  return false;
+}
+
 export function logRender(uuid) {
   if (!isProduction()) {
     console.log(uuid);


### PR DESCRIPTION
# Description
- The `secure` cookie property was causing login issues if the user was running Mage not on localhost and not with `https`. This PR updates the condition that was setting the `secure` property to `true`. Previously, it checked if the `NODE_ENV` environment variable was `production`, but the FE production build could still have a "production" `NODE_ENV` environment variable set while still using the `http` protocol.

# How Has This Been Tested?
- Tested locally in Chrome, Safari, and Firefox.

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
