### PR TITLE
Update unit tests to use the methods compatible with Python 3.12

### DIFF
--- a/mage_ai/tests/data_preparation/models/block/dbt/test_profiles.py
+++ b/mage_ai/tests/data_preparation/models/block/dbt/test_profiles.py
@@ -85,7 +85,7 @@ target: dev
             lambda: MockUUID(),
         ):
             with Profiles(self.repo_path, self.variables) as profiles:
-                self.assertNotEquals(
+                self.assertNotEqual(
                     profiles.profiles_dir,
                     self.repo_path
                 )

--- a/mage_ai/tests/data_preparation/sync/test_git_sync.py
+++ b/mage_ai/tests/data_preparation/sync/test_git_sync.py
@@ -22,8 +22,8 @@ class GitSyncTest(DBTestCase):
 
         git_sync.sync_data()
 
-        git_manager_instance_mock.reset_hard.called_once_with(branch='dev')
-        git_manager_instance_mock.submodules_update.not_called()
+        git_manager_instance_mock.reset_hard.assert_called_once_with(branch='dev')
+        git_manager_instance_mock.submodules_update.assert_not_called()
 
         with open(os.path.join(self.repo_path, '.preferences.yaml'), 'r') as f:
             preferences = yaml.safe_load(f)
@@ -42,8 +42,8 @@ class GitSyncTest(DBTestCase):
 
         git_sync.sync_data()
 
-        git_manager_instance_mock.reset_hard.called_once_with(branch='dev')
-        git_manager_instance_mock.submodules_update.called_once()
+        git_manager_instance_mock.reset_hard.assert_called_once_with(branch='dev')
+        git_manager_instance_mock.submodules_update.assert_called_once()
 
         with open(os.path.join(self.repo_path, '.preferences.yaml'), 'r') as f:
             preferences = yaml.safe_load(f)
@@ -63,7 +63,7 @@ class GitSyncTest(DBTestCase):
 
         git_sync.sync_data()
 
-        git_manager_instance_mock.reset_hard.called_once_with(branch='dev')
+        git_manager_instance_mock.reset_hard.assert_called_once_with(branch='dev')
 
         self.assertFalse(os.path.exists(preferences_file_path))
 
@@ -77,4 +77,4 @@ class GitSyncTest(DBTestCase):
 
         git_sync.reset()
 
-        git_manager_instance_mock.clone.called_once_with(sync_submodules=False)
+        git_manager_instance_mock.clone.assert_called_once_with(sync_submodules=False)

--- a/mage_ai/tests/settings/test_platform.py
+++ b/mage_ai/tests/settings/test_platform.py
@@ -205,12 +205,12 @@ class PlatformSettingsTest(ProjectPlatformMixin):
         ))
 
     def test_platform_settings_full_path(self):
-        self.assertEquals(
+        self.assertEqual(
             platform_settings_full_path(), os.path.join(base_repo_path(), 'settings.yaml'),
         )
 
     def test_local_platform_settings_full_path(self):
-        self.assertEquals(
+        self.assertEqual(
             local_platform_settings_full_path(), os.path.join(base_repo_path(), '.settings.yaml'),
         )
 


### PR DESCRIPTION
# Description

In Python 3.12, the following two methods are fully deprecated and would lead to unit test failures:

```
assertEquals
assertNotEquals
```

e.g.,

```
ERROR: test_interpolate_clean (tests.data_preparation.models.block.dbt.test_profiles.ProfilesTest.test_interpolate_clean)
Test the Profiles Interface by
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/unittest/async_case.py", line 90, in _callTestMethod
    if self._callMaybeAsync(method) is not None:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/unittest/async_case.py", line 117, in _callMaybeAsync
    return self._asyncioTestContext.run(func, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hw/workspace/dev/mage-ai/mage_ai/tests/data_preparation/models/block/dbt/test_profiles.py", line 88, in test_interpolate_clean
    self.assertNotEquals(
    ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ProfilesTest' object has no attribute 'assertNotEquals'. Did you mean: 'assertNotEqual'?
```

These two methods have been changed to the equivalent ones, i.e., 

```
assertEqual
assertNotEqual
```

In addition, the following methods are invalid assertions, that lead to unit test errors in Python 3.12:

```
called_once_with
called_once
not_called
```

which have been updated to valid ones:

```
assert_called_once_with
assert_called_once
assert_not_called
```

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [X] Tested in a local development environment

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 