### PR TITLE
[jk] Fix typo for custom frequency in trigger review

### DIFF
--- a/mage_ai/frontend/components/Triggers/Edit/TriggerInteractions.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/TriggerInteractions.tsx
@@ -34,7 +34,7 @@ import { indexBy } from '@utils/array';
 import { shouldDisplayLocalTimezone } from '@components/settings/workspace/utils';
 import { useWindowSize } from '@utils/sizes';
 
-type TriggerInteractions = {
+type TriggerInteractionsType = {
   containerRef: any;
   date?: Date;
   interactions: InteractionType[];
@@ -77,7 +77,7 @@ function TriggerInteractions({
   time,
   triggerTypes,
   variables,
-}) {
+}: TriggerInteractionsType) {
   const interactionsMapping = useMemo(() => indexBy(interactions || [], ({ uuid }) => uuid), [
     interactions,
   ]);
@@ -97,7 +97,7 @@ function TriggerInteractions({
         uuid: blockUUID,
       } = block || {
         uuid: null,
-      }
+      };
 
       const blockInteractions = blockInteractionsMapping?.[blockUUID] || [];
       const hasBlockInteractions = blockInteractions?.length >= 1;
@@ -158,7 +158,7 @@ function TriggerInteractions({
         uuid: blockUUID,
       } = block || {
         uuid: null,
-      }
+      };
 
       const blockInteractions = blockInteractionsMapping?.[blockUUID] || [];
 
@@ -176,7 +176,7 @@ function TriggerInteractions({
           }: InteractionVariableType = variable;
 
           const value = variables?.[variableUUID];
-          const missingValue = typeof value === 'undefined'
+          const missingValue = typeof value === 'undefined';
           const invalid = required && missingValue;
           const Icon = INTERACTION_VARIABLE_VALUE_TYPE_ICON_MAPPING?.[types[0]] || Alphabet;
 
@@ -346,9 +346,12 @@ function TriggerInteractions({
                     monospace
                     muted={!pipelineSchedule?.schedule_interval}
                   >
-                    {pipelineSchedule?.schedule_interval && capitalizeRemoveUnderscoreLower(
-                      pipelineSchedule?.schedule_interval?.substring(1) || '',
-                    )}
+                    {pipelineSchedule?.schedule_interval
+                      && capitalizeRemoveUnderscoreLower(pipelineSchedule?.schedule_interval?.[0] === '@'
+                        ? (pipelineSchedule?.schedule_interval?.substring(1) || '')
+                        : (pipelineSchedule?.schedule_interval || ''),
+                      )
+                    }
                     {!pipelineSchedule?.schedule_interval && 'This is required'}
                   </Text>
                 </Spacing>,

--- a/mage_ai/frontend/components/Triggers/Edit/TriggerInteractions.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/TriggerInteractions.tsx
@@ -41,9 +41,7 @@ type TriggerInteractionsType = {
   pipeline: PipelineType;
   pipelineInteraction: PipelineInteractionType;
   pipelineSchedule: PipelineScheduleType;
-  setVariables: (prev: any) => {
-    [key: string]: any;
-  };
+  setVariables: (prev: any) => void;
   showSummary?: boolean;
   time?: TimeType;
   triggerTypes?: {


### PR DESCRIPTION
# Description
- The "Frequency" row for custom frequency triggers in the trigger edit "Review" tab were appearing as `Ustom` instead of `Custom`. This PR fixes this.
- Addresses item `#2`in https://github.com/mage-ai/mage-ai/issues/5376

# How Has This Been Tested?
![image](https://github.com/user-attachments/assets/2b03100c-b5db-4956-9fdf-c370d7b111de)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
