### PR TITLE
[xy] Bump version to 0.9.78

### DIFF
--- a/mage_ai/server/constants.py
+++ b/mage_ai/server/constants.py
@@ -12,4 +12,4 @@ DATAFRAME_OUTPUT_SAMPLE_COUNT = 10
 # Dockerfile depends on it because it runs ./scripts/install_mage.sh and uses
 # the last line to determine the version to install.
 VERSION = \
-'0.9.77'
+'0.9.78'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     name='mage-ai',
     # NOTE: when you change this, change the value of VERSION in the following file:
     # mage_ai/server/constants.py
-    version='0.9.77',
+    version='0.9.78',
     author='Mage',
     author_email='eng@mage.ai',
     description='Mage is a tool for building and deploying data pipelines.',


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Bump version to 0.9.78

* Fix serializing polars dataframe for display. by @wangxiaoyou1993 in https://github.com/mage-ai/mage-ai/pull/5876
* Fix the timeout of git sync. by @wangxiaoyou1993 in https://github.com/mage-ai/mage-ai/pull/5880
* Not clean up logs for streaming pipeline. by @wangxiaoyou1993 in https://github.com/mage-ai/mage-ai/pull/5885
* BlockBrowser: Fix typeof check for focusedProp in setFocused by @disconnect3d in https://github.com/mage-ai/mage-ai/pull/5873
* Pin paramiko version. by @wangxiaoyou1993 in https://github.com/mage-ai/mage-ai/pull/5874
* [CVE-2025-2129] Set default value of user authentication to True. by @wangxiaoyou1993 in https://github.com/mage-ai/mage-ai/pull/5875

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
