### PR TITLE
[xy] Not set use_pyarrow=True as fallback for reading polars.

### DIFF
--- a/mage_ai/data_preparation/storage/local_storage.py
+++ b/mage_ai/data_preparation/storage/local_storage.py
@@ -121,7 +121,10 @@ class LocalStorage(BaseStorage):
         return pd.read_parquet(file_path, engine='pyarrow')
 
     def read_polars_parquet(self, file_path: str, **kwargs) -> pl.DataFrame:
-        return pl.read_parquet(file_path, use_pyarrow=True)
+        try:
+            return pl.read_parquet(file_path, use_pyarrow=True)
+        except Exception:
+            return pl.read_parquet(file_path)
 
     def write_csv(self, df: pd.DataFrame, file_path: str) -> None:
         File.create_parent_directories(file_path)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Close: https://github.com/mage-ai/mage-ai/issues/5859

This pull request introduces a small but important improvement to the `read_polars_parquet` method in `local_storage.py`, enhancing its robustness when reading Parquet files with Polars.

Error handling improvement:

* Updated `read_polars_parquet` to first attempt reading with `use_pyarrow=True`, and if an exception occurs, fallback to a standard read. This makes the method more resilient to different Parquet file formats or environments.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
