### PR TITLE
[dd] Update the pipelines/runs page to keep the query parameter after each delete.

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/runs/index.tsx
@@ -283,7 +283,7 @@ function PipelineRuns({
           }) => {
             // refetch to update table
             fetchPipelineRuns?.();
-            //keep the current filters query from url
+            // keep the current filters query from url
             const nextQuery = q || {};
             if (pipelineUUID) {
               router.replace(


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This PR fixes an issue where the Pipeline Runs page loses the selected run status filter after deleting a failed pipeline run.
Fixes #5816

***Problem***
In versions ≤ v0.9.76, when a user navigates to:
```
/pipelines/:pipeline/runs?status=failed&page=0
```
…and deletes a failed run using the trash icon, the page navigates to:
```
/pipelines/:pipeline/runs
```

This causes:
- The status=failed filter is to be lost
- The Runs table to reset, showing all runs
- The user has to reapply the filter manually

This behavior negatively impacts the user experience when managing failed pipeline runs.

***Solution***
This PR updates the delete navigation logic in:
```
pages/pipelines/[pipeline]/runs/index.tsx
```
Specifically, router.push() within the deletePipelineRun, a React Query, was replaced with:
```
router.replace(
  '/pipelines/[pipeline]/runs',
  `/pipelines/${pipelineUUID}/runs?${queryString(nextQuery)}`,
  { shallow: true },
);
```

Where:

* nextQuery preserves the existing URL query params (status, page, sorting, etc.)
* shallow: true prevents a full component remount and keeps UI state intact

***Effect***

After deleting a run:

- The status=failed filter remains selected
- The URL keeps all query parameters
- The table refreshes without resetting
- Pagination remains consistent
- UX is significantly improved

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Manually tested locally
&nbsp; Using WSL to start the Docker image.
&nbsp; Navigate to the UI (localhost:3000)
&nbsp; Then create a pipeline
&nbsp; Manually update the code block to error out
&nbsp; Go to the Triggers page and click Run@once
&nbsp; Go to the run page, update the filter to 'Failed', and then click the trashcan icon of the run and delete
&nbsp; Wait and see if the other runs also show up with the failed runs.
 
# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 , I am back with another PR.