### PR TITLE
#5417 Fix bug: Can't use git with Bitbucket

### DIFF
--- a/mage_ai/data_preparation/git/utils.py
+++ b/mage_ai/data_preparation/git/utils.py
@@ -172,7 +172,10 @@ def get_access_token(git_config, repo_path: str) -> str:
 def build_authenticated_remote_url(remote_url: str, username: str, token: str) -> str:
     # https://[username]:[token]@github.com/[remote_url]
     url = urlsplit(remote_url)
-    url = url._replace(netloc=f'{username}:{token}@{url.netloc}')
+    if remote_url.startswith('https://bitbucket.org/'):
+        url = url._replace(netloc=f'x-token-auth:{token}@{url.netloc}')
+    else:
+        url = url._replace(netloc=f'{username}:{token}@{url.netloc}')
     return urlunsplit(url)
 
 


### PR DESCRIPTION
# Description
Based on this documentation from Bitbucket, there is a difference between Bitbucket and the other providers like Github in using auth-token

> The literal string x-token-auth as a substitute for username is required.
![Screenshot (86)](https://github.com/user-attachments/assets/9379c033-7afd-4b6a-926c-978cd1797767)

So I changed a little bit code in function build_authenticated_remote_url‎ to customize for bitbucket only.
I don't want to change too much in the other function because it should be isolated for only this function, the other functions are the same with the other providers
# How Has This Been Tested?
![Screenshot (84)](https://github.com/user-attachments/assets/b8fc2f8f-6c25-42f8-b14d-e595fcff28d1)

- Tested this code by updating code directly in lib file: /usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/git/utils.py and it worked

![Screenshot (85)](https://github.com/user-attachments/assets/a8fa16a1-1b52-48e6-9441-fded5470240c)

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
