### PR TITLE
Update the development document to resolve one issue encountered

### DIFF
--- a/README_dev.md
+++ b/README_dev.md
@@ -91,7 +91,11 @@ Install additional dev dependencies from `pyproject.toml`:
 pip install $(python -c "import toml; print(' '.join(toml.load('pyproject.toml')['tool']['poetry']['group']['dev']['dependencies'].keys()))" | tr '\n' ' ')
 ```
 
-The above command uses the `toml` library to output the dev dependencies from the `pyproject.toml` as a space-delimited list, and passes that output to the `pip install` command.
+The above command uses the `toml` library to output the dev dependencies from the `pyproject.toml` as a space-delimited list, and passes that output to the `pip install` command. If you encounter the error: `ModuleNotFoundError: No module named 'toml'`, try running the following command instead:
+
+```bash
+pip install $(python3 -c "import toml; print(' '.join(toml.load('pyproject.toml')['tool']['poetry']['group']['dev']['dependencies'].keys()))" | tr '\n' ' ')
+```
 
 ## Mage frontend
 


### PR DESCRIPTION
# Description

On Mac, when running the following command:

```
pip install $(python -c "import toml; print(' '.join(toml.load('pyproject.toml')['tool']['poetry']['group']['dev']['dependencies'].keys()))" | tr '\n' ' ')
```

The `python` executable could be pointing to that of the system installed version, and leads to the following error:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'toml'
ERROR: You must give at least one requirement to install (see "pip help install")
```

Using the command with `python3` in the updated document would work.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [X] Tested the command in the updated document on Mac without issues.

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 