### PR TITLE
[xh]Pass OpenAI API key to OpenAI Library

### DIFF
--- a/mage_ai/ai/openai_client.py
+++ b/mage_ai/ai/openai_client.py
@@ -85,7 +85,7 @@ class OpenAIClient(AIClient):
             open_ai_config.openai_api_key or os.getenv('OPENAI_API_KEY')
         openai.api_key = openai_api_key
         self.llm = OpenAI(openai_api_key=openai_api_key, temperature=0)
-        self.openai_client = OpenAILib()
+        self.openai_client = OpenAILib(api_key=openai_api_key)
 
     def __chat_completion_request(self, messages):
         try:


### PR DESCRIPTION
# Description
Pass OpenAI API key to library

# How Has This Been Tested?
Tested in Mage UI when ENV openai key is not set. AI generated function still functionable.
![screenshot1](https://github.com/user-attachments/assets/d71633f0-3162-469a-96d2-584b9d32c1e9)

![screenshot2](https://github.com/user-attachments/assets/ef4fe009-e813-467d-ae92-d8ffbcc05a40)



# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

