### PR TITLE
[hw] Avoid throwing exceptions when `block_type` is None

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -878,7 +878,7 @@ class Block(
         relative_path: bool = False,
     ) -> str:
         file_extension = BLOCK_LANGUAGE_TO_FILE_EXTENSION[language]
-        block_directory = block_type + 's' if block_type != BlockType.CUSTOM else block_type
+        block_directory = f'{block_type}s' if block_type != BlockType.CUSTOM else block_type
 
         parts = []
         if not relative_path:
@@ -1010,7 +1010,7 @@ class Block(
         self,
         content: str,
     ) -> str:
-        return '@' + self.type + '\n' + content
+        return f'@{self.type}\n{content}'
 
     @classmethod
     def after_create(cls, block: 'Block', **kwargs) -> None:
@@ -1199,7 +1199,7 @@ class Block(
 
     @classmethod
     def file_directory_name(self, block_type: BlockType) -> str:
-        return block_type + 's' if block_type != BlockType.CUSTOM else block_type
+        return f'{block_type}s' if block_type != BlockType.CUSTOM else block_type
 
     @classmethod
     def block_type_from_path(
@@ -1218,7 +1218,7 @@ class Block(
         for block_type in BlockType:
             if BlockType.CUSTOM == block_type and dir_name == block_type:
                 return BlockType.CUSTOM
-            elif dir_name == block_type + 's':
+            elif dir_name == f'{block_type}s':
                 return block_type
 
     @classmethod

--- a/mage_ai/tests/data_preparation/models/test_block.py
+++ b/mage_ai/tests/data_preparation/models/test_block.py
@@ -746,6 +746,13 @@ def test_output(output, *args) -> None:
             ),
         )
 
+    def test_none_block_type(self):
+        block = Block(name='test block', uuid='test uuid', block_type=None)
+        self.assertEqual(
+            block.get_typed_content('test content'),
+            '@None\ntest content',
+        )
+
 
 class BlockProjectPlatformTests(ProjectPlatformMixin):
     def test_file_path(self):


### PR DESCRIPTION
# Description

When the block_type value is `None`, the following code would throw exception:

```
>> block_type + 's'

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

However, the following code works fine:
```
>> f'{block_type}s'

'Nones'
```

It was showing as “BlockType.###s” earlier for valid block_types, due to the behavior change of StrEnum in Python 3.11+. It was changed to `block_type +'s'` to pass existing unit tests. With the later StrEnum change, this work-around was not needed anymore. 

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [X] Manually tested in a local development environment
```
(.venv) mage-ai % python3 -m unittest mage_ai.tests.data_preparation.models.test_block.BlockTest
WARNING:traitlets:Message signing is disabled.  This is insecure and not recommended!
WARNING:traitlets:Message signing is disabled.  This is insecure and not recommended!
.[ERROR] Pipeline.get_block: block test_transformer with type None does not exist in pipeline test_pipeline_delete for repo_path /Users/hw/workspace/dev/mage-ai/test.
.[ERROR] Pipeline.get_block: block test_data_loader with type None does not exist in pipeline test_pipeline_delete_force for repo_path /Users/hw/workspace/dev/mage-ai/test.
................
----------------------------------------------------------------------
Ran 18 tests in 1.017s

OK
```

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 