### PR TITLE
[jk] Update test ENV value

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,6 +16,9 @@ on:
       - "requirements.txt"
       - "setup.py"
 
+env:
+  ENV: test_mage
+
 jobs:
   check-code-quality:
 

--- a/mage_ai/shared/constants.py
+++ b/mage_ai/shared/constants.py
@@ -3,7 +3,7 @@ from enum import Enum
 ENV_DEV = 'dev'
 ENV_PROD = 'prod'
 ENV_STAGING = 'staging'
-ENV_TEST = 'test'
+ENV_TEST = 'test_mage'
 
 VALID_ENVS = frozenset([
     ENV_DEV,

--- a/mage_ai/shared/environments.py
+++ b/mage_ai/shared/environments.py
@@ -17,7 +17,7 @@ def is_dev():
 
 
 def is_test():
-    return os.getenv('ENV', None) == 'test' or any('unittest' in v for v in sys.argv)
+    return os.getenv('ENV', None) == 'test_mage' or any('unittest' in v for v in sys.argv)
 
 
 def is_production():


### PR DESCRIPTION
# Description
- Using `test` as the value for the `ENV` environment variable for running unit tests could cause the test db to conflict with the metadata db used by users in their own test environments. This PR updates the value used for `ENV` in the environment for running mage's unit tests.

# How Has This Been Tested?
Before:
- Using `test` for the `ENV` env var resulted in using the `test.db` file as the metadata db, even if postgres was set as the metadata db using the `MAGE_DATABASE_CONNECTION_URL` env var.

After:
Using `test` for the `ENV` env var did not result in using the `test.db` file as the metadata db. If postgres was set as the metadata db using the `MAGE_DATABASE_CONNECTION_URL` env var, postgres would be properly used as the metadata db. Confirmed by creating new users and verifying they were stored in the postgres db.

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
