### PR TITLE
Enhance Snowflake Connection to Support Private Key Authentication

### DIFF
--- a/mage_ai/io/config.py
+++ b/mage_ai/io/config.py
@@ -127,6 +127,7 @@ class ConfigKey(StrEnum):
     SNOWFLAKE_PASSWORD = 'SNOWFLAKE_PASSWORD'
     SNOWFLAKE_PRIVATE_KEY_PASSPHRASE = 'SNOWFLAKE_PRIVATE_KEY_PASSPHRASE'
     SNOWFLAKE_PRIVATE_KEY_PATH = 'SNOWFLAKE_PRIVATE_KEY_PATH'
+    SNOWFLAKE_PRIVATE_KEY = 'SNOWFLAKE_PRIVATE_KEY'
     SNOWFLAKE_ROLE = 'SNOWFLAKE_ROLE'
     SNOWFLAKE_TIMEOUT = 'SNOWFLAKE_TIMEOUT'
     SNOWFLAKE_USER = 'SNOWFLAKE_USER'
@@ -444,6 +445,7 @@ class ConfigFileLoader(BaseConfigLoader):
         ConfigKey.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE: (
             VerboseConfigKey.SNOWFLAKE, 'private_key_passphrase'),
         ConfigKey.SNOWFLAKE_PRIVATE_KEY_PATH: (VerboseConfigKey.SNOWFLAKE, 'private_key_path'),
+        ConfigKey.SNOWFLAKE_PRIVATE_KEY: (VerboseConfigKey.SNOWFLAKE, 'private_key'),
         ConfigKey.SNOWFLAKE_ROLE: (VerboseConfigKey.SNOWFLAKE, 'role'),
         ConfigKey.SNOWFLAKE_TIMEOUT: (VerboseConfigKey.SNOWFLAKE, 'timeout'),
         ConfigKey.SNOWFLAKE_USER: (VerboseConfigKey.SNOWFLAKE, 'user'),

--- a/mage_ai/io/snowflake.py
+++ b/mage_ai/io/snowflake.py
@@ -28,15 +28,21 @@ class Snowflake(BaseSQLConnection):
 
     def __init__(self, **kwargs) -> None:
         """
-        Initializes settings for connecting to Snowflake data warehouse.
+        Initializes settings for connecting to Snowflake data warehouse,
+        with optional support for private key authentication.
         The following arguments must be provided to the connector, all other
         arguments are optional.
 
         Required Arguments:
             user (str): Username for the Snowflake user.
-            password (str): Login Password for the user.
             account (str): Snowflake account identifier (excluding
             `snowflake-computing.com` suffix).
+
+        Optional Arguments:
+            password (str): Login Password for the user (if not using private key).
+            private_key (bytes, optional): Private key bytes for authentication
+            (if not using password).
+            passphrase (str, optional): Passphrase for the private key (if applicable).
         """
         if 'login_timeout' not in kwargs:
             kwargs['login_timeout'] = DEFAULT_LOGIN_TIMEOUT
@@ -459,6 +465,9 @@ INSERT INTO "{database}"."{schema}"."{table_name}"
 
         if ConfigKey.SNOWFLAKE_PASSWORD in config:
             conn_kwargs['password'] = config[ConfigKey.SNOWFLAKE_PASSWORD]
+
+        if ConfigKey.SNOWFLAKE_PRIVATE_KEY in config:
+            conn_kwargs['private_key'] = config[ConfigKey.SNOWFLAKE_PASSWORD]
 
         elif ConfigKey.SNOWFLAKE_PRIVATE_KEY_PATH in config:
             with open(config[ConfigKey.SNOWFLAKE_PRIVATE_KEY_PATH], 'rb') as key:

--- a/mage_integrations/mage_integrations/connections/snowflake/__init__.py
+++ b/mage_integrations/mage_integrations/connections/snowflake/__init__.py
@@ -1,3 +1,4 @@
+from cryptography.hazmat.primitives import serialization
 from snowflake.connector import connect
 
 from mage_integrations.connections.sql.base import Connection
@@ -8,30 +9,66 @@ class Snowflake(Connection):
         self,
         account: str,
         database: str,
-        password: str,
         schema: str,
-        username: str,
         warehouse: str,
+        username: str = None,
+        password: str = None,
+        private_key: bytes = None,
+        passphrase: str = None,
         role: str = None,
     ):
         super().__init__()
         self.account = account
         self.database = database
-        self.password = password
         self.schema = schema
-        self.username = username
         self.warehouse = warehouse
+        self.username = username
+        self.password = password
+        self.private_key = private_key
+        self.passphrase = passphrase
         self.role = role
 
+        if private_key:
+            if not self.passphrase:
+                raise ValueError("Private key authentication requires 'passphrase'.")
+            self.private_key = self.load_private_key(private_key, passphrase)
+            self.passphrase = passphrase
+            self.password = None
+        else:
+            if not username or not password:
+                raise ValueError("Username and password are required if not using"
+                                 "private key authentication.")
+            self.password = password
+            self.private_key = None
+            self.passphrase = None
+
+    @staticmethod
+    def load_private_key(private_key_str: str, passphrase: str):
+        """Load private key content from a string and decrypt with passphrase."""
+        try:
+            private_key = serialization.load_pem_private_key(
+                private_key_str.encode('utf-8'),
+                password=passphrase.encode('utf-8'),
+            )
+            return private_key
+        except ValueError as e:
+            raise ValueError(f"Failed to load private key: {e}")
+
     def build_connection(self):
-        connect_kwargs = dict(
-            account=self.account,
-            database=self.database,
-            password=self.password,
-            schema=self.schema,
-            user=self.username,
-            warehouse=self.warehouse,
-        )
+        connect_kwargs = {
+            "account": self.account,
+            "database": self.database,
+            "schema": self.schema,
+            "warehouse": self.warehouse,
+            "user": self.username,  # Snowflake uses 'user' instead of 'username'
+        }
+
         if self.role:
-            connect_kwargs['role'] = self.role
+            connect_kwargs["role"] = self.role
+
+        if self.private_key:
+            connect_kwargs["private_key"] = self.private_key
+            connect_kwargs["passphrase"] = self.passphrase
+        else:
+            connect_kwargs["password"] = self.password
         return connect(**connect_kwargs)

--- a/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
+++ b/mage_integrations/mage_integrations/destinations/snowflake/__init__.py
@@ -44,15 +44,24 @@ class Snowflake(Destination):
         return self.config.get('disable_double_quotes', False)
 
     def build_connection(self) -> SnowflakeConnection:
-        return SnowflakeConnection(
-            account=self.config['account'],
-            database=self.config['database'],
-            password=self.config['password'],
-            schema=self.config['schema'],
-            username=self.config['username'],
-            warehouse=self.config['warehouse'],
-            role=self.config.get('role'),
-        )
+        conn_kwargs = {
+            "account": self.config["account"],
+            "database": self.config["database"],
+            "schema": self.config["schema"],
+            "warehouse": self.config["warehouse"],
+            "role": self.config.get("role"),
+            "username": self.config["username"],
+        }
+
+        if self.config.get("private_key"):
+            conn_kwargs.update({
+                "private_key": self.config["private_key"],
+                "passphrase": self.config["passphrase"],
+            })
+        else:
+            conn_kwargs["password"] = self.config["password"]
+
+        return SnowflakeConnection(**conn_kwargs)
 
     def build_create_table_commands(
         self,

--- a/mage_integrations/mage_integrations/destinations/snowflake/templates/config.json
+++ b/mage_integrations/mage_integrations/destinations/snowflake/templates/config.json
@@ -2,11 +2,13 @@
   "account": "",
   "database": "",
   "disable_double_quotes": false,
-  "password": "",
   "role": "",
   "schema": "",
   "table": "",
   "username": "",
+  "password": "",
+  "private_key": "",
+  "passphrase": "",
   "warehouse": "",
   "use_batch_load": true
 }

--- a/mage_integrations/mage_integrations/sources/snowflake/__init__.py
+++ b/mage_integrations/mage_integrations/sources/snowflake/__init__.py
@@ -17,15 +17,24 @@ class Snowflake(Source):
         return f'"{database_name}"."{schema_name}".'
 
     def build_connection(self) -> SnowflakeConnection:
-        return SnowflakeConnection(
-            account=self.config['account'],
-            database=self.config['database'],
-            password=self.config['password'],
-            schema=self.config['schema'],
-            username=self.config['username'],
-            warehouse=self.config['warehouse'],
-            role=self.config.get('role'),
-        )
+        conn_kwargs = {
+            "account": self.config["account"],
+            "database": self.config["database"],
+            "schema": self.config["schema"],
+            "warehouse": self.config["warehouse"],
+            "role": self.config.get("role"),
+            "username": self.config["username"],
+        }
+
+        if self.config.get("private_key"):
+            conn_kwargs.update({
+                "private_key": self.config["private_key"],
+                "passphrase": self.config["passphrase"],
+            })
+        else:
+            conn_kwargs["password"] = self.config["password"]
+
+        return SnowflakeConnection(**conn_kwargs)
 
     def build_discover_query(self, streams: List[str] = None) -> str:
         database = self.config['database']

--- a/mage_integrations/mage_integrations/sources/snowflake/templates/config.json
+++ b/mage_integrations/mage_integrations/sources/snowflake/templates/config.json
@@ -1,9 +1,11 @@
 {
   "account": "",
   "database": "",
-  "password": "",
   "role": "",
   "schema": "",
   "username": "",
+  "password": "",
+  "private_key": "",
+  "passphrase": "",
   "warehouse": ""
 }

--- a/mage_integrations/mage_integrations/tests/destinations/snowflake/test_snowflake.py
+++ b/mage_integrations/mage_integrations/tests/destinations/snowflake/test_snowflake.py
@@ -33,6 +33,17 @@ class SnowflakeDestinationTests(unittest.TestCase, SQLDestinationMixin):
         'warehouse': 'warehouse',
         'lower_case': False,
     }
+    config_private_key = {
+        'account': 'account',
+        'database': 'database',
+        'private_key': 'private_key',
+        'passphrase': 'passphrase',
+        'schema': 'schema',
+        'username': 'username',
+        'warehouse': 'warehouse',
+        'lower_case': False,
+    }
+
     conn_class_path = 'mage_integrations.destinations.snowflake.SnowflakeConnection'
     destination_class = Snowflake
     expected_conn_class_kwargs = dict(
@@ -44,12 +55,24 @@ class SnowflakeDestinationTests(unittest.TestCase, SQLDestinationMixin):
         warehouse='warehouse',
         role=None,
     )
+    expected_conn_class_kwargs_private_key = dict(
+        account='account',
+        database='database',
+        private_key='private_key',
+        passphrase='passphrase',
+        schema='schema',
+        username='username',
+        warehouse='warehouse',
+        role=None,
+    )
     expected_template_config = {
         'config': {
             'account': '',
             'database': '',
             'disable_double_quotes': False,
             'password': '',
+            'private_key': '',
+            'passphrase': '',
             'role': '',
             'schema': '',
             'table': '',
@@ -61,6 +84,19 @@ class SnowflakeDestinationTests(unittest.TestCase, SQLDestinationMixin):
 
     def test_create_table_commands(self):
         destination = Snowflake(config=self.config)
+        destination.key_properties = {}
+        table_commands = destination.build_create_table_commands(SCHEMA,
+                                                                 SCHEMA_NAME,
+                                                                 STREAM,
+                                                                 TABLE_NAME,
+                                                                 database_name=DATABASE_NAME)
+        self.assertEqual(
+            table_commands,
+            ['CREATE TABLE "test_db"."test"."test_table" ("ID" VARCHAR, "_USER" VARIANT)']
+        )
+
+    def test_create_table_commands__private_key(self):
+        destination = Snowflake(config=self.config_private_key)
         destination.key_properties = {}
         table_commands = destination.build_create_table_commands(SCHEMA,
                                                                  SCHEMA_NAME,


### PR DESCRIPTION
# Description
This PR improves the Snowflake connection implementation by adding robust support for private key authentication. Key changes include:

- Added load_private_key method to handle private key decryption and conversion to bytes.
- If a private key is provided, password-based authentication is ignored.
- If a private key is used, a passphrase is required.
- Implemented explicit exception handling for key loading errors.
- Ensured only required credentials are stored (e.g., no unused passwords).


# How Has This Been Tested?
Tested with Mage local

<img width="1095" alt="image" src="https://github.com/user-attachments/assets/b71eb18e-4cb5-445c-9cb1-a328723ce78b" />

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993