### PR TITLE
[jk] Environment-specific config override docs

### DIFF
--- a/docs/_snippets/contribution-process.mdx
+++ b/docs/_snippets/contribution-process.mdx
@@ -11,7 +11,6 @@
     <Step title="Tag Mage team members for a review">
     Add members for review in GitHub, please tag one of the following: 
         - `@wangxiaoyou1993` (backend/IO)
-        - `@dy46` (backend)
         - `@johnson-mage` (frontend/docs/website)
         - `@tommydangerous`
     </Step>

--- a/docs/contributing/development-environment.mdx
+++ b/docs/contributing/development-environment.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configure your development environment"
-sidebarTitle: "Environment setup"
+sidebarTitle: "Dev environment"
 icon: "alien"
 description: "Want to get started contributing code? You're in the right place! Read on to learn how to set up your development environment."
 ---

--- a/docs/extensibility/env-config/pipeline.mdx
+++ b/docs/extensibility/env-config/pipeline.mdx
@@ -4,3 +4,135 @@ sidebarTitle: "Pipeline configuration"
 description: "Add environment-specific overrides for your pipeline configuration."
 icon: "pipe-collar"
 ---
+
+import { ProButton } from '/snippets/pro/button.mdx';
+import { ProOnly } from '/snippets/pro/only.mdx';
+
+<ProOnly source="env-specific-config" />
+
+### Location of pipeline configuration
+
+Each pipeline in Mage has a `metadata.yaml` configuration file located in the
+pipeline uuid's folder under the `pipelines` directory. For example, if you
+had a pipeline with uuid `charismatic_inventor`, the folder structure for that
+pipeline might look something like this:
+
+```
+your_project/
+├─ pipelines/
+│  ├─ charismatic_inventor/
+│  │  ├─ __init__.py
+│  │  ├─ interactions.yaml
+│  │  ├─ metadata.yaml
+│  │  ├─ triggers.yaml
+├ ...
+```
+
+### **Override pipeline config based on environment**
+
+In the pipeline's `metadata.yaml` config file, add an `overrides` key at the top-level
+(no indentations) with the name of your environment (e.g. `prod`, `dev`, `test`) under
+the `overrides` key and indented once. Then under the environment name key, add the
+properties of your base pipeline config that you want to override. Make sure the
+indentations of the properties match those of the base config. Any environment-specific
+overrides will REPLACE the matching property in the base config, so be careful when
+overriding properties with nested values.
+
+<Note>
+The environment name should match the environment defined in the `ENV`
+[environment variable](https://docs.mage.ai/development/variables/environment-variables).
+</Note>
+
+### Example pipeline config file with environment overrides
+
+```yaml
+# your_project/pipelines/charismatic_inventor/metadata.yaml
+blocks:
+- all_upstream_blocks_executed: true
+  color: null
+  configuration:
+    disable_output_preview: false
+    file_source:
+      path: data_loaders/load_titanic.py
+    sample_count_preview: 0
+  downstream_blocks:
+  - starry_forest
+  executor_config: null
+  executor_type: local_python
+  has_callback: false
+  language: python
+  name: load_titanic
+  retry_config: {}
+  status: executed
+  timeout: null
+  type: data_loader
+  upstream_blocks: []
+  uuid: load_titanic
+- all_upstream_blocks_executed: true
+  color: null
+  configuration:
+    sample_count_preview: 8
+  downstream_blocks: []
+  executor_config: null
+  executor_type: local_python
+  has_callback: false
+  language: python
+  name: starry forest
+  retry_config: {}
+  status: executed
+  timeout: null
+  type: custom
+  upstream_blocks:
+  - load_titanic
+  uuid: starry_forest
+cache_block_output_in_memory: false
+callbacks: []
+concurrency_config:
+  pipeline_run_limit: 5
+  pipeline_run_limit_all_triggers: 5
+conditionals: []
+created_at: '2024-09-27 23:18:10.554952+00:00'
+data_integration: null
+description: null
+executor_config: {}
+executor_count: 1
+executor_type: null
+extensions: {}
+name: charismatic inventor
+notification_config: {}
+remote_variables_dir: null
+retry_config: {}
+run_pipeline_in_one_process: false
+settings:
+  triggers: null
+spark_config: {}
+state_store_config: {}
+tags: []
+type: python
+uuid: charismatic_inventor
+variables_dir: /root/.mage_data/default_repo
+widgets: []
+
+overrides:
+  prod:
+    concurrency_config:
+      pipeline_run_limit: 10
+      pipeline_run_limit_all_triggers: 20
+    description: Overridden description for charismatic inventor in prod
+  dev:
+    concurrency_config:
+      pipeline_run_limit: 1
+      pipeline_run_limit_all_triggers: 1
+    description: Overridden description for charismatic inventor in dev
+```
+
+In the example above when in the `dev` environment, the pipeline's configuration property
+of `concurrency_config` will have its `pipeline_run_limit` and `pipeline_run_limit_all_triggers`
+properties overridden to be `1` (instead of `5` as defined in the base config).
+The `description` property will also be overridden to be
+`Overridden description for charismatic inventor in dev` instead of `null`.
+
+Similarly for the `prod` environment, `pipeline_run_limit` will be replaced with `10` and 
+`pipeline_run_limit_all_triggers` with `20`. The `description` property will be overridden
+to be `Overridden description for charismatic inventor in prod`. Other environments
+(not `dev` or `prod`) will not utilize the `overrides` section.

--- a/docs/extensibility/env-config/pipeline.mdx
+++ b/docs/extensibility/env-config/pipeline.mdx
@@ -1,0 +1,6 @@
+---
+title: Pipeline configuration environment overrides
+sidebarTitle: "Pipeline configuration"
+description: "Add environment-specific overrides for your pipeline configuration."
+icon: "pipe-collar"
+---

--- a/docs/extensibility/env-config/project.mdx
+++ b/docs/extensibility/env-config/project.mdx
@@ -1,0 +1,6 @@
+---
+title: Project configuration environment overrides
+sidebarTitle: "Project configuration"
+description: "Add environment-specific overrides for your project configuration."
+icon: "briefcase"
+---

--- a/docs/extensibility/env-config/project.mdx
+++ b/docs/extensibility/env-config/project.mdx
@@ -4,3 +4,116 @@ sidebarTitle: "Project configuration"
 description: "Add environment-specific overrides for your project configuration."
 icon: "briefcase"
 ---
+
+import { ProButton } from '/snippets/pro/button.mdx';
+import { ProOnly } from '/snippets/pro/only.mdx';
+
+<ProOnly source="env-specific-config" />
+
+### Location of project configuration
+
+Each project in Mage has a `metadata.yaml` configuration file located in the
+project's root directory. For example, if you had a project called `your_project`,
+the folder structure for that project might look something like this:
+
+```
+your_project/
+├─ pipelines/
+├─ data_loaders/
+├─ transformers/
+├─ data_exporters/
+├─ .../
+├─ io_config.yaml
+├─ metadata.yaml
+├─ requirements.txt
+├─ ...
+```
+
+### **Override project config based on environment**
+
+In the project's `metadata.yaml` config file, add an `overrides` key at the top-level
+(no indentations) with the name of your environment (e.g. `prod`, `dev`, `test`) under
+the `overrides` key and indented once. Then under the environment name key, add the
+properties of your base project config that you want to override. Make sure the
+indentations of the properties match those of the base config. Any environment-specific
+overrides will REPLACE the matching property in the base config, so be careful when
+overriding properties with nested values.
+
+<Note>
+The environment name should match the environment defined in the `ENV`
+[environment variable](https://docs.mage.ai/development/variables/environment-variables).
+</Note>
+
+### Example project config file with environment overrides
+
+```yaml
+# your_project/metadata.yaml
+project_type: standalone
+
+variables_dir: ~/.mage_data
+remote_variables_dir: s3://bucket/path_prefix
+
+variables_retention_period: '90d'
+
+emr_config:
+  master_instance_type: 'r5.4xlarge'
+  slave_instance_type: 'r5.4xlarge'
+  master_security_group: 'sg-xxxxxxxxxxxx'
+  slave_security_group: 'sg-yyyyyyyyyyyy'
+  ec2_key_name: '[ec2_key_pair_name]'
+
+spark_config:
+  app_name: 'my spark app'
+  spark_master: 'local'
+  executor_env: {}
+  spark_jars: []
+  spark_home:
+  others: {}
+  use_custom_session: false
+  custom_session_var_name: 'spark'
+
+help_improve_mage: true
+notification_config:
+  alert_on:
+  - trigger_failure
+  - trigger_passed_sla
+  slack_config:
+    webhook_url: "{{ env_var('MAGE_SLACK_WEBHOOK_URL') }}"
+  teams_config:
+    webhook_url: "{{ env_var('MAGE_TEAMS_WEBHOOK_URL') }}"
+project_uuid: 123456781234abcd1234abcde123456
+features:
+  add_new_block_v2: true
+  code_block_v2: true
+  command_center: true
+  custom_design: true
+  data_integration_in_batch_pipeline: true
+  dbt_v2: true
+  interactions: true
+  display_local_timezone: true
+  notebook_block_output_split_view: true
+  operation_history: true
+  polars: true
+  automatic_kernel_cleanup: false
+pipelines:
+  settings:
+    triggers:
+      save_in_code_automatically: true
+
+overrides:
+  dev:
+    help_improve_mage: false
+    pipelines:
+      settings:
+        triggers:
+          save_in_code_automatically: false
+    features:
+      automatic_kernel_cleanup: true
+      global_hooks: true
+```
+
+In the example above when in the `dev` environment, the project's nested configuration
+property of `save_in_code_automatically` will be overridden to be `false` (instead of
+`true` as defined in the base config). The other properties (i.e. `help_improve_mage`,
+`automatic_kernel_cleanup`, and `global_hooks`) will also be overridden.
+Other environments (not `dev`) will not utilize the `overrides` section.

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -1104,6 +1104,13 @@
       ]
     },
     {
+      "group": "Environment-specific configuration",
+      "pages": [
+        "extensibility/env-config/project",
+        "extensibility/env-config/pipeline"
+      ]
+    },
+    {
       "group": "API",
       "icon": "robot",
       "pages": [


### PR DESCRIPTION
# Description
- Add docs for overriding project/pipeline configurations based on environment.

# How Has This Been Tested?
- Tested locally.
![image](https://github.com/user-attachments/assets/a9d76aa1-049c-4071-bde7-1e8294614b8e)
![image](https://github.com/user-attachments/assets/8fc8c4f0-e1fa-471f-ba83-b650fa2d431d)

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
