### PR TITLE
Add time delay to avoid getting the same file timestamp for multiple changes

### DIFF
--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -2329,6 +2329,10 @@ class Pipeline:
         extension_uuid: str = None,
         widget: bool = False,
     ):
+        # Introduce a small delay to prevent multiple changes from generating
+        # identical timestamps for the pipeline YAML file
+        time.sleep(0.001)
+
         blocks_current = sorted([b.uuid for b in self.blocks_by_uuid.values()])
 
         if block_uuid is not None:
@@ -2388,10 +2392,6 @@ class Pipeline:
             repo_path=self.repo_path,
             file_version_only=True,
         )
-
-        # Introduce a small delay to prevent multiple changes from generating
-        # identical timestamps for the pipeline YAML file
-        time.sleep(0.001)
 
     def should_save_trigger_in_code_automatically(self) -> bool:
         from mage_ai.data_preparation.models.project import Project

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -4,6 +4,7 @@ import json
 import os
 import shutil
 import tempfile
+import time
 import zipfile
 from datetime import datetime, timezone
 from io import BytesIO
@@ -2328,6 +2329,9 @@ class Pipeline:
         extension_uuid: str = None,
         widget: bool = False,
     ):
+        # Add a minimal delay to avoid getting the same timestamp for multiple files
+        time.sleep(0.0001)
+
         blocks_current = sorted([b.uuid for b in self.blocks_by_uuid.values()])
 
         if block_uuid is not None:

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -2331,7 +2331,7 @@ class Pipeline:
     ):
         # Introduce a small delay to prevent multiple changes from generating
         # identical timestamps for the pipeline YAML file
-        time.sleep(0.001)
+        time.sleep(0.0005)
 
         blocks_current = sorted([b.uuid for b in self.blocks_by_uuid.values()])
 

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -2330,7 +2330,7 @@ class Pipeline:
         widget: bool = False,
     ):
         # Add a minimal delay to avoid getting the same timestamp for multiple files
-        time.sleep(0.0001)
+        time.sleep(0.001)
 
         blocks_current = sorted([b.uuid for b in self.blocks_by_uuid.values()])
 

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -2329,7 +2329,8 @@ class Pipeline:
         extension_uuid: str = None,
         widget: bool = False,
     ):
-        # Add a minimal delay to avoid getting the same timestamp for multiple files
+        # Introduce a small delay to prevent multiple changes from generating
+        # identical timestamps for the pipeline YAML file
         time.sleep(0.001)
 
         blocks_current = sorted([b.uuid for b in self.blocks_by_uuid.values()])

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -2331,7 +2331,7 @@ class Pipeline:
     ):
         # Introduce a small delay to prevent multiple changes from generating
         # identical timestamps for the pipeline YAML file
-        time.sleep(0.0003)
+        time.sleep(0.00025)
 
         blocks_current = sorted([b.uuid for b in self.blocks_by_uuid.values()])
 

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -2331,7 +2331,7 @@ class Pipeline:
     ):
         # Introduce a small delay to prevent multiple changes from generating
         # identical timestamps for the pipeline YAML file
-        time.sleep(0.0005)
+        time.sleep(0.0002)
 
         blocks_current = sorted([b.uuid for b in self.blocks_by_uuid.values()])
 

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -2331,7 +2331,7 @@ class Pipeline:
     ):
         # Introduce a small delay to prevent multiple changes from generating
         # identical timestamps for the pipeline YAML file
-        time.sleep(0.00025)
+        time.sleep(0.0003)
 
         blocks_current = sorted([b.uuid for b in self.blocks_by_uuid.values()])
 

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -2329,10 +2329,6 @@ class Pipeline:
         extension_uuid: str = None,
         widget: bool = False,
     ):
-        # Introduce a small delay to prevent multiple changes from generating
-        # identical timestamps for the pipeline YAML file
-        time.sleep(0.001)
-
         blocks_current = sorted([b.uuid for b in self.blocks_by_uuid.values()])
 
         if block_uuid is not None:
@@ -2392,6 +2388,10 @@ class Pipeline:
             repo_path=self.repo_path,
             file_version_only=True,
         )
+
+        # Introduce a small delay to prevent multiple changes from generating
+        # identical timestamps for the pipeline YAML file
+        time.sleep(0.001)
 
     def should_save_trigger_in_code_automatically(self) -> bool:
         from mage_ai.data_preparation.models.project import Project

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -2331,7 +2331,7 @@ class Pipeline:
     ):
         # Introduce a small delay to prevent multiple changes from generating
         # identical timestamps for the pipeline YAML file
-        time.sleep(0.0002)
+        time.sleep(0.0003)
 
         blocks_current = sorted([b.uuid for b in self.blocks_by_uuid.values()])
 

--- a/mage_ai/tests/data_preparation/test_variable_manager_project_platform.py
+++ b/mage_ai/tests/data_preparation/test_variable_manager_project_platform.py
@@ -8,48 +8,34 @@ from mage_ai.data_preparation.variable_manager import (
 from mage_ai.tests.shared.mixins import ProjectPlatformMixin
 
 
+@patch('mage_ai.data_preparation.models.pipeline.project_platform_activated', lambda: True)
+@patch('mage_ai.data_preparation.variable_manager.project_platform_activated', lambda: True)
 class VariableManagerProjectPlatformTests(ProjectPlatformMixin):
     def test_get_global_variable(self):
-        with patch(
-            "mage_ai.data_preparation.variable_manager.project_platform_activated",
-            lambda: True,
-        ):
-            with patch(
-                "mage_ai.data_preparation.models.pipeline.project_platform_activated",
-                lambda: True,
-            ):
-                for settings in self.repo_paths.values():
-                    pipeline = Pipeline.create(
-                        self.faker.unique.name(),
-                        repo_path=settings["full_path"],
-                    )
-                    value = self.faker.unique.name()
-                    pipeline.variables = dict(mage=value)
-                    pipeline.save()
+        for settings in self.repo_paths.values():
+            pipeline = Pipeline.create(
+                self.faker.unique.name(),
+                repo_path=settings["full_path"],
+            )
+            value = self.faker.unique.name()
+            pipeline.variables = dict(mage=value)
+            pipeline.save()
 
-                    self.assertEqual(get_global_variable(pipeline.uuid, "mage"), value)
+            self.assertEqual(get_global_variable(pipeline.uuid, "mage"), value)
 
     def test_get_global_variables(self):
-        with patch(
-            "mage_ai.data_preparation.variable_manager.project_platform_activated",
-            lambda: True,
-        ):
-            with patch(
-                "mage_ai.data_preparation.models.pipeline.project_platform_activated",
-                lambda: True,
-            ):
-                for settings in self.repo_paths.values():
-                    pipeline = Pipeline.create(
-                        self.faker.unique.name(),
-                        repo_path=settings["full_path"],
-                    )
-                    pipeline.variables = self.faker.unique.name()
-                    pipeline.save()
+        for settings in self.repo_paths.values():
+            pipeline = Pipeline.create(
+                self.faker.unique.name(),
+                repo_path=settings["full_path"],
+            )
+            pipeline.variables = self.faker.unique.name()
+            pipeline.save()
 
-                    self.assertEqual(
-                        get_global_variables(None, pipeline=pipeline),
-                        pipeline.variables,
-                    )
-                    self.assertEqual(
-                        get_global_variables(pipeline.uuid), pipeline.variables
-                    )
+            self.assertEqual(
+                get_global_variables(None, pipeline=pipeline),
+                pipeline.variables,
+            )
+            self.assertEqual(
+                get_global_variables(pipeline.uuid), pipeline.variables
+            )


### PR DESCRIPTION
# Description

The root cause of some flaky unit tests was found: [the cached reading of YAML file](https://github.com/mage-ai/mage-ai/blob/master/mage_ai/cache/mem_lru.py) could not detect file changes if two changes are too close together (e.g., calling set_global_variable twice in a row as done in unit tests). This issue was explained in more detail in: https://stackoverflow.com/questions/19059877/python-os-path-getmtime-time-not-changing.

It could be an issue with Mage system overall, i.e., whenever pipeline state changes are too close to each other, the cached version of the pipeline YAML file in memory would be stale, and could lead to data loss due to wrong overwrites, e.g., the earlier set value is over-written.

I've tried the time delay value of `0.0001` and `0.0002`, which didn't work. The final value chosen was after some trial-and-errors.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested it in a local development environment

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 