### PR TITLE
[jk] Fix error detail log parsing

### DIFF
--- a/mage_ai/frontend/components/Logs/Detail/index.tsx
+++ b/mage_ai/frontend/components/Logs/Detail/index.tsx
@@ -51,16 +51,28 @@ function LogDetail({
     path,
   } = log;
   const {
-    error,
-    error_stack: errorStack,
-    error_stacktrace: errorStackTrace,
+    error: errorFromData,
+    error_stack: errorStackFromData,
+    error_stacktrace: errorStackTraceFromData,
     level,
     timestamp,
   } = data || {};
   const sharedProps =  { [level.toLowerCase()]: true };
+  let error = errorFromData;
+  let errorStack = errorStackFromData;
+  let errorStackTrace = errorStackTraceFromData;
+  if (errorFromData && !Array.isArray(errorFromData)) {
+    error = [errorFromData];
+  }
+  if (Array.isArray(errorStackFromData) && !Array.isArray(errorStackFromData?.[0])) {
+    errorStack = [errorStackFromData] as string[][];
+  }
+  if (errorStackTraceFromData && !Array.isArray(errorStackTraceFromData)) {
+    errorStackTrace = [errorStackTraceFromData];
+  }
 
   const rows = useMemo(() => {
-    const arr = [
+    const arr: any[] = [
       ['file name', name],
       ['file path', path],
     ];
@@ -230,19 +242,21 @@ function LogDetail({
             </Text>
           </Spacing>
 
-          {error?.map((lines: string) => lines.split('\n').map((line: string) => (
-            line.split('\\n').map(part => (
-              <Text
-                default
-                key={part}
-                monospace
-                preWrap
-                small
-              >
-                {part}
-              </Text>
-            ))
-          )))}
+          {Array.isArray(error) && error?.map(
+            (lines: string) => lines.split('\n').map((line: string) => (
+              line.split('\\n').map(part => (
+                <Text
+                  default
+                  key={part}
+                  monospace
+                  preWrap
+                  small
+                >
+                  {part}
+                </Text>
+              ))
+            )),
+          )}
 
           {errorStack && (
             <Spacing mt={3}>
@@ -252,17 +266,19 @@ function LogDetail({
                 </Text>
               </Spacing>
 
-              {errorStack?.map((lines: string[]) => lines?.map((line: string) => (
-                <Text
-                  default
-                  key={line}
-                  monospace
-                  preWrap
-                  small
-                >
-                  {line}
-                </Text>
-              )))}
+              {(errorStack as string[][])?.map(
+                (lines: string[]) => lines?.map((line: string) => (
+                  <Text
+                    default
+                    key={line}
+                    monospace
+                    preWrap
+                    small
+                  >
+                    {line}
+                  </Text>
+                )),
+              )}
             </Spacing>
           )}
         </Spacing>

--- a/mage_ai/frontend/components/Logs/Detail/index.tsx
+++ b/mage_ai/frontend/components/Logs/Detail/index.tsx
@@ -67,12 +67,12 @@ function LogDetail({
   if (Array.isArray(errorStackFromData) && !Array.isArray(errorStackFromData?.[0])) {
     errorStack = [errorStackFromData] as string[][];
   }
-  if (errorStackTraceFromData && !Array.isArray(errorStackTraceFromData)) {
-    errorStackTrace = [errorStackTraceFromData];
+  if (errorStackTraceFromData && Array.isArray(errorStackTraceFromData)) {
+    errorStackTrace = errorStackTraceFromData?.[0];
   }
 
   const rows = useMemo(() => {
-    const arr: any[] = [
+    const arr = [
       ['file name', name],
       ['file path', path],
     ];
@@ -84,7 +84,7 @@ function LogDetail({
     });
 
     if (errorStackTrace) {
-      arr.push(['error', errorStackTrace]);
+      arr.push(['error', errorStackTrace as string]);
     }
 
     return sortByKey(arr, ([k, _]) => k);

--- a/mage_ai/frontend/interfaces/LogType.ts
+++ b/mage_ai/frontend/interfaces/LogType.ts
@@ -32,9 +32,9 @@ export interface LogDataType {
   block_run_id?: number;
   block_type?: BlockTypeEnum;
   block_uuid?: string;
-  error?: string[];
-  error_stack?: string[][];
-  error_stacktrace: string;
+  error?: string | string[];
+  error_stack?: string[] | string[][];
+  error_stacktrace: string | string[];
   level: LogLevelEnum;
   message: string;
   pipeline_run_id?: number;


### PR DESCRIPTION
# Description
- The FE app was crashing due an error in the error log format when viewing the Log Details for an error log. This PR fixes the error.

# How Has This Been Tested?
Before (this error would appear and crash the app):
![image](https://github.com/user-attachments/assets/f8752a40-f2de-44a4-a748-e20f2640a88d)

After (error log loads without issues):
![image](https://github.com/user-attachments/assets/e0801dbd-c9d1-46bc-afc1-ebca0840b761)

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
