### PR TITLE
[jk] Display ID in block runs table

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/Table.tsx
@@ -135,7 +135,7 @@ function BlockRunsTable({
     [displayLocalTimezone],
   );
   const { columns, columnFlex } = useMemo(() => {
-    const colFlex = [1, null, 2, 2, 1, 1, 1, null];
+    const colFlex = [1, null, 2, null, 2, 1, 1, 1, null];
     const arr = [
       {
         uuid: 'Status',
@@ -146,6 +146,9 @@ function BlockRunsTable({
       },
       {
         uuid: 'Block',
+      },
+      {
+        uuid: 'ID',
       },
       {
         uuid: 'Trigger',
@@ -273,6 +276,14 @@ function BlockRunsTable({
               </Text>
             </Link>
           </NextLink>,
+          <Text
+            default
+            key={`${id}_block_run_id`}
+            monospace
+            small
+          >
+            {id}
+          </Text>,
           <NextLink
             as={`/pipelines/${pipelineUUID}/triggers/${pipelineScheduleId}`}
             href={'/pipelines/[pipeline]/triggers/[...slug]'}


### PR DESCRIPTION
# Description
- See title.

# How Has This Been Tested?
`ID` column added to Block Runs Table on `/pipelines/[pipeline_uuid]/runs/[pipeline_run_id]` and `/pipelines/[pipeline_uuid]/runs?tab=block_runs` pages:
![image](https://github.com/user-attachments/assets/36cc7ba7-847a-48e1-aaa3-bbe9425e7b28)
![image](https://github.com/user-attachments/assets/6256f596-ebb4-496a-8edf-b5ea5371adac)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
