### PR TITLE
Added the SSL Configurations to SASL

### DIFF
--- a/mage_ai/streaming/sinks/kafka.py
+++ b/mage_ai/streaming/sinks/kafka.py
@@ -89,8 +89,17 @@ class KafkaSink(BaseSink):
             kwargs['sasl_plain_username'] = self.config.sasl_config.username
             kwargs['sasl_plain_password'] = self.config.sasl_config.password
 
-            if self.config.ssl_config is not None and self.config.ssl_config.cafile:
-                kwargs['ssl_cafile'] = self.config.ssl_config.cafile
+            if self.config.ssl_config:
+                kwargs[
+                    'ssl_check_hostname'] = self.config.ssl_config.check_hostname
+                if self.config.ssl_config.cafile:
+                    kwargs['ssl_cafile'] = self.config.ssl_config.cafile
+                if self.config.ssl_config.certfile:
+                    kwargs['ssl_certfile'] = self.config.ssl_config.certfile
+                if self.config.ssl_config.keyfile:
+                    kwargs['ssl_keyfile'] = self.config.ssl_config.keyfile
+                if self.config.ssl_config.password:
+                    kwargs['ssl_password'] = self.config.ssl_config.password
 
         self.producer = KafkaProducer(**kwargs)
         self._print('Finish initializing producer.')


### PR DESCRIPTION
SSL handling was not done for the SASL protocol in Kafka sink. Now added the fix for it.

#Description
The below configuration is allowed in the kafka sink and it was working only for SSL security ptotocol. But when the security protocol is SASL_SSL the below configurations were not taking. Now added the fix for it.

ssl_config:
cafile: "CARoot.pem"
certfile: "certificate.pem"
keyfile: "key.pem"
password: password
check_hostname: true

#How Has This Been Tested?
Tested the same using the SASL_SSL connectivity and ensured that it's working.

cc: @wangxiaoyou1993 