### PR TITLE
Add SVG download for pipeline dependency graph

### DIFF
--- a/mage_ai/frontend/components/DependencyGraph/ZoomControls/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/ZoomControls/index.tsx
@@ -6,13 +6,15 @@ import Tooltip from '@oracle/components/Tooltip';
 import { BORDER_RADIUS_PILL } from '@oracle/styles/units/borders';
 import { CanvasRef } from 'reaflow';
 import { ICON_SIZE_MEDIUM } from '@oracle/styles/units/icons';
-import { Recenter, ZoomIn, ZoomOut } from '@oracle/icons';
+import { ArrowDown, Recenter, ZoomIn, ZoomOut } from '@oracle/icons';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { ZoomControlsStyle, ZoomDisplayStyle } from './index.style';
 
 type ZoomControlProps = {
   canvasRef?: { current?: CanvasRef };
-  containerRef?: { current?: any };
+  containerRef?: { current?: HTMLElement };
+  isDownloading?: boolean;
+  onDownload?: () => Promise<void> | void;
   zoomLevel: number;
 };
 
@@ -38,7 +40,13 @@ const SHARED_ICON_PROPS = {
   size: ICON_SIZE_MEDIUM,
 };
 
-function ZoomControls({ canvasRef, containerRef, zoomLevel }: ZoomControlProps) {
+function ZoomControls({
+  canvasRef,
+  containerRef,
+  isDownloading,
+  onDownload,
+  zoomLevel,
+}: ZoomControlProps) {
   const [minimizeControls, setMinimizeControls] = useState<boolean>(false);
 
   useEffect(() => {
@@ -54,11 +62,13 @@ function ZoomControls({ canvasRef, containerRef, zoomLevel }: ZoomControlProps) 
   }, [containerRef]);
 
   return (
-    <ZoomControlsStyle onDoubleClick={(event) => { event.stopPropagation(); }}>
+    <ZoomControlsStyle
+      onDoubleClick={(event) => { event.stopPropagation(); }}
+    >
       {!minimizeControls && (
         <>
           <Tooltip {...SHARED_TOOLTIP_PROPS} label="Reset (shortcut: double-click canvas)">
-            <Button 
+            <Button
               {...SHARED_BUTTON_PROPS}
               borderRadius={`${BORDER_RADIUS_PILL}px 0 0 ${BORDER_RADIUS_PILL}px`}
               onClick={() => canvasRef?.current?.fitCanvas?.()}
@@ -68,7 +78,7 @@ function ZoomControls({ canvasRef, containerRef, zoomLevel }: ZoomControlProps) 
             </Button>
           </Tooltip>
           <Tooltip {...SHARED_TOOLTIP_PROPS} label="Zoom in">
-            <Button  
+            <Button
               {...SHARED_BUTTON_PROPS}
               onClick={() => canvasRef?.current?.setZoom?.(
                 (zoomLevel - DEFAULT_ZOOM_LEVEL) + ZOOM_FACTOR,
@@ -78,7 +88,7 @@ function ZoomControls({ canvasRef, containerRef, zoomLevel }: ZoomControlProps) 
             </Button>
           </Tooltip>
           <Tooltip {...SHARED_TOOLTIP_PROPS} label="Zoom out">
-            <Button 
+            <Button
               {...SHARED_BUTTON_PROPS}
               onClick={() => canvasRef?.current?.setZoom?.(
                 (zoomLevel - DEFAULT_ZOOM_LEVEL) - ZOOM_FACTOR,
@@ -89,9 +99,23 @@ function ZoomControls({ canvasRef, containerRef, zoomLevel }: ZoomControlProps) 
           </Tooltip>
         </>
       )}
+      <Tooltip {...SHARED_TOOLTIP_PROPS} label="Download dependency tree as SVG">
+        <Button
+          {...SHARED_BUTTON_PROPS}
+          beforeIcon={<ArrowDown {...SHARED_ICON_PROPS} />}
+          borderRadius={minimizeControls
+            ? `${BORDER_RADIUS_PILL}px 0 0 ${BORDER_RADIUS_PILL}px`
+            : undefined}
+          iconOnly={false}
+          loading={isDownloading}
+          onClick={onDownload}
+        >
+          Download
+        </Button>
+      </Tooltip>
       <Tooltip {...SHARED_TOOLTIP_PROPS} label="Zoom level">
         <ZoomDisplayStyle minimizeControls={minimizeControls}>
-          <Text 
+          <Text
             center
             large
             minWidth={UNIT * 5} // Prevent button resizing due to varying number of digits

--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -1,9 +1,8 @@
 import dynamic from 'next/dynamic';
 import { CanvasRef } from 'reaflow';
+import { toast } from 'react-toastify';
 import { ThemeContext } from 'styled-components';
-import { parse } from 'yaml';
 import {
-  createRef,
   useCallback,
   useContext,
   useEffect,
@@ -20,7 +19,6 @@ import BlockType, {
   BlockRequestPayloadType,
   BlockTypeEnum,
   SetEditingBlockType,
-  StatusTypeEnum,
 } from '@interfaces/BlockType';
 import ClickOutside from '@oracle/components/ClickOutside';
 import Divider from '@oracle/elements/Divider';
@@ -38,11 +36,10 @@ import useProject from '@utils/models/project/useProject';
 import {
   EdgeType,
   NodeType,
-  PortType,
   SideEnum,
   ZOOMABLE_CANVAS_SIZE,
 } from './constants';
-import { GraphContainerStyle, STROKE_WIDTH, inverseColorsMapping } from './index.style';
+import { GraphContainerStyle, STROKE_WIDTH } from './index.style';
 import { RunStatus } from '@interfaces/BlockRunType';
 import { ThemeType } from '@oracle/styles/themes/constants';
 import {
@@ -50,26 +47,18 @@ import {
   UNIT,
 } from '@oracle/styles/units/spacing';
 import { ViewKeyEnum } from '@components/Sidekick/constants';
+import { openSaveFileDialog } from '@components/PipelineDetail/utils';
+import { buildDependencyGraphSvgBlob } from './svgExport';
 import {
-  buildEdge,
   buildNodesEdgesPorts,
   buildPortIDDownstream,
-  buildPortsDownstream,
-  buildPortsUpstream,
   getBlockStatus,
   getParentNodeID,
   getParentNodeIDShared,
-  isActivePort,
 } from './utils';
 import { find, indexBy, removeAtIndex, sortByKey } from '@utils/array';
 import { getBlockNodeHeight, getBlockNodeWidth } from './BlockNode/utils';
-import { getBlockRunBlockUUID } from '@utils/models/blockRun';
 import { getColorsForBlockType } from '@components/CodeBlock/index.style';
-import {
-  getMessagesWithType,
-  hasErrorOrOutput,
-} from '@components/CodeBlock/utils';
-import { getModelAttributes } from '@utils/models/dbt';
 import { onSuccess } from '@api/utils/response';
 import { pauseEvent } from '@utils/events';
 
@@ -257,14 +246,13 @@ function DependencyGraph({
 }: DependencyGraphProps) {
   const { featureEnabled, featureUUIDs } = useProject();
   const themeContext: ThemeType = useContext(ThemeContext);
-  const colorsInverse = useMemo(() => inverseColorsMapping(themeContext), [themeContext]);
 
   const containerRef = useRef(null);
-  const portRefs = useRef({});
   const timeoutActiveRefs = useRef({});
   const timeoutDraggingRefs = useRef({});
   const treeInnerRef = useRef<CanvasRef>(null);
   const canvasRef = treeRef || treeInnerRef;
+  const [isDownloading, setIsDownloading] = useState<boolean>(false);
   const [zoomLevel, setZoomLevel] = useState<number>(DEFAULT_ZOOM_LEVEL);
 
   const [activeEdge, setActiveEdge] = useState<{
@@ -296,7 +284,7 @@ function DependencyGraph({
         }));
       }
     };
-    const handleMouseUp = (event) => {
+    const handleMouseUp = () => {
       if (isDragging && nodeDragging) {
         setIsDragging(false);
         setTimeout(() => setNodeDragging(null), 1);
@@ -321,8 +309,6 @@ function DependencyGraph({
 
   const [selectedBlockTwice, setSelectedBlockTwice] = useState(null);
   const [edgeSelections, setEdgeSelections] = useState<string[]>([]);
-  const [showPortsState, setShowPorts] = useState<boolean>(false);
-  const showPorts = enablePorts && showPortsState;
   const {
     block: blockEditing,
     values: upstreamBlocksEditing = [],
@@ -607,7 +593,6 @@ function DependencyGraph({
   const {
     edges,
     nodes,
-    ports,
     blocksWithDownstreamBlockSet,
   } = useMemo(() => buildNodesEdgesPorts({
     activeNodes,
@@ -716,6 +701,7 @@ function DependencyGraph({
     onClickWhenEditingUpstreamBlocks,
     selectedBlock,
     selectedBlockTwice,
+    setSelectedBlock,
     setSelectedBlockTwice,
   ]);
 
@@ -724,7 +710,7 @@ function DependencyGraph({
     if (nodeID in timeoutActiveRefs.current) {
       clearTimeout(timeoutActiveRefs?.current?.[nodeID]);
     }
-  }, [activeNodes]);
+  }, []);
 
   const setTimeoutForNode = useCallback((node) => {
     const nodeID = node?.id;
@@ -738,7 +724,7 @@ function DependencyGraph({
     }, 1000);
   }, [setActiveNodes]);
 
-  const onMouseEnterNode = useCallback((event, node, opts) => {
+  const onMouseEnterNode = useCallback((event, node) => {
     pauseEvent(event);
 
     if (!isDragging && nodeDragging) {
@@ -821,9 +807,10 @@ function DependencyGraph({
     setNodeHovering,
     setTargetNode,
     setTimeoutForNode,
+    updateBlockByDragAndDrop,
   ]);
 
-  const onMouseLeaveNode = useCallback((event, node, opts) => {
+  const onMouseLeaveNode = useCallback((event, node) => {
     pauseEvent(event);
 
     setNodeHovering(null);
@@ -863,7 +850,7 @@ function DependencyGraph({
     setNodeDragging,
   ]);
 
-  const onMouseUpNode = useCallback((event, node, opts) => {
+  const onMouseUpNode = useCallback((event, node) => {
     pauseEvent(event);
 
     const nodeID = node?.id;
@@ -894,7 +881,6 @@ function DependencyGraph({
   const onEnterPort = useCallback(({
     event,
     node,
-    port,
   }) => {
     pauseEvent(event);
 
@@ -908,7 +894,6 @@ function DependencyGraph({
   const onLeavePort = useCallback(({
     event,
     node,
-    port,
   }) => {
     pauseEvent(event);
 
@@ -937,12 +922,10 @@ function DependencyGraph({
   ]);
 
   const onDragEndPort = useCallback(({
-    event,
     node,
     port,
   }) => {
     const nodeID = node?.id;
-    const side = port?.side as SideEnum;
 
     if (targetNode) {
       const fromBlock: BlockType = node?.properties?.data?.block;
@@ -992,6 +975,7 @@ function DependencyGraph({
     setActivePorts,
     setTimeoutForNode,
     targetNode,
+    updateBlockByDragAndDrop,
   ]);
 
   const determineSelectedStatus = useCallback((node: {
@@ -1199,6 +1183,7 @@ function DependencyGraph({
     blockStatus,
     callbackBlocksByBlockUUID,
     conditionalBlocksByBlockUUID,
+    determineSelectedStatus,
     disabledProp,
     extensionBlocksByBlockUUID,
     messages,
@@ -1235,19 +1220,6 @@ function DependencyGraph({
       return;
     }
 
-    const {
-      hasFailed,
-      isInProgress,
-      isQueued,
-      isSuccessful,
-    } = getBlockStatus({
-      block,
-      blockStatus,
-      messages,
-      noStatus,
-      runningBlocks,
-      runningBlocksMapping,
-    });
     const callbackBlocks = callbackBlocksByBlockUUID?.[block?.uuid];
     const conditionalBlocks = conditionalBlocksByBlockUUID?.[block?.uuid];
     const extensionBlocks = extensionBlocksByBlockUUID?.[block?.uuid];
@@ -1286,12 +1258,8 @@ function DependencyGraph({
     conditionalBlocksByBlockUUID,
     extensionBlocksByBlockUUID,
     isDragging,
-    messages,
-    noStatus,
     nodeDragging,
     pipeline,
-    runningBlocks,
-    runningBlocksMapping,
   ]);
 
   // Show a menu to add a block between or delete the connection.
@@ -1445,7 +1413,10 @@ function DependencyGraph({
     );
   }, [
     activeEdge,
+    addNewBlockAtIndex,
     blocks,
+    blocksWithDownstreamBlockSet,
+    blockUUIDMapping,
     setActiveEdge,
     updateBlockByDragAndDrop,
   ]);
@@ -1464,13 +1435,11 @@ function DependencyGraph({
     const {
       event,
       node,
-      data,
     } = contextMenuData;
     const {
       data: {
         block,
         blocks,
-        children,
       },
     } = node;
 
@@ -1661,7 +1630,6 @@ function DependencyGraph({
     );
   }, [
     addNewBlockAtIndex,
-    blocks,
     contentByBlockUUID,
     contextMenuData,
     deleteBlock,
@@ -1673,6 +1641,45 @@ function DependencyGraph({
     setContextMenuData,
     setSelectedBlock,
     setSelectedBlockTwice,
+    selectedBlock,
+    selectedBlockTwice,
+    showUpdateBlockModal,
+    updateBlockByDragAndDrop,
+  ]);
+
+  const handleDownload = useCallback(async () => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    try {
+      setIsDownloading(true);
+
+      const canvasContainer = canvasRef?.current?.containerRef?.current as HTMLDivElement;
+      const svgElement = canvasContainer?.querySelector('svg') as SVGSVGElement;
+
+      if (!canvasContainer || !svgElement) {
+        throw new Error('Unable to find dependency tree SVG.');
+      }
+
+      if (document.fonts?.ready) {
+        await document.fonts.ready;
+      }
+
+      const blob = buildDependencyGraphSvgBlob(svgElement);
+
+      openSaveFileDialog(blob, `${pipeline?.uuid || 'pipeline'}_dependency_tree.svg`);
+    } catch (error) {
+      console.error(error);
+      toast.error('Unable to download dependency tree.', {
+        position: toast.POSITION.BOTTOM_RIGHT,
+      });
+    } finally {
+      setIsDownloading(false);
+    }
+  }, [
+    canvasRef,
+    pipeline,
   ]);
 
   return (
@@ -1772,6 +1779,8 @@ function DependencyGraph({
         <ZoomControls
           canvasRef={canvasRef}
           containerRef={containerRef}
+          isDownloading={isDownloading}
+          onDownload={handleDownload}
           zoomLevel={zoomLevel}
         />
         <Canvas
@@ -1824,8 +1833,12 @@ function DependencyGraph({
                   ...block?.downstream_blocks?.map((uuid) => blockUUIDMapping?.[uuid]),
                 );
               } else {
-                const downstreamBlockUUID = block?.downstream_blocks?.find((uuid) => buildPortIDDownstream(blockUUID, uuid) === edge?.sourcePort
-                    || getParentNodeID(blockUUID) === edge.target);
+                const downstreamBlockUUID = block?.downstream_blocks?.find(
+                  (uuid) => (
+                    buildPortIDDownstream(blockUUID, uuid) === edge?.sourcePort
+                    || getParentNodeID(blockUUID) === edge.target
+                  ),
+                );
                 const downstreamBlock = blockUUIDMapping?.[downstreamBlockUUID];
                 downstreamBlocks.push(downstreamBlock);
               }
@@ -1953,7 +1966,6 @@ function DependencyGraph({
           maxZoom={1}
           minZoom={-1}
           node={(node) => {
-            const nodeID = node?.id;
             const {
               block,
               blocks: blocksWithSameDownstreamBlocks,
@@ -1989,7 +2001,6 @@ function DependencyGraph({
                     }}
                     onDragEnd={(event, _, port) => {
                       onDragEndPort({
-                        event,
                         node,
                         port,
                       });
@@ -2002,18 +2013,16 @@ function DependencyGraph({
                         port,
                       });
                     }}
-                    onEnter={(event, port) => {
+                    onEnter={(event) => {
                       onEnterPort({
                         event,
                         node,
-                        port,
                       });
                     }}
-                    onLeave={(event, port) => {
+                    onLeave={(event) => {
                       onLeavePort({
                         event,
                         node,
-                        port,
                       });
                     }}
                     rx={isActive ? 10 : 0}
@@ -2100,23 +2109,16 @@ function DependencyGraph({
                         })
                         : null
                       }
-                      onMouseEnter={(e) => onMouseEnterNode(e, node, {
-                        nodeHeight,
-                        nodeWidth,
-                      })}
-                      onMouseLeave={(e) => onMouseLeaveNode(e, node, {
-                        nodeHeight,
-                        nodeWidth,
-                      })}
+                      onMouseEnter={(e) => onMouseEnterNode(e, node)}
+                      onMouseLeave={(e) => onMouseLeaveNode(e, node)}
                       onMouseUp={dragEnabled
-                        ? (e) => onMouseUpNode(e, node, {
-                          nodeHeight,
-                          nodeWidth,
-                        })
+                        ? (e) => onMouseUpNode(e, node)
                         : null
                       }
                       style={{
-                        // https://reaflow.dev/?path=/story/docs-advanced-custom-nodes--page#the-foreignobject-will-steal-events-onclick-onenter-onleave-etc-that-are-bound-to-the-rect-node
+                        // https://reaflow.dev/?path=/story/docs-advanced-custom-nodes--page
+                        // #the-foreignobject-will-steal-events-onclick-onenter-onleave-etc
+                        // -that-are-bound-to-the-rect-node
                         // pointerEvents: 'none',
                       }}
                       width={event.width}
@@ -2151,7 +2153,9 @@ function DependencyGraph({
             );
           }}
           nodes={nodes}
-          onNodeLinkCheck={(event, from, to) => !edges.some(e => e.from === from.id && e.to === to.id)}
+          onNodeLinkCheck={(_, from, to) => !edges.some(
+            (e) => e.from === from.id && e.to === to.id,
+          )}
           onZoomChange={z => {
             const zFinal = Math.max(z, 0.05);
             setZoom?.(zFinal);

--- a/mage_ai/frontend/components/DependencyGraph/svgExport.ts
+++ b/mage_ai/frontend/components/DependencyGraph/svgExport.ts
@@ -1,0 +1,180 @@
+import { UNIT } from '@oracle/styles/units/spacing';
+
+const SVG_EXPORT_PADDING = UNIT * 4;
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+const XHTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
+const XLINK_NAMESPACE = 'http://www.w3.org/1999/xlink';
+const SVG_EXPORT_BOUND_SELECTORS = [
+  'foreignObject',
+  'path',
+  'line',
+  'polyline',
+  'polygon',
+  'rect',
+  'circle',
+  'ellipse',
+  'text',
+  'use',
+  'image',
+].join(', ');
+
+type SvgExportBounds = {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+};
+
+function buildInlineStyleValue(sourceElement: Element): string {
+  const computedStyles = window.getComputedStyle(sourceElement);
+
+  return Array.from(computedStyles).map((propertyName) => {
+    const propertyValue = computedStyles.getPropertyValue(propertyName);
+    const priority = computedStyles.getPropertyPriority(propertyName);
+
+    return `${propertyName}:${propertyValue}${priority ? ' !important' : ''};`;
+  }).join('');
+}
+
+function cloneNodeForSvgExport(sourceNode: Node, ownerDocument: XMLDocument): Node {
+  if (sourceNode.nodeType === 3) {
+    return ownerDocument.createTextNode(sourceNode.textContent || '');
+  }
+
+  if (sourceNode.nodeType !== 1) {
+    return ownerDocument.createTextNode('');
+  }
+
+  const sourceElement = sourceNode as Element;
+  const namespaceURI = sourceElement.namespaceURI || SVG_NAMESPACE;
+  const targetElement = ownerDocument.createElementNS(
+    namespaceURI,
+    sourceElement.localName,
+  );
+
+  Array.from(sourceElement.attributes).forEach((attribute) => {
+    if (attribute.namespaceURI) {
+      targetElement.setAttributeNS(attribute.namespaceURI, attribute.name, attribute.value);
+    } else {
+      targetElement.setAttribute(attribute.name, attribute.value);
+    }
+  });
+
+  const inlineStyleValue = buildInlineStyleValue(sourceElement);
+  if (inlineStyleValue.length >= 1) {
+    targetElement.setAttribute('style', inlineStyleValue);
+  }
+
+  if (namespaceURI === XHTML_NAMESPACE) {
+    targetElement.setAttribute('xmlns', XHTML_NAMESPACE);
+  }
+
+  Array.from(sourceNode.childNodes).forEach((childNode) => {
+    targetElement.appendChild(cloneNodeForSvgExport(childNode, ownerDocument));
+  });
+
+  return targetElement;
+}
+
+function calculateSvgExportBounds(svgElement: SVGSVGElement): SvgExportBounds {
+  const screenTransform = svgElement.getScreenCTM();
+
+  if (!screenTransform) {
+    const bbox = svgElement.getBBox();
+
+    return {
+      height: Math.max(bbox?.height || 0, 1),
+      width: Math.max(bbox?.width || 0, 1),
+      x: bbox?.x || 0,
+      y: bbox?.y || 0,
+    };
+  }
+
+  const inverseTransform = screenTransform.inverse();
+  const point = svgElement.createSVGPoint();
+  const elements = Array.from(
+    svgElement.querySelectorAll(SVG_EXPORT_BOUND_SELECTORS),
+  ) as SVGGraphicsElement[];
+
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+
+  elements.forEach((element) => {
+    const rect = element.getBoundingClientRect();
+    if (!rect || (rect.width <= 0 && rect.height <= 0)) {
+      return;
+    }
+
+    [
+      [rect.left, rect.top],
+      [rect.right, rect.top],
+      [rect.left, rect.bottom],
+      [rect.right, rect.bottom],
+    ].forEach(([x, y]) => {
+      point.x = x;
+      point.y = y;
+
+      const svgPoint = point.matrixTransform(inverseTransform);
+      minX = Math.min(minX, svgPoint.x);
+      minY = Math.min(minY, svgPoint.y);
+      maxX = Math.max(maxX, svgPoint.x);
+      maxY = Math.max(maxY, svgPoint.y);
+    });
+  });
+
+  if (!Number.isFinite(minX) || !Number.isFinite(minY)
+    || !Number.isFinite(maxX) || !Number.isFinite(maxY)) {
+    const bbox = svgElement.getBBox();
+
+    return {
+      height: Math.max(bbox?.height || 0, 1),
+      width: Math.max(bbox?.width || 0, 1),
+      x: bbox?.x || 0,
+      y: bbox?.y || 0,
+    };
+  }
+
+  return {
+    height: Math.max(maxY - minY, 1),
+    width: Math.max(maxX - minX, 1),
+    x: minX,
+    y: minY,
+  };
+}
+
+/**
+ * Serialize the rendered dependency graph SVG into a standalone download.
+ * The export preserves `foreignObject` node content and trims the output to
+ * the actual rendered graph bounds instead of the editor canvas.
+ */
+export function buildDependencyGraphSvgBlob(svgElement: SVGSVGElement): Blob {
+  const bounds = calculateSvgExportBounds(svgElement);
+  const width = Math.ceil(bounds.width);
+  const height = Math.ceil(bounds.height);
+  const viewBoxX = bounds.x - SVG_EXPORT_PADDING;
+  const viewBoxY = bounds.y - SVG_EXPORT_PADDING;
+  const exportWidth = width + (SVG_EXPORT_PADDING * 2);
+  const exportHeight = height + (SVG_EXPORT_PADDING * 2);
+
+  const svgDocument = document.implementation.createDocument(SVG_NAMESPACE, 'svg', null);
+  const clonedSvg = cloneNodeForSvgExport(svgElement, svgDocument) as SVGSVGElement;
+
+  svgDocument.replaceChild(clonedSvg, svgDocument.documentElement);
+  clonedSvg.setAttribute('height', `${exportHeight}`);
+  clonedSvg.setAttribute('preserveAspectRatio', 'xMinYMin meet');
+  clonedSvg.setAttribute('version', '1.1');
+  clonedSvg.setAttribute('viewBox', `${viewBoxX} ${viewBoxY} ${exportWidth} ${exportHeight}`);
+  clonedSvg.setAttribute('width', `${exportWidth}`);
+  clonedSvg.removeAttribute('style');
+  clonedSvg.setAttribute('xmlns', SVG_NAMESPACE);
+  clonedSvg.setAttribute('xmlns:xhtml', XHTML_NAMESPACE);
+  clonedSvg.setAttribute('xmlns:xlink', XLINK_NAMESPACE);
+
+  const markup = `<?xml version="1.0" encoding="UTF-8"?>\n${new XMLSerializer().serializeToString(clonedSvg)}`;
+
+  return new Blob([markup], {
+    type: 'image/svg+xml;charset=utf-8',
+  });
+}

--- a/mage_ai/frontend/tests/pipeline_dependency_graph.spec.ts
+++ b/mage_ai/frontend/tests/pipeline_dependency_graph.spec.ts
@@ -1,0 +1,30 @@
+import { readFile } from 'fs/promises';
+
+import { expect, test } from './base';
+
+test('downloads dependency graph as SVG', async ({ page }, testInfo) => {
+  await page.goto('/pipelines/example_pipeline/triggers');
+
+  await expect(page.getByText('load_titanic')).toBeVisible();
+  await expect(page.getByText('fill_in_missing_values')).toBeVisible();
+  await expect(page.getByText('export_titanic_clean')).toBeVisible();
+
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.getByRole('button', { name: 'Download' }).click(),
+  ]);
+
+  expect(download.suggestedFilename()).toBe('example_pipeline_dependency_tree.svg');
+
+  const downloadPath = testInfo.outputPath(download.suggestedFilename());
+  await download.saveAs(downloadPath);
+
+  const downloadedSvg = await readFile(downloadPath, 'utf8');
+
+  expect(downloadedSvg).toContain('<svg');
+  expect(downloadedSvg).toContain('<foreignObject');
+  expect(downloadedSvg).toContain('http://www.w3.org/1999/xhtml');
+  expect(downloadedSvg).toContain('load_titanic');
+  expect(downloadedSvg).toContain('fill_in_missing_values');
+  expect(downloadedSvg).toContain('export_titanic_clean');
+});


### PR DESCRIPTION
Add a Download action to the pipeline dependency graph controls and export the rendered graph as a standalone SVG. The export preserves foreignObject node content, inlines computed styles, and trims the output to the rendered graph bounds so the downloaded artifact matches the UI layout more closely.

# Description
This PR addresses `#6033`.

It adds a `Download` action to the pipeline dependency graph controls and exports the rendered dependency graph as a standalone SVG.

The dependency graph is rendered with `reaflow` and uses SVG `foreignObject` content for node bodies, so this implementation preserves the live rendered graph by cloning the SVG tree, inlining computed styles, and normalizing namespaces and export bounds for standalone rendering.

This avoids relying on screenshots and provides a readable, shareable export of the dependency tree.

No new dependencies were added.

# How Has This Been Tested?
Manual verification:
- verified the `Download` button appears in the dependency graph controls
- verified clicking `Download` saves an `.svg` file for `example_pipeline`
- verified the downloaded SVG opens with the dependency tree visible and tighter bounds around the rendered graph

Automated verification:
- added a focused Playwright test in `mage_ai/frontend/tests/pipeline_dependency_graph.spec.ts`
- verified lint passes for:
  - `mage_ai/frontend/components/DependencyGraph/index.tsx`
  - `mage_ai/frontend/components/DependencyGraph/ZoomControls/index.tsx`
  - `mage_ai/frontend/components/DependencyGraph/svgExport.ts`
  - `mage_ai/frontend/tests/pipeline_dependency_graph.spec.ts`

Testing note:
- I added a focused Playwright test for the SVG download artifact, but I could not complete automated execution on this machine because the local Playwright Chromium process crashes on launch in this environment. The test file is included and lint-clean, and the feature behavior was manually verified in the running app.

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc: