### PR TITLE
[hw] Use the built-in IntEnum instead of creating a new class

### DIFF
--- a/mage_ai/shared/enum.py
+++ b/mage_ai/shared/enum.py
@@ -1,11 +1,8 @@
 try:
     # breaking change introduced in python 3.11
-    from enum import Enum, IntEnum, StrEnum
+    from enum import Enum, IntEnum, StrEnum  # noqa: F401
 except ImportError:  # pragma: no cover
-    from enum import Enum  # pragma: no cover
-
-    class IntEnum(int, Enum):  # pragma: no cover
-        pass  # pragma: no cover
+    from enum import Enum, IntEnum  # noqa: F401 # pragma: no cover
 
     class StrEnum(str, Enum):  # pragma: no cover
         pass  # pragma: no cover

--- a/mage_ai/tests/api/endpoints/test_blocks.py
+++ b/mage_ai/tests/api/endpoints/test_blocks.py
@@ -1,6 +1,4 @@
-import os
-
-from mage_ai.data_preparation.models.constants import BlockLanguage, BlockType
+from mage_ai.data_preparation.models.constants import BlockType
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.settings.repo import get_repo_path
 from mage_ai.tests.api.endpoints.mixins import (
@@ -11,7 +9,6 @@ from mage_ai.tests.api.endpoints.mixins import (
     build_list_endpoint_tests,
     build_update_endpoint_tests,
 )
-from mage_ai.tests.shared.mixins import DBTMixin
 
 
 def get_pipeline(self):
@@ -105,103 +102,6 @@ build_delete_endpoint_tests(
     assert_after_delete_count=lambda self: len(get_pipeline(self).blocks_by_uuid.values()) == 3,
     assert_before_delete_count=lambda self: len(get_pipeline(self).blocks_by_uuid.values()) == 4,
     get_resource_id=lambda self: list(get_pipeline(self).blocks_by_uuid.values())[3].uuid,
-    get_resource_parent_id=lambda self: self.pipeline.uuid,
-    resource='block',
-    resource_parent='pipelines',
-)
-
-
-class DBTBlockAPIEndpointTest(BaseAPIEndpointTest, DBTMixin):
-    pass
-
-
-def __assert_after_create(self):
-    pipeline = get_pipeline(self)
-    blocks = pipeline.blocks_by_uuid.values()
-    blocks_dbt = list(filter(
-        lambda x: x.type == BlockType.DBT and x.language == BlockLanguage.SQL,
-        blocks,
-    ))
-
-    self.assertEqual(len(blocks), 5)
-    self.assertEqual(len(blocks_dbt), 1)
-
-    block = blocks_dbt[0]
-    self.assertEqual({
-      'dbt_project_name': 'dbt/test_project',
-      'file_path': 'dbt/test_project/models/example/my_first_dbt_model.sql',
-      'file_source': {
-        'path': 'dbt/test_project/models/example/my_first_dbt_model.sql',
-        'project_path': 'dbt/test_project',
-      },
-    }, block.configuration)
-
-    return True
-
-
-def __assert_after_create_yaml(self):
-    pipeline = get_pipeline(self)
-    blocks = pipeline.blocks_by_uuid.values()
-    blocks_dbt = list(filter(
-        lambda x: x.type == BlockType.DBT and x.language == BlockLanguage.YAML,
-        blocks,
-    ))
-
-    self.assertEqual(len(blocks), 5)
-    self.assertEqual(len(blocks_dbt), 1)
-
-    block = blocks_dbt[0]
-    self.assertEqual({
-      'dbt_project_name': 'dbt/test_project',
-      'file_source': {
-        'path': 'dbts/dbt_yaml.yaml',
-        'project_path': 'dbt/test_project',
-      },
-    }, block.configuration)
-
-    return True
-
-
-build_create_endpoint_tests(
-    DBTBlockAPIEndpointTest,
-    assert_after_create_count=__assert_after_create,
-    assert_before_create_count=lambda self: len(get_pipeline(self).blocks_by_uuid.values()) == 4,
-    build_payload=lambda self: dict(
-        name=self.faker.unique.name(),
-        type=BlockType.DBT,
-        language=BlockLanguage.SQL,
-        configuration=dict(
-            file_path=os.path.join(
-                os.path.basename(self.dbt_directory),
-                'test_project',
-                'models',
-                'example',
-                'my_first_dbt_model.sql',
-            ),
-        ),
-    ),
-    get_resource_parent_id=lambda self: self.pipeline.uuid,
-    resource='block',
-    resource_parent='pipelines',
-)
-
-
-build_create_endpoint_tests(
-    DBTBlockAPIEndpointTest,
-    test_uuid='dbt_yaml',
-    assert_after_create_count=__assert_after_create_yaml,
-    assert_before_create_count=lambda self: len(get_pipeline(self).blocks_by_uuid.values()) == 4,
-    build_payload=lambda self: dict(
-        name='dbt_yaml',
-        type=BlockType.DBT,
-        language=BlockLanguage.YAML,
-        configuration=dict(
-            dbt_project_name=os.path.join(
-                os.path.basename(self.dbt_directory),
-                'test_project',
-            ),
-        ),
-    ),
     get_resource_parent_id=lambda self: self.pipeline.uuid,
     resource='block',
     resource_parent='pipelines',

--- a/mage_ai/tests/api/endpoints/test_configuration_options.py
+++ b/mage_ai/tests/api/endpoints/test_configuration_options.py
@@ -1,6 +1,5 @@
 import json
 import os
-from unittest.mock import patch
 
 from mage_ai.authentication.permissions.constants import EntityName
 from mage_ai.settings.models.configuration_option import ConfigurationType, OptionType
@@ -8,7 +7,7 @@ from mage_ai.tests.api.endpoints.mixins import (
     BaseAPIEndpointTest,
     build_list_endpoint_tests,
 )
-from mage_ai.tests.shared.mixins import DBTMixin, ProjectPlatformMixin
+from mage_ai.tests.shared.mixins import DBTMixin
 
 CURRENT_FILE_PATH = os.path.dirname(os.path.realpath(__file__))
 
@@ -50,50 +49,4 @@ build_list_endpoint_tests(
     ],
     assert_after=__assert_after_list,
     build_query=__build_query,
-)
-
-
-@patch('mage_ai.settings.platform.utils.project_platform_activated', lambda: True)
-@patch('mage_ai.settings.repo.project_platform_activated', lambda: True)
-class ConfigurationOptionProjectPlatformAPIEndpointTest(
-    DBTMixin,
-    ProjectPlatformMixin,
-    BaseAPIEndpointTest,
-):
-    pass
-
-
-def __assert_after_list2(self, result, **kwargs):
-    with open(os.path.join(
-        CURRENT_FILE_PATH,
-        'mocks',
-        'mock_dbt_configuration_options_project_platform.json',
-    )) as f:
-        self.assertEqual(
-            result,
-            json.loads(f.read()),
-        )
-
-
-build_list_endpoint_tests(
-    ConfigurationOptionProjectPlatformAPIEndpointTest,
-    list_count=1,
-    get_resource_parent_id=lambda test_case: test_case.pipeline.uuid,
-    resource='configuration_option',
-    resource_parent='pipeline',
-    result_keys_to_compare=[
-        'configuration_type',
-        'metadata',
-        'option',
-        'option_type',
-        'resource_type',
-        'uuid',
-    ],
-    assert_after=__assert_after_list2,
-    build_query=__build_query,
-    patch_function_settings=[
-        ('mage_ai.settings.models.configuration_option.project_platform_activated', lambda: True),
-        ('mage_ai.settings.platform.utils.project_platform_activated', lambda: True),
-        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
-    ],
 )

--- a/mage_ai/tests/api/endpoints/test_configuration_options_project_platform.py
+++ b/mage_ai/tests/api/endpoints/test_configuration_options_project_platform.py
@@ -1,0 +1,68 @@
+import json
+import os
+from unittest.mock import patch
+
+from mage_ai.authentication.permissions.constants import EntityName
+from mage_ai.settings.models.configuration_option import ConfigurationType, OptionType
+from mage_ai.tests.api.endpoints.mixins import (
+    BaseAPIEndpointTest,
+    build_list_endpoint_tests,
+)
+from mage_ai.tests.shared.mixins import DBTMixin, ProjectPlatformMixin
+
+CURRENT_FILE_PATH = os.path.dirname(os.path.realpath(__file__))
+
+
+def __build_query(test_case):
+    return dict(
+        configuration_type=[ConfigurationType.DBT],
+        option_type=[OptionType.PROJECTS],
+        resource_type=[EntityName.Block],
+        resource_uuid=[test_case.blocks[0].uuid],
+    )
+
+
+@patch('mage_ai.settings.platform.utils.project_platform_activated', lambda: True)
+@patch('mage_ai.settings.repo.project_platform_activated', lambda: True)
+class ConfigurationOptionProjectPlatformAPIEndpointTest(
+    DBTMixin,
+    ProjectPlatformMixin,
+    BaseAPIEndpointTest,
+):
+    pass
+
+
+def __assert_after_list2(self, result, **kwargs):
+    with open(os.path.join(
+        CURRENT_FILE_PATH,
+        'mocks',
+        'mock_dbt_configuration_options_project_platform.json',
+    )) as f:
+        self.assertEqual(
+            result,
+            json.loads(f.read()),
+        )
+
+
+build_list_endpoint_tests(
+    ConfigurationOptionProjectPlatformAPIEndpointTest,
+    list_count=1,
+    get_resource_parent_id=lambda test_case: test_case.pipeline.uuid,
+    resource='configuration_option',
+    resource_parent='pipeline',
+    result_keys_to_compare=[
+        'configuration_type',
+        'metadata',
+        'option',
+        'option_type',
+        'resource_type',
+        'uuid',
+    ],
+    assert_after=__assert_after_list2,
+    build_query=__build_query,
+    patch_function_settings=[
+        ('mage_ai.settings.models.configuration_option.project_platform_activated', lambda: True),
+        ('mage_ai.settings.platform.utils.project_platform_activated', lambda: True),
+        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
+    ],
+)

--- a/mage_ai/tests/api/endpoints/test_custom_designs.py
+++ b/mage_ai/tests/api/endpoints/test_custom_designs.py
@@ -1,15 +1,13 @@
 import json
 import os
-from unittest.mock import patch
 
 from mage_ai.data_preparation.models.project.constants import FeatureUUID
-from mage_ai.settings.utils import base_repo_path
 from mage_ai.tests.api.endpoints.mixins import (
     BaseAPIEndpointTest,
     build_detail_endpoint_tests,
     build_list_endpoint_tests,
 )
-from mage_ai.tests.shared.mixins import CustomDesignMixin, ProjectPlatformMixin
+from mage_ai.tests.shared.mixins import CustomDesignMixin
 
 CURRENT_FILE_PATH = os.path.dirname(os.path.realpath(__file__))
 
@@ -100,108 +98,5 @@ build_detail_endpoint_tests(
             ]),
             lambda feature_name, user=None, **kwargs: FeatureUUID.CUSTOM_DESIGN == feature_name,
         ),
-    ],
-)
-
-
-@patch('mage_ai.presenters.design.models.project_platform_activated', lambda: True)
-@patch('mage_ai.settings.platform.utils.project_platform_activated', lambda: True)
-@patch('mage_ai.settings.repo.project_platform_activated', lambda: True)
-class CustomDesignProjectPlatformAPIEndpointTest(
-    CustomDesignMixin,
-    ProjectPlatformMixin,
-    BaseAPIEndpointTest,
-):
-    pass
-
-
-def __assert_after_list2(self, result, **kwargs):
-    with open(os.path.join(CURRENT_FILE_PATH, 'mocks', 'mock_design_project_platform.json')) as f:
-        arr = json.loads(f.read())
-        for item in arr:
-            item['project']['full_path'] = os.path.join(
-                base_repo_path(),
-                item['project']['full_path'],
-            )
-            item['project']['root_project_full_path'] = base_repo_path()
-
-        self.assertEqual(
-            result.sort(key=lambda x: x['uuid']),
-            arr.sort(key=lambda x: x['uuid']),
-        )
-
-
-def __assert_after_detail2(self, result, **kwargs):
-    with open(os.path.join(CURRENT_FILE_PATH, 'mocks', 'mock_design_project_platform.json')) as f:
-        item = json.loads(f.read())[0]
-        item['project']['full_path'] = os.path.join(
-            base_repo_path(),
-            item['project']['full_path'],
-        )
-        item['project']['root_project_full_path'] = base_repo_path()
-
-        self.assertEqual(
-            result,
-            item,
-        )
-
-
-build_list_endpoint_tests(
-    CustomDesignProjectPlatformAPIEndpointTest,
-    list_count=2,
-    resource='custom_design',
-    result_keys_to_compare=[
-        'components',
-        'pages',
-        'project',
-        'uuid',
-    ],
-    assert_after=__assert_after_list2,
-    build_query=__build_query,
-    patch_function_settings=[
-        (
-            '.'.join([
-                'mage_ai',
-                'api',
-                'resources',
-                'CustomDesignResource',
-                'Project',
-                'is_feature_enabled_in_root_or_active_project',
-            ]),
-            lambda feature_name, user=None, **kwargs: FeatureUUID.CUSTOM_DESIGN == feature_name,
-        ),
-        ('mage_ai.presenters.design.models.project_platform_activated', lambda: True),
-        ('mage_ai.settings.platform.utils.project_platform_activated', lambda: True),
-        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
-    ],
-)
-
-
-build_detail_endpoint_tests(
-    CustomDesignProjectPlatformAPIEndpointTest,
-    resource='custom_design',
-    get_resource_id=lambda self: 'pipelines',
-    result_keys_to_compare=[
-        'components',
-        'pages',
-        'project',
-        'uuid',
-    ],
-    assert_after=__assert_after_detail2,
-    patch_function_settings=[
-        (
-            '.'.join([
-                'mage_ai',
-                'api',
-                'resources',
-                'CustomDesignResource',
-                'Project',
-                'is_feature_enabled_in_root_or_active_project',
-            ]),
-            lambda feature_name, user=None, **kwargs: FeatureUUID.CUSTOM_DESIGN == feature_name,
-        ),
-        ('mage_ai.presenters.design.models.project_platform_activated', lambda: True),
-        ('mage_ai.settings.platform.utils.project_platform_activated', lambda: True),
-        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
     ],
 )

--- a/mage_ai/tests/api/endpoints/test_custom_designs_project_platform.py
+++ b/mage_ai/tests/api/endpoints/test_custom_designs_project_platform.py
@@ -1,0 +1,132 @@
+import json
+import os
+from unittest.mock import patch
+
+from mage_ai.data_preparation.models.project.constants import FeatureUUID
+from mage_ai.settings.utils import base_repo_path
+from mage_ai.tests.api.endpoints.mixins import (
+    BaseAPIEndpointTest,
+    build_detail_endpoint_tests,
+    build_list_endpoint_tests,
+)
+from mage_ai.tests.shared.mixins import CustomDesignMixin, ProjectPlatformMixin
+
+CURRENT_FILE_PATH = os.path.dirname(os.path.realpath(__file__))
+
+
+@patch('mage_ai.presenters.design.models.project_platform_activated', lambda: True)
+@patch('mage_ai.settings.platform.utils.project_platform_activated', lambda: True)
+@patch('mage_ai.settings.repo.project_platform_activated', lambda: True)
+class CustomDesignProjectPlatformAPIEndpointTest(
+    CustomDesignMixin,
+    ProjectPlatformMixin,
+    BaseAPIEndpointTest,
+):
+    pass
+
+
+def __build_query(test_case):
+    return dict(
+        operation=test_case.faker.name(),
+        page_path=test_case.faker.name(),
+        page_pathname=test_case.faker.name(),
+        page_query=test_case.faker.name(),
+        page_type=test_case.faker.name(),
+        page_uuid=test_case.faker.name(),
+        resource=test_case.faker.name(),
+        resource_id=test_case.faker.name(),
+        resource_parent=test_case.faker.name(),
+        resource_parent_id=test_case.faker.name(),
+    )
+
+
+def __assert_after_list2(self, result, **kwargs):
+    with open(os.path.join(CURRENT_FILE_PATH, 'mocks', 'mock_design_project_platform.json')) as f:
+        arr = json.loads(f.read())
+        for item in arr:
+            item['project']['full_path'] = os.path.join(
+                base_repo_path(),
+                item['project']['full_path'],
+            )
+            item['project']['root_project_full_path'] = base_repo_path()
+
+        self.assertEqual(
+            result.sort(key=lambda x: x['uuid']),
+            arr.sort(key=lambda x: x['uuid']),
+        )
+
+
+def __assert_after_detail2(self, result, **kwargs):
+    with open(os.path.join(CURRENT_FILE_PATH, 'mocks', 'mock_design_project_platform.json')) as f:
+        item = json.loads(f.read())[0]
+        item['project']['full_path'] = os.path.join(
+            base_repo_path(),
+            item['project']['full_path'],
+        )
+        item['project']['root_project_full_path'] = base_repo_path()
+
+        self.assertEqual(
+            result,
+            item,
+        )
+
+
+build_list_endpoint_tests(
+    CustomDesignProjectPlatformAPIEndpointTest,
+    list_count=2,
+    resource='custom_design',
+    result_keys_to_compare=[
+        'components',
+        'pages',
+        'project',
+        'uuid',
+    ],
+    assert_after=__assert_after_list2,
+    build_query=__build_query,
+    patch_function_settings=[
+        (
+            '.'.join([
+                'mage_ai',
+                'api',
+                'resources',
+                'CustomDesignResource',
+                'Project',
+                'is_feature_enabled_in_root_or_active_project',
+            ]),
+            lambda feature_name, user=None, **kwargs: FeatureUUID.CUSTOM_DESIGN == feature_name,
+        ),
+        ('mage_ai.presenters.design.models.project_platform_activated', lambda: True),
+        ('mage_ai.settings.platform.utils.project_platform_activated', lambda: True),
+        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
+    ],
+)
+
+
+build_detail_endpoint_tests(
+    CustomDesignProjectPlatformAPIEndpointTest,
+    resource='custom_design',
+    get_resource_id=lambda self: 'pipelines',
+    result_keys_to_compare=[
+        'components',
+        'pages',
+        'project',
+        'uuid',
+    ],
+    assert_after=__assert_after_detail2,
+    patch_function_settings=[
+        (
+            '.'.join([
+                'mage_ai',
+                'api',
+                'resources',
+                'CustomDesignResource',
+                'Project',
+                'is_feature_enabled_in_root_or_active_project',
+            ]),
+            lambda feature_name, user=None, **kwargs: FeatureUUID.CUSTOM_DESIGN == feature_name,
+        ),
+        ('mage_ai.presenters.design.models.project_platform_activated', lambda: True),
+        ('mage_ai.settings.platform.utils.project_platform_activated', lambda: True),
+        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
+    ],
+)

--- a/mage_ai/tests/api/endpoints/test_dbt_blocks.py
+++ b/mage_ai/tests/api/endpoints/test_dbt_blocks.py
@@ -1,0 +1,111 @@
+import os
+
+from mage_ai.data_preparation.models.constants import BlockLanguage, BlockType
+from mage_ai.data_preparation.models.pipeline import Pipeline
+from mage_ai.settings.repo import get_repo_path
+from mage_ai.tests.api.endpoints.mixins import (
+    BaseAPIEndpointTest,
+    build_create_endpoint_tests,
+)
+from mage_ai.tests.shared.mixins import DBTMixin
+
+
+def get_pipeline(self):
+    return Pipeline.get(self.pipeline.uuid, repo_path=get_repo_path())
+
+
+class DBTBlockAPIEndpointTest(BaseAPIEndpointTest, DBTMixin):
+    pass
+
+
+def __assert_after_create(self):
+    pipeline = get_pipeline(self)
+    blocks = pipeline.blocks_by_uuid.values()
+    blocks_dbt = list(filter(
+        lambda x: x.type == BlockType.DBT and x.language == BlockLanguage.SQL,
+        blocks,
+    ))
+
+    self.assertEqual(len(blocks), 5)
+    self.assertEqual(len(blocks_dbt), 1)
+
+    block = blocks_dbt[0]
+    self.assertEqual({
+      'dbt_project_name': 'dbt/test_project',
+      'file_path': 'dbt/test_project/models/example/my_first_dbt_model.sql',
+      'file_source': {
+        'path': 'dbt/test_project/models/example/my_first_dbt_model.sql',
+        'project_path': 'dbt/test_project',
+      },
+    }, block.configuration)
+
+    return True
+
+
+def __assert_after_create_yaml(self):
+    pipeline = get_pipeline(self)
+    blocks = pipeline.blocks_by_uuid.values()
+    blocks_dbt = list(filter(
+        lambda x: x.type == BlockType.DBT and x.language == BlockLanguage.YAML,
+        blocks,
+    ))
+
+    self.assertEqual(len(blocks), 5)
+    self.assertEqual(len(blocks_dbt), 1)
+
+    block = blocks_dbt[0]
+    self.assertEqual({
+      'dbt_project_name': 'dbt/test_project',
+      'file_source': {
+        'path': 'dbts/dbt_yaml.yaml',
+        'project_path': 'dbt/test_project',
+      },
+    }, block.configuration)
+
+    return True
+
+
+build_create_endpoint_tests(
+    DBTBlockAPIEndpointTest,
+    assert_after_create_count=__assert_after_create,
+    assert_before_create_count=lambda self: len(get_pipeline(self).blocks_by_uuid.values()) == 4,
+    build_payload=lambda self: dict(
+        name=self.faker.unique.name(),
+        type=BlockType.DBT,
+        language=BlockLanguage.SQL,
+        configuration=dict(
+            file_path=os.path.join(
+                os.path.basename(self.dbt_directory),
+                'test_project',
+                'models',
+                'example',
+                'my_first_dbt_model.sql',
+            ),
+        ),
+    ),
+    get_resource_parent_id=lambda self: self.pipeline.uuid,
+    resource='block',
+    resource_parent='pipelines',
+)
+
+
+build_create_endpoint_tests(
+    DBTBlockAPIEndpointTest,
+    test_uuid='dbt_yaml',
+    assert_after_create_count=__assert_after_create_yaml,
+    assert_before_create_count=lambda self: len(get_pipeline(self).blocks_by_uuid.values()) == 4,
+    build_payload=lambda self: dict(
+        name='dbt_yaml',
+        type=BlockType.DBT,
+        language=BlockLanguage.YAML,
+        configuration=dict(
+            dbt_project_name=os.path.join(
+                os.path.basename(self.dbt_directory),
+                'test_project',
+            ),
+        ),
+    ),
+    get_resource_parent_id=lambda self: self.pipeline.uuid,
+    resource='block',
+    resource_parent='pipelines',
+)

--- a/mage_ai/tests/api/endpoints/test_file_contents.py
+++ b/mage_ai/tests/api/endpoints/test_file_contents.py
@@ -1,12 +1,10 @@
 import urllib.parse
-from unittest.mock import patch
 
 from mage_ai.tests.api.endpoints.mixins import (
     BaseAPIEndpointTest,
     build_detail_endpoint_tests,
     build_update_endpoint_tests,
 )
-from mage_ai.tests.shared.mixins import ProjectPlatformMixin
 
 
 def get_resource_id(self) -> str:
@@ -43,50 +41,4 @@ build_update_endpoint_tests(
     build_payload=lambda self: dict(content=self.faker.unique.name()),
     get_model_before_update=get_model_before_update,
     assert_after_update=lambda self, result, model: model != result['content'],
-)
-
-
-class FileContentWithProjectPlatformAPIEndpointTest(BaseAPIEndpointTest, ProjectPlatformMixin):
-    def setUp(self):
-        with patch('mage_ai.settings.platform.project_platform_activated', lambda: True):
-            with patch('mage_ai.settings.repo.project_platform_activated', lambda: True):
-                super().setUp()
-                self.setup_final()
-
-    def tearDown(self):
-        with patch('mage_ai.settings.platform.project_platform_activated', lambda: True):
-            with patch('mage_ai.settings.repo.project_platform_activated', lambda: True):
-                self.teardown_final()
-                super().tearDown()
-
-
-build_detail_endpoint_tests(
-    FileContentWithProjectPlatformAPIEndpointTest,
-    resource='file_content',
-    get_resource_id=get_resource_id,
-    result_keys_to_compare=[
-        'content',
-        'name',
-        'path',
-    ],
-    patch_function_settings=[
-        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
-        ('mage_ai.settings.platform.project_platform_activated', lambda: True),
-        ('mage_ai.api.resources.FileContentResource.ensure_file_is_in_project', lambda _x: True),
-    ],
-)
-
-
-build_update_endpoint_tests(
-    FileContentWithProjectPlatformAPIEndpointTest,
-    resource='file_content',
-    get_resource_id=get_resource_id,
-    build_payload=lambda self: dict(content=self.faker.unique.name()),
-    get_model_before_update=get_model_before_update,
-    assert_after_update=lambda self, result, model, mocks: model != result['content'],
-    patch_function_settings=[
-        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
-        ('mage_ai.settings.platform.project_platform_activated', lambda: True),
-        ('mage_ai.api.resources.FileContentResource.ensure_file_is_in_project', lambda _x: True),
-    ],
 )

--- a/mage_ai/tests/api/endpoints/test_file_contents_with_project_platform.py
+++ b/mage_ai/tests/api/endpoints/test_file_contents_with_project_platform.py
@@ -1,0 +1,66 @@
+import urllib.parse
+from unittest.mock import patch
+
+from mage_ai.tests.api.endpoints.mixins import (
+    BaseAPIEndpointTest,
+    build_detail_endpoint_tests,
+    build_update_endpoint_tests,
+)
+from mage_ai.tests.shared.mixins import ProjectPlatformMixin
+
+
+def get_resource_id(self) -> str:
+    block = list(self.pipeline.blocks_by_uuid.values())[0]
+    pk = block.file_path.replace(f'{self.pipeline.repo_path}/', '')
+    return urllib.parse.quote_plus(pk)
+
+
+def get_model_before_update(self):
+    block = list(self.pipeline.blocks_by_uuid.values())[0]
+    return block.file.content()
+
+
+class FileContentWithProjectPlatformAPIEndpointTest(BaseAPIEndpointTest, ProjectPlatformMixin):
+    def setUp(self):
+        with patch('mage_ai.settings.platform.project_platform_activated', lambda: True):
+            with patch('mage_ai.settings.repo.project_platform_activated', lambda: True):
+                super().setUp()
+                self.setup_final()
+
+    def tearDown(self):
+        with patch('mage_ai.settings.platform.project_platform_activated', lambda: True):
+            with patch('mage_ai.settings.repo.project_platform_activated', lambda: True):
+                self.teardown_final()
+                super().tearDown()
+
+
+build_detail_endpoint_tests(
+    FileContentWithProjectPlatformAPIEndpointTest,
+    resource='file_content',
+    get_resource_id=get_resource_id,
+    result_keys_to_compare=[
+        'content',
+        'name',
+        'path',
+    ],
+    patch_function_settings=[
+        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
+        ('mage_ai.settings.platform.project_platform_activated', lambda: True),
+        ('mage_ai.api.resources.FileContentResource.ensure_file_is_in_project', lambda _x: True),
+    ],
+)
+
+
+build_update_endpoint_tests(
+    FileContentWithProjectPlatformAPIEndpointTest,
+    resource='file_content',
+    get_resource_id=get_resource_id,
+    build_payload=lambda self: dict(content=self.faker.unique.name()),
+    get_model_before_update=get_model_before_update,
+    assert_after_update=lambda self, result, model, mocks: model != result['content'],
+    patch_function_settings=[
+        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
+        ('mage_ai.settings.platform.project_platform_activated', lambda: True),
+        ('mage_ai.api.resources.FileContentResource.ensure_file_is_in_project', lambda _x: True),
+    ],
+)

--- a/mage_ai/tests/api/endpoints/test_pipelines.py
+++ b/mage_ai/tests/api/endpoints/test_pipelines.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 from mage_ai.data_preparation.models.pipeline import Pipeline
 from mage_ai.tests.api.endpoints.mixins import (
     BaseAPIEndpointTest,
@@ -9,7 +7,6 @@ from mage_ai.tests.api.endpoints.mixins import (
     build_list_endpoint_tests,
     build_update_endpoint_tests,
 )
-from mage_ai.tests.shared.mixins import ProjectPlatformMixin
 
 
 class PipelineAPIEndpointTest(BaseAPIEndpointTest):
@@ -110,135 +107,4 @@ build_delete_endpoint_tests(
     assert_before_delete_count=lambda self: len(
         Pipeline.get_all_pipelines(self.repo_path),
     ) == 1,
-)
-
-
-class PipelineWithProjectPlatformAPIEndpointTest(BaseAPIEndpointTest, ProjectPlatformMixin):
-    def setUp(self):
-        with patch('mage_ai.settings.platform.project_platform_activated', lambda: True):
-            with patch('mage_ai.settings.repo.project_platform_activated', lambda: True):
-                super().setUp()
-                self.setup_final()
-
-    def tearDown(self):
-        with patch('mage_ai.settings.platform.project_platform_activated', lambda: True):
-            with patch('mage_ai.settings.repo.project_platform_activated', lambda: True):
-                self.teardown_final()
-                super().tearDown()
-
-
-build_list_endpoint_tests(
-    PipelineWithProjectPlatformAPIEndpointTest,
-    resource='pipelines',
-    list_count=3,
-    result_keys_to_compare=[
-        'blocks',
-        'callbacks',
-        'concurrency_config',
-        'conditionals',
-        'created_at',
-        'data_integration',
-        'description',
-        'executor_config',
-        'executor_count',
-        'executor_type',
-        'name',
-        'notification_config',
-        'retry_config',
-        'run_pipeline_in_one_process',
-        'spark_config',
-        'tags',
-        'type',
-        'updated_at',
-        'uuid',
-        'widgets',
-    ],
-    patch_function_settings=[
-        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
-        ('mage_ai.settings.platform.project_platform_activated', lambda: True),
-    ],
-)
-
-
-build_create_endpoint_tests(
-    PipelineWithProjectPlatformAPIEndpointTest,
-    resource='pipelines',
-    assert_after_create_count=lambda self, mocks: len(
-        Pipeline.get_all_pipelines(self.repo_path),
-    ) == 4,
-    assert_before_create_count=lambda self, mocks: len(
-        Pipeline.get_all_pipelines(self.repo_path),
-    ) == 3,
-    build_payload=lambda self: dict(
-        name=self.faker.unique.name(),
-    ),
-    patch_function_settings=[
-        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
-        ('mage_ai.settings.platform.project_platform_activated', lambda: True),
-    ],
-)
-
-
-build_detail_endpoint_tests(
-    PipelineWithProjectPlatformAPIEndpointTest,
-    resource='pipelines',
-    get_resource_id=lambda self: self.pipeline.uuid,
-    result_keys_to_compare=[
-        'blocks',
-        'callbacks',
-        'concurrency_config',
-        'conditionals',
-        'created_at',
-        'data_integration',
-        'description',
-        'executor_config',
-        'executor_count',
-        'executor_type',
-        'extensions',
-        'name',
-        'notification_config',
-        'retry_config',
-        'run_pipeline_in_one_process',
-        'spark_config',
-        'tags',
-        'type',
-        'updated_at',
-        'uuid',
-        'widgets',
-    ],
-    patch_function_settings=[
-        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
-        ('mage_ai.settings.platform.project_platform_activated', lambda: True),
-    ],
-)
-
-
-build_update_endpoint_tests(
-    PipelineWithProjectPlatformAPIEndpointTest,
-    resource='pipelines',
-    get_resource_id=lambda self: self.pipeline.uuid,
-    build_payload=lambda self: dict(name=self.faker.unique.name()),
-    get_model_before_update=lambda self: self.pipeline,
-    assert_after_update=lambda self, result, model, mocks: model.name != result['name'],
-    patch_function_settings=[
-        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
-        ('mage_ai.settings.platform.project_platform_activated', lambda: True),
-    ],
-)
-
-
-build_delete_endpoint_tests(
-    PipelineWithProjectPlatformAPIEndpointTest,
-    resource='pipelines',
-    get_resource_id=lambda self: self.pipeline.uuid,
-    assert_after_delete_count=lambda self, mocks: len(
-        Pipeline.get_all_pipelines(self.repo_path),
-    ) == 2,
-    assert_before_delete_count=lambda self, mocks: len(
-        Pipeline.get_all_pipelines(self.repo_path),
-    ) == 3,
-    patch_function_settings=[
-        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
-        ('mage_ai.settings.platform.project_platform_activated', lambda: True),
-    ],
 )

--- a/mage_ai/tests/api/endpoints/test_pipelines_with_project_platform.py
+++ b/mage_ai/tests/api/endpoints/test_pipelines_with_project_platform.py
@@ -1,0 +1,143 @@
+from unittest.mock import patch
+
+from mage_ai.data_preparation.models.pipeline import Pipeline
+from mage_ai.tests.api.endpoints.mixins import (
+    BaseAPIEndpointTest,
+    build_create_endpoint_tests,
+    build_delete_endpoint_tests,
+    build_detail_endpoint_tests,
+    build_list_endpoint_tests,
+    build_update_endpoint_tests,
+)
+from mage_ai.tests.shared.mixins import ProjectPlatformMixin
+
+
+class PipelineWithProjectPlatformAPIEndpointTest(BaseAPIEndpointTest, ProjectPlatformMixin):
+    def setUp(self):
+        with patch('mage_ai.settings.platform.project_platform_activated', lambda: True):
+            with patch('mage_ai.settings.repo.project_platform_activated', lambda: True):
+                super().setUp()
+                self.setup_final()
+
+    def tearDown(self):
+        with patch('mage_ai.settings.platform.project_platform_activated', lambda: True):
+            with patch('mage_ai.settings.repo.project_platform_activated', lambda: True):
+                self.teardown_final()
+                super().tearDown()
+
+
+build_list_endpoint_tests(
+    PipelineWithProjectPlatformAPIEndpointTest,
+    resource='pipelines',
+    list_count=3,
+    result_keys_to_compare=[
+        'blocks',
+        'callbacks',
+        'concurrency_config',
+        'conditionals',
+        'created_at',
+        'data_integration',
+        'description',
+        'executor_config',
+        'executor_count',
+        'executor_type',
+        'name',
+        'notification_config',
+        'retry_config',
+        'run_pipeline_in_one_process',
+        'spark_config',
+        'tags',
+        'type',
+        'updated_at',
+        'uuid',
+        'widgets',
+    ],
+    patch_function_settings=[
+        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
+        ('mage_ai.settings.platform.project_platform_activated', lambda: True),
+    ],
+)
+
+
+build_create_endpoint_tests(
+    PipelineWithProjectPlatformAPIEndpointTest,
+    resource='pipelines',
+    assert_after_create_count=lambda self, mocks: len(
+        Pipeline.get_all_pipelines(self.repo_path),
+    ) == 4,
+    assert_before_create_count=lambda self, mocks: len(
+        Pipeline.get_all_pipelines(self.repo_path),
+    ) == 3,
+    build_payload=lambda self: dict(
+        name=self.faker.unique.name(),
+    ),
+    patch_function_settings=[
+        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
+        ('mage_ai.settings.platform.project_platform_activated', lambda: True),
+    ],
+)
+
+
+build_detail_endpoint_tests(
+    PipelineWithProjectPlatformAPIEndpointTest,
+    resource='pipelines',
+    get_resource_id=lambda self: self.pipeline.uuid,
+    result_keys_to_compare=[
+        'blocks',
+        'callbacks',
+        'concurrency_config',
+        'conditionals',
+        'created_at',
+        'data_integration',
+        'description',
+        'executor_config',
+        'executor_count',
+        'executor_type',
+        'extensions',
+        'name',
+        'notification_config',
+        'retry_config',
+        'run_pipeline_in_one_process',
+        'spark_config',
+        'tags',
+        'type',
+        'updated_at',
+        'uuid',
+        'widgets',
+    ],
+    patch_function_settings=[
+        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
+        ('mage_ai.settings.platform.project_platform_activated', lambda: True),
+    ],
+)
+
+
+build_update_endpoint_tests(
+    PipelineWithProjectPlatformAPIEndpointTest,
+    resource='pipelines',
+    get_resource_id=lambda self: self.pipeline.uuid,
+    build_payload=lambda self: dict(name=self.faker.unique.name()),
+    get_model_before_update=lambda self: self.pipeline,
+    assert_after_update=lambda self, result, model, mocks: model.name != result['name'],
+    patch_function_settings=[
+        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
+        ('mage_ai.settings.platform.project_platform_activated', lambda: True),
+    ],
+)
+
+
+build_delete_endpoint_tests(
+    PipelineWithProjectPlatformAPIEndpointTest,
+    resource='pipelines',
+    get_resource_id=lambda self: self.pipeline.uuid,
+    assert_after_delete_count=lambda self, mocks: len(
+        Pipeline.get_all_pipelines(self.repo_path),
+    ) == 2,
+    assert_before_delete_count=lambda self, mocks: len(
+        Pipeline.get_all_pipelines(self.repo_path),
+    ) == 3,
+    patch_function_settings=[
+        ('mage_ai.settings.repo.project_platform_activated', lambda: True),
+        ('mage_ai.settings.platform.project_platform_activated', lambda: True),
+    ],
+)


### PR DESCRIPTION
# Description

There is a built-in type IntEnum in Python 3.8 - 3.10, thus no need to create a new class.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [X] Manuall tested in a local development environment

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 