### PR TITLE
[xy] Update doc for trigger migration

### DIFF
--- a/docs/migrations/mage-oss-to-mage-pro.mdx
+++ b/docs/migrations/mage-oss-to-mage-pro.mdx
@@ -181,7 +181,12 @@ Mage Pro is more performant, reliable, and cost-effective than Mage OSS, with en
        - Configuration files (including IO configs)
        - Variables and secrets (if stored in Git)
        - Project structure
+       - Trigger files (triggers will be created automatically)
      - No code changes required—Mage Pro is 100% compatible with Mage OSS code
+   - **Migrate triggers**:
+     - **Before migration**: In Mage OSS, save your triggers in code by following the [configure triggers in code guide](/orchestration/triggers/configure-triggers-in-code#configure-triggers-in-code)
+     - **After pulling code from GitHub**: When you pull code from GitHub in Mage Pro, the trigger files will be automatically imported and triggers will be created in Mage Pro
+     - All your scheduled triggers, event triggers, and API triggers will be automatically set up
    - **Deploy commits**:
      - The deployments page will show a list of commits from your GitHub branch
      - Click the "Deploy" button next to any commit to deploy that version
@@ -280,6 +285,7 @@ If you prefer not to use Git-based import, you can manually migrate your project
 - **Block types**: All block types (data loaders, transformers, data exporters, sensors) are fully supported
 - **Dependencies**: Python dependencies defined in `requirements.txt` are automatically installed
 - **IO Configs**: Existing IO configs are automatically imported from your GitHub repository and work as-is, with optional Pro enhancements available
+- **Triggers**: Save triggers in code in Mage OSS (see [configure triggers in code guide](/orchestration/triggers/configure-triggers-in-code#configure-triggers-in-code)). When you pull code from GitHub in Mage Pro, trigger files are automatically imported and triggers are created automatically
 
 ### Workspace Organization
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This pull request updates the Mage OSS to Mage Pro migration documentation to clarify and enhance instructions around migrating triggers. The changes make it explicit that trigger files can be saved in code in Mage OSS and will be automatically imported and set up in Mage Pro, reducing manual migration effort.

**Improvements to migration documentation:**

* Added a new section outlining the steps for migrating triggers, including saving triggers in code in Mage OSS and automatic import/setup in Mage Pro after pulling code from GitHub.
* Clarified in the manual migration section that triggers saved in code in Mage OSS will be automatically imported and created in Mage Pro, referencing the relevant guide for configuring triggers in code.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Previewed locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
