### PR TITLE
[xy] Update data integration transformer block doc.

### DIFF
--- a/docs/design/blocks/transformer.mdx
+++ b/docs/design/blocks/transformer.mdx
@@ -3,6 +3,9 @@ title: "Transformer"
 description: "Use these blocks to clean, transform, and enhance data from other blocks."
 ---
 
+import { ProButton } from '/snippets/pro/button.mdx';
+import { ProOnly } from '/snippets/pro/only.mdx';
+
 ## Example
 
 ```python
@@ -55,7 +58,46 @@ In this case, there can be edge case mismatches between the data types in the so
 
 For example, a TIMESTAMPTZ value of `2023-01-09T20:01:00`, once it's renamed, can look like a string, but using an INSERT with `CAST('2023-01-09T20:01:00' AS TEXT)` to a column with data type `TIMESTAMPTZ` will fail.
 
-In order to fix this, you can add column "aliases" in the pipeline's data integration catalog.
+### Using the `rename_columns` decorator parameter (Recommended)
+
+<ProOnly source="transformer-rename-columns" />
+
+The recommended way to rename columns in data integration pipelines is to use the `rename_columns` parameter in the `@transformer` decorator. This approach automatically preserves original column types and updates schema metadata including `unique_constraints` and `key_properties`.
+
+**Benefits:**
+- **Type preservation**: Original column types are maintained after renaming
+- **Schema integrity**: `unique_constraints` and `key_properties` are automatically updated
+- **Declarative**: Column renaming is specified at the decorator level, making intent clear
+- **Only renames existing columns**: Columns that don't exist in the DataFrame are silently skipped
+
+**Example:**
+
+```python
+from pandas import DataFrame
+
+@transformer(rename_columns={
+    'impressions': 'field_5627',
+    'clicks': 'field_5628',
+    'new_free_signups': 'field_5629',
+    'new_paid_signups': 'field_5626',
+    'event_timestamp': 'field_5630'
+})
+def transform(data, *args, **kwargs):
+    # Your transformation logic here
+    # Columns are automatically renamed after this function executes
+    data.insert(0, 'trashed', False)
+    return data
+```
+
+The `rename_columns` parameter accepts a dictionary where:
+- **Keys** are the original column names (must exist in the DataFrame)
+- **Values** are the new column names
+
+**Note:** If a column in `rename_columns` doesn't exist in the DataFrame, it will be silently skipped. All target column names must be unique.
+
+### Using manual column renaming with aliases (Legacy approach)
+
+If you need more control or are using an older version, you can manually rename columns in your transformer function and add column "aliases" in the pipeline's data integration catalog.
 
 1. Have a transformer block in your integration pipeline that does some column renaming:
 
@@ -161,3 +203,5 @@ def transform(data, *args, **kwargs):
 ```
 
 Now, pipeline runs will use the correct data types for INSERT commands, thanks to transformer column aliases defined in the schema.
+
+**Note:** When using the `rename_columns` decorator parameter, you don't need to manually add aliases to the catalog - the schema metadata is automatically updated. The manual approach with aliases is only needed when renaming columns inside the transformer function code.


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This pull request updates the documentation for the Transformer block to recommend and explain the new `rename_columns` parameter in the `@transformer` decorator, which simplifies and improves column renaming in data integration pipelines. The changes clarify best practices, add examples, and distinguish between the new recommended approach and the legacy manual method.

**Improvements to documentation and guidance:**

* Added a new section recommending the use of the `rename_columns` parameter in the `@transformer` decorator for column renaming, with a detailed explanation of its benefits (type preservation, schema integrity, declarative syntax, and silent skipping of missing columns) and a code example.
* Clarified that when using `rename_columns`, manual addition of column aliases to the catalog is unnecessary, as schema metadata is updated automatically.
* Reorganized the documentation to distinguish between the new recommended approach (`rename_columns`) and the legacy manual aliasing method, providing guidance for both. [[1]](diffhunk://#diff-12937a300925740ad9c4638f0d957601ea9583e9971b858da673d86fea1fddacL58-R100) [[2]](diffhunk://#diff-12937a300925740ad9c4638f0d957601ea9583e9971b858da673d86fea1fddacR206-R207)

**General documentation enhancements:**

* Imported `ProButton` and `ProOnly` components for improved documentation formatting and to highlight Pro-only features.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Previewed locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
