### PR TITLE
[xy] Close log file on logger deletion.

### DIFF
--- a/mage_ai/data_preparation/logging/logger_manager.py
+++ b/mage_ai/data_preparation/logging/logger_manager.py
@@ -3,6 +3,7 @@ import io
 import logging
 import logging.handlers
 import os
+import traceback
 from datetime import datetime
 from typing import Callable, Dict, List
 
@@ -106,6 +107,18 @@ class LoggerManager:
                     self.stream = stream_handler.stream
 
         self.storage = LocalStorage()
+
+    def __del__(self):
+        """
+        Close the log file if the logger uses the file handler.
+        """
+        for handler in list(self.logger.handlers):
+            try:
+                if isinstance(handler, (logging.FileHandler, logging.handlers.RotatingFileHandler)):
+                    self.logger.removeHandler(handler)
+                    handler.close()
+            except Exception:
+                traceback.print_exc()
 
     def create_stream_handler(self):
         """


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Close: https://github.com/mage-ai/mage-ai/issues/5921

This pull request introduces a resource management improvement to the `LoggerManager` class, ensuring that log file handlers are properly closed when the object is destroyed. This helps prevent resource leaks and potential issues with open log files.

Resource management improvement:

* Added a `__del__` method to the `LoggerManager` class to close any file-based log handlers (`FileHandler` and `RotatingFileHandler`) and remove them from the logger when the object is deleted. Exceptions during handler cleanup are caught and printed using `traceback.print_exc()`.

Minor update:

* Imported the `traceback` module to support exception logging in the new destructor.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
