### PR TITLE
Fix typo

### DIFF
--- a/docs/design/data-pipeline-management.mdx
+++ b/docs/design/data-pipeline-management.mdx
@@ -240,7 +240,7 @@ The default value of `block_run_limit` and `pipeline_run_limit` can be set via e
 
 * `block_run_limit`: limit the concurrent blocks runs in one pipeline run.
 * `pipeline_run_limit`: limit the concurrent pipeline runs in one pipeline trigger.
-* `pipeline_run_limit_all_triggers`: limit the concurrent pipeline runs across all trigers in a pipeline.
+* `pipeline_run_limit_all_triggers`: limit the concurrent pipeline runs across all triggers in a pipeline.
 * `on_pipeline_run_limit_reached`: choose whether to `wait` or `skip` when the pipeline run limit is reached.
 
 ## Variable storage

--- a/mage_ai/frontend/components/PipelineDetail/Settings/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Settings/index.tsx
@@ -252,7 +252,7 @@ function PipelineSettings({
             description={(
               <>
                 <Text muted small>
-                  Limit the concurrent pipeline runs across all trigers in this pipeline.
+                  Limit the concurrent pipeline runs across all triggers in this pipeline.
                 </Text>
               </>
             )}


### PR DESCRIPTION
Fixes small typo (`"trigers" -> "triggers"`) I came across while working.