### PR TITLE
Update logger.py

### DIFF
--- a/mage_ai/data_preparation/logging/logger.py
+++ b/mage_ai/data_preparation/logging/logger.py
@@ -61,9 +61,9 @@ class DictLogger():
         )
 
         if error:
-            data['error'] = traceback.format_exc(),
-            data['error_stack'] = traceback.format_stack(),
-            data['error_stacktrace'] = str(error),
+            data['error'] = traceback.format_exc()
+            data['error_stack'] = traceback.format_stack()
+            data['error_stacktrace'] = str(error)
 
         msg = simplejson.dumps(
             merge_dict(self.logging_tags or dict(), merge_dict(kwargs, data)),


### PR DESCRIPTION
The error message you encountered is related to improper handling of traceback data in the DictLogger class. Specifically, the error arises from creating tuples unintentionally due to trailing commas, which leads to issues when serializing the log data into JSON.

Solution:

Remove the trailing commas to ensure that traceback.format_exc(), traceback.format_stack(), and str(error) return plain strings instead of tuples.