### PR TITLE
BlockBrowser: Fix typeof check for focusedProp in setFocused

### DIFF
--- a/mage_ai/frontend/components/BlockBrowser/index.tsx
+++ b/mage_ai/frontend/components/BlockBrowser/index.tsx
@@ -137,7 +137,7 @@ function Browser({
 
   const [focusedState, setFocusedState] = useState<boolean>(false);
   const setFocused = useCallback((value: boolean) => {
-    if (setFocusedProp && typeof focusedProp !== undefined) {
+    if (setFocusedProp && typeof focusedProp !== "undefined") {
       setFocusedProp?.(value);
     } else {
       setFocusedState(value);


### PR DESCRIPTION

# Description
The `typeof` operator returns a string so any comparison of its result should be done with a string, not a constant like `undefined`.

The `typeof sth !== undefined` always evaluates to `true` and such a check should be performed as: `typeof sth !== "undefined"`

# How Has This Been Tested?
I haven't performed any tests for this PR.
