### PR TITLE
Bumping facebook_ads version

### DIFF
--- a/mage_integrations/requirements.txt
+++ b/mage_integrations/requirements.txt
@@ -8,7 +8,7 @@ couchbase==4.1.1; python_version < '3.11'
 couchbase==4.3.5; python_version >= '3.11'
 deltalake==0.20.2
 elasticsearch==8.15.1
-facebook_business==20.0.2
+facebook_business==22.0.2
 gnupg==2.3.1
 google-ads==25.1.0
 google-analytics-data==0.14.2; python_version < '3.11'

--- a/requirements.txt
+++ b/requirements.txt
@@ -141,7 +141,7 @@ attrs==24.2.0; python_version >= '3.12'
 backoff
 clickhouse_sqlalchemy
 deltalake==0.20.2
-facebook_business==20.0.2
+facebook_business==22.0.2
 gnupg==2.3.1
 google-analytics-data==0.14.2; python_version < '3.11'
 google-analytics-data==0.15.0; python_version >= '3.11'


### PR DESCRIPTION
Meta is deprecating all their API-versions prior to v21.0 on Tuesday, May 6, 2025. [https://developers.facebook.com/docs/marketing-api/marketing-api-changelog#available-marketing-api-versions](url)

Bumping Facebook Ads SDK to version 22.0.2

No changes on the source tap code were made to support this version.

Tested on local Mage run with the updated SDK and no bugs/issues were detected.

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code

cc:
@wangxiaoyou1993 
