### PR TITLE
[enhancement] Elasticsearch support of _op_type for bulk operations

### DIFF
--- a/docs/streaming/destinations/elasticsearch.mdx
+++ b/docs/streaming/destinations/elasticsearch.mdx
@@ -8,6 +8,8 @@ title: "Elasticsearch"
 connector_type: elasticsearch
 host: http://localhost
 index_name: elastic_index
+# When using Data streams this must be set to create as they are Append-only indexes
+# _op_type: None / index, create or update
 # Whether to have update for the documents, need to mention the unique key field in the document as _id
 # _id: _key
 # # Whether to verify SSL certificates to authenticate.

--- a/mage_ai/data_preparation/templates/data_exporters/streaming/elasticsearch.yaml
+++ b/mage_ai/data_preparation/templates/data_exporters/streaming/elasticsearch.yaml
@@ -2,6 +2,8 @@ connector_type: elasticsearch
 host: http://localhost
 index_name: elastic_index
 api_key: api_key_for_elastic_search
+# # When using Data streams this must be set to create as they are Append-only indexes
+# _op_type: None / index, create or update
 # # Whether to verify SSL certificates to authenticate.
 # verify_certs: true
 # ca_cert: "certificate.cert"

--- a/mage_ai/streaming/sinks/elasticsearch.py
+++ b/mage_ai/streaming/sinks/elasticsearch.py
@@ -61,7 +61,8 @@ class ElasticSearchSink(BaseSink):
                         'doc': doc} for doc in messages]
         else:
             if self.config._op_type is not None:
-                docs = [{'_index': self.config.index_name, 'doc': doc, '_op_type': self.config._op_type} for doc in messages]
+                docs = [{'_index': self.config.index_name, 'doc': doc,
+                        '_op_type': self.config._op_type} for doc in messages]
             else:
                 docs = [{'_index': self.config.index_name, 'doc': doc} for doc in messages]
 

--- a/mage_ai/streaming/sinks/elasticsearch.py
+++ b/mage_ai/streaming/sinks/elasticsearch.py
@@ -16,6 +16,7 @@ class ElasticSearchConfig(BaseConfig):
     api_key: str = None
     ca_cert: str = None
     _id: str = None
+    _op_type: str = None
 
 
 class ElasticSearchSink(BaseSink):
@@ -52,8 +53,16 @@ class ElasticSearchSink(BaseSink):
     def batch_write(self, messages: List[Dict]):
         self._print(f'Batch ingest data {messages}, time={time.time()}')
         if self.config._id is not None:
-            docs = [{'_index': self.config.index_name, '_id': doc[self.config._id],
-                     'doc': doc} for doc in messages]
+            if self.config._op_type is not None:
+                docs = [{'_index': self.config.index_name, '_id': doc[self.config._id],
+                        'doc': doc, '_op_type': self.config._op_type} for doc in messages]
+            else:
+                docs = [{'_index': self.config.index_name, '_id': doc[self.config._id],
+                        'doc': doc} for doc in messages]
         else:
-            docs = [{'_index': self.config.index_name, 'doc': doc} for doc in messages]
+            if self.config._op_type is not None:
+                docs = [{'_index': self.config.index_name, 'doc': doc, '_op_type': self.config._op_type} for doc in messages]
+            else:
+                docs = [{'_index': self.config.index_name, 'doc': doc} for doc in messages]
+
         helpers.bulk(self.client, docs)

--- a/mage_ai/streaming/sinks/elasticsearch.py
+++ b/mage_ai/streaming/sinks/elasticsearch.py
@@ -54,7 +54,7 @@ class ElasticSearchSink(BaseSink):
         self._print(f'Batch ingest data {messages}, time={time.time()}')
         docs = []
         for msg in messages:
-            doc = {'_index': self.config.index_name, 'doc': doc}
+            doc = {'_index': self.config.index_name, 'doc': msg}
             if self.config._id is not None:
                 doc['id'] = msg[self.config._id]
             if self.config._op_type is not None:

--- a/mage_ai/streaming/sinks/elasticsearch.py
+++ b/mage_ai/streaming/sinks/elasticsearch.py
@@ -53,7 +53,7 @@ class ElasticSearchSink(BaseSink):
     def batch_write(self, messages: List[Dict]):
         self._print(f'Batch ingest data {messages}, time={time.time()}')
         docs = []
-        for msg in in messages:
+        for msg in messages:
             doc = {'_index': self.config.index_name, 'doc': doc}
             if self.config._id is not None:
                 doc['id'] = msg[self.config._id]

--- a/mage_ai/streaming/sinks/elasticsearch.py
+++ b/mage_ai/streaming/sinks/elasticsearch.py
@@ -52,18 +52,13 @@ class ElasticSearchSink(BaseSink):
 
     def batch_write(self, messages: List[Dict]):
         self._print(f'Batch ingest data {messages}, time={time.time()}')
-        if self.config._id is not None:
+        docs = []
+        for msg in in messages:
+            doc = {'_index': self.config.index_name, 'doc': doc}
+            if self.config._id is not None:
+                doc['id'] = msg[self.config._id]
             if self.config._op_type is not None:
-                docs = [{'_index': self.config.index_name, '_id': doc[self.config._id],
-                        'doc': doc, '_op_type': self.config._op_type} for doc in messages]
-            else:
-                docs = [{'_index': self.config.index_name, '_id': doc[self.config._id],
-                        'doc': doc} for doc in messages]
-        else:
-            if self.config._op_type is not None:
-                docs = [{'_index': self.config.index_name, 'doc': doc,
-                        '_op_type': self.config._op_type} for doc in messages]
-            else:
-                docs = [{'_index': self.config.index_name, 'doc': doc} for doc in messages]
+                doc['_op_type'] = self.config._op_type
+            docs.append(doc)
 
         helpers.bulk(self.client, docs)


### PR DESCRIPTION
# Description
Adds support for the  bulk operations with [Data streams](https://www.elastic.co/guide/en/elasticsearch/reference/current/data-streams.html) as they require this as they are Append-only indexes

https://elasticsearch-py.readthedocs.io/en/v8.15.1/helpers.html#bulk-helpers


# How Has This Been Tested?
- [X] Tested locally


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

# cc:
@tommydangerous