### PR TITLE
BUG MongoDB config.json needs username instead of user

### DIFF
--- a/mage_integrations/mage_integrations/sources/mongodb/templates/config.json
+++ b/mage_integrations/mage_integrations/sources/mongodb/templates/config.json
@@ -3,5 +3,5 @@
   "host": "",
   "password": "",
   "port": 27017,
-  "user": ""
+  "username": ""
 }


### PR DESCRIPTION
When the template is presented in a new dataintegration pipeline it uses the wrong parameter for the username.

When using user, login is not possible. using username it works

# Description
I noticed login does not work on MongoDB, using username instead of user made the difference.


# How Has This Been Tested?
Create new dataintegration pipeline and setup mongodb as a source.

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
