### PR TITLE
fix: correct typos 'seperate' and 'occurences'

### DIFF
--- a/mage_ai/server/execution_manager.py
+++ b/mage_ai/server/execution_manager.py
@@ -12,7 +12,7 @@ class PipelineExecution:
     """
     Singleton class to manage the current pipeline execution running in
     the websocket. We need to track the state of this execution because
-    it will be run in a seperate process, and the user can choose to cancel
+    it will be run in a separate process, and the user can choose to cancel
     the execution.
     """
     def __init__(self):

--- a/mage_ai/shared/croniter.py
+++ b/mage_ai/shared/croniter.py
@@ -1005,7 +1005,7 @@ class croniter(object):
                         # Add FirstBound -> ENDRANGE, respecting step
                         rng = list(range(low, cls.RANGES[field_index][1] + 1, step))
                         # Then 0 -> SecondBound, but skipping n
-                        # first occurences according to step
+                        # first occurrences according to step
                         # EG to respect such expressions : Apr-Jan/3
                         to_skip = 0
                         if rng:


### PR DESCRIPTION
Corrects two spelling errors:
- `seperate` → `separate` in execution_manager.py
- `occurences` → `occurrences` in croniter.py