### PR TITLE
[jk] Render json objects in block outputs as string instead of nested table

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/TableOutput.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/TableOutput.tsx
@@ -1,5 +1,5 @@
 import InnerHTML from 'dangerously-set-html-content';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import DataTable from '@components/DataTable';
 import FlexContainer from '@oracle/components/FlexContainer';

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -219,7 +219,7 @@ function estimateCellHeight({
     original?.every(o => Array.isArray(o) || isObject(o)) &&
     variableListProps
   ) {
-    const { columnHeaderHeight, height, maxHeight, width: width2 } = variableListProps;
+    const { columnHeaderHeight, height, maxHeight } = variableListProps;
 
     return original?.reduce((acc: number, vals: any) => {
       let rows = [];
@@ -580,14 +580,12 @@ function Table({ ...props }: TableProps) {
     },
     [
       columnsAll,
-      height,
       indexProp,
       invalidValues,
       maxWidthOfIndexColumns,
       numberOfIndexes,
       prepareRow,
       previewIndexes,
-      props,
       rows,
       shouldUseIndexProp,
     ],

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -190,6 +190,11 @@ const Styles = styled.div<{
   }
 `;
 
+const PreStyle = styled.pre`
+  overflow: auto;
+  ${ScrollbarStyledCss}
+`;
+
 function estimateCellHeight({
   original,
   values,
@@ -525,46 +530,15 @@ function Table({ ...props }: TableProps) {
               if (isJsonString(cellValue)) {
                 try {
                   const cellObject = JSON.parse(cellValue);
-                  if (Array.isArray(cellObject)) {
+                  if (Array.isArray(cellObject) || isObject(cellObject)) {
+                    // Render JSON object as formmated text
                     cellValueDisplay = (
-                      <Table
-                        {...props}
-                        columns={[
-                          {
-                            Header: 'value',
-                            accessor: () => 'Column for value',
-                          },
-                        ]}
-                        data={cellObject?.map(v => [v])}
-                        disableScrolling
-                        height={height}
-                        maxHeight={1000}
-                        numberOfIndexes={0}
-                        width={props.width - maxWidthOfIndexColumns[idx]}
-                      />
+                      <PreStyle>
+                        <Text default wordBreak>
+                          {JSON.stringify(cellObject, null, 2)}
+                        </Text>
+                      </PreStyle>
                     );
-                    cellStyle.padding = 0;
-                  } else if (isObject(cellObject)) {
-                    const cols = Object.keys(cellObject).map(key => ({
-                      Header: key,
-                      accessor: () => 'Column for value',
-                    }));
-                    const vals: (string | number)[] =
-                      (Object.values(cellObject) as (string | number)[]) || [];
-
-                    cellValueDisplay = (
-                      <Table
-                        {...props}
-                        columns={cols}
-                        data={[vals]}
-                        disableScrolling
-                        height={height}
-                        maxHeight={1000}
-                        numberOfIndexes={0}
-                        width={props.width - maxWidthOfIndexColumns[idx]}
-                      />
-                    );
-                    cellStyle.padding = 0;
                   }
                 } catch {}
               }

--- a/mage_ai/frontend/components/PipelineDetail/utils.ts
+++ b/mage_ai/frontend/components/PipelineDetail/utils.ts
@@ -94,7 +94,6 @@ export function prepareOutputsForDisplay(outputs: OutputType[]) {
       });
     }
   });
-  console.log('outputsFinal', outputsFinal);
 
   if (DataTypeEnum.TEXT_PLAIN === outputType) {
     return outputsFinal;


### PR DESCRIPTION
# Description
- Fix formatting of nested tables inside of rows for block outputs in Pipeline Editor. Previously, JSON objects would be rendered as nested tables inside the cells of tables for the block output, but the formatting was broken and the nested tables could not scroll or view the contents easily. This PR renders the JSON objects simply as formatted strings.

# How Has This Been Tested?
Before:
![before-unscrollable nested tables](https://github.com/user-attachments/assets/8c45a37f-a393-47e8-9c18-e06bcc48b220)

After:
![after-no nested tables](https://github.com/user-attachments/assets/e5dcca45-2e85-4095-b55a-650e64c31175)


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
