### PR TITLE
Add support to scheduler name on k8s executor

### DIFF
--- a/mage_ai/services/k8s/config.py
+++ b/mage_ai/services/k8s/config.py
@@ -58,6 +58,7 @@ class K8sExecutorConfig(BaseConfig):
         service_account_name = DEFAULT_SERVICE_ACCOUNT_NAME
         affinity = None
         node_selector = None
+        scheduler_name = None
         tolerations = []
         volumes = []
         image_pull_secrets = {}
@@ -71,6 +72,8 @@ class K8sExecutorConfig(BaseConfig):
 
             if executor_config.pod.get('node_selector'):
                 node_selector = executor_config.pod['node_selector']
+            if executor_config.pod.get('scheduler_name'):
+                scheduler_name = executor_config.pod['scheduler_name']
 
             if executor_config.pod.get('tolerations'):
                 tolerations += [V1Toleration(**e) for e in executor_config.pod['tolerations']]
@@ -123,6 +126,7 @@ class K8sExecutorConfig(BaseConfig):
             containers=[container],
             image_pull_secrets=image_pull_secrets,
             node_selector=node_selector,
+            scheduler_name=scheduler_name,
             restart_policy='Never',
             service_account_name=service_account_name,
             tolerations=tolerations,

--- a/mage_ai/services/k8s/job_manager.py
+++ b/mage_ai/services/k8s/job_manager.py
@@ -172,6 +172,8 @@ class JobManager():
             pod_spec.tolerations = mage_server_pod_spec.tolerations
         if not pod_spec.node_selector:
             pod_spec.node_selector = mage_server_pod_spec.node_selector
+        if not pod_spec.scheduler_name:
+            pod_spec.scheduler_name = mage_server_pod_spec.scheduler_name
         pod_spec.image_pull_secrets = pod_spec.image_pull_secrets if pod_spec.image_pull_secrets \
             else mage_server_pod_spec.image_pull_secrets
         return pod_spec


### PR DESCRIPTION
# Description
This PR introduces the ability to customize the Kubernetes scheduler options when using the Kubernetes Executor. It allows users to specify scheduler configurations directly, enhancing flexibility and control over pod scheduling behavior in Kubernetes environments.

Mentioned in [this issue](https://github.com/mage-ai/mage-ai/issues/5411)
# How Has This Been Tested?
- [x] Tested on k8s cluster
![image](https://github.com/user-attachments/assets/59d2e18d-9862-4703-b1fb-639e24eaaa84)
![image](https://github.com/user-attachments/assets/dcd06a75-638c-4a1d-9250-ffff99afa9fe)


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc: @wangxiaoyou1993 
