### PR TITLE
Fix unable to pass extra parameters to psycopg2 in Postgres connector

### DIFF
--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -99,6 +99,8 @@ class Postgres(BaseSQL):
             password = self.settings['password']
             port = self.settings['port']
             user = self.settings['user']
+            keepalives = self.settings.get('keepalives', 1)
+            keepalives_idle = self.settings.get('keepalives_idle', 300)
             if self.settings['connection_method'] == 'ssh_tunnel':
                 ssh_setting = dict(ssh_username=self.settings['ssh_username'])
                 if self.settings['ssh_pkey'] is not None:
@@ -128,18 +130,34 @@ class Postgres(BaseSQL):
                 host = '127.0.0.1'
                 port = self.ssh_tunnel.local_bind_port
 
-            connect_opts = dict(
-                database=database,
-                host=host,
-                password=password,
-                port=port,
-                user=user,
-                keepalives=1,
-                keepalives_idle=300,
-            )
+            connect_opts = self.settings.copy()
+            # See recognized keyword parameters for psycopg2.connect()
+            # https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
+            unrecognized_keys = [
+                'dbname',
+                'schema',
+                'connection_method',
+                'ssh_host',
+                'ssh_port',
+                'ssh_username',
+                'ssh_password',
+                'ssh_pkey',
+                "verbose"
+            ]
+            for key in unrecognized_keys:
+                connect_opts.pop(key, None)
 
-            if self.settings.get('connect_timeout'):
-                connect_opts['connect_timeout'] = self.settings['connect_timeout']
+            connect_opts.update(
+                {
+                    'database': database,
+                    'host': host,
+                    'password': password,
+                    'port': port,
+                    'user': user,
+                    'keepalives': keepalives,
+                    'keepalives_idle': keepalives_idle,
+                }
+            )
 
             try:
                 self._ctx = connect(**connect_opts)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

This fix allows  all valid psycopg2 connection parameters as keyword arguments. Previously, only a limited set of parameters were passed to connect(), restricting customization options like `sslmode` and `keepalives`. The fix now allows users to specify any connection parameter, which is then properly passed to `connect()`, enhancing flexibility in PostgreSQL connections.

fixes #5442

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

Manually tested and confirmed output. Did not see existing test for the class.
Open to writing test if requested.

```python
from mage_ai.io.postgres import Postgres

credentials = {
    'dbname': 'postgres',
    'user': 'postgres',
    'password': 'postgres',
    'host': 'localhost',
    'port': '5432',
    'sslmode': 'disable'
}

with Postgres(dbname = credentials['dbname'],
                user = credentials['user'],
                password = credentials['password'],
                host = credentials['host'],
                port = credentials['port'],
                sslmode = 'disable',
                keepalives=15,
                keepalives_idle=500,
                connect_timeout=10,
                verbose=True,
                ) as loader:
    print(f"\nloader: {loader.conn.get_dsn_parameters()}")

# Postgres initialized
#└─ Opening connection to PostgreSQL database...DONE
# loader: {'user': 'postgres', 'channel_binding': 'prefer', 'connect_timeout': '10', 'dbname': 'postgres', 'host': 'localhost', 'port': '5432', 'options': '', 'keepalives': '15', 'keepalives_idle': '500', 'sslmode': 'disable', 'sslcompression': '0', 'sslsni': '1', 'ssl_min_protocol_version': 'TLSv1.2', 'gssencmode': 'prefer', 'krbsrvname': 'postgres', 'target_session_attrs': 'any'}

```
**Mage Version**: 0.9.74
**Python**: 3.11.3
**OS**: Mac Sequoia 15


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993