### PR TITLE
Fix #5850: Properly identify and serialize custom objects

### DIFF
--- a/mage_ai/data_preparation/models/block/outputs.py
+++ b/mage_ai/data_preparation/models/block/outputs.py
@@ -43,7 +43,7 @@ from mage_ai.shared.parsers import (
     convert_matrix_to_dataframe,
     encode_complex,
     has_to_dict,
-    has_dict
+    is_custom_object_with_dict
 )
 from mage_ai.shared.strings import is_json
 
@@ -150,13 +150,7 @@ def format_output_data(
             text_data=encode_complex(data),
             variable_uuid=variable_uuid,
         )
-        if has_to_dict(data) or (
-        has_dict(data)
-        and not inspect.isclass(data)
-        and not inspect.isfunction(data)
-        and not inspect.ismethod(data)
-        and not inspect.ismodule(data)
-    ):
+        if has_to_dict(data) or is_custom_object_with_dict(data):
             return_output['type'] = DataType.OBJECT
         else:
             return_output['type'] = DataType.TEXT


### PR DESCRIPTION
# Description
**Summary of Changes:**

- Updated `encode_complex()` to safely handle objects with `__dict__`, including circular references.
- Added an additional check in `format_output_data()` for `has_dict()` to ensure custom objects are correctly detected on both page load and block execution.
- Ensures custom objects now display serialized output in the UI.
- Added unit tests for `encode_complex()` covering:
    - Simple objects with `__dict__`
    - Objects with circular references

 **Motivation / Context:**

- Previously, custom objects with circular references or `__dict__` attributes could cause serialization errors, leading to broken UI rendering or block execution failures.
- This fix ensures reliable serialization and improves stability and predictability for pipelines that return custom objects.

Related Issue:

[#5850](https://github.com/mage-ai/mage-ai/issues/5850)


# How Has This Been Tested?

- Added unit tests in `mage_ai/tests/shared/test_parsers.py` for `encode_complex()`:
    - `test_encode_simple_object_with_dict()` → tests a simple object with` __dict__`.
    - `test_encode_circular_object_with_dict() `→ tests object containing a circular reference.
- Verified that the serialized output for these objects is correct and safe.
- Verified that blocks execute correctly and the UI displays the serialized custom objects.


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993 
