### PR TITLE
Docs: use YouTube embed URLs and add proper thumbnail/preview

### DIFF
--- a/docs/ai/sidekick/index.mdx
+++ b/docs/ai/sidekick/index.mdx
@@ -25,7 +25,31 @@ It’s like having a senior data engineer available 24/7 — inside your repo.
 
 **Mage Pro AI** is your always-on data expert. Whether you’re building data pipelines, designing warehouse schemas, troubleshooting integrations, or making sense of your analytics stack, Mage Pro AI has the answer. It’s trained to understand the language of modern data teams — from ETL to orchestration to compliance — so you can move faster, with confidence.
 
-[![Watch the video](https://img.youtube.com/vi/18PYIQYfDgM/0.jpg)](https://www.youtube.com/watch?v=18PYIQYfDgM)
+<div style={{
+  position: 'relative',
+  width: '100%',
+  paddingBottom: '56.25%', /* 16:9 ratio */
+  height: 0,
+  overflow: 'hidden',
+  borderRadius: '12px',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.1)'
+}}>
+  <iframe
+    src="https://www.youtube.com/embed/18PYIQYfDgM"
+    title="AI-Powered Answers for Data Engineering, Analytics, and ML"
+    allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+    style={{
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      border: 0,
+      borderRadius: '12px'
+    }}
+  />
+</div>
 
 ### How it works
 
@@ -42,8 +66,31 @@ Data teams lose countless hours searching for answers across scattered documenta
 
 Stop wasting hours piecing together pipelines by hand. Mage Pro AI can design and build complex data workflows in seconds. Just describe your goal in plain English, and Mage Pro AI auto-generates the full pipeline—every block, every dependency, every line of code.
 
-
-[![Watch the video](https://img.youtube.com/vi/7C8qnPFbGHA/0.jpg)](https://www.youtube.com/watch?v=7C8qnPFbGHA)
+<div style={{
+  position: 'relative',
+  width: '100%',
+  paddingBottom: '56.25%', /* 16:9 ratio */
+  height: 0,
+  overflow: 'hidden',
+  borderRadius: '12px',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.1)'
+}}>
+  <iframe
+    src="https://www.youtube.com/embed/7C8qnPFbGHA"
+    title="Design Complex Data Pipelines in Seconds"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+    style={{
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      border: 0,
+      borderRadius: '12px'
+    }}
+  />
+</div>
 
 ### How it works
 
@@ -60,8 +107,31 @@ Manually building pipelines is slow, error-prone, and often blocks teams from ex
 
 Design your pipeline one step at a time—without writing a single line of code. Mage Pro AI can generate complete, production-ready code blocks for every stage of your data workflow.
 
-
-[![Watch the video](https://img.youtube.com/vi/OD5Vby6-O8w/0.jpg)](https://www.youtube.com/watch?v=OD5Vby6-O8w)
+<div style={{
+  position: 'relative',
+  width: '100%',
+  paddingBottom: '56.25%', /* 16:9 ratio */
+  height: 0,
+  overflow: 'hidden',
+  borderRadius: '12px',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.1)'
+}}>
+  <iframe
+    src="https://www.youtube.com/embed/OD5Vby6-O8w?si=I2oG_qE2GLHS9NkK"
+    title="AI-Generated Code Blocks for Data Pipelines"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+    style={{
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      border: 0,
+      borderRadius: '12px'
+    }}
+  />
+</div>
 
 ### How it works
 
@@ -82,8 +152,31 @@ Writing every block by hand is slow and repetitive. Mage Pro AI speeds up develo
 
 Mage Pro AI helps you evolve your workflows by intelligently updating, refactoring, and improving code blocks in place.
 
-
-[![Watch the video](https://img.youtube.com/vi/PVxzrx4Ng7Q/0.jpg)](https://www.youtube.com/watch?v=PVxzrx4Ng7Q)
+<div style={{
+  position: 'relative',
+  width: '100%',
+  paddingBottom: '56.25%', /* 16:9 ratio */
+  height: 0,
+  overflow: 'hidden',
+  borderRadius: '12px',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.1)'
+}}>
+  <iframe
+    src="https://www.youtube.com/embed/PVxzrx4Ng7Q"
+    title="Smarter, Faster Code for Every Pipeline Block"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+    style={{
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      border: 0,
+      borderRadius: '12px'
+    }}
+  />
+</div>
 
 ### How it works
 
@@ -100,8 +193,31 @@ Mage Pro AI handles updates safely, intelligently, and instantly—saving hours 
 
 Mage Pro AI helps you resolve issues in your pipeline code with intelligent, context-aware fixes.
 
-
-[![Watch the video](https://img.youtube.com/vi/_J-TkoDZegA/0.jpg)](https://www.youtube.com/watch?v=_J-TkoDZegA)
+<div style={{
+  position: 'relative',
+  width: '100%',
+  paddingBottom: '56.25%', /* 16:9 ratio */
+  height: 0,
+  overflow: 'hidden',
+  borderRadius: '12px',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.1)'
+}}>
+  <iframe
+    src="https://www.youtube.com/embed/_J-TkoDZegA"
+    title="Fix Pipeline Code Errors with AI-Powered Debugging"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+    style={{
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      border: 0,
+      borderRadius: '12px'
+    }}
+  />
+</div>
 
 ### How it works
 
@@ -118,8 +234,31 @@ Debugging pipeline code wastes valuable time. Mage Pro AI reduces that friction 
 
 Mage Pro AI makes it possible to build pipelines that detect failures, diagnose errors, and fix themselves.
 
-
-[![Watch the video](https://img.youtube.com/vi/TuEA_RfM3H0/0.jpg)](https://www.youtube.com/watch?v=TuEA_RfM3H0)
+<div style={{
+  position: 'relative',
+  width: '100%',
+  paddingBottom: '56.25%', /* 16:9 ratio */
+  height: 0,
+  overflow: 'hidden',
+  borderRadius: '12px',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.1)'
+}}>
+  <iframe
+    src="https://www.youtube.com/embed/TuEA_RfM3H0"
+    title="Self-Healing Data Pipelines with AI"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+    style={{
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      border: 0,
+      borderRadius: '12px'
+    }}
+  />
+</div>
 
 ### How it works
 
@@ -136,8 +275,31 @@ Mage Pro AI automatically fixes pipelines, ensuring that data quality checks are
 
 With Mage Pro AI, you can ask questions about your pipeline data and get clear answers.
 
-
-[![Watch the video](https://img.youtube.com/vi/RavUBmG3okY/0.jpg)](https://www.youtube.com/watch?v=RavUBmG3okY)
+<div style={{
+  position: 'relative',
+  width: '100%',
+  paddingBottom: '56.25%', /* 16:9 ratio */
+  height: 0,
+  overflow: 'hidden',
+  borderRadius: '12px',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.1)'
+}}>
+  <iframe
+    src="https://www.youtube.com/embed/RavUBmG3okY"
+    title="Understand Your Pipeline Data with AI-Powered Q&A and Analysis"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+    style={{
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      border: 0,
+      borderRadius: '12px'
+    }}
+  />
+</div>
 
 ### How it works
 
@@ -154,8 +316,31 @@ Mage Pro AI eliminates the need to query logs or write SQL—helping you underst
 
 Mage Pro AI transforms pipeline outputs into insightful, ready-to-use visualizations.
 
-
-[![Watch the video](https://img.youtube.com/vi/ib-u3KPwjYQ/0.jpg)](https://www.youtube.com/watch?v=ib-u3KPwjYQ)
+<div style={{
+  position: 'relative',
+  width: '100%',
+  paddingBottom: '56.25%', /* 16:9 ratio */
+  height: 0,
+  overflow: 'hidden',
+  borderRadius: '12px',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.1)'
+}}>
+  <iframe
+    src="https://www.youtube.com/embed/ib-u3KPwjYQ"
+    title="AI-Powered Data Visualizations for Every Step in Your Pipeline"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+    style={{
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      border: 0,
+      borderRadius: '12px'
+    }}
+  />
+</div>
 
 ### How it works
 
@@ -172,8 +357,31 @@ Visual feedback helps you debug faster and understand your data more deeply at e
 
 Mage Pro AI lets you turn raw pipeline outputs into smart, explorable tables—instantly.
 
-
-[![Watch the video](https://img.youtube.com/vi/i2JKXwA36iE/0.jpg)](https://www.youtube.com/watch?v=i2JKXwA36iE)
+<div style={{
+  position: 'relative',
+  width: '100%',
+  paddingBottom: '56.25%', /* 16:9 ratio */
+  height: 0,
+  overflow: 'hidden',
+  borderRadius: '12px',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.1)'
+}}>
+  <iframe
+    src="https://www.youtube.com/embed/i2JKXwA36iE"
+    title="Build Interactive Data Products Instantly with AI-Generated Tables"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+    style={{
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      border: 0,
+      borderRadius: '12px'
+    }}
+  />
+</div>
 
 ### How it works
 


### PR DESCRIPTION
# Description
Close: https://github.com/mage-ai/mage-ai/issues/5823

This PR updates the docs to correctly embed YouTube videos by using the /embed/:id URL instead of the watch?v= URL. This fixes the “refused to connect” issue in the iframe and improves the UX. These fixes should improve the user experience when they are looking through the docs and don't realize these photos are actually videos.


# How Has This Been Tested?
1. Run docs locally:

``` bash 
cd docs
mint dev
```

2. Navigate to the updated page(s) and verify:

- Video renders and plays inline.
- Page is responsive; iframe fills the text column.
- No console errors.
- Thumbnail preview (if used) swaps to the player on click.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993, sorry to bother you again, but I just wanted to add you so this PR has some visibility.