### PR TITLE
Migrate to unittest.assertEqual

### DIFF
--- a/mage_integrations/mage_integrations/sources/facebook_ads/tests/test_facebook_invalid_attribution_window.py
+++ b/mage_integrations/mage_integrations/sources/facebook_ads/tests/test_facebook_invalid_attribution_window.py
@@ -46,7 +46,7 @@ class FacebookInvalidAttributionWindowInt(FacebookBaseTest):
         # get discovery error message
         discovery_error_message = exit_status.get('discovery_error_message')
         # validate the error message
-        self.assertEquals(discovery_error_message, "The attribution window must be 1, 7 or 28.")
+        self.assertEqual(discovery_error_message, "The attribution window must be 1, 7 or 28.")
         self.assertIsNone(exit_status.get('target_exit_status'))
         self.assertIsNone(exit_status.get('tap_exit_status'))
 
@@ -62,4 +62,4 @@ class FacebookInvalidAttributionWindowStr(FacebookInvalidAttributionWindowInt):
         self.ATTRIBUTION_WINDOW = 'something'
         self.run_test()
 
-    # BUG : TDL-18569 created to standarize the error message for sting values for attribution window
+    # BUG : TDL-18569 created to standardize the error message for sting values for attribution window

--- a/mage_integrations/mage_integrations/sources/facebook_ads/tests/unittests/test_attribute_error_retry.py
+++ b/mage_integrations/mage_integrations/sources/facebook_ads/tests/unittests/test_attribute_error_retry.py
@@ -4,7 +4,7 @@ from unittest import mock
 from tap_facebook import AdCreative, Ads, AdSets, Campaigns, AdsInsights, Leads
 
 @mock.patch("time.sleep")
-class TestAttributErrorBackoff(unittest.TestCase):
+class TestAttributeErrorBackoff(unittest.TestCase):
     """A set of unit tests to ensure that requests are retrying properly for AttributeError Error"""
     def test_get_adcreatives(self, mocked_sleep):
         """ 
@@ -24,7 +24,7 @@ class TestAttributErrorBackoff(unittest.TestCase):
             ad_creative_object.get_adcreatives()
 
         # verify get_ad_creatives() is called 5 times as max 5 reties provided for function
-        self.assertEquals(mocked_account.get_ad_creatives.call_count, 5)
+        self.assertEqual(mocked_account.get_ad_creatives.call_count, 5)
 
     def test_call_get_ads(self, mocked_sleep):
         """ 
@@ -44,7 +44,7 @@ class TestAttributErrorBackoff(unittest.TestCase):
             ad_object._call_get_ads('test')
 
         # verify get_ads() is called 5 times as max 5 reties provided for function
-        self.assertEquals(mocked_account.get_ads.call_count, 5)
+        self.assertEqual(mocked_account.get_ads.call_count, 5)
 
     @mock.patch("pendulum.parse")
     def test_ad_prepare_record(self, mocked_parse, mocked_sleep):
@@ -72,7 +72,7 @@ class TestAttributErrorBackoff(unittest.TestCase):
                 pass
 
         # verify prepare_record() function by checking call count of mocked ad.api_get()
-        self.assertEquals(mocked_ad.api_get.call_count, 5)
+        self.assertEqual(mocked_ad.api_get.call_count, 5)
 
     def test__call_get_ad_sets(self, mocked_sleep):
         """ 
@@ -92,7 +92,7 @@ class TestAttributErrorBackoff(unittest.TestCase):
             ad_set_object._call_get_ad_sets('test')
 
         # verify get_ad_sets() is called 5 times as max 5 reties provided for function
-        self.assertEquals(mocked_account.get_ad_sets.call_count, 5)
+        self.assertEqual(mocked_account.get_ad_sets.call_count, 5)
 
     @mock.patch("pendulum.parse")
     def test_adset_prepare_record(self, mocked_parse, mocked_sleep):
@@ -121,7 +121,7 @@ class TestAttributErrorBackoff(unittest.TestCase):
                 pass
 
         # verify prepare_record() function by checking call count of mocked ad.api_get()
-        self.assertEquals(mocked_adset.api_get.call_count, 5)
+        self.assertEqual(mocked_adset.api_get.call_count, 5)
 
     def test__call_get_campaigns(self, mocked_sleep):
         """ 
@@ -141,7 +141,7 @@ class TestAttributErrorBackoff(unittest.TestCase):
             campaigns_object._call_get_campaigns('test')
 
         # verify get_campaigns() is called 5 times as max 5 reties provided for function
-        self.assertEquals(mocked_account.get_campaigns.call_count, 5)
+        self.assertEqual(mocked_account.get_campaigns.call_count, 5)
 
     @mock.patch("pendulum.parse")
     def test_campaign_prepare_record(self, mocked_parse, mocked_sleep):
@@ -170,7 +170,7 @@ class TestAttributErrorBackoff(unittest.TestCase):
                 pass
 
         # verify prepare_record() function by checking call count of mocked ad.api_get()
-        self.assertEquals(mocked_campaign.api_get.call_count, 5)
+        self.assertEqual(mocked_campaign.api_get.call_count, 5)
 
     def test_run_job(self, mocked_sleep):
         """ 
@@ -190,4 +190,4 @@ class TestAttributErrorBackoff(unittest.TestCase):
             ads_insights_object.run_job('test')
 
         # verify get_insights() is called 5 times as max 5 reties provided for function
-        self.assertEquals(mocked_account.get_insights.call_count, 5)
+        self.assertEqual(mocked_account.get_insights.call_count, 5)

--- a/mage_integrations/mage_integrations/sources/facebook_ads/tests/unittests/test_attribution_window.py
+++ b/mage_integrations/mage_integrations/sources/facebook_ads/tests/unittests/test_attribution_window.py
@@ -26,4 +26,4 @@ class TestAttributionWindow(unittest.TestCase):
             error_message = str(e)
 
         # verify the error message was as expected
-        self.assertEquals(error_message, "The attribution window must be 1, 7 or 28.")
+        self.assertEqual(error_message, "The attribution window must be 1, 7 or 28.")

--- a/mage_integrations/mage_integrations/sources/facebook_ads/tests/unittests/test_request_timeout.py
+++ b/mage_integrations/mage_integrations/sources/facebook_ads/tests/unittests/test_request_timeout.py
@@ -26,7 +26,7 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
             ad_creative_object.get_adcreatives()
 
         # verify get_ad_creatives() is called 5 times as max 5 reties provided for function
-        self.assertEquals(mocked_account.get_ad_creatives.call_count, 5)
+        self.assertEqual(mocked_account.get_ad_creatives.call_count, 5)
 
     def test__call_get_ads(self, mocked_sleep):
         """ 
@@ -46,7 +46,7 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
             ad_object._call_get_ads('test')
 
         # verify get_ads() is called 5 times as max 5 reties provided for function
-        self.assertEquals(mocked_account.get_ads.call_count, 5)
+        self.assertEqual(mocked_account.get_ads.call_count, 5)
 
     @mock.patch("pendulum.parse")
     def test_ad_prepare_record(self, mocked_parse, mocked_sleep):
@@ -74,7 +74,7 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
                 pass
 
         # verify prepare_record() function by checking call count of mocked ad.api_get()
-        self.assertEquals(mocked_ad.api_get.call_count, 5)
+        self.assertEqual(mocked_ad.api_get.call_count, 5)
 
     def test__call_get_ad_sets(self, mocked_sleep):
         """ 
@@ -94,7 +94,7 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
             ad_set_object._call_get_ad_sets('test')
 
         # verify get_ad_sets() is called 5 times as max 5 reties provided for function
-        self.assertEquals(mocked_account.get_ad_sets.call_count, 5)
+        self.assertEqual(mocked_account.get_ad_sets.call_count, 5)
 
     @mock.patch("pendulum.parse")
     def test_adset_prepare_record(self, mocked_parse, mocked_sleep):
@@ -123,7 +123,7 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
                 pass
 
         # verify prepare_record() function by checking call count of mocked ad.api_get()
-        self.assertEquals(mocked_adset.api_get.call_count, 5)
+        self.assertEqual(mocked_adset.api_get.call_count, 5)
 
     def test__call_get_campaigns(self, mocked_sleep):
         """ 
@@ -143,7 +143,7 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
             campaigns_object._call_get_campaigns('test')
 
         # verify get_campaigns() is called 5 times as max 5 reties provided for function
-        self.assertEquals(mocked_account.get_campaigns.call_count, 5)
+        self.assertEqual(mocked_account.get_campaigns.call_count, 5)
 
     @mock.patch("pendulum.parse")
     def test_campaign_prepare_record(self, mocked_parse, mocked_sleep):
@@ -172,7 +172,7 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
                 pass
 
         # verify prepare_record() function by checking call count of mocked ad.api_get()
-        self.assertEquals(mocked_campaign.api_get.call_count, 5)
+        self.assertEqual(mocked_campaign.api_get.call_count, 5)
 
     def test_run_job(self, mocked_sleep):
         """ 
@@ -192,7 +192,7 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
             ads_insights_object.run_job('test')
 
         # verify get_insights() is called 5 times as max 5 reties provided for function
-        self.assertEquals(mocked_account.get_insights.call_count, 5)
+        self.assertEqual(mocked_account.get_insights.call_count, 5)
 
 @mock.patch("time.sleep")
 class TestConnectionErrorBackoff(unittest.TestCase):
@@ -215,7 +215,7 @@ class TestConnectionErrorBackoff(unittest.TestCase):
             ad_creative_object.get_adcreatives()
 
         # verify get_ad_creatives() is called 5 times as max 5 reties provided for function
-        self.assertEquals(mocked_account.get_ad_creatives.call_count, 5)
+        self.assertEqual(mocked_account.get_ad_creatives.call_count, 5)
 
     def test__call_get_ads(self, mocked_sleep):
         """ 
@@ -235,7 +235,7 @@ class TestConnectionErrorBackoff(unittest.TestCase):
             ad_object._call_get_ads('test')
 
         # verify get_ads() is called 5 times as max 5 reties provided for function
-        self.assertEquals(mocked_account.get_ads.call_count, 5)
+        self.assertEqual(mocked_account.get_ads.call_count, 5)
 
     @mock.patch("pendulum.parse")
     def test_ad_prepare_record(self, mocked_parse, mocked_sleep):
@@ -263,7 +263,7 @@ class TestConnectionErrorBackoff(unittest.TestCase):
                 pass
 
         # verify prepare_record() function by checking call count of mocked ad.api_get()
-        self.assertEquals(mocked_ad.api_get.call_count, 5)
+        self.assertEqual(mocked_ad.api_get.call_count, 5)
 
     def test__call_get_ad_sets(self, mocked_sleep):
         """ 
@@ -283,7 +283,7 @@ class TestConnectionErrorBackoff(unittest.TestCase):
             ad_set_object._call_get_ad_sets('test')
 
         # verify get_ad_sets() is called 5 times as max 5 reties provided for function
-        self.assertEquals(mocked_account.get_ad_sets.call_count, 5)
+        self.assertEqual(mocked_account.get_ad_sets.call_count, 5)
 
     @mock.patch("pendulum.parse")
     def test_adset_prepare_record(self, mocked_parse, mocked_sleep):
@@ -312,7 +312,7 @@ class TestConnectionErrorBackoff(unittest.TestCase):
                 pass
 
         # verify prepare_record() function by checking call count of mocked ad.api_get()
-        self.assertEquals(mocked_adset.api_get.call_count, 5)
+        self.assertEqual(mocked_adset.api_get.call_count, 5)
 
     def test__call_get_campaigns(self, mocked_sleep):
         """ 
@@ -332,7 +332,7 @@ class TestConnectionErrorBackoff(unittest.TestCase):
             campaigns_object._call_get_campaigns('test')
 
         # verify get_campaigns() is called 5 times as max 5 reties provided for function
-        self.assertEquals(mocked_account.get_campaigns.call_count, 5)
+        self.assertEqual(mocked_account.get_campaigns.call_count, 5)
 
     @mock.patch("pendulum.parse")
     def test_campaign_prepare_record(self, mocked_parse, mocked_sleep):
@@ -361,7 +361,7 @@ class TestConnectionErrorBackoff(unittest.TestCase):
                 pass
 
         # verify prepare_record() function by checking call count of mocked ad.api_get()
-        self.assertEquals(mocked_campaign.api_get.call_count, 5)
+        self.assertEqual(mocked_campaign.api_get.call_count, 5)
 
     def test_run_job(self, mocked_sleep):
         """ 
@@ -381,7 +381,7 @@ class TestConnectionErrorBackoff(unittest.TestCase):
             ads_insights_object.run_job('test')
 
         # verify get_insights() is called 5 times as max 5 reties provided for function
-        self.assertEquals(mocked_account.get_insights.call_count, 5)
+        self.assertEqual(mocked_account.get_insights.call_count, 5)
 
 
 # Mock args

--- a/mage_integrations/mage_integrations/sources/facebook_ads/tests/unittests/test_retry_logic.py
+++ b/mage_integrations/mage_integrations/sources/facebook_ads/tests/unittests/test_retry_logic.py
@@ -40,7 +40,7 @@ class TestAdCreative(unittest.TestCase):
         with self.assertRaises(FacebookRequestError):
             ad_creative_object.sync()
         # 5 is the max tries specified in the tap
-        self.assertEquals(5, mocked_account.get_ad_creatives.call_count )
+        self.assertEqual(5, mocked_account.get_ad_creatives.call_count )
 
     def test_catch_a_type_error(self):
         """`AdCreative.sync.do_request()` calls a `facebook_business` method `get_ad_creatives()`.
@@ -57,7 +57,7 @@ class TestAdCreative(unittest.TestCase):
         with self.assertRaises(TypeError):
             ad_creative_object.sync()
         # 5 is the max tries specified in the tap
-        self.assertEquals(5, mocked_account.get_ad_creatives.call_count )
+        self.assertEqual(5, mocked_account.get_ad_creatives.call_count )
 
     def test_retries_and_good_response(self):
         """Facebook has a class called `FacebookResponse` and it is created from a `requests.Response`. Some
@@ -126,7 +126,7 @@ class TestInsightJobs(unittest.TestCase):
         with self.assertRaises(FacebookBadObjectError):
             ad_creative_object.run_job({})
         # 5 is the max tries specified in the tap
-        self.assertEquals(5, mocked_account.get_insights.call_count )
+        self.assertEqual(5, mocked_account.get_insights.call_count )
 
     def test_retries_on_type_error(self):
         """`AdInsights.run_job()` calls a `facebook_business` method, `get_insights()`, to make a request to
@@ -144,7 +144,7 @@ class TestInsightJobs(unittest.TestCase):
         with self.assertRaises(TypeError):
             ad_creative_object.run_job({})
         # 5 is the max tries specified in the tap
-        self.assertEquals(5, mocked_account.get_insights.call_count )
+        self.assertEqual(5, mocked_account.get_insights.call_count )
 
     def test_retries_and_good_response(self):
         """Facebook has a class called `FacebookResponse` and it is created from a `requests.Response`. Some
@@ -215,8 +215,8 @@ class TestInsightJobs(unittest.TestCase):
         with self.assertRaises(FacebookRequestError):
             ad_insights_object.run_job({})
         # 5 is the max tries specified in the tap
-        self.assertEquals(25, mocked_account.get_insights.return_value.api_get.call_count)
-        self.assertEquals(5, mocked_account.get_insights.call_count )
+        self.assertEqual(25, mocked_account.get_insights.return_value.api_get.call_count)
+        self.assertEqual(5, mocked_account.get_insights.call_count )
 
 
 
@@ -257,5 +257,5 @@ class TestInsightJobs(unittest.TestCase):
         # Initialize the object and call `sync()`
         ad_insights_object = AdsInsights('', mocked_account, '', '', {}, {})
         ad_insights_object.run_job({})
-        self.assertEquals(3, mocked_account.get_insights.return_value.api_get.call_count)
-        self.assertEquals(1, mocked_account.get_insights.call_count)
+        self.assertEqual(3, mocked_account.get_insights.return_value.api_get.call_count)
+        self.assertEqual(1, mocked_account.get_insights.call_count)

--- a/mage_integrations/mage_integrations/sources/facebook_ads/tests/unittests/test_sync_batches_retry.py
+++ b/mage_integrations/mage_integrations/sources/facebook_ads/tests/unittests/test_sync_batches_retry.py
@@ -49,8 +49,8 @@ class TestAdCreativeSyncBbatches(unittest.TestCase):
             ad_creative_object.sync_batches([])
 
         # verify calls inside sync_batches are called 5 times as max 5 retries provided for function
-        self.assertEquals(5, mocked_api.new_batch.call_count)
-        self.assertEquals(5, mocked_schema.call_count)
+        self.assertEqual(5, mocked_api.new_batch.call_count)
+        self.assertEqual(5, mocked_schema.call_count)
 
     @mock.patch("tap_facebook.API")
     @mock.patch("singer.resolve_schema_references")
@@ -74,8 +74,8 @@ class TestAdCreativeSyncBbatches(unittest.TestCase):
             ad_creative_object.sync_batches([])
 
         # verify calls inside sync_batches are called 5 times as max 5 reties provided for function
-        self.assertEquals(5, mocked_api.new_batch.call_count)
-        self.assertEquals(5, mocked_schema.call_count)
+        self.assertEqual(5, mocked_api.new_batch.call_count)
+        self.assertEqual(5, mocked_schema.call_count)
 
     @mock.patch("tap_facebook.API")
     @mock.patch("singer.resolve_schema_references")
@@ -97,8 +97,8 @@ class TestAdCreativeSyncBbatches(unittest.TestCase):
         ad_creative_object.sync_batches([])
 
         # verify calls inside sync_batches are called once as no exception is thrown
-        self.assertEquals(1, mocked_api.new_batch.call_count)
-        self.assertEquals(1, mocked_schema.call_count)
+        self.assertEqual(1, mocked_api.new_batch.call_count)
+        self.assertEqual(1, mocked_schema.call_count)
 
 
 class TestLeadsSyncBatches(unittest.TestCase):
@@ -125,8 +125,8 @@ class TestLeadsSyncBatches(unittest.TestCase):
             leads_object.sync_batches([])
 
         # verify calls inside sync_batches are called 5 times as max 5 reties provided for function
-        self.assertEquals(5, mocked_api.new_batch.call_count)
-        self.assertEquals(5, mocked_schema.call_count)
+        self.assertEqual(5, mocked_api.new_batch.call_count)
+        self.assertEqual(5, mocked_schema.call_count)
 
     @mock.patch("tap_facebook.API")
     @mock.patch("singer.resolve_schema_references")
@@ -150,5 +150,5 @@ class TestLeadsSyncBatches(unittest.TestCase):
             leads_object.sync_batches([])
 
         # verify calls inside sync_batches are called 5 times as max 5 reties provided for function
-        self.assertEquals(5, mocked_api.new_batch.call_count)
-        self.assertEquals(5, mocked_schema.call_count)
+        self.assertEqual(5, mocked_api.new_batch.call_count)
+        self.assertEqual(5, mocked_schema.call_count)

--- a/mage_integrations/mage_integrations/sources/linkedin_ads/tests/unittests/test_account_number.py
+++ b/mage_integrations/mage_integrations/sources/linkedin_ads/tests/unittests/test_account_number.py
@@ -48,7 +48,7 @@ class TestValidLinkedInAccount(unittest.TestCase):
         config = {"accounts": "1111, 2222"}
         client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token')
         tap_linkedin_ads.do_discover(client, config)
-        self.assertEquals(mocked_discover.call_count, 1)
+        self.assertEqual(mocked_discover.call_count, 1)
 
     def test_invalid_linkedIn_accounts(self, mocked_request, mocked_discover):
         '''

--- a/mage_integrations/mage_integrations/sources/linkedin_ads/tests/unittests/test_adCampaignGroup_4XX.py
+++ b/mage_integrations/mage_integrations/sources/linkedin_ads/tests/unittests/test_adCampaignGroup_4XX.py
@@ -50,7 +50,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             client.request("GET")
         except _client.LinkedInBadRequestError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 400, Error: " + str(json.get("errorDetails")))
+            self.assertEqual(str(e), "HTTP-error-code: 400, Error: " + str(json.get("errorDetails")))
 
     def test_400_error_simple_json(self, mocked_access_token, mocked_request):
         json = {"message": "Invalid params for account.",
@@ -63,7 +63,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             client.request("GET")
         except _client.LinkedInBadRequestError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 400, Error: Invalid params for account.")
+            self.assertEqual(str(e), "HTTP-error-code: 400, Error: Invalid params for account.")
 
     def test_400_error_empty_json(self, mocked_access_token, mocked_request):
         mocked_request.return_value = get_response(400, raise_error = True)
@@ -72,7 +72,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             client.request("GET")
         except _client.LinkedInBadRequestError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
+            self.assertEqual(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
 
     def test_404_error(self, mocked_access_token, mocked_request):
         json = {"message": "Not Found.",
@@ -85,7 +85,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             client.request("GET")
         except _client.LinkedInNotFoundError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Either the accounts provided are invalid or you do not have access to the Ad Account.")
+            self.assertEqual(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Either the accounts provided are invalid or you do not have access to the Ad Account.")
 
     def test_404_error_empty_json(self, mocked_access_token, mocked_request):
         mocked_request.return_value = get_response(404, raise_error = True)
@@ -94,4 +94,4 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             client.request("GET")
         except _client.LinkedInNotFoundError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Either the accounts provided are invalid or you do not have access to the Ad Account.")
+            self.assertEqual(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Either the accounts provided are invalid or you do not have access to the Ad Account.")

--- a/mage_integrations/mage_integrations/sources/linkedin_ads/tests/unittests/test_exception_handling.py
+++ b/mage_integrations/mage_integrations/sources/linkedin_ads/tests/unittests/test_exception_handling.py
@@ -34,7 +34,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             linkedIn_client.request("GET")
         except client.LinkedInBadRequestError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
+            self.assertEqual(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
 
     def test_401_error_custom_message(self, mocked_access_token, mocked_request):
         mocked_request.return_value = get_response(401, raise_error = True)
@@ -42,7 +42,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             linkedIn_client.request("POST")
         except client.LinkedInUnauthorizedError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 401, Error: Invalid authorization credentials.")
+            self.assertEqual(str(e), "HTTP-error-code: 401, Error: Invalid authorization credentials.")
 
     def test_403_error_custom_message(self,mocked_access_token, mocked_request):
         mocked_request.return_value = get_response(403, raise_error = True)
@@ -50,7 +50,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             linkedIn_client.request("POST")
         except client.LinkedInForbiddenError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 403, Error: User does not have permission to access the resource.")
+            self.assertEqual(str(e), "HTTP-error-code: 403, Error: User does not have permission to access the resource.")
 
     def test_404_error_custom_message(self, mocked_access_token, mocked_request):
         mocked_request.return_value = get_response(404, raise_error = True)
@@ -58,7 +58,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             linkedIn_client.request("POST")
         except client.LinkedInNotFoundError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Either the accounts provided are invalid or you do not have access to the Ad Account.")
+            self.assertEqual(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Either the accounts provided are invalid or you do not have access to the Ad Account.")
 
     def test_405_error_custom_message(self, mocked_access_token, mocked_request):
         mocked_request.return_value = get_response(405, raise_error = True)
@@ -66,7 +66,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             linkedIn_client.request("POST")
         except client.LinkedInMethodNotAllowedError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 405, Error: The provided HTTP method is not supported by the URL.")
+            self.assertEqual(str(e), "HTTP-error-code: 405, Error: The provided HTTP method is not supported by the URL.")
 
     def test_411_error_custom_message(self, mocked_access_token, mocked_request):
         mocked_request.return_value = get_response(411, raise_error = True)
@@ -74,7 +74,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             linkedIn_client.request("POST")
         except client.LinkedInLengthRequiredError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 411, Error: The server refuses to accept the request without a defined Content-Length header.")
+            self.assertEqual(str(e), "HTTP-error-code: 411, Error: The server refuses to accept the request without a defined Content-Length header.")
 
     def test_400_error_response_message(self, mocked_access_token, mocked_request):
         response_json = {"message": "Invalid params for account.",
@@ -85,7 +85,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             linkedIn_client.request("POST")
         except client.LinkedInBadRequestError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 400, Error: {}".format(response_json.get('message')))
+            self.assertEqual(str(e), "HTTP-error-code: 400, Error: {}".format(response_json.get('message')))
 
     def test_401_error_response_message(self, mocked_access_token, mocked_request):
         response_json = {"message": "The authorization has expired, please re-authorize.",
@@ -96,7 +96,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             linkedIn_client.request("POST")
         except client.LinkedInUnauthorizedError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 401, Error: {}".format(response_json.get('message')))
+            self.assertEqual(str(e), "HTTP-error-code: 401, Error: {}".format(response_json.get('message')))
 
     def test_403_error_response_message(self, mocked_access_token, mocked_request):
         response_json = {"message": "You do not have permission to access this resource.",
@@ -107,7 +107,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             linkedIn_client.request("POST")
         except client.LinkedInForbiddenError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 403, Error: {}".format(response_json.get('message')))
+            self.assertEqual(str(e), "HTTP-error-code: 403, Error: {}".format(response_json.get('message')))
 
     def test_404_error_response_message(self, mocked_access_token, mocked_request):
         response_json = {"message": "Not Found.",
@@ -118,7 +118,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             linkedIn_client.request("POST")
         except client.LinkedInNotFoundError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Either the accounts provided are invalid or you do not have access to the Ad Account.")
+            self.assertEqual(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Either the accounts provided are invalid or you do not have access to the Ad Account.")
 
     def test_405_error_response_message(self, mocked_access_token, mocked_request):
         response_json = {"message": "The URL doesn't support this HTTP method.",
@@ -129,7 +129,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             linkedIn_client.request("POST")
         except client.LinkedInMethodNotAllowedError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 405, Error: {}".format(response_json.get('message')))
+            self.assertEqual(str(e), "HTTP-error-code: 405, Error: {}".format(response_json.get('message')))
 
     def test_411_error_response_message(self, mocked_access_token, mocked_request):
         response_json = {"message": "Please add a defined Content-Length header.",
@@ -140,7 +140,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             linkedIn_client.request("POST")
         except client.LinkedInLengthRequiredError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 411, Error: {}".format(response_json.get('message')))
+            self.assertEqual(str(e), "HTTP-error-code: 411, Error: {}".format(response_json.get('message')))
 
     @mock.patch("tap_linkedin_ads.client.LOGGER.error")
     def test_401_error_expired_access_token(self, mocked_logger, mocked_access_token, mocked_request):
@@ -153,7 +153,7 @@ class TestExceptionHandling(unittest.TestCase):
             linkedIn_client.request("POST")
         except client.LinkedInUnauthorizedError as e:
             mocked_logger.assert_called_with("Your access_token has expired as per LinkedIn’s security policy. Please re-authenticate your connection to generate a new token and resume extraction.")
-            self.assertEquals(str(e), "HTTP-error-code: 401, Error: {}".format(response_json.get('message')))
+            self.assertEqual(str(e), "HTTP-error-code: 401, Error: {}".format(response_json.get('message')))
 
 @mock.patch("requests.Session.post")
 class TestAccessToken(unittest.TestCase):
@@ -164,7 +164,7 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInBadRequestError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
+            self.assertEqual(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
 
     def test_401_error_custom_message(self, mocked_request):
         mocked_request.return_value = get_response(401, raise_error = True)
@@ -172,7 +172,7 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInUnauthorizedError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 401, Error: Invalid authorization credentials.")
+            self.assertEqual(str(e), "HTTP-error-code: 401, Error: Invalid authorization credentials.")
 
     def test_403_error_custom_message(self, mocked_request):
         mocked_request.return_value = get_response(403, raise_error = True)
@@ -180,7 +180,7 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInForbiddenError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 403, Error: User does not have permission to access the resource.")
+            self.assertEqual(str(e), "HTTP-error-code: 403, Error: User does not have permission to access the resource.")
 
     def test_404_error_custom_message(self, mocked_request):
         mocked_request.return_value = get_response(404, raise_error = True)
@@ -188,7 +188,7 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInNotFoundError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Either the accounts provided are invalid or you do not have access to the Ad Account.")
+            self.assertEqual(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Either the accounts provided are invalid or you do not have access to the Ad Account.")
 
     def test_405_error_custom_message(self, mocked_request):
         mocked_request.return_value = get_response(405, raise_error = True)
@@ -196,7 +196,7 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInMethodNotAllowedError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 405, Error: The provided HTTP method is not supported by the URL.")
+            self.assertEqual(str(e), "HTTP-error-code: 405, Error: The provided HTTP method is not supported by the URL.")
 
     def test_411_error_custom_message(self, mocked_request):
         mocked_request.return_value = get_response(411, raise_error = True)
@@ -204,7 +204,7 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInLengthRequiredError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 411, Error: The server refuses to accept the request without a defined Content-Length header.")
+            self.assertEqual(str(e), "HTTP-error-code: 411, Error: The server refuses to accept the request without a defined Content-Length header.")
 
     def test_429_error_custom_message(self, mocked_request):
         mocked_request.return_value = get_response(429, raise_error = True)
@@ -212,7 +212,7 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInRateLimitExceeededError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 429, Error: API rate limit exceeded, please retry after some time.")
+            self.assertEqual(str(e), "HTTP-error-code: 429, Error: API rate limit exceeded, please retry after some time.")
 
     @mock.patch("time.sleep")
     def test_500_error_custom_message(self, mocked_sleep, mocked_request):
@@ -221,8 +221,8 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInInternalServiceError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 500, Error: An error has occurred at LinkedIn's end.")
-        self.assertEquals(mocked_request.call_count, 5)
+            self.assertEqual(str(e), "HTTP-error-code: 500, Error: An error has occurred at LinkedIn's end.")
+        self.assertEqual(mocked_request.call_count, 5)
 
     @mock.patch("time.sleep")
     def test_504_error_custom_message(self, mocked_sleep, mocked_request):
@@ -231,8 +231,8 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInGatewayTimeoutError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 504, Error: A gateway timeout occurred. There is a problem at LinkedIn's end.")
-        self.assertEquals(mocked_request.call_count, 5)
+            self.assertEqual(str(e), "HTTP-error-code: 504, Error: A gateway timeout occurred. There is a problem at LinkedIn's end.")
+        self.assertEqual(mocked_request.call_count, 5)
 
     def test_400_error_response_message(self, mocked_request):
         response_json = {"message": "Invalid params for account.",
@@ -243,7 +243,7 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInBadRequestError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 400, Error: {}".format(response_json.get('message')))
+            self.assertEqual(str(e), "HTTP-error-code: 400, Error: {}".format(response_json.get('message')))
 
     def test_401_error_response_message(self, mocked_request):
         response_json = {"message": "The authorization has expired, please re-authorize.",
@@ -254,7 +254,7 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInUnauthorizedError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 401, Error: {}".format(response_json.get('message')))
+            self.assertEqual(str(e), "HTTP-error-code: 401, Error: {}".format(response_json.get('message')))
 
     def test_403_error_response_message(self, mocked_request):
         response_json = {"message": "You do not have permission to access this resource.",
@@ -265,7 +265,7 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInForbiddenError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 403, Error: {}".format(response_json.get('message')))
+            self.assertEqual(str(e), "HTTP-error-code: 403, Error: {}".format(response_json.get('message')))
 
     def test_404_error_response_message(self, mocked_request):
         response_json = {"message": "Not Found.",
@@ -276,7 +276,7 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInNotFoundError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Either the accounts provided are invalid or you do not have access to the Ad Account.")
+            self.assertEqual(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Either the accounts provided are invalid or you do not have access to the Ad Account.")
 
     def test_405_error_response_message(self, mocked_request):
         response_json = {"message": "The URL doesn't support this HTTP method.",
@@ -287,7 +287,7 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInMethodNotAllowedError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 405, Error: {}".format(response_json.get('message')))
+            self.assertEqual(str(e), "HTTP-error-code: 405, Error: {}".format(response_json.get('message')))
 
     def test_411_error_response_message(self, mocked_request):
         response_json = {"message": "Please add a defined Content-Length header.",
@@ -298,7 +298,7 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInLengthRequiredError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 411, Error: {}".format(response_json.get('message')))
+            self.assertEqual(str(e), "HTTP-error-code: 411, Error: {}".format(response_json.get('message')))
 
     def test_429_error_response_message(self, mocked_request):
         response_json = {"message": "APT ratelimit exceeded, retry after some time.",
@@ -309,7 +309,7 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInRateLimitExceeededError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 429, Error: {}".format(response_json.get('message')))
+            self.assertEqual(str(e), "HTTP-error-code: 429, Error: {}".format(response_json.get('message')))
 
     @mock.patch("time.sleep")
     def test_500_error_response_message(self, mocked_sleep, mocked_request):
@@ -321,8 +321,8 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInInternalServiceError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 500, Error: {}".format(response_json.get('message')))
-        self.assertEquals(mocked_request.call_count, 5)
+            self.assertEqual(str(e), "HTTP-error-code: 500, Error: {}".format(response_json.get('message')))
+        self.assertEqual(mocked_request.call_count, 5)
 
     @mock.patch("time.sleep")
     def test_504_error_response_message(self, mocked_sleep, mocked_request):
@@ -334,8 +334,8 @@ class TestAccessToken(unittest.TestCase):
         try:
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInGatewayTimeoutError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 504, Error: {}".format(response_json.get('message')))
-        self.assertEquals(mocked_request.call_count, 5)
+            self.assertEqual(str(e), "HTTP-error-code: 504, Error: {}".format(response_json.get('message')))
+        self.assertEqual(mocked_request.call_count, 5)
 
     @mock.patch("tap_linkedin_ads.client.LOGGER.error")
     def test_401_error_expired_access_token(self, mocked_logger, mocked_request):
@@ -348,4 +348,4 @@ class TestAccessToken(unittest.TestCase):
             linkedIn_client.fetch_and_set_access_token()
         except client.LinkedInUnauthorizedError as e:
             mocked_logger.assert_called_with("Your access_token has expired as per LinkedIn’s security policy. Please re-authenticate your connection to generate a new token and resume extraction.")
-            self.assertEquals(str(e), "HTTP-error-code: 401, Error: {}".format(response_json.get('message')))
+            self.assertEqual(str(e), "HTTP-error-code: 401, Error: {}".format(response_json.get('message')))

--- a/mage_integrations/mage_integrations/sources/linkedin_ads/tests/unittests/test_fetch_access_token.py
+++ b/mage_integrations/mage_integrations/sources/linkedin_ads/tests/unittests/test_fetch_access_token.py
@@ -24,7 +24,7 @@ class TestFetchAccessToken(unittest.TestCase):
         """Test that when refresh token is not passed in config properties, conection uses the existing access token"""
         cl=LinkedinClient(None, None, None, 'access_token')
         cl.fetch_and_set_access_token()
-        self.assertEquals(cl.access_token, 'access_token')
+        self.assertEqual(cl.access_token, 'access_token')
     
     @mock.patch("requests.Session.post")
     def test_fetch_access_token_with_refresh_token(self, mock_session_post):
@@ -33,4 +33,4 @@ class TestFetchAccessToken(unittest.TestCase):
 
         cl=LinkedinClient('client_id', 'client_secret', 'refresh_token', 'old_access_token')
         cl.fetch_and_set_access_token()
-        self.assertEquals(cl.access_token, 'new_access_token')
+        self.assertEqual(cl.access_token, 'new_access_token')

--- a/mage_integrations/mage_integrations/sources/linkedin_ads/tests/unittests/test_timeout.py
+++ b/mage_integrations/mage_integrations/sources/linkedin_ads/tests/unittests/test_timeout.py
@@ -25,7 +25,7 @@ class TestTimeoutValue(unittest.TestCase):
                                    request_timeout=config.get('request_timeout'))
 
         # verify that timeout value is default as request timeout is not passed in config
-        self.assertEquals(300, cl.request_timeout)
+        self.assertEqual(300, cl.request_timeout)
 
     def test_timeout_int_value_passed_in_config(self):
         config = {"client_id": "test_client_id",
@@ -44,7 +44,7 @@ class TestTimeoutValue(unittest.TestCase):
                                    request_timeout=config.get('request_timeout'))
 
         # verify that timeout value is same as the value passed in the config
-        self.assertEquals(100.0, cl.request_timeout)
+        self.assertEqual(100.0, cl.request_timeout)
 
     def test_timeout_string_value_passed_in_config(self):
         config = {"client_id": "test_client_id",
@@ -63,7 +63,7 @@ class TestTimeoutValue(unittest.TestCase):
                                    request_timeout=config.get('request_timeout'))
 
         # verify that timeout value is same as the value passed in the config
-        self.assertEquals(100.0, cl.request_timeout)
+        self.assertEqual(100.0, cl.request_timeout)
 
     def test_timeout_empty_value_passed_in_config(self):
         config = {"client_id": "test_client_id",
@@ -82,7 +82,7 @@ class TestTimeoutValue(unittest.TestCase):
                                    request_timeout=config.get('request_timeout'))
 
         # verify that timeout value is default as request timeout is empty in the config
-        self.assertEquals(300, cl.request_timeout)
+        self.assertEqual(300, cl.request_timeout)
 
     def test_timeout_0_value_passed_in_config(self):
         config = {"client_id": "test_client_id",
@@ -101,7 +101,7 @@ class TestTimeoutValue(unittest.TestCase):
                                    request_timeout=config.get('request_timeout'))
 
         # verify that timeout value is default as request timeout is zero in the config
-        self.assertEquals(300, cl.request_timeout)
+        self.assertEqual(300, cl.request_timeout)
 
     def test_timeout_string_0_value_passed_in_config(self):
         config = {"client_id": "test_client_id",
@@ -120,7 +120,7 @@ class TestTimeoutValue(unittest.TestCase):
                                    request_timeout=config.get('request_timeout'))
 
         # verify that timeout value is default as request timeout is zero in the config
-        self.assertEquals(300, cl.request_timeout)
+        self.assertEqual(300, cl.request_timeout)
 
 
 @mock.patch("time.sleep")
@@ -154,7 +154,7 @@ class TestTimeoutBackoff(unittest.TestCase):
             pass
 
         # verify that we backoff for 5 times
-        self.assertEquals(mocked_request.call_count, 5)
+        self.assertEqual(mocked_request.call_count, 5)
 
     def test_timeout_error__check_accounts(self, mocked_request, mocked_sleep):
 
@@ -183,7 +183,7 @@ class TestTimeoutBackoff(unittest.TestCase):
             pass
 
         # verify that we backoff for 5 times
-        self.assertEquals(mocked_request.call_count, 5)
+        self.assertEqual(mocked_request.call_count, 5)
 
     def test_timeout_error__request(self, mocked_request, mocked_sleep):
 
@@ -212,7 +212,7 @@ class TestTimeoutBackoff(unittest.TestCase):
             pass
 
         # verify that we backoff for 5 times
-        self.assertEquals(mocked_request.call_count, 5)
+        self.assertEqual(mocked_request.call_count, 5)
 
 
 @mock.patch("time.sleep")
@@ -247,7 +247,7 @@ class TestConnectionErrorBackoff(unittest.TestCase):
             pass
 
         # verify that we backoff for 5 times
-        self.assertEquals(mocked_request.call_count, 5)
+        self.assertEqual(mocked_request.call_count, 5)
 
     def test_connection_error__check_accounts(self, mocked_request, mocked_sleep):
 
@@ -276,4 +276,4 @@ class TestConnectionErrorBackoff(unittest.TestCase):
             pass
 
         # verify that we backoff for 5 times
-        self.assertEquals(mocked_request.call_count, 5)
+        self.assertEqual(mocked_request.call_count, 5)

--- a/mage_integrations/mage_integrations/sources/mongodb/tests/test_mongodb_datatype.py
+++ b/mage_integrations/mage_integrations/sources/mongodb/tests/test_mongodb_datatype.py
@@ -243,4 +243,4 @@ class MongoDBDatatype(unittest.TestCase):
                             "collection": "some_collection"}
         }
 
-        self.assertEquals(expected_record, records_by_stream['datatype_coll_1']['messages'][1]['data'])
+        self.assertEqual(expected_record, records_by_stream['datatype_coll_1']['messages'][1]['data'])


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This PR migrates from `unittest.assertEquals` to `unittest.assertEqual` which is deprecated from Python2.7:
```python
DeprecationWarning: Please use assertEqual instead.
```

# How Has This Been Tested?
Run tests.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
