### PR TITLE
enhancement: bump duckdb to 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ boto3==1.26.60
 botocore==1.29.60
 clickhouse-connect~=0.6.23
 db-dtypes==1.0.5
-duckdb==0.9.2
+duckdb==1.0.0
 google-api-core~=2.15.0
 google-api-python-client~=2.70.0
 google-cloud-bigquery~=3.14.1


### PR DESCRIPTION
# Description
DuckDB Version 0.9.2 is old and causing conflicts with MotherDuck.
This commit updates the Version to 1.0.0 which resolves the compatibility issue.
DuckDB 1.0.0 introduces some [new features](https://duckdb.org/2024/06/03/announcing-duckdb-100.html) and is currently the stable version of DuckDB.


# How Has This Been Tested?
We use this package in production at MotherDuck.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
