### PR TITLE
feat(frontend): Add Move Up and Move to Top actions to block UI list (T-5642)

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
@@ -712,6 +712,8 @@ function CommandButtons({
                 project,
                 savePipelineContent,
                 updatePipeline,
+                blocks,
+                pipeline,
               },
             )}
             onClickCallback={() => setShowMoreActions(false)}


### PR DESCRIPTION
# Description
This PR introduces two new UI-only ordering controls — “Move Up” and “Move to Top” — to the More Actions menu for each code block in the pipeline editor.

These options allow users to quickly reorder code blocks within the visual stack without affecting pipeline logic or upstream/downstream dependencies. The reordering affects only the UI presentation and is persisted by saving the new block order via savePipelineContent. No tests were added as the test coverage of the repo isn't comprehensive enough to merit adding these button tests.

### Details

- Added moveBlockInList helper inside getMoreActionsItems to handle array-based block reordering.
- Added two new menu items:
- Move up (UI order) → moves the selected block one position up.
- Move to top (UI order) → moves the selected block to the first position.
- The helper reuses the same persistence logic already used by drag-and-drop reordering:
  ```
  savePipelineContent({
    pipeline: { blocks: arr, uuid: pipeline?.uuid },
  }).then(fetchPipeline);
  ```
- Added blocks and pipeline to the opts object in CommandButtons so getMoreActionsItems can access them.

### Behavior

- Selecting “Move up” repositions the selected block one slot earlier in the visual stack.
- Selecting “Move to top” repositions the selected block to index 0.
- Order changes persist after reload since they’re stored in the pipeline’s saved state.
- No backend logic or DAG relationships are modified.

# How Has This Been Tested?

- [ ] Opened a pipeline with multiple stacked blocks.
- [ ] Selected More Actions → Move up — confirmed the block shifted up one position.
- [ ] Selected More Actions → Move to top — confirmed the block moved to the top.
- [ ] Reloaded the pipeline — confirmed order persisted.
- [ ] Verified no upstream/downstream connections were altered.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993
@johnson-mage 