### PR TITLE
[xy] Fix MySQL error.

### DIFF
--- a/mage_ai/io/mysql.py
+++ b/mage_ai/io/mysql.py
@@ -42,14 +42,16 @@ class MySQL(BaseSQL):
 
     @classmethod
     def with_config(cls, config: BaseConfigLoader) -> 'MySQL':
-        return cls(
+        conn_kwargs = dict(
             database=config[ConfigKey.MYSQL_DATABASE],
             host=config[ConfigKey.MYSQL_HOST],
             password=config[ConfigKey.MYSQL_PASSWORD],
             port=config[ConfigKey.MYSQL_PORT],
             user=config[ConfigKey.MYSQL_USER],
-            allow_local_infile=config[ConfigKey.MYSQL_ALLOW_LOCAL_INFILE],
         )
+        if config[ConfigKey.MYSQL_ALLOW_LOCAL_INFILE] is not None:
+            conn_kwargs['allow_local_infile'] = config[ConfigKey.MYSQL_ALLOW_LOCAL_INFILE]
+        return cls(**conn_kwargs)
 
     def build_create_table_command(
         self,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix MySQL error.
```
MySQL initialized
└─ Opening connection to MySQL database...
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
File /usr/local/lib/python3.10/site-packages/mage_ai/data_preparation/models/block/sql/__init__.py:401, in execute_sql_code(block, query, dynamic_block_index, dynamic_upstream_block_uuids, execution_partition, from_notebook, global_vars, config_file_loader, configuration)
    398 elif DataSource.MYSQL.value == data_provider:
    399     from mage_ai.io.mysql import MySQL
--> 401     with MySQL.with_config(config_file_loader) as loader:
    402         mysql.create_upstream_block_tables(
    403             loader,
    404             block,
    405             **create_upstream_block_tables_kwargs,
    406         )
    408         query_string = mysql.interpolate_input_data(
    409             block,
    410             query,
    411             **interpolate_input_data_kwargs,
    412         )
File /usr/local/lib/python3.10/site-packages/mage_ai/io/base.py:426, in BaseSQLConnection.__enter__(self)
    425 def __enter__(self):
--> 426     self.open()
    427     return self
File /usr/local/lib/python3.10/site-packages/mage_ai/io/mysql.py:94, in MySQL.open(self)
     92 def open(self) -> None:
     93     with self.printer.print_msg('Opening connection to MySQL database'):
---> 94         self._ctx = connect(**self.settings)
File /usr/local/lib/python3.10/site-packages/mysql/connector/pooling.py:322, in connect(*args, **kwargs)
    319         raise ImportError(ERROR_NO_CEXT)
    321 if CMySQLConnection and not use_pure:
--> 322     return CMySQLConnection(*args, **kwargs)
    323 return MySQLConnection(*args, **kwargs)
File /usr/local/lib/python3.10/site-packages/mysql/connector/connection_cext.py:144, in CMySQLConnection.__init__(self, **kwargs)
    142 if kwargs:
    143     try:
--> 144         self.connect(**kwargs)
    145     except Exception:
    146         self.close()
File /usr/local/lib/python3.10/site-packages/mysql/connector/abstracts.py:1360, in MySQLConnectionAbstract.connect(self, **kwargs)
   1357     self.config(**kwargs)
   1359 self.disconnect()
-> 1360 self._open_connection()
   1362 charset, collation = (
   1363     kwargs.pop("charset", None),
   1364     kwargs.pop("collation", None),
   1365 )
   1366 if charset or collation:
File /usr/local/lib/python3.10/site-packages/mysql/connector/connection_cext.py:327, in CMySQLConnection._open_connection(self)
    324     cnx_kwargs["use_kerberos_gssapi"] = True
    326 try:
--> 327     self._cmysql.connect(**cnx_kwargs)
    328     self._cmysql.converter_str_fallback = self._converter_str_fallback
    329     if self.converter:
TypeError: 'NoneType' object cannot be interpreted as an integer
```

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
