### PR TITLE
Fix kafka module related unit test failure issues in Python 3.12

### DIFF
--- a/mage_ai/streaming/sources/kafka.py
+++ b/mage_ai/streaming/sources/kafka.py
@@ -1,5 +1,11 @@
 import importlib
 import json
+import sys
+
+if sys.version_info >= (3, 12, 0):
+    import six
+    sys.modules['kafka.vendor.six.moves'] = six.moves
+
 import time
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List

--- a/mage_integrations/mage_integrations/destinations/kafka/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/kafka/__init__.py
@@ -2,6 +2,11 @@ import argparse
 import ast
 import json
 import sys
+
+if sys.version_info >= (3, 12, 0):
+    import six
+    sys.modules['kafka.vendor.six.moves'] = six.moves
+
 from typing import Dict, List
 
 from kafka import KafkaConsumer, KafkaProducer


### PR DESCRIPTION
# Description

Resolve the following unit test failure issue when running with Python 3.12:

```
ERROR: tests.streaming.sources.test_kafka (unittest.loader._FailedTest.tests.streaming.sources.test_kafka)
----------------------------------------------------------------------
ImportError: Failed to import test module: tests.streaming.sources.test_kafka
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/unittest/loader.py", line 396, in _find_test_path
    module = self._get_module_from_name(name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/unittest/loader.py", line 339, in _get_module_from_name
    __import__(name)
  File "/Users/hw/workspace/dev/mage-ai/mage_ai/tests/streaming/sources/test_kafka.py", line 3, in <module>
    from mage_ai.streaming.sources.kafka import KafkaSource
  File "/Users/hw/workspace/dev/mage-ai/mage_ai/streaming/sources/kafka.py", line 7, in <module>
    from kafka import KafkaConsumer, TopicPartition
  File "/Users/hw/workspace/dev/mage-ai/.venv/lib/python3.12/site-packages/kafka/__init__.py", line 23, in <module>
    from kafka.consumer import KafkaConsumer
  File "/Users/hw/workspace/dev/mage-ai/.venv/lib/python3.12/site-packages/kafka/consumer/__init__.py", line 3, in <module>
    from kafka.consumer.group import KafkaConsumer
  File "/Users/hw/workspace/dev/mage-ai/.venv/lib/python3.12/site-packages/kafka/consumer/group.py", line 13, in <module>
    from kafka.consumer.fetcher import Fetcher
  File "/Users/hw/workspace/dev/mage-ai/.venv/lib/python3.12/site-packages/kafka/consumer/fetcher.py", line 19, in <module>
    from kafka.record import MemoryRecords
  File "/Users/hw/workspace/dev/mage-ai/.venv/lib/python3.12/site-packages/kafka/record/__init__.py", line 1, in <module>
    from kafka.record.memory_records import MemoryRecords, MemoryRecordsBuilder
  File "/Users/hw/workspace/dev/mage-ai/.venv/lib/python3.12/site-packages/kafka/record/memory_records.py", line 27, in <module>
    from kafka.record.legacy_records import LegacyRecordBatch, LegacyRecordBatchBuilder
  File "/Users/hw/workspace/dev/mage-ai/.venv/lib/python3.12/site-packages/kafka/record/legacy_records.py", line 50, in <module>
    from kafka.codec import (
  File "/Users/hw/workspace/dev/mage-ai/.venv/lib/python3.12/site-packages/kafka/codec.py", line 9, in <module>
    from kafka.vendor.six.moves import range
ModuleNotFoundError: No module named 'kafka.vendor.six.moves'
```

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [X] Tested in a local development environment


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 