### PR TITLE
Update deltalake version from 0.17.4 to 0.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -135,7 +135,7 @@ attrs==17.4.0; python_version < '3.12'
 attrs==24.2.0; python_version >= '3.12'
 backoff
 clickhouse_sqlalchemy
-deltalake==0.17.4
+deltalake==0.20.0
 facebook_business==17.0.2
 gnupg==2.3.1
 google-analytics-data==0.14.2; python_version < '3.11'


### PR DESCRIPTION
Working with Mage AI in a local environment on M1 Mac I faced the following error when trying to write data to datalake.

> Generic S3 error: Error after 10 retries in 2.612435942s, max_retries:10, retry_timeout:180s, source:error sending request for url (https://s3..../_delta_log/_last_checkpoint): error trying to connect: invalid peer certificate: BadSignature

Seems it's a [known issue](https://github.com/delta-io/delta-rs/issues/2551). And can be solved by upgrading deltalake lib to 0.18.2 version.

This PR updates deltalake version from 0.17.4 to the most recent 0.20.0., however [`overwrite_schema` parameter has been dropped](https://github.com/delta-io/delta-rs/releases/tag/python-v0.18.0) since 0.18.0 due to

> fix: remove deprecated overwrite_schema configuration which has incorrect behavior

# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [ ] Test A
- [ ] Test B


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
