### PR TITLE
Updated Facebook Ads SDK to 20.0.2

### DIFF
--- a/mage_integrations/requirements.txt
+++ b/mage_integrations/requirements.txt
@@ -5,7 +5,7 @@ clickhouse_sqlalchemy~=0.2.4
 couchbase==4.1.1
 deltalake==0.17.2
 elasticsearch==8.9.0
-facebook_business==17.0.2
+facebook_business==20.0.2
 gnupg==2.3.1
 google-ads==22.1.0
 google-analytics-data==0.14.2


### PR DESCRIPTION
Updated Facebook Ads SDK to version 20.0.2

No changes on the source tap code were made to support this version. 

Tested on local Mage run with the updated SDK and no bugs/issues were detected.


#5384 

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code

cc:
@wangxiaoyou1993 
