### PR TITLE
Add support to multiples webhook endpoints for Microsoft Teams notification service

### DIFF
--- a/mage_ai/services/teams/config.py
+++ b/mage_ai/services/teams/config.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass
+from typing import List
 
 from mage_ai.shared.config import BaseConfig
 
 
 @dataclass
 class TeamsConfig(BaseConfig):
-    webhook_url: str = None
+    webhook_url: List[str] = None
 
     def __post_init__(self):
         # Normalize webhook_url to a list if it's provided as a string

--- a/mage_ai/services/teams/config.py
+++ b/mage_ai/services/teams/config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+
 from mage_ai.shared.config import BaseConfig
 
 
@@ -6,6 +7,15 @@ from mage_ai.shared.config import BaseConfig
 class TeamsConfig(BaseConfig):
     webhook_url: str = None
 
+    def __post_init__(self):
+        # Normalize webhook_url to a list if it's provided as a string
+        if isinstance(self.webhook_url, str):
+            self.webhook_url = [self.webhook_url]
+        elif self.webhook_url is None:
+            self.webhook_url = []
+
     @property
     def is_valid(self) -> bool:
-        return self.webhook_url is not None and self.webhook_url != 'None'
+        return bool(self.webhook_url) and all(
+            url and url != 'None' and url.strip() != '' for url in self.webhook_url
+        )

--- a/mage_ai/services/teams/teams.py
+++ b/mage_ai/services/teams/teams.py
@@ -1,5 +1,6 @@
-from mage_ai.services.teams.config import TeamsConfig
 import requests
+
+from mage_ai.services.teams.config import TeamsConfig
 
 
 def send_teams_message(
@@ -7,13 +8,14 @@ def send_teams_message(
     message: str,
     title: str = 'Mage pipeline run status logs',
 ) -> None:
-    requests.post(
-        url=config.webhook_url,
-        json={
-            'summary': title,
-            'sections': [{
-                'activityTitle': title,
-                'activitySubtitle': message,
-            }],
-        },
-    )
+    for url in config.webhook_url:
+        requests.post(
+            url=url,
+            json={
+                'summary': title,
+                'sections': [{
+                    'activityTitle': title,
+                    'activitySubtitle': message,
+                }],
+            },
+        )

--- a/mage_ai/tests/orchestration/notification/test_config.py
+++ b/mage_ai/tests/orchestration/notification/test_config.py
@@ -2,10 +2,10 @@ from mage_ai.orchestration.notification.config import NotificationConfig
 from mage_ai.tests.base_test import TestCase
 from mage_ai.tests.orchestration.notification.constants import (
     EMAIL_NOTIFICATION_CONFIG,
+    GOOGLE_CHAT_NOTIFICATION_CONFIG,
+    OPSGENIE_NOTIFICATION_CONFIG,
     SLACK_NOTIFICATION_CONFIG,
     TEAMS_NOTIFICATION_CONFIG,
-    GOOGLE_CHAT_NOTIFICATION_CONFIG,
-    OPSGENIE_NOTIFICATION_CONFIG
 )
 
 
@@ -43,7 +43,7 @@ class NotificationConfigTests(TestCase):
         self.assertIsNone(config3.email_config)
         self.assertEqual(config3.slack_config.webhook_url, 'test_webhook_url')
 
-        self.assertEqual(config4.teams_config.webhook_url, 'test_webhook_url')
+        self.assertEqual(config4.teams_config.webhook_url, ['test_webhook_url'])
 
         self.assertEqual(config5.google_chat_config.webhook_url, 'test_webhook_url')
 


### PR DESCRIPTION
# Description
Fixes https://github.com/mage-ai/mage-ai/issues/5507
This change introduces support for multiple Microsoft Teams webhook URLs within the notification configuration. The previous structure allowed for a single webhook URL, as follows:

```yaml
notification_config:
  alert_on:
    - trigger_failure
    - trigger_success
  teams_config:
    webhook_url: URL 1
```

The updated structure enables the configuration of multiple webhook URLs:
```
notification_config:
  alert_on:
    - trigger_failure
    - trigger_success
  teams_config:
    webhook_url: 
      - URL 1
      - URL 2
```

This enhancement allows users to send notifications to multiple Teams channels simultaneously, providing greater flexibility in notification management.

Additionally, the new implementation retains compatibility with the existing configuration model. This ensures that current users can continue to operate without disruption, as the system will still recognize and function with the single webhook URL format.

PR for documentation update: https://github.com/mage-ai/mage-ai/pull/5511

**The test was updated to match the new data type `List[str]`

# How Has This Been Tested?
It was testing with 3 scenarios. 
1st - Single webhook as string 
2nd - Single webhook as list
3rd - Two webhooks as list

Here's some evidences for multiple webhooks (same message was sent to both channels):
Channel 1
![image](https://github.com/user-attachments/assets/3709d905-5e88-41d4-b06d-83779216248f)
Channel 2
![image](https://github.com/user-attachments/assets/fdcc6183-7940-4488-bc64-9ba3555ddedb)

- [ ] Test A
- [ ] Test B


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993 