### PR TITLE
adds support of _op_type for bulk operations of destinations

### DIFF
--- a/mage_integrations/mage_integrations/destinations/elasticsearch/README.md
+++ b/mage_integrations/mage_integrations/destinations/elasticsearch/README.md
@@ -19,6 +19,7 @@ By default, table name config is used to set elasticsearch `index` name
 | api_key | api key for auth key authorization | None | Not Required |
 | ssl_ca_file | path of the the SSL certificate for cert verification | None | Not Required |
 | index_schema_fields | this id map allows you to specify specific record values via jsonpath from the stream to be used in index formulation. | None | Not Required |
+| _op_type | select the operation type depending on the indexing mode | "index" | Not Required |
 | metadata_fields | this config is used to pull out specific fields from the record to be included in the ES index request. | None | Not Required |
 | bulk_kwargs | the arguments of this field will configure the `bulk` operation in the destination. See options below this table | None | Not Required |
 

--- a/mage_integrations/mage_integrations/destinations/elasticsearch/target_elasticsearch/common.py
+++ b/mage_integrations/mage_integrations/destinations/elasticsearch/target_elasticsearch/common.py
@@ -14,6 +14,7 @@ API_KEY_ID = "api_key_id"
 API_KEY = "api_key"
 SSL_CA_FILE = "ssl_ca_file"
 INDEX_FORMAT = "index_format"
+INDEX_OP_TYPE = "_op_type"
 INDEX_TEMPLATE_FIELDS = "index_schema_fields"
 METADATA_FIELDS = "metadata_fields"
 

--- a/mage_integrations/mage_integrations/destinations/elasticsearch/target_elasticsearch/sinks.py
+++ b/mage_integrations/mage_integrations/destinations/elasticsearch/target_elasticsearch/sinks.py
@@ -17,6 +17,7 @@ from mage_integrations.destinations.elasticsearch.target_elasticsearch.common im
     ELASTIC_YEARLY_FORMAT,
     HOST,
     INDEX_FORMAT,
+    INDEX_OP_TYPE,
     INDEX_TEMPLATE_FIELDS,
     METADATA_FIELDS,
     PASSWORD,
@@ -139,7 +140,8 @@ class ElasticSink(BatchSink):
             distinct_indices.add(index)
             updated_records.append(
                 {
-                    **{"_op_type": "index", "_index": index, "_source": r},
+                    **{"_op_type": self.config.get(INDEX_OP_TYPE, "index"), "_index": index,
+                       "_source": r},
                     **build_fields(self.stream_name, metadata_fields, r, self.logger),
                 }
             )

--- a/mage_integrations/mage_integrations/destinations/elasticsearch/target_elasticsearch/target.py
+++ b/mage_integrations/mage_integrations/destinations/elasticsearch/target_elasticsearch/target.py
@@ -14,6 +14,7 @@ from mage_integrations.destinations.elasticsearch.target_elasticsearch.common im
     BEARER_TOKEN,
     HOST,
     INDEX_FORMAT,
+    INDEX_OP_TYPE,
     INDEX_TEMPLATE_FIELDS,
     METADATA_FIELDS,
     PASSWORD,
@@ -111,6 +112,16 @@ class TargetElasticsearch(Target):
     to yearly `{{ to_yearly(timestamp) }}`
             """,
             default="{{ stream_name }}",
+        ),
+        th.Property(
+            INDEX_OP_TYPE,
+            th.StringType,
+            description="""Elasticsearch Data Streams support only the `create` action
+            within the _op_type field, for other index modes refer to the documentation:
+
+    https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/client-helpers.html
+            """,
+            default="index",
         ),
         th.Property(
             INDEX_TEMPLATE_FIELDS,


### PR DESCRIPTION
# Description
Same as #5471 but for the integration destination.
Adds support for the  bulk operations with [Data streams](https://www.elastic.co/guide/en/elasticsearch/reference/current/data-streams.html) as they require this as they are Append-only indexes

https://elasticsearch-py.readthedocs.io/en/v8.15.1/helpers.html#bulk-helpers


# How Has This Been Tested?
- [X] Tested locally


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [X] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

# cc:
@wangxiaoyou1993 