### PR TITLE
Fix DataFrame dtype silently reverting between blocks

### DIFF
--- a/mage_ai/data_preparation/models/utils.py
+++ b/mage_ai/data_preparation/models/utils.py
@@ -55,6 +55,7 @@ CAST_TYPE_COLUMN_TYPES = {
 # need to cast them back to object and restore None values in place of NaT.
 DATETIME_OBJECT_COLUMN_TYPES = {
     'Timestamp',
+    'datetime',
 }
 
 POLARS_CAST_TYPE_COLUMN_TYPES = {

--- a/mage_ai/tests/data_preparation/models/test_utils.py
+++ b/mage_ai/tests/data_preparation/models/test_utils.py
@@ -6,7 +6,7 @@ from scipy.sparse import csr_matrix
 from sklearn.linear_model import LinearRegression
 
 from mage_ai.data_preparation.models.project.constants import FeatureUUID
-from mage_ai.data_preparation.models.utils import infer_variable_type
+from mage_ai.data_preparation.models.utils import cast_column_types, infer_variable_type
 from mage_ai.data_preparation.models.variables.constants import VariableType
 from mage_ai.tests.base_test import TestCase
 
@@ -78,3 +78,32 @@ class TestModelUtils(TestCase):
         data = [1, 2, 3]
         variable_type_use, basic_iterable = infer_variable_type(data)
         self.assertEqual(variable_type_use, VariableType.ITERABLE)
+
+    def test_cast_column_types_preserves_object_datetime(self):
+        """Columns saved as 'Timestamp' type should be restored to object dtype
+        with None instead of NaT after a parquet roundtrip (issue #5913)."""
+        # Simulate a DataFrame as it comes back from parquet: datetime64 with NaT
+        df = pd.DataFrame({
+            'date_col': pd.to_datetime([
+                '2025-01-01', '2025-02-15', None, '2025-04-30', None
+            ]),
+            'other_col': [1, 2, 3, 4, 5],
+        })
+        self.assertEqual(str(df['date_col'].dtype), 'datetime64[ns]')
+
+        # The column_types dict as saved by __get_column_types for an object
+        # column containing Timestamp values
+        column_types = {'date_col': 'Timestamp', 'other_col': 'int64'}
+
+        result = cast_column_types(df, column_types)
+
+        # date_col should be restored to object dtype
+        self.assertEqual(result['date_col'].dtype, object)
+        # Non-null values should still be Timestamps
+        self.assertIsInstance(result['date_col'].iloc[0], pd.Timestamp)
+        self.assertEqual(result['date_col'].iloc[0], pd.Timestamp('2025-01-01'))
+        # NaT values should be restored to None
+        self.assertIsNone(result['date_col'].iloc[2])
+        self.assertIsNone(result['date_col'].iloc[4])
+        # other_col should be unchanged
+        self.assertEqual(str(result['other_col'].dtype), 'int64')

--- a/mage_ai/tests/data_preparation/models/test_utils.py
+++ b/mage_ai/tests/data_preparation/models/test_utils.py
@@ -107,3 +107,29 @@ class TestModelUtils(TestCase):
         self.assertIsNone(result['date_col'].iloc[4])
         # other_col should be unchanged
         self.assertEqual(str(result['other_col'].dtype), 'int64')
+
+    def test_cast_column_types_preserves_object_native_datetime(self):
+        """Columns saved as 'datetime' type (Python datetime.datetime values)
+        should also be restored to object dtype with None instead of NaT."""
+        # Simulate a DataFrame as it comes back from parquet: datetime64 with NaT
+        df = pd.DataFrame({
+            'date_col': pd.to_datetime([
+                '2025-01-01', '2025-02-15', None, '2025-04-30', None
+            ]),
+            'other_col': [1, 2, 3, 4, 5],
+        })
+        self.assertEqual(str(df['date_col'].dtype), 'datetime64[ns]')
+
+        # __get_column_types records 'datetime' (the coltype class __name__)
+        # for object columns holding native datetime.datetime values
+        column_types = {'date_col': 'datetime', 'other_col': 'int64'}
+
+        result = cast_column_types(df, column_types)
+
+        # date_col should be restored to object dtype
+        self.assertEqual(result['date_col'].dtype, object)
+        # NaT values should be restored to None
+        self.assertIsNone(result['date_col'].iloc[2])
+        self.assertIsNone(result['date_col'].iloc[4])
+        # other_col should be unchanged
+        self.assertEqual(str(result['other_col'].dtype), 'int64')


### PR DESCRIPTION
## Summary

Fixes #5913

When a user explicitly converts a column from `datetime64[ns]` to `object` dtype (e.g. replacing `pd.NaT` with `None`), the conversion is silently lost when data passes between blocks. This happens because the inter-block serialization writes DataFrames to parquet, and PyArrow infers `Timestamp` values in object columns back to `datetime64`. On read, the saved column type metadata (`'Timestamp'`) was not being used to restore the original `object` dtype, so `None` values reappear as `NaT` and downstream exporters (like OracleDB) write them as `0001-01-01` instead of NULL.

### Changes

**`mage_ai/data_preparation/models/utils.py`**
- Added `DATETIME_OBJECT_COLUMN_TYPES` set containing `'Timestamp'` to identify columns that were originally object dtype with datetime-like values
- Extended `cast_column_types()` to handle these columns: when parquet has inferred them back to `datetime64`, cast to `object` and restore `NaT` → `None`

**`mage_ai/tests/data_preparation/models/test_utils.py`**
- Added test covering the parquet roundtrip scenario from the issue

### Root cause

The write path (`Variable.__get_column_types`) correctly records the column type as `'Timestamp'` for object-dtype columns containing `pd.Timestamp` values. However, the read path (`cast_column_types`) only handled `Int64`/`int64`/`float64` types — it had no handling for `'Timestamp'`, so the column stayed as `datetime64` after the parquet read.

## Test plan

- [x] Added unit test `test_cast_column_types_preserves_object_datetime` that simulates the exact scenario from the issue
- [ ] Manual test: create a pipeline with two blocks where block 1 replaces `NaT` with `None` and block 2 inspects the dtype — should show `object` dtype with `None` values preserved