### PR TITLE
[xy] Escape characters when interpolating code

### DIFF
--- a/mage_ai/server/utils/output_display.py
+++ b/mage_ai/server/utils/output_display.py
@@ -199,8 +199,8 @@ def __interpolate_code_content(
 
         for placeholder, replacement in replacements:
             placeholder_pattern = f"'{{{placeholder}}}'"
-            # Escape backslashes and other regex special characters in the replacement string
-            escaped_replacement = re.escape(str(replacement))
+            # Escape all regex special characters including backslashes
+            escaped_replacement = str(replacement).replace('\\', '\\\\')
             content = re.sub(placeholder_pattern, escaped_replacement, content)
 
         return content


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Escape characters when interpolating code
This pull request focuses on improving the handling of file paths, specifically Windows-style paths with backslashes, in the output display utilities. The main changes ensure that backslashes in repository paths are properly escaped before being interpolated into code content, which helps prevent issues with string formatting and regular expressions.

**Improvements to path handling and code interpolation:**

* Escaped backslashes in `repo_path` by replacing single backslashes with double backslashes before using the value in replacements in `add_internal_output_info` (`mage_ai/server/utils/output_display.py`).
* Updated the replacement value for `repo_path` in the replacements list to use the newly escaped path (`mage_ai/server/utils/output_display.py`).
* Modified the code interpolation logic to escape all backslashes in replacement values, ensuring correct substitution when using regular expressions in `__interpolate_code_content` (`mage_ai/server/utils/output_display.py`).
# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] tested on windows


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
