### PR TITLE
Split out unittest classes to avoid potential racing conditions when running in Python 3.11 and 3.12

### DIFF
--- a/mage_ai/ai/llm_pipeline_wizard.py
+++ b/mage_ai/ai/llm_pipeline_wizard.py
@@ -156,16 +156,18 @@ TEMPLATE_CLASSIFICATION_FUNCTION = [
                     "type": "string",
                     "description": "Programming language of the code block. "
                                    f"Default value is {BlockLanguage.__name__}__python.",
-                    "enum": [f"{BlockLanguage.__name__}__{type.name.lower()}"
-                             for type in BlockLanguage]
+                    "enum": [
+                        f"{BlockLanguage.__name__}__{type.name.lower()}"
+                        for type in BlockLanguage]
                 },
                 PipelineType.__name__: {
                     "type": "string",
                     "description": "Type of pipeline to build. Default value is "
                                    f"{PipelineType.__name__}__python if pipeline type "
                                    "is not mentioned in the description.",
-                    "enum": [f"{PipelineType.__name__}__{type.name.lower()}"
-                             for type in PipelineType]
+                    "enum": [
+                        f"{PipelineType.__name__}__{type.name.lower()}"
+                        for type in PipelineType]
                 },
                 ActionType.__name__: {
                     "type": "string",

--- a/mage_ai/tests/data_preparation/test_repo_manager.py
+++ b/mage_ai/tests/data_preparation/test_repo_manager.py
@@ -10,13 +10,10 @@ from mage_ai.data_preparation.repo_manager import (
     get_project_uuid,
     get_repo_config,
     init_project_uuid,
-    init_repo,
     set_project_uuid_from_metadata,
 )
 from mage_ai.settings.repo import MAGE_DATA_DIR_ENV_VAR
-from mage_ai.settings.utils import base_repo_path
 from mage_ai.tests.base_test import DBTestCase
-from mage_ai.tests.shared.mixins import ProjectPlatformMixin
 
 
 def mock_uuid_value():
@@ -134,63 +131,3 @@ class RepoManagerTest(DBTestCase):
         self.assertEqual(get_project_uuid(), '000000')
 
         os.remove(metadata_path)
-
-
-@patch('mage_ai.settings.platform.project_platform_activated', lambda: True)
-@patch('mage_ai.settings.repo.project_platform_activated', lambda: True)
-class RepoManagerProjectPlatformTest(ProjectPlatformMixin):
-    def test_init(self):
-        repo = RepoConfig(root_project=False)
-        self.assertFalse(repo.root_project)
-        self.assertEqual(repo.repo_path, os.path.join(base_repo_path(), 'mage_platform'))
-        self.assertEqual(repo.variables_dir, os.path.join(base_repo_path(), 'mage_platform'))
-
-        repo = RepoConfig(root_project=True)
-        self.assertTrue(repo.root_project)
-        self.assertEqual(repo.repo_path, base_repo_path())
-        self.assertEqual(repo.variables_dir, base_repo_path())
-
-    def test_from_dict(self):
-        repo = RepoConfig.from_dict(dict(), root_project=False)
-        self.assertFalse(repo.root_project)
-        self.assertEqual(repo.repo_path, os.path.join(base_repo_path(), 'mage_platform'))
-        self.assertEqual(repo.variables_dir, os.path.join(base_repo_path(), 'mage_platform'))
-
-        repo = RepoConfig.from_dict(dict(), root_project=True)
-        self.assertTrue(repo.root_project)
-        self.assertEqual(repo.repo_path, base_repo_path())
-        self.assertEqual(repo.variables_dir, base_repo_path())
-
-    def test_metadata_path(self):
-        repo = RepoConfig(root_project=False)
-        self.assertEqual(
-            repo.metadata_path, os.path.join(base_repo_path(), 'mage_platform/metadata.yaml'),
-        )
-
-        repo = RepoConfig(root_project=True)
-        self.assertEqual(repo.metadata_path, os.path.join(base_repo_path(), 'metadata.yaml'))
-
-    def test_get_repo_config(self):
-        repo = get_repo_config(root_project=False)
-        self.assertFalse(repo.root_project)
-        self.assertEqual(repo.repo_path, os.path.join(base_repo_path(), 'mage_platform'))
-        self.assertEqual(repo.variables_dir, os.path.join(base_repo_path(), 'mage_platform'))
-
-        repo = get_repo_config(root_project=True)
-        self.assertTrue(repo.root_project)
-        self.assertEqual(repo.repo_path, base_repo_path())
-        self.assertEqual(repo.variables_dir, base_repo_path())
-
-    def test_init_repo(self):
-        path = os.path.join(os.path.dirname(base_repo_path()), 'test2')
-        try:
-            shutil.rmtree(path)
-        except Exception:
-            pass
-        with patch('mage_ai.data_preparation.repo_manager.get_repo_config') as mock_get_repo_config:
-            init_repo(path, root_project=True)
-            mock_get_repo_config.assert_called_once_with(path, root_project=True)
-        try:
-            shutil.rmtree(path)
-        except Exception:
-            pass

--- a/mage_ai/tests/data_preparation/test_repo_manager_project_platform.py
+++ b/mage_ai/tests/data_preparation/test_repo_manager_project_platform.py
@@ -1,0 +1,67 @@
+import os
+import shutil
+from unittest.mock import patch
+
+from mage_ai.data_preparation.repo_manager import RepoConfig, get_repo_config, init_repo
+from mage_ai.settings.utils import base_repo_path
+from mage_ai.tests.shared.mixins import ProjectPlatformMixin
+
+
+@patch('mage_ai.settings.platform.project_platform_activated', lambda: True)
+@patch('mage_ai.settings.repo.project_platform_activated', lambda: True)
+class RepoManagerProjectPlatformTest(ProjectPlatformMixin):
+    def test_init(self):
+        repo = RepoConfig(root_project=False)
+        self.assertFalse(repo.root_project)
+        self.assertEqual(repo.repo_path, os.path.join(base_repo_path(), 'mage_platform'))
+        self.assertEqual(repo.variables_dir, os.path.join(base_repo_path(), 'mage_platform'))
+
+        repo = RepoConfig(root_project=True)
+        self.assertTrue(repo.root_project)
+        self.assertEqual(repo.repo_path, base_repo_path())
+        self.assertEqual(repo.variables_dir, base_repo_path())
+
+    def test_from_dict(self):
+        repo = RepoConfig.from_dict(dict(), root_project=False)
+        self.assertFalse(repo.root_project)
+        self.assertEqual(repo.repo_path, os.path.join(base_repo_path(), 'mage_platform'))
+        self.assertEqual(repo.variables_dir, os.path.join(base_repo_path(), 'mage_platform'))
+
+        repo = RepoConfig.from_dict(dict(), root_project=True)
+        self.assertTrue(repo.root_project)
+        self.assertEqual(repo.repo_path, base_repo_path())
+        self.assertEqual(repo.variables_dir, base_repo_path())
+
+    def test_metadata_path(self):
+        repo = RepoConfig(root_project=False)
+        self.assertEqual(
+            repo.metadata_path, os.path.join(base_repo_path(), 'mage_platform/metadata.yaml'),
+        )
+
+        repo = RepoConfig(root_project=True)
+        self.assertEqual(repo.metadata_path, os.path.join(base_repo_path(), 'metadata.yaml'))
+
+    def test_get_repo_config(self):
+        repo = get_repo_config(root_project=False)
+        self.assertFalse(repo.root_project)
+        self.assertEqual(repo.repo_path, os.path.join(base_repo_path(), 'mage_platform'))
+        self.assertEqual(repo.variables_dir, os.path.join(base_repo_path(), 'mage_platform'))
+
+        repo = get_repo_config(root_project=True)
+        self.assertTrue(repo.root_project)
+        self.assertEqual(repo.repo_path, base_repo_path())
+        self.assertEqual(repo.variables_dir, base_repo_path())
+
+    def test_init_repo(self):
+        path = os.path.join(os.path.dirname(base_repo_path()), 'test2')
+        try:
+            shutil.rmtree(path)
+        except Exception:
+            pass
+        with patch('mage_ai.data_preparation.repo_manager.get_repo_config') as mock_get_repo_config:
+            init_repo(path, root_project=True)
+            mock_get_repo_config.assert_called_once_with(path, root_project=True)
+        try:
+            shutil.rmtree(path)
+        except Exception:
+            pass

--- a/mage_ai/tests/data_preparation/test_variable_manager.py
+++ b/mage_ai/tests/data_preparation/test_variable_manager.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
@@ -10,12 +8,10 @@ from mage_ai.data_preparation.repo_manager import get_repo_config
 from mage_ai.data_preparation.variable_manager import (
     VariableManager,
     get_global_variable,
-    get_global_variables,
     set_global_variable,
 )
 from mage_ai.settings.repo import set_repo_path
 from mage_ai.tests.base_test import DBTestCase
-from mage_ai.tests.shared.mixins import ProjectPlatformMixin
 
 
 class VariableManagerTest(DBTestCase):
@@ -128,50 +124,3 @@ class VariableManagerTest(DBTestCase):
     #         get_global_variables(None, pipeline=pipeline), pipeline.variables
     #     )
     #     self.assertEqual(get_global_variables(pipeline.uuid), pipeline.variables)
-
-
-class VariableManagerProjectPlatformTests(ProjectPlatformMixin):
-    def test_get_global_variable(self):
-        with patch(
-            "mage_ai.data_preparation.variable_manager.project_platform_activated",
-            lambda: True,
-        ):
-            with patch(
-                "mage_ai.data_preparation.models.pipeline.project_platform_activated",
-                lambda: True,
-            ):
-                for settings in self.repo_paths.values():
-                    pipeline = Pipeline.create(
-                        self.faker.unique.name(),
-                        repo_path=settings["full_path"],
-                    )
-                    value = self.faker.unique.name()
-                    pipeline.variables = dict(mage=value)
-                    pipeline.save()
-
-                    self.assertEqual(get_global_variable(pipeline.uuid, "mage"), value)
-
-    def test_get_global_variables(self):
-        with patch(
-            "mage_ai.data_preparation.variable_manager.project_platform_activated",
-            lambda: True,
-        ):
-            with patch(
-                "mage_ai.data_preparation.models.pipeline.project_platform_activated",
-                lambda: True,
-            ):
-                for settings in self.repo_paths.values():
-                    pipeline = Pipeline.create(
-                        self.faker.unique.name(),
-                        repo_path=settings["full_path"],
-                    )
-                    pipeline.variables = self.faker.unique.name()
-                    pipeline.save()
-
-                    self.assertEqual(
-                        get_global_variables(None, pipeline=pipeline),
-                        pipeline.variables,
-                    )
-                    self.assertEqual(
-                        get_global_variables(pipeline.uuid), pipeline.variables
-                    )

--- a/mage_ai/tests/data_preparation/test_variable_manager_project_platform.py
+++ b/mage_ai/tests/data_preparation/test_variable_manager_project_platform.py
@@ -1,0 +1,55 @@
+from unittest.mock import patch
+
+from mage_ai.data_preparation.models.pipeline import Pipeline
+from mage_ai.data_preparation.variable_manager import (
+    get_global_variable,
+    get_global_variables,
+)
+from mage_ai.tests.shared.mixins import ProjectPlatformMixin
+
+
+class VariableManagerProjectPlatformTests(ProjectPlatformMixin):
+    def test_get_global_variable(self):
+        with patch(
+            "mage_ai.data_preparation.variable_manager.project_platform_activated",
+            lambda: True,
+        ):
+            with patch(
+                "mage_ai.data_preparation.models.pipeline.project_platform_activated",
+                lambda: True,
+            ):
+                for settings in self.repo_paths.values():
+                    pipeline = Pipeline.create(
+                        self.faker.unique.name(),
+                        repo_path=settings["full_path"],
+                    )
+                    value = self.faker.unique.name()
+                    pipeline.variables = dict(mage=value)
+                    pipeline.save()
+
+                    self.assertEqual(get_global_variable(pipeline.uuid, "mage"), value)
+
+    def test_get_global_variables(self):
+        with patch(
+            "mage_ai.data_preparation.variable_manager.project_platform_activated",
+            lambda: True,
+        ):
+            with patch(
+                "mage_ai.data_preparation.models.pipeline.project_platform_activated",
+                lambda: True,
+            ):
+                for settings in self.repo_paths.values():
+                    pipeline = Pipeline.create(
+                        self.faker.unique.name(),
+                        repo_path=settings["full_path"],
+                    )
+                    pipeline.variables = self.faker.unique.name()
+                    pipeline.save()
+
+                    self.assertEqual(
+                        get_global_variables(None, pipeline=pipeline),
+                        pipeline.variables,
+                    )
+                    self.assertEqual(
+                        get_global_variables(pipeline.uuid), pipeline.variables
+                    )


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

When test classes share some physical resources (e.g., file storage), some potential racing conditions could happen  in Python 3.11 and 3.12 if these classes are stored in one source file.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [X] Tested in a local development environment


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 