### PR TITLE
[xy] Don't fail the server if installing dependency fails.

### DIFF
--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -26,7 +26,13 @@ fi
 REQUIREMENTS_FILE="${PROJECT_PATH}/requirements.txt"
 if [ -f "$REQUIREMENTS_FILE" ]; then
     echo "$REQUIREMENTS_FILE exists."
-    pip3 install -r $REQUIREMENTS_FILE
+
+    # Run pip install and handle errors gracefully
+    if ! pip3 install -r "$REQUIREMENTS_FILE"; then
+        echo "Warning: Failed to install requirements from $REQUIREMENTS_FILE" >&2
+    else
+        echo "Requirements installed successfully."
+    fi
 fi
 
 mage_args=()


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This pull request improves the robustness of the `scripts/run_app.sh` script by adding error handling to the requirements installation step. Now, if the `pip install` command fails, a warning will be displayed instead of causing the script to exit unexpectedly.

- Shell script improvements:
  * Added error handling for the `pip3 install -r requirements.txt` command in `scripts/run_app.sh`, so that failures are caught and a warning is printed instead of stopping the script.

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

- [x] Tested locally

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
