### PR TITLE
[jk] User management pagination

### DIFF
--- a/mage_ai/api/resources/UserResource.py
+++ b/mage_ai/api/resources/UserResource.py
@@ -28,7 +28,7 @@ class UserResource(DatabaseResource):
         results = (
             User.
             query.
-            order_by(User.username.asc())
+            order_by(User.id.asc())
         )
 
         if user and user.is_admin:


### PR DESCRIPTION
# Description
- Add pagination to users table on `/settings/workspace/users` and `/manage/users` pages.

# How Has This Been Tested?
- Tested locally and confirmed that all users were visible by viewing different pages.

`/settings/workspace/users`
<img width="1483" alt="image" src="https://github.com/user-attachments/assets/458c62c1-e6b9-4352-b21d-53d298055ce8" />

`/manage/users`
<img width="1419" alt="image" src="https://github.com/user-attachments/assets/03830001-1fad-4080-80cc-747dc89b83f1" />

# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
