### PR TITLE
[xy] Update bigquery streaming doc.

### DIFF
--- a/docs/guides/streaming/destinations/bigquery.mdx
+++ b/docs/guides/streaming/destinations/bigquery.mdx
@@ -61,7 +61,7 @@ dead_letter:
 |-----------|------|-------------|---------|
 | `table_id` | string | BigQuery table identifier. Use `project_id.dataset_id.table_id` or `dataset_id.table_id` (project from profile or `database`). Supports [metadata interpolation](#metadata-interpolation), e.g. `"{schema}.{table}"` for CDC. | *(required)* |
 | `database` | string | Default project when `table_id` is two-part (`dataset_id.table_id`). Overrides the profile project if set. | profile project |
-| `if_exists` | string | Behavior when the table already exists: `append` (add rows), `replace` (drop and recreate), or `fail` (throw an error). | `append` |
+| `if_exists` | string | Behavior when the table already exists: `append` (add rows), `replace` (truncate/overwrite existing rows; preserves table schema), or `fail` (throw an error). | `append` |
 | `overwrite_types` | object | Map of column name → BigQuery type (e.g. `STRING`, `INT64`, `TIMESTAMP`, `RECORD`). Used to cast columns before write. Useful for `_mage_*` or custom columns. | — |
 | `unique_constraints` | list (or string) | List of column names for upsert/merge. When set with `unique_conflict_method`, exports as MERGE instead of append. Supports interpolation, e.g. `"{key_columns}"` from [PostgreSQL CDC](/guides/streaming/sources/postgres-cdc). | — |
 | `unique_conflict_method` | string | For upsert: e.g. `UPDATE` to update existing rows on conflict. Used only when `unique_constraints` is set. | — |


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This pull request significantly expands and clarifies the documentation for streaming data to BigQuery. The changes introduce detailed explanations for configuration options, provide guidance on using the Storage Write API, and add documentation for dead-letter queue support and metadata interpolation. These updates make it easier for users to understand advanced features and configure BigQuery streaming destinations correctly.

**Major documentation enhancements:**

* Added a comprehensive overview of how the BigQuery streaming destination works, including the use of the Storage Write API, schema handling, and CDC column mapping.
* Documented support for a dead-letter queue, including configuration options and record format for handling failed rows, with examples for both file and table destinations.
* Explained metadata interpolation in config parameters, enabling dynamic table routing based on message metadata (especially useful for CDC sources).

**Expanded configuration details:**

* Provided a detailed table of config parameters, including `table_id`, `database`, `if_exists`, `overwrite_types`, `unique_constraints`, and `unique_conflict_method`, with explanations and defaults.
* Added YAML examples for both basic and advanced configurations, including dead-letter queue and metadata interpolation usage.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Previewed locally


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
