### PR TITLE
[jk] Handle encoded page_block_layouts and block_outputs routes

### DIFF
--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -357,6 +357,15 @@ def make_app(
             r'/(?P<child>file_versions)',
             ApiChildListHandler
         ),
+        # Override APIs with encoded resource ID
+        (
+            r'/api/(?P<resource>page_block_layouts)/(?P<pk>.+)',
+            ApiResourceDetailHandler,
+        ),
+        (
+            r'/api/(?P<resource>block_outputs)/(?P<pk>.+)',
+            ApiResourceDetailHandler,
+        ),
         # Generic API patterns
         (
             r'/api/(?P<resource>\w+)/(?P<pk>[\w\-\%2f\.]+)'


### PR DESCRIPTION
# Description
- Fix handling of these routes with encoded forward slashes (`%2f`) when using nginx, which converts the `%2f` to a `/`:
- `/api/block_outputs/some_nested%2fblock`
- `/api/page_block_layouts/overview%2Fdashboard`
These routes were treating the part before the `%2f` as the `pk` and the part after as the `child` in this regex pattern: `r'/api/(?P<resource>\w+)/(?P<pk>[\w\-\%2f\.]+)/(?P<child>\w+)'`.

# How Has This Been Tested?
- Tested the correct matching of the regex patterns with the specific order of the routes in the `mage_ai/server/server.py` file.

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
