### PR TITLE
Update a few unit tests that failed on Python 3.12

### DIFF
--- a/mage_ai/tests/orchestration/queue/test_process_queue.py
+++ b/mage_ai/tests/orchestration/queue/test_process_queue.py
@@ -33,9 +33,10 @@ class ProcessQueueTests(TestCase):
         self.assertFalse('block_run_3' in self.queue.job_dict)
         self.assertFalse('block_run_4' in self.queue.job_dict)
 
-    @patch('mage_ai.orchestration.queue.process_queue.poll_job_and_execute')
+    @patch.object(ProcessQueue, 'start_worker_pool')
     @patch('mage_ai.orchestration.queue.process_queue.psutil.pid_exists')
-    def test_has_job(self, mock_pid_exists, mock_poll_job_and_execute):
+    def test_has_job(self, mock_pid_exists, mock_start_worker_pool):
+        mock_start_worker_pool.return_value = None
         mock_pid_exists.return_value = True
 
         self.queue.job_dict['block_run_1'] = JobStatus.QUEUED

--- a/mage_ai/tests/streaming/sinks/test_generic_io.py
+++ b/mage_ai/tests/streaming/sinks/test_generic_io.py
@@ -54,7 +54,7 @@ TEST_DATABASES = [
 class GenericIOTests(TestCase):
     def setUp(self):
         super().setUp()
-        self.test_path = Path('./test')
+        self.test_path = Path(self.repo_path)
         self.test_config_path = self.test_path / 'io_config.yaml'
         sample_yaml = """
 test_profile:


### PR DESCRIPTION
# Description

When running on Python 3.12, a few unit tests failed. These tests have been updated to run without issues on Python 3.12.

```
ERROR: test_has_job (tests.orchestration.queue.test_process_queue.ProcessQueueTests.test_has_job)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/unittest/mock.py", line 1393, in patched
    return func(*newargs, **newkeywargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hw/workspace/dev/mage-ai/mage_ai/tests/orchestration/queue/test_process_queue.py", line 49, in test_has_job
    self.queue.enqueue('block_run_1', run_block)
  File "/Users/hw/workspace/dev/mage-ai/mage_ai/orchestration/queue/process_queue.py", line 121, in enqueue
    self.start_worker_pool()
  File "/Users/hw/workspace/dev/mage-ai/mage_ai/orchestration/queue/process_queue.py", line 198, in start_worker_pool
    self.worker_pool_proc.start()
  File "/usr/local/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
                  ^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/context.py", line 224, in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/context.py", line 289, in _Popen
    return Popen(process_obj)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/popen_spawn_posix.py", line 32, in __init__
    super().__init__(process_obj)
  File "/usr/local/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "/usr/local/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/popen_spawn_posix.py", line 47, in _launch
    reduction.dump(process_obj, fp)
  File "/usr/local/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
_pickle.PicklingError: Can't pickle <class 'unittest.mock.MagicMock'>: it's not the same object as unittest.mock.MagicMock

----------------------------------------------------------------------
Ran 4764 tests in 146.619s

FAILED (errors=1)
```
and
```
ERROR: test_init_client (mage_ai.tests.streaming.sinks.test_generic_io.GenericIOTests.test_init_client)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/unittest/mock.py", line 1393, in patched
    return func(*newargs, **newkeywargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hw/workspace/dev/mage-ai/mage_ai/tests/streaming/sinks/test_generic_io.py", line 60, in test_init_client
    mock_objects = self.__mock_objects(mock_import_module, mock_config_loader, database)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hw/workspace/dev/mage-ai/mage_ai/tests/streaming/sinks/test_generic_io.py", line 141, in __mock_objects
    generic_io_sink = GenericIOSink(dict(
                      ^^^^^^^^^^^^^^^^^^^
  File "/Users/hw/workspace/dev/mage-ai/mage_ai/streaming/sinks/base.py", line 25, in __init__
    self.init_client()
  File "/Users/hw/workspace/dev/mage-ai/mage_ai/streaming/sinks/generic_io.py", line 50, in init_client
    config_file_loader = ConfigFileLoader(config_path, self.config.profile)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hw/workspace/dev/mage-ai/mage_ai/io/config.py", line 501, in __init__
    with self.filepath.open('r') as fin:
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pathlib.py", line 1013, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/Users/hw/workspace/dev/mage-ai/test/io_config.yaml'

----------------------------------------------------------------------
Ran 1 test in 0.164s
```

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [X] Manually tested in a local development environment


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 