### PR TITLE
[xy] Support configuring redis default timeout

### DIFF
--- a/mage_ai/orchestration/pipeline_scheduler_original.py
+++ b/mage_ai/orchestration/pipeline_scheduler_original.py
@@ -1583,7 +1583,7 @@ def schedule_all():
         pipeline_runs_excluded_by_limit = []
         for pipeline_schedule in active_schedules:
             lock_key = f'pipeline_schedule_{pipeline_schedule.id}'
-            if not lock.try_acquire_lock(lock_key):
+            if not lock.try_acquire_lock(lock_key, timeout=30):
                 continue
 
             trigger_pipeline_run_limit = pipeline_schedule.get_settings().pipeline_run_limit

--- a/mage_ai/orchestration/pipeline_scheduler_project_platform.py
+++ b/mage_ai/orchestration/pipeline_scheduler_project_platform.py
@@ -1567,7 +1567,7 @@ def schedule_all():
                 concurrency_config = ConcurrencyConfig.load(config=pipeline.concurrency_config)
 
                 lock_key = f'pipeline_schedule_{pipeline_schedule.id}'
-                if not lock.try_acquire_lock(lock_key):
+                if not lock.try_acquire_lock(lock_key, timeout=30):
                     continue
 
                 try:

--- a/mage_ai/orchestration/utils/distributed_lock.py
+++ b/mage_ai/orchestration/utils/distributed_lock.py
@@ -1,12 +1,19 @@
+import os
+
 from mage_ai.services.redis.redis import init_redis_client
 from mage_ai.settings import REDIS_URL
+
+try:
+    REDIS_LOCK_DEFAULT_TIMEOUT = int(os.getenv('REDIS_LOCK_DEFAULT_TIMEOUT', 30) or 30)
+except Exception:
+    REDIS_LOCK_DEFAULT_TIMEOUT = 30
 
 
 class DistributedLock:
     def __init__(
         self,
         lock_key_prefix='LOCK_KEY',
-        lock_timeout=30,
+        lock_timeout=REDIS_LOCK_DEFAULT_TIMEOUT,
     ):
         self.lock_key_prefix = lock_key_prefix
         self.lock_timeout = lock_timeout


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Support configuring Redis default timeout. 
* Set `REDIS_LOCK_DEFAULT_TIMEOUT` env var to number of seconds for the lock timeout

Close: https://github.com/mage-ai/mage-ai/issues/5619

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested  locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
