### PR TITLE
Add ensure_ascii=False to JSON serialization for better Unicode handling. Fixes issue #5803

### DIFF
--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -329,18 +329,21 @@ class Postgres(BaseSQL):
                 return simplejson.dumps(
                     val,
                     default=encode_complex,
+                    ensure_ascii=False,
                     ignore_nan=True,
                 )
             elif type(val) is list and len(val) >= 1 and type(val[0]) is dict:
                 return simplejson.dumps(
                     val,
                     default=encode_complex,
+                    ensure_ascii=False,
                     ignore_nan=True,
                 )
             elif not use_insert_command and type(val) is list:
                 return self._clean_array_value(simplejson.dumps(
                     val,
                     default=encode_complex,
+                    ensure_ascii=False,
                     ignore_nan=True,
                 ))
             return val

--- a/mage_ai/tests/io/create_table/test_postgresql.py
+++ b/mage_ai/tests/io/create_table/test_postgresql.py
@@ -33,14 +33,14 @@ class TestTablePostgres(DBTestCase):
         test_cases = [
             [],
             [123],
-            [['abc', 'def']],
+            [['àabc', 'deèéf']],
             [['08:00', '12:00'], ['15:00', '20:00']],
             [['08:00', '12:00'], []],
         ]
         expected = [
             '{}',
             '{123}',
-            '{{"abc", "def"}}',
+            '{{"àabc", "deèéf"}}',
             '{{"08:00", "12:00"}, {"15:00", "20:00"}}',
             '{{"08:00", "12:00"}, {}}',
         ]
@@ -49,6 +49,7 @@ class TestTablePostgres(DBTestCase):
                 simplejson.dumps(
                     val,
                     default=encode_complex,
+                    ensure_ascii=False,
                     ignore_nan=True,
                 )
             )


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This PR fixes the issue #5803 which is about incorrect encoding when exporting `text[]` columns with non-ASCII characters to Postgres

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->
- Navigate to the relevant directory `cd mage_ai/tests/io/create_table/`
- Run the test `python3 -m unittest discover -s . --failfast`
- I also ran all the other tests and they passed as well:
  - Navigate back to the root of the repo
  - Run `python3 -m unittest discover -s mage_ai/ --failfast`

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 