### PR TITLE
fix: correct typo 'Recieved' to 'Received' in activemq.py

### DIFF
--- a/mage_ai/streaming/sources/activemq.py
+++ b/mage_ai/streaming/sources/activemq.py
@@ -21,7 +21,7 @@ class ActiveMQConfig(BaseConfig):
 
 
 def messageProcessingFunction(message, handler):
-    print('Recieved message: "%s"' % message)
+    print('Received message: "%s"' % message)
     handler([message])
 
 


### PR DESCRIPTION
Simple typo fix in a comment string