### PR TITLE
SASL_SSL kafka Host Name Validation

### DIFF
--- a/mage_ai/streaming/sources/kafka.py
+++ b/mage_ai/streaming/sources/kafka.py
@@ -104,6 +104,8 @@ class KafkaSource(BaseSource):
 
             if self.config.ssl_config is not None and self.config.ssl_config.cafile:
                 consumer_kwargs['ssl_cafile'] = self.config.ssl_config.cafile
+                consumer_kwargs[
+                    'ssl_check_hostname'] = self.config.ssl_config.check_hostname
         elif self.config.security_protocol == SecurityProtocol.SASL_PLAINTEXT:
             consumer_kwargs['security_protocol'] = SecurityProtocol.SASL_PLAINTEXT
             consumer_kwargs['sasl_mechanism'] = self.config.sasl_config.mechanism


### PR DESCRIPTION

# Description
Hostname validation was not working properly for SASL_SSL security protocol. Always connector was validating the hostname against the SSL, added a logic to disable this validation as well.
This issue was reported by multiple people.

This is associated with the bug, https://github.com/mage-ai/mage-ai/issues/5031

# How Has This Been Tested?
Yes. 


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993  @tommydangerous 
