### PR TITLE
[xy] Fix encoded URL for git_custom_branches.

### DIFF
--- a/mage_ai/server/server.py
+++ b/mage_ai/server/server.py
@@ -366,6 +366,10 @@ def make_app(
             r'/api/(?P<resource>block_outputs)/(?P<pk>.+)',
             ApiResourceDetailHandler,
         ),
+        (
+            r'/api/(?P<resource>git_custom_branches)/(?P<pk>.+)',
+            ApiResourceDetailHandler,
+        ),
         # Generic API patterns
         (
             r'/api/(?P<resource>\w+)/(?P<pk>[\w\-\%2f\.]+)'


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Close: https://github.com/mage-ai/mage-ai/issues/5973

When Mage is deployed in production environment and serve requests behind Nginx proxy/or other proxies, the URL is automatically decoded and sometimes causes 405 Method Not Allowed error for git_custom_branches API when the branch name contains slash. This PR fixes the issue.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested on staging environment


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
