### PR TITLE
Update google-ads to version 25.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,8 @@ RUN \
   pip3 install --no-cache-dir "git+https://github.com/mage-ai/sqlglot#egg=sqlglot" && \
   # faster-fifo is not supported on Windows: https://github.com/alex-petrenko/faster-fifo/issues/17
   pip3 install --no-cache-dir faster-fifo && \
+  pip3 install --no-cache-dir google-ads==25.1.0 && \
+  pip3 install --no-cache-dir protobuf==4.25.6 && \
   if [ -z "$FEATURE_BRANCH" ] || [ "$FEATURE_BRANCH" = "null" ]; then \
   pip3 install --no-cache-dir "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations&subdirectory=mage_integrations"; \
   else \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -52,7 +52,9 @@ RUN \
   pip3 install --no-cache-dir "git+https://github.com/mage-ai/dbt-mysql.git#egg=dbt-mysql" && \
   pip3 install --no-cache-dir "git+https://github.com/mage-ai/sqlglot#egg=sqlglot" && \
   # faster-fifo is not supported on Windows: https://github.com/alex-petrenko/faster-fifo/issues/17
-  pip3 install --no-cache-dir faster-fifo
+  pip3 install --no-cache-dir faster-fifo && \
+  pip3 install --no-cache-dir google-ads==25.1.0 && \
+  pip3 install --no-cache-dir protobuf==4.25.6
 COPY mage_integrations /tmp/mage_integrations
 RUN \
   pip3 install --no-cache-dir /tmp/mage_integrations && \


### PR DESCRIPTION
Fixes #5674

Update `google-ads` module to version 25.1.0 in Dockerfiles

* **dev.Dockerfile**
  - Add `google-ads==25.1.0` to the list of Python packages to install
  - Add `protobuf==4.25.6` to the list of Python packages to install

* **Dockerfile**
  - Add `google-ads==25.1.0` to the list of Python packages to install
  - Add `protobuf==4.25.6` to the list of Python packages to install

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mage-ai/mage-ai/pull/5675?shareId=4de2b760-8365-447d-b468-c214acbc843a).