### PR TITLE
[hw] Update a deprecated git action version

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -100,7 +100,7 @@ jobs:
         env:
           PYTHONPATH: ${{ env.pythonLocation }}:. # Playwright tests on CI depend on the Python web server
         if: matrix.python-version == '3.10'
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report
@@ -139,7 +139,7 @@ jobs:
           yarn playwright install chromium &&
           yarn playwright test -c playwright-windows.config.ci.ts
         working-directory: mage_ai/frontend/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
# Description

Resolve the following error encountered in the GitHub build:

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Verified through successful GitHub builds.

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 