### PR TITLE
Feat 4143 data table filter row

### DIFF
--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/TableOutput.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/TableOutput.tsx
@@ -1,5 +1,5 @@
 import InnerHTML from 'dangerously-set-html-content';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import DataTable from '@components/DataTable';
 import FlexContainer from '@oracle/components/FlexContainer';
@@ -39,6 +39,7 @@ function TableOutput({
   uuid,
 }: TableOutputProps) {
   const { data, resource_usage: resourceUsage, sample_data: sampleData } = output;
+  const [filteredRowCount, setFilteredRowCount] = useState<number | null>(null);
   const shape = useMemo(
     // @ts-ignore
     () =>
@@ -119,7 +120,9 @@ function TableOutput({
     const arr1 = [];
     const arr2 = [];
 
-    if (shape?.length >= 1) {
+    if (filteredRowCount !== null && shape?.length >= 1) {
+      arr1.push(`Showing ${filteredRowCount} of ${pluralize('row', shape[0])}`);
+    } else if (shape?.length >= 1) {
       const r = pluralize('row', shape?.[0]);
       if (shape?.length >= 2) {
         const c = pluralize('column', shape?.[1]);
@@ -161,19 +164,21 @@ function TableOutput({
         </Text>
       </>
     );
-  }, [shape, resourceUsage]);
+  }, [filteredRowCount, shape, resourceUsage]);
 
   return (
     <>
       <DataTable
         columns={columns}
         disableScrolling={!selected}
+        enableFiltering
         key={`data-table-${order}`}
         maxHeight={maxHeight || UNIT * 60}
         noBorderBottom
         noBorderLeft
         noBorderRight
         noBorderTop={!borderTop}
+        onFilteredRowCount={setFilteredRowCount}
         renderColumnHeaderCell={(
           { Header: columnName },
           _,

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/TableOutput.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/TableOutput.tsx
@@ -1,5 +1,5 @@
 import InnerHTML from 'dangerously-set-html-content';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import DataTable from '@components/DataTable';
 import FlexContainer from '@oracle/components/FlexContainer';
@@ -40,6 +40,11 @@ function TableOutput({
 }: TableOutputProps) {
   const { data, resource_usage: resourceUsage, sample_data: sampleData } = output;
   const [filteredRowCount, setFilteredRowCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    setFilteredRowCount(null);
+  }, [output]);
+
   const shape = useMemo(
     // @ts-ignore
     () =>

--- a/mage_ai/frontend/components/DataTable/FilterRow.tsx
+++ b/mage_ai/frontend/components/DataTable/FilterRow.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import dark from '@oracle/styles/themes/dark';
+import { FONT_FAMILY_REGULAR } from '@oracle/styles/fonts/primary';
+import { REGULAR } from '@oracle/styles/fonts/sizes';
+import { UNIT } from '@oracle/styles/units/spacing';
+
+type FilterRowProps = {
+  columnCount: number;
+  columnWidth: number;
+  filters: Record<number, string>;
+  indexColumnWidths: number[];
+  onFilterChange: (columnIndex: number, value: string) => void;
+};
+
+const FilterInputStyle = styled.input`
+  ${REGULAR}
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid transparent;
+  box-sizing: border-box;
+  font-family: ${FONT_FAMILY_REGULAR};
+  height: 100%;
+  outline: none;
+  padding: ${UNIT * 0.5}px ${UNIT}px;
+  width: 100%;
+
+  &:focus {
+    border-bottom-color: ${props => (props.theme.interactive || dark.interactive).linkPrimary};
+  }
+
+  &::placeholder {
+    color: ${props => (props.theme.content || dark.content).disabled};
+  }
+`;
+
+function FilterRow({
+  columnCount,
+  columnWidth,
+  filters,
+  indexColumnWidths,
+  onFilterChange,
+}: FilterRowProps) {
+  return (
+    <div
+      className="tr tr-filter"
+      style={{
+        display: 'flex',
+      }}
+    >
+      {indexColumnWidths.map((w, idx) => (
+        <div
+          className="td td-index-column"
+          key={`filter-index-${idx}`}
+          style={{
+            left: 0,
+            minWidth: w,
+            position: 'sticky',
+            width: w,
+          }}
+        />
+      ))}
+      {Array.from({ length: columnCount }).map((_, colIdx) => (
+        <div
+          className="td"
+          key={`filter-col-${colIdx}`}
+          style={{
+            minWidth: columnWidth,
+            padding: 0,
+            width: columnWidth,
+          }}
+        >
+          <FilterInputStyle
+            onChange={e => onFilterChange(colIdx, e.target.value)}
+            placeholder="Filter..."
+            value={filters[colIdx] || ''}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default FilterRow;

--- a/mage_ai/frontend/components/DataTable/filterUtils.ts
+++ b/mage_ai/frontend/components/DataTable/filterUtils.ts
@@ -1,0 +1,196 @@
+type ParsedFilter = {
+  operator: string;
+  value: string;
+  valueLower: string;
+  numericValue?: number;
+  dateValue?: number;
+};
+
+const OPERATOR_REGEX = /^(>=|<=|!=|>|<|=)\s*(.*)$/;
+const STRICT_NUMBER_REGEX = /^-?\d+(\.\d+)?$/;
+const DATE_SEPARATOR_REGEX = /[-/]/;
+
+function tryParseDate(s: string): number | undefined {
+  if (!s || !DATE_SEPARATOR_REGEX.test(s)) {
+    return undefined;
+  }
+  const t = new Date(s).getTime();
+  return isNaN(t) ? undefined : t;
+}
+
+export function parseFilterExpression(expr: string): ParsedFilter | null {
+  const trimmed = expr.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const trimmedLower = trimmed.toLowerCase();
+  if (trimmedLower === 'is blank') {
+    return { operator: 'blank', value: '', valueLower: '' };
+  }
+  if (trimmedLower === 'is not blank') {
+    return { operator: 'notblank', value: '', valueLower: '' };
+  }
+
+  const match = trimmed.match(OPERATOR_REGEX);
+  if (match) {
+    const operator = match[1];
+    const value = match[2];
+    const valueTrimmed = value.trim();
+    const isStrictNumber = STRICT_NUMBER_REGEX.test(valueTrimmed);
+    const numericValue = isStrictNumber ? parseFloat(value) : undefined;
+    const dateValue = tryParseDate(valueTrimmed);
+    return {
+      dateValue,
+      numericValue,
+      operator,
+      value,
+      valueLower: value.toLowerCase(),
+    };
+  }
+
+  return {
+    operator: 'contains',
+    value: trimmed,
+    valueLower: trimmedLower,
+  };
+}
+
+export function matchesFilter(cellValue: any, parsed: ParsedFilter): boolean {
+  const { operator } = parsed;
+
+  if (operator === 'blank') {
+    return cellValue === null || cellValue === undefined || cellValue === 'null' || cellValue === '';
+  }
+  if (operator === 'notblank') {
+    return cellValue !== null && cellValue !== undefined && cellValue !== 'null' && cellValue !== '';
+  }
+
+  let displayValue: string;
+  if (cellValue === null || cellValue === undefined || cellValue === 'null') {
+    displayValue = 'None';
+  } else if (cellValue === true) {
+    displayValue = 'True';
+  } else if (cellValue === false) {
+    displayValue = 'False';
+  } else {
+    displayValue = String(cellValue);
+  }
+
+  const { valueLower, numericValue, dateValue } = parsed;
+
+  if (operator === 'contains') {
+    return displayValue.toLowerCase().includes(valueLower);
+  }
+
+  // Date comparison takes priority over numeric — skip when filter isn't a date
+  if (dateValue !== undefined) {
+    const cellDate = tryParseDate(displayValue);
+    if (cellDate !== undefined) {
+      switch (operator) {
+        case '=':
+          return cellDate === dateValue;
+        case '!=':
+          return cellDate !== dateValue;
+        case '>':
+          return cellDate > dateValue;
+        case '<':
+          return cellDate < dateValue;
+        case '>=':
+          return cellDate >= dateValue;
+        case '<=':
+          return cellDate <= dateValue;
+      }
+    }
+  }
+
+  // Numeric comparison — skip regex when filter isn't numeric
+  if (numericValue !== undefined) {
+    const isStrictCellNumber = STRICT_NUMBER_REGEX.test(displayValue);
+    if (isStrictCellNumber) {
+      const cellNumeric = parseFloat(displayValue);
+      switch (operator) {
+        case '=':
+          return cellNumeric === numericValue;
+        case '!=':
+          return cellNumeric !== numericValue;
+        case '>':
+          return cellNumeric > numericValue;
+        case '<':
+          return cellNumeric < numericValue;
+        case '>=':
+          return cellNumeric >= numericValue;
+        case '<=':
+          return cellNumeric <= numericValue;
+      }
+    }
+  }
+
+  // String fallback
+  const displayLower = displayValue.toLowerCase();
+  if (operator === '=') {
+    return displayLower === valueLower;
+  }
+  if (operator === '!=') {
+    return displayLower !== valueLower;
+  }
+
+  const cmp = displayLower.localeCompare(valueLower);
+  switch (operator) {
+    case '>':
+      return cmp > 0;
+    case '<':
+      return cmp < 0;
+    case '>=':
+      return cmp >= 0;
+    case '<=':
+      return cmp <= 0;
+  }
+
+  return false;
+}
+
+export function filterRows(
+  rows: any[][],
+  filters: Record<number, string>,
+): {
+  filteredRows: any[][];
+  originalIndices: number[];
+} {
+  const activeFilters: { colIndex: number; parsed: ParsedFilter }[] = [];
+
+  Object.entries(filters).forEach(([key, expr]) => {
+    const parsed = parseFilterExpression(expr);
+    if (parsed) {
+      activeFilters.push({ colIndex: Number(key), parsed });
+    }
+  });
+
+  if (activeFilters.length === 0) {
+    return {
+      filteredRows: rows,
+      originalIndices: rows.map((_, i) => i),
+    };
+  }
+
+  const filteredRows: any[][] = [];
+  const originalIndices: number[] = [];
+  const filterCount = activeFilters.length;
+
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    const row = rows[rowIndex];
+    let matches = true;
+    for (let f = 0; f < filterCount; f++) {
+      if (!matchesFilter(row[activeFilters[f].colIndex], activeFilters[f].parsed)) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      filteredRows.push(row);
+      originalIndices.push(rowIndex);
+    }
+  }
+
+  return { filteredRows, originalIndices };
+}

--- a/mage_ai/frontend/components/DataTable/filterUtils.ts
+++ b/mage_ai/frontend/components/DataTable/filterUtils.ts
@@ -8,7 +8,7 @@ type ParsedFilter = {
 
 const OPERATOR_REGEX = /^(>=|<=|!=|>|<|=)\s*(.*)$/;
 const STRICT_NUMBER_REGEX = /^-?\d+(\.\d+)?$/;
-const DATE_SEPARATOR_REGEX = /[-/]/;
+const DATE_SEPARATOR_REGEX = /^\d{1,4}[-/]\d{1,2}[-/]\d{1,4}/;
 
 function tryParseDate(s: string): number | undefined {
   if (!s || !DATE_SEPARATOR_REGEX.test(s)) {
@@ -45,7 +45,7 @@ export function parseFilterExpression(expr: string): ParsedFilter | null {
       numericValue,
       operator,
       value,
-      valueLower: value.toLowerCase(),
+      valueLower: valueTrimmed.toLowerCase(),
     };
   }
 

--- a/mage_ai/frontend/components/DataTable/filterUtils.ts
+++ b/mage_ai/frontend/components/DataTable/filterUtils.ts
@@ -1,7 +1,10 @@
+type Operator = '=' | '!=' | '>' | '<' | '>=' | '<=' | 'contains' | 'blank' | 'notblank';
+
 type ParsedFilter = {
-  operator: string;
+  filterType: 'contains' | 'string' | 'numeric' | 'date' | 'blank';
+  operator: Operator;
   value: string;
-  valueLower: string;
+  valueLower?: string;
   numericValue?: number;
   dateValue?: number;
 };
@@ -9,6 +12,7 @@ type ParsedFilter = {
 const OPERATOR_REGEX = /^(>=|<=|!=|>|<|=)\s*(.*)$/;
 const STRICT_NUMBER_REGEX = /^-?\d+(\.\d+)?$/;
 const DATE_SEPARATOR_REGEX = /^\d{1,4}[-/]\d{1,2}[-/]\d{1,4}/;
+const DATE_PREFIX_REGEX = /^date\s+(>=|<=|!=|>|<|=)\s*(.*)$/i;
 
 function tryParseDate(s: string): number | undefined {
   if (!s || !DATE_SEPARATOR_REGEX.test(s)) {
@@ -16,6 +20,29 @@ function tryParseDate(s: string): number | undefined {
   }
   const t = new Date(s).getTime();
   return isNaN(t) ? undefined : t;
+}
+
+function isBlankValue(cellValue: any): boolean {
+  return cellValue === null || cellValue === undefined || cellValue === 'null' || cellValue === '';
+}
+
+function compareNumbers(a: number, b: number, operator: Operator): boolean {
+  switch (operator) {
+    case '=':
+      return a === b;
+    case '!=':
+      return a !== b;
+    case '>':
+      return a > b;
+    case '<':
+      return a < b;
+    case '>=':
+      return a >= b;
+    case '<=':
+      return a <= b;
+    default:
+      return false;
+  }
 }
 
 export function parseFilterExpression(expr: string): ParsedFilter | null {
@@ -26,30 +53,62 @@ export function parseFilterExpression(expr: string): ParsedFilter | null {
 
   const trimmedLower = trimmed.toLowerCase();
   if (trimmedLower === 'is blank') {
-    return { operator: 'blank', value: '', valueLower: '' };
+    return { filterType: 'blank', operator: 'blank', value: '' };
   }
   if (trimmedLower === 'is not blank') {
-    return { operator: 'notblank', value: '', valueLower: '' };
+    return { filterType: 'blank', operator: 'notblank', value: '' };
   }
 
-  const match = trimmed.match(OPERATOR_REGEX);
-  if (match) {
-    const operator = match[1];
-    const value = match[2];
-    const valueTrimmed = value.trim();
-    const isStrictNumber = STRICT_NUMBER_REGEX.test(valueTrimmed);
-    const numericValue = isStrictNumber ? parseFloat(valueTrimmed) : undefined;
+  // date prefix: "date >= 2024-01-01"
+  const dateMatch = trimmed.match(DATE_PREFIX_REGEX);
+  if (dateMatch) {
+    const operator = dateMatch[1] as Operator;
+    const valueTrimmed = dateMatch[2].trim();
     const dateValue = tryParseDate(valueTrimmed);
+    if (dateValue === undefined) {
+      return null;
+    }
     return {
       dateValue,
-      numericValue,
+      filterType: 'date',
       operator,
-      value,
+      value: valueTrimmed,
+    };
+  }
+
+  // operator match: >, <, >=, <=, =, !=
+  const match = trimmed.match(OPERATOR_REGEX);
+  if (match) {
+    const operator = match[1] as Operator;
+    const valueTrimmed = match[2].trim();
+    const isNumeric = STRICT_NUMBER_REGEX.test(valueTrimmed);
+
+    // Numeric value → numeric filter for all operators
+    if (isNumeric) {
+      return {
+        filterType: 'numeric',
+        numericValue: parseFloat(valueTrimmed),
+        operator,
+        value: valueTrimmed,
+      };
+    }
+
+    // Non-numeric value with >, <, >=, <= → invalid (these are always numeric)
+    if (operator !== '=' && operator !== '!=') {
+      return null;
+    }
+
+    return {
+      filterType: 'string',
+      operator,
+      value: valueTrimmed,
       valueLower: valueTrimmed.toLowerCase(),
     };
   }
 
+  // No operator → contains
   return {
+    filterType: 'contains',
     operator: 'contains',
     value: trimmed,
     valueLower: trimmedLower,
@@ -57,17 +116,14 @@ export function parseFilterExpression(expr: string): ParsedFilter | null {
 }
 
 export function matchesFilter(cellValue: any, parsed: ParsedFilter): boolean {
-  const { operator } = parsed;
+  const { filterType, operator } = parsed;
 
-  if (operator === 'blank') {
-    return cellValue === null || cellValue === undefined || cellValue === 'null' || cellValue === '';
-  }
-  if (operator === 'notblank') {
-    return cellValue !== null && cellValue !== undefined && cellValue !== 'null' && cellValue !== '';
+  if (filterType === 'blank') {
+    return operator === 'blank' ? isBlankValue(cellValue) : !isBlankValue(cellValue);
   }
 
   let displayValue: string;
-  if (cellValue === null || cellValue === undefined || cellValue === 'null') {
+  if (isBlankValue(cellValue)) {
     displayValue = 'None';
   } else if (cellValue === true) {
     displayValue = 'True';
@@ -77,74 +133,33 @@ export function matchesFilter(cellValue: any, parsed: ParsedFilter): boolean {
     displayValue = String(cellValue);
   }
 
-  const { valueLower, numericValue, dateValue } = parsed;
-
-  if (operator === 'contains') {
-    return displayValue.toLowerCase().includes(valueLower);
+  if (filterType === 'contains') {
+    return displayValue.toLowerCase().includes(parsed.valueLower ?? '');
   }
 
-  // Date comparison takes priority over numeric — skip when filter isn't a date
-  if (dateValue !== undefined) {
+  if (filterType === 'string') {
+    const displayLower = displayValue.toLowerCase();
+    if (operator === '=') {
+      return displayLower === (parsed.valueLower ?? '');
+    }
+    // !=
+    return displayLower !== (parsed.valueLower ?? '');
+  }
+
+  if (filterType === 'numeric') {
+    const cellNumeric = parseFloat(displayValue);
+    if (isNaN(cellNumeric)) {
+      return false;
+    }
+    return compareNumbers(cellNumeric, parsed.numericValue ?? 0, operator);
+  }
+
+  if (filterType === 'date') {
     const cellDate = tryParseDate(displayValue);
-    if (cellDate !== undefined) {
-      switch (operator) {
-        case '=':
-          return cellDate === dateValue;
-        case '!=':
-          return cellDate !== dateValue;
-        case '>':
-          return cellDate > dateValue;
-        case '<':
-          return cellDate < dateValue;
-        case '>=':
-          return cellDate >= dateValue;
-        case '<=':
-          return cellDate <= dateValue;
-      }
+    if (cellDate === undefined) {
+      return false;
     }
-  }
-
-  // Numeric comparison — skip regex when filter isn't numeric
-  if (numericValue !== undefined) {
-    const isStrictCellNumber = STRICT_NUMBER_REGEX.test(displayValue);
-    if (isStrictCellNumber) {
-      const cellNumeric = parseFloat(displayValue);
-      switch (operator) {
-        case '=':
-          return cellNumeric === numericValue;
-        case '!=':
-          return cellNumeric !== numericValue;
-        case '>':
-          return cellNumeric > numericValue;
-        case '<':
-          return cellNumeric < numericValue;
-        case '>=':
-          return cellNumeric >= numericValue;
-        case '<=':
-          return cellNumeric <= numericValue;
-      }
-    }
-  }
-
-  // String fallback
-  const displayLower = displayValue.toLowerCase();
-  if (operator === '=') {
-    return displayLower === valueLower;
-  }
-  if (operator === '!=') {
-    return displayLower !== valueLower;
-  }
-
-  const cmp = displayLower.localeCompare(valueLower);
-  switch (operator) {
-    case '>':
-      return cmp > 0;
-    case '<':
-      return cmp < 0;
-    case '>=':
-      return cmp >= 0;
-    case '<=':
-      return cmp <= 0;
+    return compareNumbers(cellDate, parsed.dateValue ?? 0, operator);
   }
 
   return false;

--- a/mage_ai/frontend/components/DataTable/filterUtils.ts
+++ b/mage_ai/frontend/components/DataTable/filterUtils.ts
@@ -38,7 +38,7 @@ export function parseFilterExpression(expr: string): ParsedFilter | null {
     const value = match[2];
     const valueTrimmed = value.trim();
     const isStrictNumber = STRICT_NUMBER_REGEX.test(valueTrimmed);
-    const numericValue = isStrictNumber ? parseFloat(value) : undefined;
+    const numericValue = isStrictNumber ? parseFloat(valueTrimmed) : undefined;
     const dateValue = tryParseDate(valueTrimmed);
     return {
       dateValue,

--- a/mage_ai/frontend/components/DataTable/filterUtils.ts
+++ b/mage_ai/frontend/components/DataTable/filterUtils.ts
@@ -147,10 +147,11 @@ export function matchesFilter(cellValue: any, parsed: ParsedFilter): boolean {
   }
 
   if (filterType === 'numeric') {
-    const cellNumeric = parseFloat(displayValue);
-    if (isNaN(cellNumeric)) {
+    const normalizedDisplay = displayValue.trim();
+    if (!STRICT_NUMBER_REGEX.test(normalizedDisplay)) {
       return false;
     }
+    const cellNumeric = parseFloat(normalizedDisplay);
     return compareNumbers(cellNumeric, parsed.numericValue ?? 0, operator);
   }
 

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -395,7 +395,7 @@ function Table({ ...props }: TableProps) {
   const handleFilterChange = useCallback((colIndex: number, value: string) => {
     setFilters(prev => {
       const next = { ...prev };
-      if (value) {
+      if (value.trim()) {
         next[colIndex] = value;
       } else {
         delete next[colIndex];
@@ -408,6 +408,11 @@ function Table({ ...props }: TableProps) {
     debouncer(setDebouncedFilters, 300, filters);
     return cancelDebounce;
   }, [cancelDebounce, debouncer, filters]);
+
+  useEffect(() => {
+    setFilters({});
+    setDebouncedFilters({});
+  }, [data]);
 
   const { filteredData, originalIndices, isFiltering } = useMemo(() => {
     const hasActiveFilters = enableFiltering && Object.keys(debouncedFilters).length > 0;

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import Link from '@oracle/elements/Link';
 import NextLink from 'next/link';
 import styled from 'styled-components';
@@ -28,6 +28,12 @@ import { isJsonString } from '@utils/string';
 const BASE_ROW_HEIGHT = UNIT * 2 + REGULAR_LINE_HEIGHT;
 const DEFAULT_COLUMN_WIDTH = UNIT * 20;
 const WIDTH_OF_CHARACTER = 8.5;
+
+const EMPTY_FILTER_OUTER_STYLE: React.CSSProperties = {
+  overflowX: 'auto',
+  overflowY: 'hidden',
+};
+
 export const WIDTH_OF_SINGLE_CHARACTER_MONOSPACE = 8.7;
 
 type InvalidValueType = {
@@ -385,6 +391,7 @@ function Table({ ...props }: TableProps) {
 
   const themeContext = useContext(ThemeContext);
   const refHeader = useRef(null);
+  const refListInner = useRef<HTMLDivElement>(null);
   const refListOuter = useRef(null);
   const refList = useRef<VariableSizeList>(null);
 
@@ -430,6 +437,8 @@ function Table({ ...props }: TableProps) {
     };
   }, [data, debouncedFilters, enableFiltering]);
 
+  const isFilteredEmpty = enableFiltering && isFiltering && filteredData.length === 0;
+
   useEffect(() => {
     if (enableFiltering && onFilteredRowCount) {
       onFilteredRowCount(isFiltering ? filteredData.length : null);
@@ -443,20 +452,19 @@ function Table({ ...props }: TableProps) {
   }, [filteredData]);
 
   useEffect(() => {
-    const onScrollCallback = e => {
-      refHeader?.current?.scroll(e.target.scrollLeft, 0);
+    const el = refListOuter.current;
+    if (!el) return;
+
+    const onScrollCallback = (e: Event) => {
+      refHeader?.current?.scroll((e.target as HTMLElement).scrollLeft, 0);
     };
 
-    if (refListOuter) {
-      refListOuter.current.addEventListener('scroll', onScrollCallback);
-    }
-
-    const listOuter = refListOuter.current;
+    el.addEventListener('scroll', onScrollCallback);
 
     return () => {
-      listOuter?.removeEventListener('scroll', onScrollCallback);
+      el.removeEventListener('scroll', onScrollCallback);
     };
-  }, [refHeader, refListOuter]);
+  }, [isFilteredEmpty]);
 
   const shouldUseIndexProp = useMemo(
     () => indexProp && data && indexProp.length === data.length,
@@ -504,6 +512,17 @@ function Table({ ...props }: TableProps) {
     };
   }, [columns, maxWidthOfIndexColumns, scrollBarSize, width]);
 
+  const totalColumnsWidth = useMemo(
+    () => sum(maxWidthOfIndexColumns) + (columns.length - numberOfIndexes) * defaultColumn.width,
+    [columns.length, defaultColumn.width, maxWidthOfIndexColumns, numberOfIndexes],
+  );
+
+  useLayoutEffect(() => {
+    if (refListInner.current) {
+      refListInner.current.style.minWidth = `${totalColumnsWidth}px`;
+    }
+  }, [totalColumnsWidth, isFilteredEmpty]);
+
   const { getTableBodyProps, getTableProps, headerGroups, prepareRow, rows } = useTable(
     {
       columns,
@@ -514,9 +533,13 @@ function Table({ ...props }: TableProps) {
     useSticky,
   );
 
+  const removedRowIndexes = useMemo(
+    () => new Set(previewIndexes?.removedRows || []),
+    [previewIndexes?.removedRows],
+  );
+
   const renderRow = useCallback(
     ({ index, style }) => {
-      const removedRowIndexes = new Set(previewIndexes?.removedRows || []);
       const originalIndex = isFiltering && originalIndices.length > 0 ? originalIndices[index] : index;
 
       const row = rows[index];
@@ -667,7 +690,7 @@ function Table({ ...props }: TableProps) {
       numberOfIndexes,
       originalIndices,
       prepareRow,
-      previewIndexes,
+      removedRowIndexes,
       rows,
       shouldUseIndexProp,
     ],
@@ -675,47 +698,55 @@ function Table({ ...props }: TableProps) {
 
   const variableListMemo = useMemo(
     () => {
+      if (isFilteredEmpty) {
+        return (
+          <div
+            ref={refListOuter}
+            style={EMPTY_FILTER_OUTER_STYLE}
+          >
+            <div style={{ minWidth: totalColumnsWidth, padding: UNIT * 2 }}>
+              <Text muted>No rows match the current filters.</Text>
+            </div>
+          </div>
+        );
+      }
+
       const listHeight = getVariableListHeight(columnHeaderHeight, height, maxHeight, rows, width);
       const adjustedHeight = enableFiltering ? Math.max(0, listHeight - BASE_ROW_HEIGHT) : listHeight;
 
       return (
-        <>
-          {rows?.length === 0 && isFiltering && (
-            <div style={{ padding: UNIT * 2 }}>
-              <Text muted>No rows match the current filters.</Text>
-            </div>
-          )}
-          <VariableSizeList
-            estimatedItemSize={BASE_ROW_HEIGHT}
-            height={adjustedHeight}
-            itemCount={rows?.length || 0}
-            itemSize={(idx: number) => {
-              const size = estimateCellHeight({
-                ...rows[idx],
-                variableListProps: {
-                  columnHeaderHeight,
-                  height,
-                  maxHeight,
-                  width,
-                },
+        <VariableSizeList
+          estimatedItemSize={BASE_ROW_HEIGHT}
+          height={adjustedHeight}
+          innerRef={refListInner}
+          itemCount={rows?.length || 0}
+          itemSize={(idx: number) =>
+            estimateCellHeight({
+              ...rows[idx],
+              variableListProps: {
+                columnHeaderHeight,
+                height,
+                maxHeight,
                 width,
-              });
-
-              return size;
-            }}
-            outerRef={refListOuter}
-            ref={refList}
-            style={{
-              maxHeight: maxHeight && enableFiltering ? maxHeight - BASE_ROW_HEIGHT : maxHeight,
-              pointerEvents: disableScrolling ? 'none' : null,
-            }}
-          >
-            {renderRow}
-          </VariableSizeList>
-        </>
+              },
+              width,
+            })
+          }
+          outerRef={refListOuter}
+          ref={refList}
+          style={{
+            maxHeight: maxHeight && enableFiltering ? maxHeight - BASE_ROW_HEIGHT : maxHeight,
+            pointerEvents: disableScrolling ? 'none' : null,
+          }}
+        >
+          {renderRow}
+        </VariableSizeList>
       );
     },
-    [columnHeaderHeight, disableScrolling, enableFiltering, height, isFiltering, maxHeight, renderRow, rows, width],
+    [
+      columnHeaderHeight, disableScrolling, enableFiltering, height, isFilteredEmpty,
+      maxHeight, renderRow, rows, totalColumnsWidth, width,
+    ],
   );
 
   return (

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -80,6 +80,7 @@ type TableProps = {
     sticky?: string;
   }[];
   data: (string | number | { [key: string]: string | number | boolean } | (string | number)[])[][];
+  disableZeroIndexRowNumber?: boolean;
   enableFiltering?: boolean;
   numberOfIndexes: number;
   onFilteredRowCount?: (count: number | null) => void;
@@ -376,6 +377,7 @@ function Table({ ...props }: TableProps) {
     columns,
     data,
     disableScrolling,
+    disableZeroIndexRowNumber,
     enableFiltering,
     height,
     index: indexProp,
@@ -608,7 +610,7 @@ function Table({ ...props }: TableProps) {
                   indexColumnValue = indexColumnValue[idx];
                 }
               } else if (isFiltering) {
-                indexColumnValue = String(displayIndex);
+                indexColumnValue = String(displayIndex + (disableZeroIndexRowNumber ? 1 : 0));
               } else {
                 indexColumnValue = cell.render('Cell');
               }
@@ -683,6 +685,7 @@ function Table({ ...props }: TableProps) {
     },
     [
       columnsAll,
+      disableZeroIndexRowNumber,
       indexProp,
       invalidValues,
       isFiltering,
@@ -892,6 +895,7 @@ function DataTable({
           columns={columns}
           data={rowsProp}
           disableScrolling={disableScrolling}
+          disableZeroIndexRowNumber={disableZeroIndexRowNumber}
           enableFiltering={enableFiltering}
           height={height}
           index={index}
@@ -909,9 +913,10 @@ function DataTable({
       columnHeaderHeight,
       columnHeadersContainEmptyString,
       columns,
+      disableScrolling,
+      disableZeroIndexRowNumber,
       enableFiltering,
       rowsProp,
-      disableScrolling,
       height,
       index,
       invalidValues,

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -395,7 +395,7 @@ function Table({ ...props }: TableProps) {
   const handleFilterChange = useCallback((colIndex: number, value: string) => {
     setFilters(prev => {
       const next = { ...prev };
-      if (value.trim()) {
+      if (value) {
         next[colIndex] = value;
       } else {
         delete next[colIndex];
@@ -409,10 +409,13 @@ function Table({ ...props }: TableProps) {
     return cancelDebounce;
   }, [cancelDebounce, debouncer, filters]);
 
-  useEffect(() => {
+  const [prevData, setPrevData] = useState(data);
+  if (data !== prevData) {
+    setPrevData(data);
     setFilters({});
     setDebouncedFilters({});
-  }, [data]);
+    cancelDebounce();
+  }
 
   const { filteredData, originalIndices, isFiltering } = useMemo(() => {
     const hasActiveFilters = enableFiltering && Object.keys(debouncedFilters).length > 0;
@@ -675,42 +678,41 @@ function Table({ ...props }: TableProps) {
       const listHeight = getVariableListHeight(columnHeaderHeight, height, maxHeight, rows, width);
       const adjustedHeight = enableFiltering ? Math.max(0, listHeight - BASE_ROW_HEIGHT) : listHeight;
 
-      if (rows?.length === 0 && isFiltering) {
-        return (
-          <div style={{ padding: UNIT * 2 }}>
-            <Text muted>No rows match the current filters.</Text>
-          </div>
-        );
-      }
-
       return (
-        <VariableSizeList
-          estimatedItemSize={BASE_ROW_HEIGHT}
-          height={adjustedHeight}
-          itemCount={rows?.length}
-          itemSize={(idx: number) => {
-            const size = estimateCellHeight({
-              ...rows[idx],
-              variableListProps: {
-                columnHeaderHeight,
-                height,
-                maxHeight,
+        <>
+          {rows?.length === 0 && isFiltering && (
+            <div style={{ padding: UNIT * 2 }}>
+              <Text muted>No rows match the current filters.</Text>
+            </div>
+          )}
+          <VariableSizeList
+            estimatedItemSize={BASE_ROW_HEIGHT}
+            height={adjustedHeight}
+            itemCount={rows?.length || 0}
+            itemSize={(idx: number) => {
+              const size = estimateCellHeight({
+                ...rows[idx],
+                variableListProps: {
+                  columnHeaderHeight,
+                  height,
+                  maxHeight,
+                  width,
+                },
                 width,
-              },
-              width,
-            });
+              });
 
-            return size;
-          }}
-          outerRef={refListOuter}
-          ref={refList}
-          style={{
-            maxHeight: maxHeight && enableFiltering ? maxHeight - BASE_ROW_HEIGHT : maxHeight,
-            pointerEvents: disableScrolling ? 'none' : null,
-          }}
-        >
-          {renderRow}
-        </VariableSizeList>
+              return size;
+            }}
+            outerRef={refListOuter}
+            ref={refList}
+            style={{
+              maxHeight: maxHeight && enableFiltering ? maxHeight - BASE_ROW_HEIGHT : maxHeight,
+              pointerEvents: disableScrolling ? 'none' : null,
+            }}
+          >
+            {renderRow}
+          </VariableSizeList>
+        </>
       );
     },
     [columnHeaderHeight, disableScrolling, enableFiltering, height, isFiltering, maxHeight, renderRow, rows, width],
@@ -786,17 +788,16 @@ function Table({ ...props }: TableProps) {
               })}
             </div>
           ))}
+          {enableFiltering && (
+            <FilterRow
+              columnCount={columns.length - numberOfIndexes}
+              columnWidth={defaultColumn.width}
+              filters={filters}
+              indexColumnWidths={maxWidthOfIndexColumns}
+              onFilterChange={handleFilterChange}
+            />
+          )}
         </div>
-
-        {enableFiltering && (
-          <FilterRow
-            columnCount={columns.length - numberOfIndexes}
-            columnWidth={defaultColumn.width}
-            filters={filters}
-            indexColumnWidths={maxWidthOfIndexColumns}
-            onFilterChange={handleFilterChange}
-          />
-        )}
 
         {variableListMemo}
       </div>

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -509,11 +509,12 @@ function Table({ ...props }: TableProps) {
   const renderRow = useCallback(
     ({ index, style }) => {
       const removedRowIndexes = new Set(previewIndexes?.removedRows || []);
+      const originalIndex = isFiltering && originalIndices.length > 0 ? originalIndices[index] : index;
 
       const row = rows[index];
       prepareRow(row);
       const { original } = row;
-      const rowToBeRemoved = removedRowIndexes.has(index);
+      const rowToBeRemoved = removedRowIndexes.has(originalIndex);
 
       return (
         <div
@@ -529,7 +530,7 @@ function Table({ ...props }: TableProps) {
             const indexColumn = idx <= numberOfIndexes - 1;
             const cellProps = cell.getCellProps();
             const header = cell.column.id;
-            const isInvalid = invalidValues?.[header]?.includes(index);
+            const isInvalid = invalidValues?.[header]?.includes(originalIndex);
             const cellStyle: {
               [key: string]: number | string;
             } = {
@@ -569,7 +570,7 @@ function Table({ ...props }: TableProps) {
             let indexColumnValue: any;
 
             if (indexColumn) {
-              const displayIndex = isFiltering && originalIndices.length > 0 ? originalIndices[index] : index;
+              const displayIndex = originalIndex;
               if (shouldUseIndexProp) {
                 indexColumnValue = indexProp[displayIndex];
                 if (Array.isArray(indexColumnValue)) {

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import Link from '@oracle/elements/Link';
 import NextLink from 'next/link';
 import styled from 'styled-components';
@@ -6,11 +6,13 @@ import { VariableSizeList } from 'react-window';
 import { TableHeaderProps, useBlockLayout, useTable } from 'react-table';
 import { useSticky } from 'react-table-sticky';
 
+import FilterRow from './FilterRow';
 import FlexContainer from '@oracle/components/FlexContainer';
 import Text from '@oracle/elements/Text';
 import dark from '@oracle/styles/themes/dark';
 import light from '@oracle/styles/themes/light';
 import scrollbarWidth from './scrollbarWidth';
+import useDynamicDebounce from '@utils/hooks/useDebounce';
 import { FONT_FAMILY_REGULAR, MONO_FONT_FAMILY_REGULAR } from '@oracle/styles/fonts/primary';
 import { REGULAR, REGULAR_LINE_HEIGHT, SMALL } from '@oracle/styles/fonts/sizes';
 import { ScrollbarStyledCss } from '@oracle/styles/scrollbars';
@@ -18,6 +20,7 @@ import { TAB_REPORTS } from '@components/datasets/overview/constants';
 import { ThemeContext } from 'styled-components';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { createDatasetTabRedirectLink } from '@components/utils';
+import { filterRows } from './filterUtils';
 import { range, sum } from '@utils/array';
 import { isObject } from '@utils/hash';
 import { isJsonString } from '@utils/string';
@@ -71,16 +74,20 @@ type TableProps = {
     sticky?: string;
   }[];
   data: (string | number | { [key: string]: string | number | boolean } | (string | number)[])[][];
+  enableFiltering?: boolean;
   numberOfIndexes: number;
+  onFilteredRowCount?: (count: number | null) => void;
 } & SharedProps;
 
 type DataTableProps = {
   columns: string[];
   disableZeroIndexRowNumber?: boolean;
+  enableFiltering?: boolean;
   noBorderBottom?: boolean;
   noBorderLeft?: boolean;
   noBorderRight?: boolean;
   noBorderTop?: boolean;
+  onFilteredRowCount?: (count: number | null) => void;
   rows: string[][] | number[][];
 } & SharedProps;
 
@@ -186,6 +193,12 @@ const Styles = styled.div<{
 
     .header {
       overflow: hidden;
+    }
+
+    .tr-filter {
+      .td {
+        padding: 0;
+      }
     }
   }
 `;
@@ -357,11 +370,13 @@ function Table({ ...props }: TableProps) {
     columns,
     data,
     disableScrolling,
+    enableFiltering,
     height,
     index: indexProp,
     invalidValues,
     maxHeight,
     numberOfIndexes,
+    onFilteredRowCount,
     previewIndexes,
     renderColumnHeader,
     renderColumnHeaderCell,
@@ -371,6 +386,53 @@ function Table({ ...props }: TableProps) {
   const themeContext = useContext(ThemeContext);
   const refHeader = useRef(null);
   const refListOuter = useRef(null);
+  const refList = useRef<VariableSizeList>(null);
+
+  const [filters, setFilters] = useState<Record<number, string>>({});
+  const [debouncedFilters, setDebouncedFilters] = useState<Record<number, string>>({});
+  const [debouncer, cancelDebounce] = useDynamicDebounce();
+
+  const handleFilterChange = useCallback((colIndex: number, value: string) => {
+    setFilters(prev => {
+      const next = { ...prev };
+      if (value) {
+        next[colIndex] = value;
+      } else {
+        delete next[colIndex];
+      }
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    debouncer(setDebouncedFilters, 300, filters);
+    return cancelDebounce;
+  }, [cancelDebounce, debouncer, filters]);
+
+  const { filteredData, originalIndices, isFiltering } = useMemo(() => {
+    const hasActiveFilters = enableFiltering && Object.keys(debouncedFilters).length > 0;
+    if (!hasActiveFilters) {
+      return { filteredData: data, originalIndices: [], isFiltering: false };
+    }
+    const result = filterRows(data, debouncedFilters);
+    return {
+      filteredData: result.filteredRows,
+      originalIndices: result.originalIndices,
+      isFiltering: true,
+    };
+  }, [data, debouncedFilters, enableFiltering]);
+
+  useEffect(() => {
+    if (enableFiltering && onFilteredRowCount) {
+      onFilteredRowCount(isFiltering ? filteredData.length : null);
+    }
+  }, [enableFiltering, filteredData.length, isFiltering, onFilteredRowCount]);
+
+  useEffect(() => {
+    if (refList.current) {
+      refList.current.resetAfterIndex(0);
+    }
+  }, [filteredData]);
 
   useEffect(() => {
     const onScrollCallback = e => {
@@ -437,7 +499,7 @@ function Table({ ...props }: TableProps) {
   const { getTableBodyProps, getTableProps, headerGroups, prepareRow, rows } = useTable(
     {
       columns,
-      data,
+      data: filteredData,
       defaultColumn,
     },
     useBlockLayout,
@@ -507,11 +569,14 @@ function Table({ ...props }: TableProps) {
             let indexColumnValue: any;
 
             if (indexColumn) {
+              const displayIndex = isFiltering && originalIndices.length > 0 ? originalIndices[index] : index;
               if (shouldUseIndexProp) {
-                indexColumnValue = indexProp[index];
+                indexColumnValue = indexProp[displayIndex];
                 if (Array.isArray(indexColumnValue)) {
                   indexColumnValue = indexColumnValue[idx];
                 }
+              } else if (isFiltering) {
+                indexColumnValue = String(displayIndex);
               } else {
                 indexColumnValue = cell.render('Cell');
               }
@@ -588,8 +653,10 @@ function Table({ ...props }: TableProps) {
       columnsAll,
       indexProp,
       invalidValues,
+      isFiltering,
       maxWidthOfIndexColumns,
       numberOfIndexes,
+      originalIndices,
       prepareRow,
       previewIndexes,
       rows,
@@ -598,35 +665,49 @@ function Table({ ...props }: TableProps) {
   );
 
   const variableListMemo = useMemo(
-    () => (
-      <VariableSizeList
-        estimatedItemSize={BASE_ROW_HEIGHT}
-        height={getVariableListHeight(columnHeaderHeight, height, maxHeight, rows, width)}
-        itemCount={rows?.length}
-        itemSize={(idx: number) => {
-          const size = estimateCellHeight({
-            ...rows[idx],
-            variableListProps: {
-              columnHeaderHeight,
-              height,
-              maxHeight,
-              width,
-            },
-            width,
-          });
+    () => {
+      const listHeight = getVariableListHeight(columnHeaderHeight, height, maxHeight, rows, width);
+      const adjustedHeight = enableFiltering ? Math.max(0, listHeight - BASE_ROW_HEIGHT) : listHeight;
 
-          return size;
-        }}
-        outerRef={refListOuter}
-        style={{
-          maxHeight: maxHeight,
-          pointerEvents: disableScrolling ? 'none' : null,
-        }}
-      >
-        {renderRow}
-      </VariableSizeList>
-    ),
-    [columnHeaderHeight, disableScrolling, height, maxHeight, renderRow, rows, width],
+      if (rows?.length === 0 && isFiltering) {
+        return (
+          <div style={{ padding: UNIT * 2 }}>
+            <Text muted>No rows match the current filters.</Text>
+          </div>
+        );
+      }
+
+      return (
+        <VariableSizeList
+          estimatedItemSize={BASE_ROW_HEIGHT}
+          height={adjustedHeight}
+          itemCount={rows?.length}
+          itemSize={(idx: number) => {
+            const size = estimateCellHeight({
+              ...rows[idx],
+              variableListProps: {
+                columnHeaderHeight,
+                height,
+                maxHeight,
+                width,
+              },
+              width,
+            });
+
+            return size;
+          }}
+          outerRef={refListOuter}
+          ref={refList}
+          style={{
+            maxHeight: maxHeight && enableFiltering ? maxHeight - BASE_ROW_HEIGHT : maxHeight,
+            pointerEvents: disableScrolling ? 'none' : null,
+          }}
+        >
+          {renderRow}
+        </VariableSizeList>
+      );
+    },
+    [columnHeaderHeight, disableScrolling, enableFiltering, height, isFiltering, maxHeight, renderRow, rows, width],
   );
 
   return (
@@ -701,6 +782,16 @@ function Table({ ...props }: TableProps) {
           ))}
         </div>
 
+        {enableFiltering && (
+          <FilterRow
+            columnCount={columns.length - numberOfIndexes}
+            columnWidth={defaultColumn.width}
+            filters={filters}
+            indexColumnWidths={maxWidthOfIndexColumns}
+            onFilterChange={handleFilterChange}
+          />
+        )}
+
         {variableListMemo}
       </div>
     </div>
@@ -712,6 +803,7 @@ function DataTable({
   columns: columnsProp,
   disableScrolling,
   disableZeroIndexRowNumber,
+  enableFiltering,
   height,
   index,
   invalidValues,
@@ -720,6 +812,7 @@ function DataTable({
   noBorderLeft,
   noBorderRight,
   noBorderTop,
+  onFilteredRowCount,
   previewIndexes,
   renderColumnHeader,
   renderColumnHeaderCell,
@@ -761,11 +854,13 @@ function DataTable({
           columns={columns}
           data={rowsProp}
           disableScrolling={disableScrolling}
+          enableFiltering={enableFiltering}
           height={height}
           index={index}
           invalidValues={invalidValues}
           maxHeight={maxHeight}
           numberOfIndexes={numberOfIndexes}
+          onFilteredRowCount={onFilteredRowCount}
           previewIndexes={previewIndexes}
           renderColumnHeader={renderColumnHeader}
           renderColumnHeaderCell={renderColumnHeaderCell}
@@ -776,6 +871,7 @@ function DataTable({
       columnHeaderHeight,
       columnHeadersContainEmptyString,
       columns,
+      enableFiltering,
       rowsProp,
       disableScrolling,
       height,
@@ -783,6 +879,7 @@ function DataTable({
       invalidValues,
       maxHeight,
       numberOfIndexes,
+      onFilteredRowCount,
       previewIndexes,
       renderColumnHeader,
       renderColumnHeaderCell,

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -412,6 +412,7 @@ function Sidekick({
         : TABLE_COLUMN_HEADER_HEIGHT
       }
       columns={columns}
+      enableFiltering
       height={heightWindow - heightOffset - ASIDE_SUBHEADER_HEIGHT}
       noBorderBottom
       noBorderLeft


### PR DESCRIPTION
# Description
Add inline column filtering to the DataTable component, as requested in #4143. Users can filter rows directly from text inputs rendered below the column headers.                

  Key changes:                                                                                                                                                                     
  - New FilterRow component that renders a text input beneath each column header                                                                                                   
  - New filterUtils.ts module with filter expression parsing and matching logic supporting:                                                                                        
    - Text search (substring match, case-insensitive)                                      
    - Comparison operators: >, <, >=, <=, =, !=                                                                                                                                    
    - Numeric and date-aware comparisons with string fallback
    - Special keywords: is blank, is not blank                                                                                                                                     
  - DataTable (index.tsx) integrates filtering with debounced input, preserves original row indices for correct index display/invalid-value highlighting/row-removal previews, and
  shows a "No rows match" message when the filtered result is empty                                                                                                                
  - TableOutput displays "Showing X of Y rows" when a filter is active via the onFilteredRowCount callback                                                                         
  - Filtering is enabled in both TableOutput (code block output) and Sidekick data preview


# How Has This Been Tested?
  - Typed text into filter inputs and verified substring matching works across columns                                                                                             
  - Tested comparison operators (>100, <=50, !=0) on numeric columns                                                                                                                 
  - Verified is blank / is not blank filters correctly identify null/empty cells                                                                                                 
  - Confirmed row indices remain correct after filtering (original index shown, not filtered index)
  - Confirmed invalid value highlighting and row removal previews reference original row indices                                                                                   
  - Verified "No rows match the current filters" message appears for empty results                                                                                                 
  - Confirmed horizontal scrollbar still works when filtered result is empty                                                                                                       
  - Verified filters reset when underlying data changes
  - Tested debounce behavior — rapid typing doesn't cause excessive re-renders    


# Checklist
- [ *] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ *] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993
