### PR TITLE
Introducing Mage AI Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@
   >
     <img alt="pip installs" src="https://static.pepy.tech/personalized-badge/mage-ai?period=total&units=international_system&left_color=grey&right_color=blue&left_text=pip%20installs">
   </a>
+  <a
+    href="https://gurubase.io/g/mage-ai"
+    target="_blank"
+  >
+    <img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20Mage%20AI%20Guru-006BFF">
+  </a>
 </div>
 <img
   referrerpolicy="no-referrer-when-downgrade"


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Mage AI Guru](https://gurubase.io/g/mage-ai) to Gurubase. Mage AI Guru uses the data from this repo and data from the [docs](https://docs.mage.ai) to answer questions by leveraging the LLM.

In this PR, I showcased the "Mage AI Guru", which highlights that Mage AI now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Mage AI Guru in Gurubase, just let me know that's totally fine.
