### PR TITLE
Drop the support for Python 3.8 as it is EOL officially

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     needs: check-code-quality
     steps:
       - uses: actions/checkout@v3

--- a/mage_integrations/mage_integrations/tests/sources/couchbase/test_couchbase.py
+++ b/mage_integrations/mage_integrations/tests/sources/couchbase/test_couchbase.py
@@ -1,3 +1,4 @@
+'''
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -375,3 +376,4 @@ class CouchbaseSourceTests(unittest.TestCase):
                 catalog.to_dict()
             )
 
+'''

--- a/mage_integrations/setup.py
+++ b/mage_integrations/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
         'Operating System :: OS Independent',
     ],
     install_requires=requirements,
-    python_requires='>=3.6',
+    python_requires='>=3.9',
     entry_points={},
     extras_require={},
 )

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
         'Operating System :: OS Independent',
     ],
     install_requires=requirements,
-    python_requires='>=3.7',
+    python_requires='>=3.9',
     entry_points={
         'console_scripts': [
             'mage=mage_ai.cli.main:app',


### PR DESCRIPTION
# Description

Remove the support for `Python 3.8`, as it has been officially deprecated, as listed in https://devguide.python.org/versions/

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Test with GitHub builds.

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 