### PR TITLE
Feat: Add ability to download dependency pipeline tree as an image

### DIFF
--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -260,6 +260,7 @@ function DependencyGraph({
   const colorsInverse = useMemo(() => inverseColorsMapping(themeContext), [themeContext]);
 
   const containerRef = useRef(null);
+  const graphContainerElRef = useRef(null);
   const portRefs = useRef({});
   const timeoutActiveRefs = useRef({});
   const timeoutDraggingRefs = useRef({});
@@ -484,6 +485,13 @@ function DependencyGraph({
       }
     }, 1000);
   }, [canvasRef]);
+
+  useEffect(() => {
+    if (treeRef && graphContainerElRef.current) {
+      (treeRef as any).graphContainerRef = graphContainerElRef;
+      (treeRef as any).resetZoom = () => canvasRef?.current?.fitCanvas?.();
+    }
+  }, [treeRef, graphContainerElRef.current]);
 
   const [updateBlock, { isLoading: isLoadingUpdateBlock }] = useMutation(
     api.blocks.pipelines.useUpdate(
@@ -1768,12 +1776,15 @@ function DependencyGraph({
       <GraphContainerStyle
         height={containerHeight}
         onDoubleClick={() => canvasRef?.current?.fitCanvas?.()}
+        ref={graphContainerElRef}
       >
-        <ZoomControls
-          canvasRef={canvasRef}
-          containerRef={containerRef}
-          zoomLevel={zoomLevel}
-        />
+        <div data-html2canvas-ignore="true">
+          <ZoomControls
+            canvasRef={canvasRef}
+            containerRef={containerRef}
+            zoomLevel={zoomLevel}
+          />
+        </div>
         <Canvas
           // arrow={<MarkerArrow style={{ fill: themeContext?.borders?.light }} />}
           arrow={null}

--- a/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/AddNewBlocks/index.tsx
@@ -11,7 +11,7 @@ import PipelineType, { PipelineTypeEnum } from '@interfaces/PipelineType';
 import ProjectType, { FeatureUUIDEnum } from '@interfaces/ProjectType';
 import Tooltip from '@oracle/components/Tooltip';
 import useProject from '@utils/models/project/useProject';
-import { Add, HexagonAll, Sensor as SensorIcon } from '@oracle/icons';
+import { Add, CubeWithArrowDown, HexagonAll, Sensor as SensorIcon } from '@oracle/icons';
 import { AxisEnum } from '@interfaces/ActionPayloadType';
 import {
   BlockLanguageEnum,
@@ -48,6 +48,7 @@ type AddNewBlocksProps = {
   hideDataLoader?: boolean;
   hideDbt?: boolean;
   hideCustom?: boolean;
+  hideDownload?: boolean;
   hideMarkdown?: boolean;
   hideScratchpad?: boolean;
   hideSensor?: boolean;
@@ -74,6 +75,7 @@ type AddNewBlocksProps = {
   showGlobalDataProducts?: (opts?: {
     addNewBlock?: (block: BlockRequestPayloadType) => Promise<any>;
   }) => void;
+  downloadImage?: (fileType: 'jpeg' | 'png' | 'svg') => void;
 } & OpenBlockBrowserModalType;
 
 const DATA_LOADER_BUTTON_INDEX = 0;
@@ -83,6 +85,7 @@ const DBT_BUTTON_INDEX = 3;
 const CUSTOM_BUTTON_INDEX = 4;
 const SENSOR_BUTTON_INDEX = 6;
 const MARKDOWN_BUTTON_INDEX = 7;
+const DOWNLOAD_BUTTON_INDEX = 8;
 
 function AddNewBlocks({
   addNewBlock,
@@ -94,6 +97,7 @@ function AddNewBlocks({
   hideDataExporter,
   hideDataLoader,
   hideDbt,
+  hideDownload,
   hideMarkdown,
   hideScratchpad,
   hideSensor,
@@ -110,6 +114,7 @@ function AddNewBlocks({
   showBrowseTemplates,
   showConfigureProjectModal,
   showGlobalDataProducts,
+  downloadImage,
 }: AddNewBlocksProps) {
   const {
     featureEnabled,
@@ -124,6 +129,7 @@ function AddNewBlocks({
   const customBlockButtonRef = useRef(null);
   const sensorButtonRef = useRef(null);
   const markdownButtonRef = useRef(null);
+  const downloadButtonRef = useRef(null);
   const sharedProps = {
     compact,
     inline: true,
@@ -777,6 +783,62 @@ function AddNewBlocks({
                 >
                   Markdown
                 </KeyboardShortcutButton>
+              </FlyoutMenuWrapper>
+            </ButtonWrapper>
+          )}
+
+
+          {!hideDownload && (
+            <ButtonWrapper increasedZIndex={buttonMenuOpenIndex === DOWNLOAD_BUTTON_INDEX}>
+              <FlyoutMenuWrapper
+                disableKeyboardShortcuts
+                items={[
+                  {
+                    label: () => 'JPEG Format',
+                    onClick: () => downloadImage('jpeg'),
+                    uuid: 'download_jpeg_button',
+                  },
+                  {
+                    label: () => 'PNG Format',
+                    onClick: () => downloadImage('png'),
+                    uuid: 'download_png_button',
+                  },
+                ]}
+                onClickCallback={closeButtonMenu}
+                open={buttonMenuOpenIndex === DOWNLOAD_BUTTON_INDEX}
+                parentRef={downloadButtonRef}
+                uuid="download_menu_items"
+              >
+                <Tooltip
+                  block
+                  label="Download pipeline dependency tree."
+                  maxWidth={MAX_TOOLTIP_WIDTH}
+                  size={null}
+                >
+                  <KeyboardShortcutButton
+                    {...sharedProps}
+                    beforeElement={
+                      <IconContainerStyle compact={compact} sky>
+                        <CubeWithArrowDown
+                          inverted
+                          size={iconSize}
+                        />
+                      </IconContainerStyle>
+                    }
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setButtonMenuOpenIndex(val =>
+                        val === DOWNLOAD_BUTTON_INDEX
+                          ? null
+                          : DOWNLOAD_BUTTON_INDEX,
+                      );
+                      handleBlockZIndex(DOWNLOAD_BUTTON_INDEX);
+                    }}
+                    uuid="download_context_menu_button"
+                  >
+                    Download image
+                  </KeyboardShortcutButton>
+                </Tooltip>
               </FlyoutMenuWrapper>
             </ButtonWrapper>
           )}

--- a/mage_ai/frontend/components/PipelineDetail/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/index.tsx
@@ -1,5 +1,7 @@
 import NextLink from 'next/link';
 import React, { createRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import html2canvas from 'html2canvas';
+import { CanvasRef } from 'reaflow';
 import { CSSTransition } from 'react-transition-group';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
@@ -92,6 +94,37 @@ import { pushAtIndex, removeAtIndex } from '@utils/array';
 import { selectKeys } from '@utils/hash';
 import { useKeyboardContext } from '@context/Keyboard';
 import { useWindowSize } from '@utils/sizes';
+
+const GRAPH_CAPTURE_CSS_PROPERTIES = [
+  'display', 'flex-direction', 'flex-wrap', 'flex', 'flex-grow', 'flex-shrink', 'flex-basis',
+  'align-items', 'align-self', 'justify-content', 'justify-self',
+  'width', 'min-width', 'max-width', 'height', 'min-height', 'max-height',
+  'padding-top', 'padding-right', 'padding-bottom', 'padding-left',
+  'margin-top', 'margin-right', 'margin-bottom', 'margin-left',
+  'position', 'top', 'right', 'bottom', 'left', 'z-index',
+  'overflow', 'overflow-x', 'overflow-y',
+  'box-sizing',
+  'border-top-color', 'border-right-color', 'border-bottom-color', 'border-left-color',
+  'border-top-width', 'border-right-width', 'border-bottom-width', 'border-left-width',
+  'border-top-style', 'border-right-style', 'border-bottom-style', 'border-left-style',
+  'border-radius',
+  'fill', 'stroke',
+  'font-size', 'font-weight', 'font-family', 'line-height', 'white-space',
+  'opacity',
+];
+const GRAPH_CAPTURE_SCALE = 2;
+const GRAPH_DEFAULT_BACKGROUND_COLOR = '#13131a';
+const GRAPH_TEXT_COLOR = '#fff';
+const JPEG_BLACK_BACKGROUND_COLOR = '#000000';
+const JPEG_ENCODER_QUALITY = 0.95;
+const FIT_CANVAS_ANIMATION_DELAY_MS = 500;
+const RGBA_TRANSPARENT = 'rgba(0, 0, 0, 0)';
+
+type TreeRef = {
+  current?: CanvasRef;
+  graphContainerRef?: React.MutableRefObject<HTMLElement | null>;
+  resetZoom?: () => void;
+};
 
 type PipelineDetailProps = {
   addNewBlockAtIndex: (
@@ -202,6 +235,7 @@ type PipelineDetailProps = {
   showUpdateBlockModal?: (block: BlockType, name: string) => void;
   sideBySideEnabled?: boolean;
   textareaFocused: boolean;
+  treeRef: TreeRef;
   widgets: BlockType[];
 } & SetEditingBlockType &
   OpenDataIntegrationModalType &
@@ -270,6 +304,7 @@ function PipelineDetail({
   showUpdateBlockModal,
   sideBySideEnabled,
   textareaFocused,
+  treeRef,
   widgets,
 }: PipelineDetailProps) {
   const { featureEnabled, featureUUIDs, project } = useProject();
@@ -827,6 +862,102 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
     [setAddDBTModelVisible, setDisableShortcuts, setLastBlockIndex],
   );
 
+  const downloadImage = useCallback(async (fileType: 'jpeg' | 'png') => {
+    const graphContainerEl: HTMLElement | null =
+      treeRef?.graphContainerRef?.current
+      ?? (treeRef?.current?.containerRef?.current as HTMLElement | null);
+
+    if (!graphContainerEl) return;
+
+    if (treeRef?.resetZoom) {
+      treeRef.resetZoom();
+      await new Promise(resolve => setTimeout(resolve, FIT_CANVAS_ANIMATION_DELAY_MS));
+    }
+
+    const childElements = Array.from(graphContainerEl.querySelectorAll('*')) as HTMLElement[];
+    const originalChildStyles = childElements.map(el => el.getAttribute('style'));
+    const originalContainerStyle = graphContainerEl.getAttribute('style');
+
+    childElements.forEach(el => {
+      if (!el.style) return;
+      const computedStyle = window.getComputedStyle(el);
+
+      GRAPH_CAPTURE_CSS_PROPERTIES.forEach(property => {
+        const value = computedStyle.getPropertyValue(property);
+        if (value) el.style.setProperty(property, value);
+      });
+
+      const resolvedBackgroundColor = computedStyle.getPropertyValue('background-color');
+      if (resolvedBackgroundColor && resolvedBackgroundColor !== RGBA_TRANSPARENT) {
+        el.style.setProperty('background-color', resolvedBackgroundColor);
+      }
+
+      el.style.setProperty('color', GRAPH_TEXT_COLOR);
+    });
+
+    const resolvedContainerBackground =
+      window.getComputedStyle(graphContainerEl).backgroundColor;
+    graphContainerEl.style.setProperty(
+      'background-color',
+      resolvedContainerBackground && resolvedContainerBackground !== RGBA_TRANSPARENT
+        ? resolvedContainerBackground
+        : GRAPH_DEFAULT_BACKGROUND_COLOR,
+    );
+
+    const graphSvgEl = graphContainerEl.querySelector('svg');
+    const graphSvgBounds = graphSvgEl?.getBoundingClientRect();
+    const graphContainerBounds = graphContainerEl.getBoundingClientRect();
+    const exportWidth = graphSvgBounds
+      ? Math.max(graphContainerBounds.width, graphSvgBounds.width)
+      : graphContainerEl.scrollWidth;
+    const exportHeight = graphSvgBounds
+      ? Math.max(graphContainerBounds.height, graphSvgBounds.height)
+      : graphContainerEl.scrollHeight;
+
+    graphContainerEl.style.setProperty('overflow', 'visible');
+    graphContainerEl.style.setProperty('width', `${exportWidth}px`);
+    graphContainerEl.style.setProperty('height', `${exportHeight}px`);
+
+    try {
+      const renderedCanvas = await html2canvas(graphContainerEl, {
+        scale: GRAPH_CAPTURE_SCALE,
+        useCORS: true,
+        allowTaint: false,
+        logging: false,
+        width: exportWidth,
+        height: exportHeight,
+      });
+
+      const mimeType = fileType === 'jpeg' ? 'image/jpeg' : 'image/png';
+      const fileExtension = fileType === 'jpeg' ? 'jpeg' : 'png';
+
+      let exportCanvas = renderedCanvas;
+      if (fileType === 'jpeg') {
+        exportCanvas = document.createElement('canvas');
+        exportCanvas.width = renderedCanvas.width;
+        exportCanvas.height = renderedCanvas.height;
+        const ctx = exportCanvas.getContext('2d');
+        ctx.fillStyle = JPEG_BLACK_BACKGROUND_COLOR;
+        ctx.fillRect(0, 0, exportCanvas.width, exportCanvas.height);
+        ctx.drawImage(renderedCanvas, 0, 0);
+      }
+
+      const downloadLink = document.createElement('a');
+      downloadLink.download = `dependency-graph.${fileExtension}`;
+      downloadLink.href = exportCanvas.toDataURL(mimeType, JPEG_ENCODER_QUALITY);
+      downloadLink.click();
+    } finally {
+      childElements.forEach((el, index) => {
+        const originalStyle = originalChildStyles[index];
+        if (originalStyle === null) el.removeAttribute('style');
+        else el.setAttribute('style', originalStyle);
+      });
+
+      if (originalContainerStyle === null) graphContainerEl.removeAttribute('style');
+      else graphContainerEl.setAttribute('style', originalContainerStyle);
+    }
+  }, [treeRef]);
+
   const closeAddDBTModelPopup = useCallback(() => {
     setAddDBTModelVisible(false);
     setCreatingNewDBTModel(false);
@@ -889,6 +1020,7 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
             showBrowseTemplates={showBrowseTemplates}
             showConfigureProjectModal={showConfigureProjectModal}
             showGlobalDataProducts={showGlobalDataProducts}
+            downloadImage={downloadImage}
           />
 
           {!useV2AddNewBlock && !isIntegration && !isStreaming && (
@@ -930,6 +1062,7 @@ df = get_variable('${pipeline.uuid}', '${block.uuid}', 'output_0')
       showBrowseTemplates,
       showConfigureProjectModal,
       showGlobalDataProducts,
+      downloadImage,
       useV2AddNewBlock,
     ],
   );

--- a/mage_ai/frontend/package.json
+++ b/mage_ai/frontend/package.json
@@ -52,6 +52,7 @@
     "framer-motion": "^11.2.11",
     "global": "^4.4.0",
     "html-react-parser": "^5.1.10",
+    "html2canvas": "1.4.1",
     "immutability-helper": "^3.1.1",
     "js-cookie": "^3.0.5",
     "jwt-decode": "^3.1.2",

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -3181,6 +3181,7 @@ function PipelineDetailPage({
       showUpdateBlockModal={showUpdateBlockModalCallbackMemo}
       sideBySideEnabled={sideBySideEnabled}
       textareaFocused={textareaFocused}
+      treeRef={treeRef}
       widgets={widgets}
     />
   ), [
@@ -3241,6 +3242,7 @@ function PipelineDetailPage({
     showUpdateBlockModalCallbackMemo,
     sideBySideEnabled,
     textareaFocused,
+    treeRef,
     widgets,
   ]);
 

--- a/mage_ai/frontend/tests/pipeline_edit.spec.ts
+++ b/mage_ai/frontend/tests/pipeline_edit.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from './base';
+
+test('ensure users can download jpeg image of dependency graph', async ({ page }) => {
+  await page.goto('/pipelines/example_pipeline/edit');
+  await expect(page.getByRole('button', { name: 'Download' })).toBeVisible();
+  await page.getByRole('button', { name: 'Download' }).click();
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.getByText('JPEG Format').click(),
+  ]);
+  expect(download.suggestedFilename()).toMatch(/^dependency-graph\.jpe?g$/);
+  const path = await download.path();
+  expect(path).not.toBeNull();
+});
+
+test('ensure users can download png image of dependency graph', async ({ page }) => {
+  await page.goto('/pipelines/example_pipeline/edit');
+  await expect(page.getByRole('button', { name: 'Download' })).toBeVisible();
+  await page.getByRole('button', { name: 'Download' }).click();
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.getByText('PNG Format').click(),
+  ]);
+  expect(download.suggestedFilename()).toMatch(/^dependency-graph\.png$/);
+  const path = await download.path();
+  expect(path).not.toBeNull();
+});

--- a/mage_ai/frontend/tests/pipeline_edit.spec.ts
+++ b/mage_ai/frontend/tests/pipeline_edit.spec.ts
@@ -2,10 +2,14 @@ import { expect, test } from './base';
 
 test('ensure users can download jpeg image of dependency graph', async ({ page }) => {
   await page.goto('/pipelines/example_pipeline/edit');
-  const downloadButton = page.getByRole('button', { name: 'Download' });
+  await expect(page.locator('svg').first()).toBeVisible({ timeout: 30000 });
+
+  const downloadButton = page.getByRole('button', { name: 'Download image' });
   await downloadButton.scrollIntoViewIfNeeded();
   await expect(downloadButton).toBeVisible();
   await downloadButton.click();
+
+  await expect(page.getByText('JPEG Format')).toBeVisible();
   const [download] = await Promise.all([
     page.waitForEvent('download'),
     page.getByText('JPEG Format').click(),
@@ -17,10 +21,14 @@ test('ensure users can download jpeg image of dependency graph', async ({ page }
 
 test('ensure users can download png image of dependency graph', async ({ page }) => {
   await page.goto('/pipelines/example_pipeline/edit');
-  const downloadButton = page.getByRole('button', { name: 'Download' });
+  await expect(page.locator('svg').first()).toBeVisible({ timeout: 30000 });
+
+  const downloadButton = page.getByRole('button', { name: 'Download image' });
   await downloadButton.scrollIntoViewIfNeeded();
   await expect(downloadButton).toBeVisible();
   await downloadButton.click();
+
+  await expect(page.getByText('PNG Format')).toBeVisible();
   const [download] = await Promise.all([
     page.waitForEvent('download'),
     page.getByText('PNG Format').click(),
@@ -29,3 +37,4 @@ test('ensure users can download png image of dependency graph', async ({ page })
   const path = await download.path();
   expect(path).not.toBeNull();
 });
+

--- a/mage_ai/frontend/tests/pipeline_edit.spec.ts
+++ b/mage_ai/frontend/tests/pipeline_edit.spec.ts
@@ -2,8 +2,10 @@ import { expect, test } from './base';
 
 test('ensure users can download jpeg image of dependency graph', async ({ page }) => {
   await page.goto('/pipelines/example_pipeline/edit');
-  await expect(page.getByRole('button', { name: 'Download' })).toBeVisible();
-  await page.getByRole('button', { name: 'Download' }).click();
+  const downloadButton = page.getByRole('button', { name: 'Download' });
+  await downloadButton.scrollIntoViewIfNeeded();
+  await expect(downloadButton).toBeVisible();
+  await downloadButton.click();
   const [download] = await Promise.all([
     page.waitForEvent('download'),
     page.getByText('JPEG Format').click(),
@@ -15,8 +17,10 @@ test('ensure users can download jpeg image of dependency graph', async ({ page }
 
 test('ensure users can download png image of dependency graph', async ({ page }) => {
   await page.goto('/pipelines/example_pipeline/edit');
-  await expect(page.getByRole('button', { name: 'Download' })).toBeVisible();
-  await page.getByRole('button', { name: 'Download' }).click();
+  const downloadButton = page.getByRole('button', { name: 'Download' });
+  await downloadButton.scrollIntoViewIfNeeded();
+  await expect(downloadButton).toBeVisible();
+  await downloadButton.click();
   const [download] = await Promise.all([
     page.waitForEvent('download'),
     page.getByText('PNG Format').click(),

--- a/mage_ai/frontend/yarn.lock
+++ b/mage_ai/frontend/yarn.lock
@@ -4929,6 +4929,11 @@ bare-stream@^2.0.0:
   dependencies:
     streamx "^2.18.0"
 
+base64-arraybuffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
+  integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
+
 base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -5742,6 +5747,13 @@ css-color-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
   integrity sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==
+
+css-line-break@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-line-break/-/css-line-break-2.1.0.tgz#bfef660dfa6f5397ea54116bb3cb4873edbc4fa0"
+  integrity sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==
+  dependencies:
+    utrie "^1.0.2"
 
 css-loader@^6.7.1, css-loader@^6.7.3:
   version "6.11.0"
@@ -7956,6 +7968,14 @@ html-webpack-plugin@^5.5.0:
     lodash "^4.17.21"
     pretty-error "^4.0.0"
     tapable "^2.0.0"
+
+html2canvas@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/html2canvas/-/html2canvas-1.4.1.tgz#7cef1888311b5011d507794a066041b14669a543"
+  integrity sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==
+  dependencies:
+    css-line-break "^2.1.0"
+    text-segmentation "^1.0.3"
 
 htmlparser2@9.1.0:
   version "9.1.0"
@@ -12448,6 +12468,13 @@ text-decoder@^1.1.0:
   dependencies:
     b4a "^1.6.4"
 
+text-segmentation@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/text-segmentation/-/text-segmentation-1.0.3.tgz#52a388159efffe746b24a63ba311b6ac9f2d7943"
+  integrity sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==
+  dependencies:
+    utrie "^1.0.2"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -13009,6 +13036,13 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+utrie@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/utrie/-/utrie-1.0.2.tgz#d42fe44de9bc0119c25de7f564a6ed1b2c87a645"
+  integrity sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==
+  dependencies:
+    base64-arraybuffer "^1.0.2"
 
 uuid@^9.0.0:
   version "9.0.1"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

This pr adds the ability to download the dependency graph in jpeg or png format.


# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

Had issues with instillation of playwright library most likely due to working with github codespace on an old laptop.  

- [ ] Test downloading jpeg
- [ ] Test downloading png


# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 tagging you here to see my pull request that is due tomorrow.
