### PR TITLE
[Bug] Updated SalesForce source to handle multiple date formats

### DIFF
--- a/mage_integrations/mage_integrations/sources/salesforce/client/tap_salesforce/__init__.py
+++ b/mage_integrations/mage_integrations/sources/salesforce/client/tap_salesforce/__init__.py
@@ -84,7 +84,7 @@ def stream_is_selected(mdata):
 
 def build_state(raw_state, catalog):
     state = {}
-
+    raw_state = raw_state or {}
     for catalog_entry in catalog['streams']:
         tap_stream_id = catalog_entry['tap_stream_id']
         catalog_metadata = metadata.to_map(catalog_entry['metadata'])

--- a/mage_integrations/mage_integrations/sources/salesforce/client/tap_salesforce/salesforce/__init__.py
+++ b/mage_integrations/mage_integrations/sources/salesforce/client/tap_salesforce/salesforce/__init__.py
@@ -226,7 +226,8 @@ class Salesforce():
         self.domain = domain
         self.select_fields_by_default = select_fields_by_default is True or (isinstance(
             select_fields_by_default, str) and select_fields_by_default.lower() == 'true')
-        self.default_start_date = default_start_date
+        # validate date and convert to the proper format
+        self.default_start_date = singer_utils.strptime_to_utc(default_start_date).strftime( "%Y-%m-%dT%H:%M:%SZ")
         self.rest_requests_attempted = 0
         self.jobs_completed = 0
         self.data_url = "{}/services/data/v53.0/{}"
@@ -234,9 +235,6 @@ class Salesforce():
         self.login_timer = None
 
         self.auth = SalesforceAuth.from_credentials(credentials, domain=self.domain)
-
-        # validate start_date
-        singer_utils.strptime(default_start_date)
 
     # pylint: disable=anomalous-backslash-in-string,line-too-long
     def check_rest_quota_usage(self, headers):


### PR DESCRIPTION
# Description
For Issue #5409 
When configuring the Salesforce Source in a batch pipeline the 'start_date' is being converted before it is passed through - even though it is correctly entered in the config. 

The root cause looks like it is with how yaml.safe_load parses the date string and returns to the frontend. Opted to change the SalesForce data integration to handle both formats to reduce impact. Updated to `strptime_to_utc` as `strptime` is [deprecated](https://github.com/singer-io/singer-python/blob/master/singer/utils.py#L30C8-L30C18)  

Once this bug was resolved, there was an initial error with the sync because the `raw_state` was not set. Updated to default the raw_state


# How Has This Been Tested?
Verified the integration using the SalesForce data integration within a batch pipeline locally. Confirmed loading data from SalesForce with sandbox
https://www.loom.com/share/b460861fb4804ea7b072d726a455b157

- [x] Verified Test integration with date `2024-01-01T00:00:00Z` 
- [x] Verified loading data with date `2024-01-01T00:00:00Z` 
- [x] Verified Test integration with date `2024-09-01T00:00:01+00:00`
- [x]  Verified loading data with date `2024-09-01T00:00:01+00:00`
- [x] Verified test integration FAILED with bad date  `2024-02-30T00:00:00Z`



# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation) -- I am not able to add labels
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A)

cc: @wangxiaoyou1993 
