### PR TITLE
[xy] Support hiding and rotating API trigger token.

### DIFF
--- a/mage_ai/api/policies/PipelineSchedulePolicy.py
+++ b/mage_ai/api/policies/PipelineSchedulePolicy.py
@@ -100,6 +100,7 @@ PipelineSchedulePolicy.allow_read(PipelineSchedulePresenter.default_attributes +
 PipelineSchedulePolicy.allow_read(PipelineSchedulePresenter.default_attributes + [
     'event_matchers',
     'next_pipeline_run_date',
+    'rotate_token',
     'tags',
 ], scopes=[
     OauthScope.CLIENT_PRIVATE,

--- a/mage_ai/api/presenters/PipelineSchedulePresenter.py
+++ b/mage_ai/api/presenters/PipelineSchedulePresenter.py
@@ -1,5 +1,6 @@
 from mage_ai.api.operations import constants
 from mage_ai.api.presenters.BasePresenter import BasePresenter
+from mage_ai.settings.server import HIDE_API_TRIGGER_TOKEN
 
 
 class PipelineSchedulePresenter(BasePresenter):
@@ -32,8 +33,6 @@ class PipelineSchedulePresenter(BasePresenter):
             ])
             data['tags'] = sorted([tag.name for tag in self.get_tag_associations])
             data['next_pipeline_run_date'] = self.model.next_execution_date()
-
-            return data
         elif 'with_runtime_average' == display_format:
             data = self.model.to_dict()
             data['runtime_average'] = self.model.runtime_average()
@@ -47,6 +46,16 @@ class PipelineSchedulePresenter(BasePresenter):
         else:
             data = self.model.to_dict()
 
+        if display_format == constants.UPDATE:
+            rotate_token = kwargs.get(
+                'payload', dict(),
+            ).get(
+                'pipeline_schedule', dict(),
+            ).get('rotate_token')
+        else:
+            rotate_token = False
+        if HIDE_API_TRIGGER_TOKEN and not rotate_token:
+            data['token'] = '[API_TOKEN_PLACEHOLDER]'
         return data
 
 

--- a/mage_ai/api/resources/PipelineScheduleResource.py
+++ b/mage_ai/api/resources/PipelineScheduleResource.py
@@ -29,7 +29,7 @@ from mage_ai.orchestration.db.models.tags import (
 )
 from mage_ai.settings.platform import project_platform_activated
 from mage_ai.settings.repo import get_repo_path
-from mage_ai.shared.hash import merge_dict
+from mage_ai.shared.hash import ignore_keys, merge_dict
 
 
 class PipelineScheduleResource(DatabaseResource):
@@ -282,6 +282,7 @@ class PipelineScheduleResource(DatabaseResource):
 
     @safe_db_query
     def update(self, payload, **kwargs):
+        # Update associated event matchers
         arr = payload.pop('event_matchers', None)
         event_matchers = []
         if arr is not None:
@@ -320,6 +321,7 @@ class PipelineScheduleResource(DatabaseResource):
                 ]
                 em.update(pipeline_schedules=ps)
 
+        # Update associated tags
         tag_names = payload.pop('tags', None)
         if tag_names is not None:
             # 1. Fetch all tag associations
@@ -408,7 +410,11 @@ class PipelineScheduleResource(DatabaseResource):
 
         old_name = self.model.name
 
-        resource = super().update(payload)
+        # Rotate token
+        if payload.get('rotate_token'):
+            payload['token'] = uuid.uuid4().hex
+
+        resource = super().update(ignore_keys(payload, ['rotate_token']))
         updated_model = resource.model
 
         repo_path = get_repo_path(user=self.current_user)

--- a/mage_ai/settings/server.py
+++ b/mage_ai/settings/server.py
@@ -121,7 +121,7 @@ CONCURRENCY_CONFIG_PIPELINE_RUN_LIMIT = get_int_value(
 )
 DISABLE_AUTO_BROWSER_OPEN = get_bool_value(os.getenv('DISABLE_AUTO_BROWSER_OPEN', 'False'))
 DISABLE_AUTORELOAD = get_bool_value(os.getenv('DISABLE_AUTORELOAD', 'False'))
-HIDE_API_TRIGGER_TOKEN = get_bool_value(os.getenv('DISABLE_AUTORELOAD', 'False'))
+HIDE_API_TRIGGER_TOKEN = get_bool_value(os.getenv('HIDE_API_TRIGGER_TOKEN', 'False'))
 
 # The hostname in Kubernetes or AWS ECS
 HOSTNAME = os.getenv('HOSTNAME')

--- a/mage_ai/settings/server.py
+++ b/mage_ai/settings/server.py
@@ -121,6 +121,8 @@ CONCURRENCY_CONFIG_PIPELINE_RUN_LIMIT = get_int_value(
 )
 DISABLE_AUTO_BROWSER_OPEN = get_bool_value(os.getenv('DISABLE_AUTO_BROWSER_OPEN', 'False'))
 DISABLE_AUTORELOAD = get_bool_value(os.getenv('DISABLE_AUTORELOAD', 'False'))
+HIDE_API_TRIGGER_TOKEN = get_bool_value(os.getenv('DISABLE_AUTORELOAD', 'False'))
+
 # The hostname in Kubernetes or AWS ECS
 HOSTNAME = os.getenv('HOSTNAME')
 INITIAL_METADATA = os.getenv('INITIAL_METADATA')


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Support hiding and rotating API trigger token.
* It can be enabled with env var `HIDE_API_TRIGGER_TOKEN=true`
* Once it's enabled, any API calls to pipeline schedule API won't return the token in response. API trigger token won't be shown in the UI
<img width="638" alt="image" src="https://github.com/user-attachments/assets/d88416d7-bf92-42fd-929f-b02359702132" />

  * API trigger token will only be returned once on PipelineSchedule UPDATE request with `"rotate_token": true" in the paylod
 * How to rotate token
```
PUT /api/pipeline_schedules/[pipeline_schedule_id]
{
    "pipeline_schedule": {
        "rotate_token": true
    }
}
```

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally
<img width="446" alt="image" src="https://github.com/user-attachments/assets/6b1b6ba3-99d7-4eba-94f6-2c491d88439e" />



# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc: @tommydangerous @johnson-mage 
<!-- Optionally mention someone to let them know about this pull request -->
