### PR TITLE
[xy] Bump image version to 0.9.79

### DIFF
--- a/mage_ai/server/constants.py
+++ b/mage_ai/server/constants.py
@@ -12,4 +12,4 @@ DATAFRAME_OUTPUT_SAMPLE_COUNT = 10
 # Dockerfile depends on it because it runs ./scripts/install_mage.sh and uses
 # the last line to determine the version to install.
 VERSION = \
-'0.9.78'
+'0.9.79'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     name='mage-ai',
     # NOTE: when you change this, change the value of VERSION in the following file:
     # mage_ai/server/constants.py
-    version='0.9.78',
+    version='0.9.79',
     author='Mage',
     author_email='eng@mage.ai',
     description='Mage is a tool for building and deploying data pipelines.',


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at master -->

## What's Changed
## 🐛 Bug Fixes

- Copy `croniter` into the shared repository to avoid external dependency issues (@matrixstone)  
  https://github.com/mage-ai/mage-ai/pull/5703
- Fix SQLAlchemy compatibility issues when upgrading to v2.0 (@wangxiaoyou1993)  
  https://github.com/mage-ai/mage-ai/pull/5906
- Properly escape characters during code interpolation (@wangxiaoyou1993)  
  https://github.com/mage-ai/mage-ai/pull/5920
- Close log files correctly when loggers are deleted (@wangxiaoyou1993)  
  https://github.com/mage-ai/mage-ai/pull/5923
- Lock `scikit-learn` version to prevent breaking changes (@wangxiaoyou1993)  
  https://github.com/mage-ai/mage-ai/pull/5988
- Fix URL encoding for `git_custom_branches` (@wangxiaoyou1993)  
  https://github.com/mage-ai/mage-ai/pull/6004
- Avoid UTF-8 decoding errors for Kafka message keys under `RAW_VALUE` mode (@gitpranjal)  
  https://github.com/mage-ai/mage-ai/pull/5934
- Correct memory usage calculation in containerized environments (@Copilot)  
  https://github.com/mage-ai/mage-ai/pull/5992

## 💅 Enhancements & Polish

- Address security vulnerabilities across dependencies (@matrixstone)  
  https://github.com/mage-ai/mage-ai/pull/5863
- Lock package versions to improve build reproducibility (@wangxiaoyou1993)  
  https://github.com/mage-ai/mage-ai/pull/5939
- Add validation for Kafka streaming configuration (@wangxiaoyou1993)  
  https://github.com/mage-ai/mage-ai/pull/6003
- Sort projects alphabetically by name in the UI (@andexte)  
  https://github.com/mage-ai/mage-ai/pull/5918
- Upgrade GitHub Actions workflows to latest versions (@deining)  
  https://github.com/mage-ai/mage-ai/pull/5930
- Upgrade to `sentry-sdk` v2.x with envelope transport and graceful flush on exit (@dacdao1)  
  https://github.com/mage-ai/mage-ai/pull/5932
- Relax `polars` dependency to `>= 1.30.0` (@nitishbelagali)  
  https://github.com/mage-ai/mage-ai/pull/5983
- Upgrade `duckdb` dependency (@elefeint)  
  https://github.com/mage-ai/mage-ai/pull/5982
- Use project-wide timeout configuration when calling `.result()` (@sm-data)  
  https://github.com/mage-ai/mage-ai/pull/5986

## ✨ Features & Other Improvements

- Initialize `run_pipeline_in_one_process` via environment variable instead of a hardcoded default (@nayak-03)  
  https://github.com/mage-ai/mage-ai/pull/5922
- Preserve query parameters on the pipeline runs page after deletions (@dacdao1)  
  https://github.com/mage-ai/mage-ai/pull/5936
- Add **Move Up** and **Move to Top** actions to the block list UI (@DevDevvy)  
  https://github.com/mage-ai/mage-ai/pull/5941
- Add OAuth **BEARER** authentication support for Kafka streaming (@Copilot)  
  https://github.com/mage-ai/mage-ai/pull/5990

## 🙌 New Contributors

- @andexte — https://github.com/mage-ai/mage-ai/pull/5918  
- @dacdao1 — https://github.com/mage-ai/mage-ai/pull/5932 
- @deining — https://github.com/mage-ai/mage-ai/pull/5929  
- @nayak-03 — https://github.com/mage-ai/mage-ai/pull/5922  
- @DevDevvy — https://github.com/mage-ai/mage-ai/pull/5941  
- @gitpranjal — https://github.com/mage-ai/mage-ai/pull/5934  
- @nitishbelagali — https://github.com/mage-ai/mage-ai/pull/5983  
- @sm-data — https://github.com/mage-ai/mage-ai/pull/5986 

**Full Changelog**: https://github.com/mage-ai/mage-ai/compare/0.9.78...0.9.79

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
