### PR TITLE
[xy] Pass execution_partition to interpolate content method.

### DIFF
--- a/mage_ai/data_preparation/models/block/sql/__init__.py
+++ b/mage_ai/data_preparation/models/block/sql/__init__.py
@@ -150,6 +150,7 @@ def execute_sql_code(
     interpolate_vars_options = dict(
         block=block,
         dynamic_block_index=dynamic_block_index,
+        execution_partition=execution_partition,
         global_vars=global_vars,
     )
 

--- a/mage_ai/data_preparation/models/block/sql/utils/shared.py
+++ b/mage_ai/data_preparation/models/block/sql/utils/shared.py
@@ -232,7 +232,8 @@ def interpolate_vars(
     content: str,
     global_vars: Dict = None,
     block=None,
-    dynamic_block_index: int = None
+    dynamic_block_index: int = None,
+    execution_partition: str = None,
 ) -> str :
     if not content:
         return content
@@ -241,7 +242,10 @@ def interpolate_vars(
 
     if block:
         content = block.interpolate_content(
-            content, variables=global_vars, dynamic_block_index=dynamic_block_index,
+            content,
+            variables=global_vars,
+            dynamic_block_index=dynamic_block_index,
+            execution_partition=execution_partition,
         )
 
     return Template(


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Pass execution_partition to interpolate content method. so that we can interpolate the `block_output` with correct execution_partition.
https://docs.mage.ai/guides/blocks/sql-blocks#upstream-block-output

Close: https://github.com/mage-ai/mage-ai/issues/5660

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
