### PR TITLE
[cf] removed TS_AUTH_KEY env variable from docs

### DIFF
--- a/docs/guides/developer-ux/visual-studio-code.mdx
+++ b/docs/guides/developer-ux/visual-studio-code.mdx
@@ -70,7 +70,7 @@ Step 1: Navigate to your Mage Pro management cluster.
 Step 2: Select "Edit/Add variable’ to add environment variables.
 Step 3: Add a new custom variable:
 
-- Key: `TS_AUTH_KEY`
+- Key: `TS_AUTHKEY`
 - Value: `YOUR_AUTH_KEY`
 
 Step 4: Click the “Save changes” button to save the TS_AUTHKEY variable. 
@@ -79,7 +79,7 @@ Step 4: Click the “Save changes” button to save the TS_AUTHKEY variable.
 <Frame>
   <img
     alt="TS Authkey Environment Variable"
-    src="https://mage-ai.github.io/assets/pro/features/vs-code/tailscale-authkey.png"
+    src="https://mage-ai.github.io/assets/pro/features/vs-code/new-ts-authkey.png"
   />
 </Frame>
 


### PR DESCRIPTION
# Description
removed the TS_AUTH_KEY env variable documentation from doc and replaced with TS_AUTHKEY


# How Has This Been Tested?
tested in local mintlify dev env.

- [ ] Test A
- [ ] Test B


# Checklist
- [X] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

cc:
cc @johnson-mage 

<img width="788" height="778" alt="Screenshot 2025-11-19 at 10 24 55 AM" src="https://github.com/user-attachments/assets/3d250356-676a-424d-868d-1401e911cb7f" />

