### PR TITLE
Add pipeline-level success and failure callbacks

### DIFF
--- a/mage_ai/api/policies/PipelinePolicy.py
+++ b/mage_ai/api/policies/PipelinePolicy.py
@@ -53,6 +53,7 @@ PipelinePolicy.allow_read(
         'callbacks',
         'conditionals',
         'extensions',
+        'pipeline_callbacks',
         'schedules',
     ],
     scopes=[
@@ -70,6 +71,7 @@ PipelinePolicy.allow_read(
         'callbacks',
         'conditionals',
         'extensions',
+        'pipeline_callbacks',
     ],
     scopes=[
         OauthScope.CLIENT_PRIVATE,
@@ -87,6 +89,7 @@ PipelinePolicy.allow_read(
         'callbacks',
         'conditionals',
         'extensions',
+        'pipeline_callbacks',
     ],
     scopes=[
         OauthScope.CLIENT_PRIVATE,
@@ -105,6 +108,7 @@ PipelinePolicy.allow_read(
         'extensions',
         'history',
         'operation_history',
+        'pipeline_callbacks',
         'schedules',
     ],
     scopes=[
@@ -126,6 +130,7 @@ PipelinePolicy.allow_write(
         'extensions',
         'llm',
         'name',
+        'pipeline_callbacks',
         'tags',
         'type',
     ],
@@ -145,6 +150,7 @@ PipelinePolicy.allow_write(
         'conditionals',
         'extensions',
         'llm',
+        'pipeline_callbacks',
         'schedules',
     ]
     + PipelinePresenter.default_attributes,

--- a/mage_ai/data_preparation/models/pipeline.py
+++ b/mage_ai/data_preparation/models/pipeline.py
@@ -118,6 +118,8 @@ class Pipeline:
         self.extensions = {}
         self.name = None
         self.notification_config = dict()
+        self.pipeline_callback_configs = []
+        self.pipeline_callbacks_by_uuid = {}
         self.execution_framework = execution_framework
 
         # For multi project
@@ -276,6 +278,7 @@ class Pipeline:
             self.block_configs
             + self.conditional_configs
             + self.callback_configs
+            + self.pipeline_callback_configs
             + self.widget_configs
         )
 
@@ -735,6 +738,11 @@ class Pipeline:
             os.path.join(pipeline_path, PIPELINE_CONFIG_FILE)
         )
 
+    def _get_callback_mapping(self, block_uuid: str = None):
+        if block_uuid and block_uuid in self.pipeline_callbacks_by_uuid:
+            return self.pipeline_callbacks_by_uuid
+        return self.callbacks_by_uuid
+
     def block_deletable(self, block, widget=False):
         mapping = {}
         if widget:
@@ -744,7 +752,7 @@ class Pipeline:
                 self.extensions[block.extension_uuid] = {}
             mapping = self.extensions[block.extension_uuid].get('blocks_by_uuid', {})
         elif BlockType.CALLBACK == block.type:
-            mapping = self.callbacks_by_uuid
+            mapping = self._get_callback_mapping(block.uuid)
         else:
             mapping = self.blocks_by_uuid
 
@@ -855,6 +863,48 @@ class Pipeline:
             ),
         )
 
+    def execute_pipeline_callbacks(
+        self,
+        callback: str,
+        callback_kwargs: Dict = None,
+        execution_partition: str = None,
+        global_vars: Dict = None,
+        logger=None,
+        logging_tags: Dict = None,
+        pipeline_run=None,
+    ) -> None:
+        callback_blocks = list(self.pipeline_callbacks_by_uuid.values())
+        if not callback_blocks:
+            return
+
+        for callback_block in callback_blocks:
+            try:
+                callback_block.execute_callback(
+                    callback,
+                    callback_kwargs=callback_kwargs,
+                    execution_partition=execution_partition,
+                    global_vars=global_vars,
+                    logger=logger,
+                    logging_tags=logging_tags,
+                    pipeline_run=pipeline_run,
+                )
+            except Exception as err:
+                if logger is not None:
+                    logger.exception(
+                        f'Failed to execute {callback} pipeline callback block '
+                        f'{callback_block.uuid} for pipeline {self.uuid}.',
+                        **merge_dict(
+                            logging_tags or {},
+                            dict(error=err),
+                        ),
+                    )
+                else:
+                    print(
+                        f'[ERROR] Pipeline.execute_pipeline_callbacks: '
+                        f'failed to execute {callback} for block {callback_block.uuid} '
+                        f'in pipeline {self.uuid}: {err}'
+                    )
+
     def load_config_from_yaml(self):
         catalog = None
         if os.path.exists(self.catalog_config_path):
@@ -885,6 +935,7 @@ class Pipeline:
         self.executor_config = config.get('executor_config') or {}
         self.executor_type = config.get('executor_type')
         self.notification_config = config.get('notification_config') or {}
+        self.pipeline_callback_configs = config.get('pipeline_callbacks') or []
         self.retry_config = config.get('retry_config') or {}
         self.run_pipeline_in_one_process = config.get(
             'run_pipeline_in_one_process',
@@ -932,9 +983,12 @@ class Pipeline:
 
         blocks = [build_shared_args_kwargs(c) for c in self.block_configs]
         callbacks = [build_shared_args_kwargs(c) for c in self.callback_configs]
+        pipeline_callbacks = [
+            build_shared_args_kwargs(c) for c in self.pipeline_callback_configs
+        ]
         conditionals = [build_shared_args_kwargs(c) for c in self.conditional_configs]
         widgets = [build_shared_args_kwargs(c) for c in self.widget_configs]
-        all_blocks = blocks + callbacks + conditionals + widgets
+        all_blocks = blocks + callbacks + pipeline_callbacks + conditionals + widgets
 
         self.blocks_by_uuid = self.__initialize_blocks_by_uuid(
             self.block_configs,
@@ -945,6 +999,11 @@ class Pipeline:
         self.callbacks_by_uuid = self.__initialize_blocks_by_uuid(
             self.callback_configs,
             callbacks,
+            all_blocks,
+        )
+        self.pipeline_callbacks_by_uuid = self.__initialize_blocks_by_uuid(
+            self.pipeline_callback_configs,
+            pipeline_callbacks,
             all_blocks,
         )
         self.conditionals_by_uuid = self.__initialize_blocks_by_uuid(
@@ -1097,6 +1156,9 @@ class Pipeline:
 
         blocks_data = [b.to_dict(**shared_kwargs) for b in self.blocks_by_uuid.values()]
         callbacks_data = [b.to_dict(**shared_kwargs) for b in self.callbacks_by_uuid.values()]
+        pipeline_callbacks_data = [
+            b.to_dict(**shared_kwargs) for b in self.pipeline_callbacks_by_uuid.values()
+        ]
         conditionals_data = [
             b.to_dict(**shared_kwargs) for b in self.conditionals_by_uuid.values()
         ]
@@ -1105,6 +1167,7 @@ class Pipeline:
         data = dict(
             blocks=blocks_data,
             callbacks=callbacks_data,
+            pipeline_callbacks=pipeline_callbacks_data,
             conditionals=conditionals_data,
             widgets=widgets_data,
         )
@@ -1194,6 +1257,9 @@ class Pipeline:
         callbacks_data = await asyncio.gather(*[
             b.to_dict_async(**shared_kwargs) for b in self.callbacks_by_uuid.values()
         ])
+        pipeline_callbacks_data = await asyncio.gather(*[
+            b.to_dict_async(**shared_kwargs) for b in self.pipeline_callbacks_by_uuid.values()
+        ])
         conditionals_data = await asyncio.gather(*[
             b.to_dict_async(**shared_kwargs) for b in self.conditionals_by_uuid.values()
         ])
@@ -1208,6 +1274,7 @@ class Pipeline:
         data = dict(
             blocks=blocks_data,
             callbacks=callbacks_data,
+            pipeline_callbacks=pipeline_callbacks_data,
             conditionals=conditionals_data,
             widgets=widgets_data,
         )
@@ -1360,6 +1427,13 @@ class Pipeline:
 
             if 'callbacks' in data:
                 arr.append(('callbacks', data['callbacks'], self.callbacks_by_uuid))
+
+            if 'pipeline_callbacks' in data:
+                arr.append((
+                    'pipeline_callbacks',
+                    data['pipeline_callbacks'],
+                    self.pipeline_callbacks_by_uuid,
+                ))
 
             if 'conditionals' in data:
                 arr.append(('conditionals', data['conditionals'], self.conditionals_by_uuid))
@@ -1809,6 +1883,7 @@ class Pipeline:
         upstream_block_uuids: List[str] = None,
         downstream_block_uuids: List[str] = None,
         priority: int = None,
+        pipeline_callback: bool = False,
         widget: bool = False,
     ) -> Block:
         if upstream_block_uuids is None:
@@ -1842,12 +1917,17 @@ class Pipeline:
                 priority=priority,
             )
         elif BlockType.CALLBACK == block.type:
-            self.callbacks_by_uuid = self.__add_block_to_mapping(
-                self.callbacks_by_uuid,
+            mapping = self.pipeline_callbacks_by_uuid if pipeline_callback else self.callbacks_by_uuid
+            mapping = self.__add_block_to_mapping(
+                mapping,
                 block,
                 upstream_blocks=self.get_blocks(upstream_block_uuids),
                 priority=priority,
             )
+            if pipeline_callback:
+                self.pipeline_callbacks_by_uuid = mapping
+            else:
+                self.callbacks_by_uuid = mapping
         elif BlockType.CONDITIONAL == block.type:
             self.conditionals_by_uuid = self.__add_block_to_mapping(
                 self.conditionals_by_uuid,
@@ -1893,7 +1973,7 @@ class Pipeline:
         elif extension_uuid:
             mapping = self.extensions.get(extension_uuid, {}).get('blocks_by_uuid', {})
         elif BlockType.CALLBACK == block_type:
-            mapping = self.callbacks_by_uuid
+            mapping = self._get_callback_mapping(block_uuid)
         elif BlockType.CONDITIONAL == block_type:
             mapping = self.conditionals_by_uuid
         else:
@@ -1999,7 +2079,7 @@ class Pipeline:
                 and block_uuid in self.extensions[extension_uuid]['blocks_by_uuid']
             )
         elif BlockType.CALLBACK == block_type:
-            return block_uuid in self.callbacks_by_uuid
+            return block_uuid in self._get_callback_mapping(block_uuid)
         elif BlockType.CONDITIONAL == block_type:
             return block_uuid in self.conditionals_by_uuid
 
@@ -2128,7 +2208,7 @@ class Pipeline:
                 block.uuid: block,
             })
         elif is_callback:
-            self.callbacks_by_uuid[block.uuid] = block
+            self._get_callback_mapping(block.uuid)[block.uuid] = block
         elif is_conditional:
             self.conditionals_by_uuid[block.uuid] = block
         else:
@@ -2166,9 +2246,15 @@ class Pipeline:
                     new_uuid if k == old_uuid else k: v for k, v in blocks_by_uuid.items()
                 }
         elif BlockType.CALLBACK == block.type:
-            self.callbacks_by_uuid = {
-                new_uuid if k == old_uuid else k: v for k, v in self.callbacks_by_uuid.items()
+            mapping = self._get_callback_mapping(old_uuid)
+            mapping_updated = {
+                new_uuid if k == old_uuid else k: v
+                for k, v in mapping.items()
             }
+            if mapping is self.pipeline_callbacks_by_uuid:
+                self.pipeline_callbacks_by_uuid = mapping_updated
+            else:
+                self.callbacks_by_uuid = mapping_updated
         elif BlockType.CONDITIONAL == block.type:
             self.conditionals_by_uuid = {
                 new_uuid if k == old_uuid else k: v for k, v in self.conditionals_by_uuid.items()
@@ -2258,7 +2344,7 @@ class Pipeline:
         elif is_extension:
             mapping = self.extensions.get(block.extension_uuid, {}).get('blocks_by_uuid', {})
         elif is_callback:
-            mapping = self.callbacks_by_uuid
+            mapping = self._get_callback_mapping(block.uuid)
         elif is_conditional:
             mapping = self.conditionals_by_uuid
         else:
@@ -2310,7 +2396,7 @@ class Pipeline:
         elif is_extension:
             del self.extensions[block.extension_uuid]['blocks_by_uuid'][block.uuid]
         elif is_callback:
-            del self.callbacks_by_uuid[block.uuid]
+            del self._get_callback_mapping(block.uuid)[block.uuid]
         elif is_conditional:
             del self.conditionals_by_uuid[block.uuid]
         else:
@@ -2357,7 +2443,7 @@ class Pipeline:
                     self.extensions[extension_uuid]['blocks_by_uuid'] = {}
                 self.extensions[extension_uuid]['blocks_by_uuid'][block_uuid] = block
             elif BlockType.CALLBACK == block.type:
-                current_pipeline.callbacks_by_uuid[block_uuid] = block
+                current_pipeline._get_callback_mapping(block_uuid)[block_uuid] = block
             elif BlockType.CONDITIONAL == block.type:
                 current_pipeline.conditionals_by_uuid[block_uuid] = block
             else:
@@ -2427,7 +2513,12 @@ class Pipeline:
 
         if block_uuid is not None:
             current_pipeline = await Pipeline.get_async(self.uuid, self.repo_path)
-            block = self.get_block(block_uuid, extension_uuid=extension_uuid, widget=widget)
+            block = self.get_block(
+                block_uuid,
+                block_type=block_type,
+                extension_uuid=extension_uuid,
+                widget=widget,
+            )
             if widget:
                 current_pipeline.widgets_by_uuid[block_uuid] = block
             elif extension_uuid:
@@ -2437,7 +2528,7 @@ class Pipeline:
                     self.extensions[extension_uuid]['blocks_by_uuid'] = {}
                 self.extensions[extension_uuid]['blocks_by_uuid'][block_uuid] = block
             elif BlockType.CALLBACK == block_type:
-                current_pipeline.callbacks_by_uuid[block_uuid] = block
+                current_pipeline._get_callback_mapping(block_uuid)[block_uuid] = block
             elif BlockType.CONDITIONAL == block_type:
                 current_pipeline.conditionals_by_uuid[block_uuid] = block
             else:
@@ -2511,6 +2602,7 @@ class Pipeline:
 
         combined_blocks.update(self.widgets_by_uuid)
         combined_blocks.update(self.callbacks_by_uuid)
+        combined_blocks.update(self.pipeline_callbacks_by_uuid)
         combined_blocks.update(self.conditionals_by_uuid)
         combined_blocks.update(self.blocks_by_uuid)
         status = {uuid: 'unvisited' for uuid in combined_blocks}

--- a/mage_ai/data_preparation/templates/callbacks/pipeline_default.py
+++ b/mage_ai/data_preparation/templates/callbacks/pipeline_default.py
@@ -1,0 +1,25 @@
+@on_success
+def on_pipeline_success(pipeline_run, pipeline, **kwargs):
+    """
+    Called when the pipeline run completes successfully.
+
+    Args:
+        pipeline_run: The pipeline run model instance.
+        pipeline: The pipeline model instance.
+        **kwargs: Additional keyword arguments including global variables.
+    """
+    pass
+
+
+@on_failure
+def on_pipeline_failure(pipeline_run, pipeline, __error=None, **kwargs):
+    """
+    Called when the pipeline run fails.
+
+    Args:
+        pipeline_run: The pipeline run model instance.
+        pipeline: The pipeline model instance.
+        __error: The failure exception passed to the callback.
+        **kwargs: Additional keyword arguments including global variables.
+    """
+    pass

--- a/mage_ai/data_preparation/templates/template.py
+++ b/mage_ai/data_preparation/templates/template.py
@@ -111,7 +111,7 @@ def fetch_template_source(
             language=language,
         )
     elif block_type == BlockType.CALLBACK:
-        template_source = __fetch_callback_templates()
+        template_source = __fetch_callback_templates(config)
     elif block_type == BlockType.CONDITIONAL:
         template_source = __fetch_conditional_templates()
 
@@ -329,8 +329,10 @@ def __fetch_custom_templates(
     )
 
 
-def __fetch_callback_templates() -> str:
-    template_path = 'callbacks/default.py'
+def __fetch_callback_templates(config: Mapping[str, str]) -> str:
+    template_path = 'callbacks/pipeline_default.py' if config.get(
+        'pipeline_callback'
+    ) else 'callbacks/default.py'
     return (
         template_env.get_template(template_path).render()
         + '\n'

--- a/mage_ai/orchestration/pipeline_scheduler_original.py
+++ b/mage_ai/orchestration/pipeline_scheduler_original.py
@@ -26,6 +26,7 @@ from mage_ai.data_preparation.models.triggers import (
 )
 from mage_ai.data_preparation.repo_manager import get_repo_config
 from mage_ai.data_preparation.sync.git_sync import get_sync_config
+from mage_ai.data_preparation.variable_manager import get_global_variables
 from mage_ai.orchestration.concurrency import ConcurrencyConfig, OnLimitReached
 from mage_ai.orchestration.db import db_connection, safe_db_query
 from mage_ai.orchestration.db.models.schedules import (
@@ -260,6 +261,7 @@ class PipelineScheduler:
                         pipeline=self.pipeline,
                         pipeline_run=self.pipeline_run,
                     )
+                    self.__execute_pipeline_callbacks('on_success')
                     UsageStatisticLogger().pipeline_run_ended_sync(self.pipeline_run)
 
                 self.logger_manager.output_logs_to_destination()
@@ -364,6 +366,10 @@ class PipelineScheduler:
                 pipeline_run=self.pipeline_run,
                 error=error_msg,
                 stacktrace=stacktrace,
+            )
+            self.__execute_pipeline_callbacks(
+                'on_failure',
+                callback_kwargs=dict(__error=Exception(error_msg)),
             )
 
         # Cancel block runs that are still in progress for the pipeline run.
@@ -507,6 +513,44 @@ class PipelineScheduler:
                 logger=self.logger,
                 logging_tags=tags,
             )
+
+    def __execute_pipeline_callbacks(
+        self,
+        callback: str,
+        callback_kwargs: Dict = None,
+    ) -> None:
+        if not self.pipeline.pipeline_callbacks_by_uuid:
+            return
+
+        tags = self.build_tags()
+        global_vars = self.pipeline_run.variables or dict()
+        if self.pipeline_run.pipeline_schedule:
+            global_vars = self.pipeline_run.get_variables(
+                pipeline_uuid=self.pipeline.uuid,
+            )
+        else:
+            global_vars = merge_dict(
+                get_global_variables(self.pipeline.uuid) or dict(),
+                global_vars,
+            )
+        callback_kwargs = merge_dict(
+            dict(
+                pipeline=self.pipeline,
+                pipeline_run=self.pipeline_run,
+                pipeline_uuid=self.pipeline.uuid,
+            ),
+            callback_kwargs or dict(),
+        )
+
+        self.pipeline.execute_pipeline_callbacks(
+            callback,
+            callback_kwargs=callback_kwargs,
+            execution_partition=self.pipeline_run.execution_partition,
+            global_vars=global_vars,
+            logger=self.logger,
+            logging_tags=tags,
+            pipeline_run=self.pipeline_run,
+        )
 
     def build_tags(self, block_run=None, **kwargs):
         base_tags = dict(

--- a/mage_ai/orchestration/pipeline_scheduler_project_platform.py
+++ b/mage_ai/orchestration/pipeline_scheduler_project_platform.py
@@ -26,6 +26,7 @@ from mage_ai.data_preparation.models.triggers import (
 )
 from mage_ai.data_preparation.repo_manager import get_repo_config
 from mage_ai.data_preparation.sync.git_sync import get_sync_config
+from mage_ai.data_preparation.variable_manager import get_global_variables
 from mage_ai.orchestration.concurrency import ConcurrencyConfig, OnLimitReached
 from mage_ai.orchestration.db import db_connection, safe_db_query
 from mage_ai.orchestration.db.models.schedules import (
@@ -249,17 +250,14 @@ class PipelineScheduler:
                         'Failed blocks: '
                         f'{", ".join([b.block_uuid for b in failed_block_runs])}.'
                     )
-                    self.notification_sender.send_pipeline_run_failure_message(
-                        error=error_msg,
-                        pipeline=self.pipeline,
-                        pipeline_run=self.pipeline_run,
-                    )
+                    self.on_pipeline_run_failure(error_msg)
                 else:
                     self.pipeline_run.complete()
                     self.notification_sender.send_pipeline_run_success_message(
                         pipeline=self.pipeline,
                         pipeline_run=self.pipeline_run,
                     )
+                    self.__execute_pipeline_callbacks('on_success')
 
                 UsageStatisticLogger().pipeline_run_ended_sync(self.pipeline_run)
 
@@ -302,7 +300,7 @@ class PipelineScheduler:
                 )
                 self.pipeline_run.update(status=status)
 
-                self.on_pipeline_run_failure('Pipeline run timed out.')
+                self.on_pipeline_run_failure('Pipeline run timed out.', status=status)
             elif self.pipeline_run.any_blocks_failed() and not self.allow_blocks_to_fail:
                 self.pipeline_run.update(status=PipelineRun.PipelineRunStatus.FAILED)
 
@@ -336,13 +334,24 @@ class PipelineScheduler:
                     self.__schedule_blocks(block_runs)
 
     @safe_db_query
-    def on_pipeline_run_failure(self, error: str) -> None:
+    def on_pipeline_run_failure(
+        self,
+        error: str,
+        status=PipelineRun.PipelineRunStatus.FAILED,
+    ) -> None:
         UsageStatisticLogger().pipeline_run_ended_sync(self.pipeline_run)
-        self.notification_sender.send_pipeline_run_failure_message(
-            pipeline=self.pipeline,
-            pipeline_run=self.pipeline_run,
-            error=error,
-        )
+
+        if status == PipelineRun.PipelineRunStatus.FAILED:
+            self.notification_sender.send_pipeline_run_failure_message(
+                pipeline=self.pipeline,
+                pipeline_run=self.pipeline_run,
+                error=error,
+            )
+            self.__execute_pipeline_callbacks(
+                'on_failure',
+                callback_kwargs=dict(__error=Exception(error)),
+            )
+
         # Cancel block runs that are still in progress for the pipeline run.
         cancel_block_runs_and_jobs(self.pipeline_run, self.pipeline)
 
@@ -481,6 +490,44 @@ class PipelineScheduler:
                 logger=self.logger,
                 logging_tags=tags,
             )
+
+    def __execute_pipeline_callbacks(
+        self,
+        callback: str,
+        callback_kwargs: Dict = None,
+    ) -> None:
+        if not self.pipeline.pipeline_callbacks_by_uuid:
+            return
+
+        tags = self.build_tags()
+        global_vars = self.pipeline_run.variables or dict()
+        if self.pipeline_run.pipeline_schedule:
+            global_vars = self.pipeline_run.get_variables(
+                pipeline_uuid=self.pipeline.uuid,
+            )
+        else:
+            global_vars = merge_dict(
+                get_global_variables(self.pipeline.uuid) or dict(),
+                global_vars,
+            )
+        callback_kwargs = merge_dict(
+            dict(
+                pipeline=self.pipeline,
+                pipeline_run=self.pipeline_run,
+                pipeline_uuid=self.pipeline.uuid,
+            ),
+            callback_kwargs or dict(),
+        )
+
+        self.pipeline.execute_pipeline_callbacks(
+            callback,
+            callback_kwargs=callback_kwargs,
+            execution_partition=self.pipeline_run.execution_partition,
+            global_vars=global_vars,
+            logger=self.logger,
+            logging_tags=tags,
+            pipeline_run=self.pipeline_run,
+        )
 
     def build_tags(self, **kwargs):
         base_tags = dict(

--- a/mage_ai/tests/data_preparation/models/test_pipeline.py
+++ b/mage_ai/tests/data_preparation/models/test_pipeline.py
@@ -106,7 +106,7 @@ class PipelineTest(AsyncDBTestCase):
             spark_config=dict(),
             type='python',
             remote_variables_dir=None,
-            variables_dir=self.repo_path,
+            variables_dir=pipeline.variables_dir,
             blocks=[
                 dict(
                     language='python',
@@ -179,6 +179,7 @@ class PipelineTest(AsyncDBTestCase):
             ],
             callbacks=[],
             conditionals=[],
+            pipeline_callbacks=[],
             settings=dict(triggers=None),
             created_at='2023-08-01 08:08:24+00:00',
             widgets=[
@@ -271,7 +272,7 @@ class PipelineTest(AsyncDBTestCase):
             spark_config=dict(),
             type='python',
             remote_variables_dir=None,
-            variables_dir=self.repo_path,
+            variables_dir=pipeline.variables_dir,
             blocks=[
                 dict(
                     language='python',
@@ -327,6 +328,7 @@ class PipelineTest(AsyncDBTestCase):
             ],
             callbacks=[],
             conditionals=[],
+            pipeline_callbacks=[],
             settings=dict(triggers=None),
             created_at='2023-08-01 08:08:24+00:00',
             widgets=[],
@@ -364,7 +366,7 @@ class PipelineTest(AsyncDBTestCase):
             spark_config=dict(),
             type='python',
             remote_variables_dir=None,
-            variables_dir=self.repo_path,
+            variables_dir=pipeline.variables_dir,
             blocks=[
                 dict(
                     language='python',
@@ -437,6 +439,7 @@ class PipelineTest(AsyncDBTestCase):
             ],
             callbacks=[],
             conditionals=[],
+            pipeline_callbacks=[],
             settings=dict(triggers=None),
             created_at='2023-08-01 08:08:24+00:00',
             widgets=[],
@@ -480,7 +483,7 @@ class PipelineTest(AsyncDBTestCase):
             spark_config=dict(),
             type='python',
             remote_variables_dir=None,
-            variables_dir=self.repo_path,
+            variables_dir=pipeline.variables_dir,
             blocks=[
                 dict(
                     language='python',
@@ -604,6 +607,7 @@ class PipelineTest(AsyncDBTestCase):
             ],
             callbacks=[],
             conditionals=[],
+            pipeline_callbacks=[],
             settings=dict(triggers=None),
             created_at='2023-08-01 08:08:24+00:00',
             widgets=[],
@@ -735,7 +739,7 @@ class PipelineTest(AsyncDBTestCase):
                     type='integration',
                     uuid='test_pipeline_9',
                     remote_variables_dir=None,
-                    variables_dir=self.repo_path,
+                    variables_dir=pipeline.variables_dir,
                     blocks=[
                         dict(
                             all_upstream_blocks_executed=True,
@@ -774,6 +778,7 @@ class PipelineTest(AsyncDBTestCase):
                     ],
                     callbacks=[],
                     conditionals=[],
+                    pipeline_callbacks=[],
                     settings=dict(triggers=None),
                     widgets=[],
                 ),

--- a/mage_ai/tests/data_preparation/models/test_pipeline_callbacks.py
+++ b/mage_ai/tests/data_preparation/models/test_pipeline_callbacks.py
@@ -1,0 +1,117 @@
+from uuid import uuid4
+from unittest.mock import MagicMock
+
+from mage_ai.data_preparation.models.block import Block, CallbackBlock
+from mage_ai.data_preparation.models.pipeline import Pipeline
+from mage_ai.tests.base_test import DBTestCase
+from mage_ai.tests.factory import create_pipeline
+
+
+class PipelineCallbacksTest(DBTestCase):
+    def setUp(self):
+        self.pipeline = create_pipeline(
+            f'pipeline_callback_test_{uuid4().hex[:8]}',
+            self.repo_path,
+        )
+
+    def tearDown(self):
+        self.pipeline.delete()
+
+    def test_pipeline_callbacks_by_uuid_initialized(self):
+        self.assertEqual({}, self.pipeline.pipeline_callbacks_by_uuid)
+        self.assertEqual([], self.pipeline.pipeline_callback_configs)
+
+    def test_add_pipeline_callback_block(self):
+        callback_block = CallbackBlock.create(f'pipeline_cb_{uuid4().hex[:8]}', self.repo_path)
+
+        self.pipeline.add_block(callback_block, pipeline_callback=True)
+
+        self.assertIn(callback_block.uuid, self.pipeline.pipeline_callbacks_by_uuid)
+        self.assertNotIn(callback_block.uuid, self.pipeline.callbacks_by_uuid)
+
+    def test_delete_pipeline_callback_block(self):
+        callback_block = CallbackBlock.create(f'pipeline_cb_{uuid4().hex[:8]}', self.repo_path)
+        self.pipeline.add_block(callback_block, pipeline_callback=True)
+
+        self.pipeline.delete_block(callback_block)
+
+        self.assertNotIn(callback_block.uuid, self.pipeline.pipeline_callbacks_by_uuid)
+
+    def test_to_dict_includes_pipeline_callbacks(self):
+        result = self.pipeline.to_dict()
+
+        self.assertIn('pipeline_callbacks', result)
+        self.assertEqual([], result['pipeline_callbacks'])
+
+    def test_to_dict_with_pipeline_callback_block(self):
+        callback_block = CallbackBlock.create(f'pipeline_cb_{uuid4().hex[:8]}', self.repo_path)
+        self.pipeline.add_block(callback_block, pipeline_callback=True)
+
+        result = self.pipeline.to_dict()
+
+        self.assertEqual(1, len(result['pipeline_callbacks']))
+        self.assertEqual(callback_block.uuid, result['pipeline_callbacks'][0]['uuid'])
+
+    def test_load_config_with_pipeline_callbacks(self):
+        callback_block = CallbackBlock.create(f'pipeline_cb_{uuid4().hex[:8]}', self.repo_path)
+        self.pipeline.add_block(callback_block, pipeline_callback=True)
+
+        reloaded = Pipeline(self.pipeline.uuid, repo_path=self.repo_path)
+
+        self.assertIn(callback_block.uuid, reloaded.pipeline_callbacks_by_uuid)
+        self.assertEqual(1, len(reloaded.pipeline_callbacks_by_uuid))
+
+    def test_execute_pipeline_callbacks_on_success(self):
+        mock_callback_block = MagicMock()
+        mock_callback_block.uuid = 'mock_pipeline_cb'
+        self.pipeline.pipeline_callbacks_by_uuid = dict(
+            mock_pipeline_cb=mock_callback_block,
+        )
+
+        self.pipeline.execute_pipeline_callbacks(
+            'on_success',
+            callback_kwargs=dict(
+                pipeline_run=dict(
+                    pipeline_uuid='test',
+                    status='completed',
+                ),
+            ),
+            global_vars=dict(env='test'),
+        )
+
+        mock_callback_block.execute_callback.assert_called_once()
+        self.assertEqual(
+            'on_success',
+            mock_callback_block.execute_callback.call_args[0][0],
+        )
+
+    def test_execute_pipeline_callbacks_handles_exception(self):
+        mock_callback_block = MagicMock()
+        mock_callback_block.uuid = 'failing_cb'
+        mock_callback_block.execute_callback.side_effect = Exception('callback error')
+        self.pipeline.pipeline_callbacks_by_uuid = dict(
+            failing_cb=mock_callback_block,
+        )
+
+        self.pipeline.execute_pipeline_callbacks(
+            'on_failure',
+            callback_kwargs=dict(__error=Exception('pipeline failed')),
+        )
+
+    def test_regular_callback_not_in_pipeline_callbacks(self):
+        block = Block.create(
+            f'test_loader_{uuid4().hex[:8]}',
+            'data_loader',
+            self.repo_path,
+            pipeline=self.pipeline,
+        )
+        self.pipeline.add_block(block)
+
+        callback_block = CallbackBlock.create(f'block_level_cb_{uuid4().hex[:8]}', self.repo_path)
+        self.pipeline.add_block(
+            callback_block,
+            upstream_block_uuids=[block.uuid],
+        )
+
+        self.assertIn(callback_block.uuid, self.pipeline.callbacks_by_uuid)
+        self.assertNotIn(callback_block.uuid, self.pipeline.pipeline_callbacks_by_uuid)

--- a/mage_ai/tests/orchestration/test_pipeline_scheduler.py
+++ b/mage_ai/tests/orchestration/test_pipeline_scheduler.py
@@ -5,6 +5,7 @@ import pytz
 import yaml
 from freezegun import freeze_time
 
+from mage_ai.data_preparation.models.block import Block
 from mage_ai.data_preparation.models.constants import PipelineType
 from mage_ai.data_preparation.models.triggers import (
     ScheduleInterval,
@@ -54,6 +55,29 @@ class PipelineSchedulerTests(DBTestCase):
             'test integration pipeline',
             self.repo_path,
         )
+
+    def _create_pipeline_with_callbacks(self):
+        pipeline = create_pipeline_with_blocks(
+            self.faker.unique.slug().replace('-', '_'),
+            self.repo_path,
+        )
+        suffix = self.faker.unique.pystr(min_chars=8, max_chars=8).lower()
+        pipeline_callback = Block.create(
+            f'pipeline_callback_{suffix}',
+            'callback',
+            self.repo_path,
+            language='python',
+        )
+        block_callback = Block.create(
+            f'block_callback_{suffix}',
+            'callback',
+            self.repo_path,
+            language='python',
+        )
+        pipeline.add_block(pipeline_callback, pipeline_callback=True)
+        pipeline.add_block(block_callback, upstream_block_uuids=['block1'])
+
+        return pipeline, pipeline_callback.uuid, block_callback.uuid
 
     def test_start(self):
         pipeline_run = PipelineRun.create(pipeline_uuid='test_pipeline')
@@ -133,6 +157,96 @@ class PipelineSchedulerTests(DBTestCase):
                 pipeline=scheduler.pipeline,
                 pipeline_run=pipeline_run,
             )
+
+    def test_schedule_all_blocks_completed_executes_pipeline_callbacks_only(self):
+        pipeline, pipeline_callback_uuid, block_callback_uuid = self._create_pipeline_with_callbacks()
+        pipeline_run = PipelineRun.create(pipeline_uuid=pipeline.uuid)
+        pipeline_run.update(status=PipelineRun.PipelineRunStatus.RUNNING)
+        for block_run in pipeline_run.block_runs:
+            block_run.update(status=BlockRun.BlockRunStatus.COMPLETED)
+
+        scheduler = PipelineScheduler(pipeline_run=pipeline_run)
+        pipeline_callback = scheduler.pipeline.pipeline_callbacks_by_uuid[pipeline_callback_uuid]
+        block_callback = scheduler.pipeline.callbacks_by_uuid[block_callback_uuid]
+
+        with patch.object(
+            scheduler.notification_sender, 'send_pipeline_run_success_message',
+        ) as mock_send_message:
+            with patch.object(pipeline_callback, 'execute_callback') as mock_pipeline_callback:
+                with patch.object(block_callback, 'execute_callback') as mock_block_callback:
+                    scheduler.schedule()
+
+        self.assertEqual(pipeline_run.status, PipelineRun.PipelineRunStatus.COMPLETED)
+        mock_send_message.assert_called_once_with(
+            pipeline=scheduler.pipeline,
+            pipeline_run=pipeline_run,
+        )
+        mock_pipeline_callback.assert_called_once()
+        self.assertEqual('on_success', mock_pipeline_callback.call_args[0][0])
+        self.assertEqual(
+            pipeline_run,
+            mock_pipeline_callback.call_args[1]['callback_kwargs']['pipeline_run'],
+        )
+        self.assertEqual(
+            scheduler.pipeline.uuid,
+            mock_pipeline_callback.call_args[1]['callback_kwargs']['pipeline_uuid'],
+        )
+        mock_block_callback.assert_not_called()
+
+    def test_schedule_failed_pipeline_executes_pipeline_failure_callbacks_only(self):
+        pipeline, pipeline_callback_uuid, block_callback_uuid = self._create_pipeline_with_callbacks()
+        pipeline_run = PipelineRun.create(pipeline_uuid=pipeline.uuid)
+        pipeline_run.update(status=PipelineRun.PipelineRunStatus.RUNNING)
+        failed_block_run = find(lambda br: br.block_uuid == 'block1', pipeline_run.block_runs)
+        failed_block_run.update(status=BlockRun.BlockRunStatus.FAILED)
+
+        scheduler = PipelineScheduler(pipeline_run=pipeline_run)
+        pipeline_callback = scheduler.pipeline.pipeline_callbacks_by_uuid[pipeline_callback_uuid]
+        block_callback = scheduler.pipeline.callbacks_by_uuid[block_callback_uuid]
+
+        with patch.object(
+            scheduler.notification_sender, 'send_pipeline_run_failure_message',
+        ) as mock_send_message:
+            with patch.object(pipeline_callback, 'execute_callback') as mock_pipeline_callback:
+                with patch.object(block_callback, 'execute_callback') as mock_block_callback:
+                    scheduler.schedule()
+
+        self.assertEqual(pipeline_run.status, PipelineRun.PipelineRunStatus.FAILED)
+        mock_send_message.assert_called_once()
+        mock_pipeline_callback.assert_called_once()
+        self.assertEqual('on_failure', mock_pipeline_callback.call_args[0][0])
+        self.assertIsInstance(
+            mock_pipeline_callback.call_args[1]['callback_kwargs']['__error'],
+            Exception,
+        )
+        mock_block_callback.assert_not_called()
+
+    @freeze_time('2023-05-01 01:20:33')
+    def test_pipeline_run_timeout_cancel_does_not_execute_failure_callbacks(self):
+        pipeline, pipeline_callback_uuid, _ = self._create_pipeline_with_callbacks()
+        pipeline_run = create_pipeline_run_with_schedule(
+            pipeline_uuid=pipeline.uuid,
+            execution_date=datetime(2023, 5, 1, 1, 10, 32, tzinfo=pytz.utc).astimezone(),
+            pipeline_schedule_settings=dict(
+                timeout=600,
+                timeout_status=PipelineRun.PipelineRunStatus.CANCELLED,
+            ),
+            started_at=datetime(2023, 5, 1, 1, 10, 32, tzinfo=pytz.utc).astimezone(),
+        )
+        pipeline_run.update(status=PipelineRun.PipelineRunStatus.RUNNING)
+
+        scheduler = PipelineScheduler(pipeline_run=pipeline_run)
+        pipeline_callback = scheduler.pipeline.pipeline_callbacks_by_uuid[pipeline_callback_uuid]
+
+        with patch.object(
+            scheduler.notification_sender, 'send_pipeline_run_failure_message',
+        ) as mock_send_message:
+            with patch.object(pipeline_callback, 'execute_callback') as mock_pipeline_callback:
+                scheduler.schedule()
+
+        self.assertEqual(pipeline_run.status, PipelineRun.PipelineRunStatus.CANCELLED)
+        mock_send_message.assert_not_called()
+        mock_pipeline_callback.assert_not_called()
 
     @freeze_time('2023-11-11 12:30:00')
     def test_backfill_status_with_completed_pipeline_run(self):

--- a/mage_ai/tests/orchestration/test_pipeline_scheduler_project_platform.py
+++ b/mage_ai/tests/orchestration/test_pipeline_scheduler_project_platform.py
@@ -1,8 +1,10 @@
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
+import pytz
 from freezegun import freeze_time
 
+from mage_ai.data_preparation.models.block import Block
 from mage_ai.data_preparation.models.triggers import ScheduleStatus, ScheduleType
 from mage_ai.orchestration.db.models.schedules import (
     BlockRun,
@@ -29,6 +31,29 @@ from mage_ai.tests.shared.mixins import ProjectPlatformMixin
     lambda: True,
 )
 class PipelineSchedulerProjectPlatformTests(ProjectPlatformMixin, DBTestCase):
+    def _create_pipeline_with_callbacks(self, full_path):
+        pipeline = create_pipeline_with_blocks(
+            self.faker.unique.slug().replace('-', '_'),
+            repo_path=full_path,
+        )
+        suffix = self.faker.unique.pystr(min_chars=8, max_chars=8).lower()
+        pipeline_callback = Block.create(
+            f'pipeline_callback_{suffix}',
+            'callback',
+            full_path,
+            language='python',
+        )
+        block_callback = Block.create(
+            f'block_callback_{suffix}',
+            'callback',
+            full_path,
+            language='python',
+        )
+        pipeline.add_block(pipeline_callback, pipeline_callback=True)
+        pipeline.add_block(block_callback, upstream_block_uuids=['block1'])
+
+        return pipeline, pipeline_callback.uuid, block_callback.uuid
+
     def test_init(self):
         with patch(
             'mage_ai.orchestration.pipeline_scheduler_original.project_platform_activated',
@@ -211,6 +236,203 @@ class PipelineSchedulerProjectPlatformTests(ProjectPlatformMixin, DBTestCase):
                     with patch.object(PipelineRunMock, 'in_progress_runs') as mock:
                         check_sla()
                         mock.assert_called_once_with(set([s.id for s in pipeline_schedules]))
+
+    def test_schedule_all_blocks_completed_executes_pipeline_callbacks_only(self):
+        with patch(
+            'mage_ai.orchestration.pipeline_scheduler_original.project_platform_activated',
+            lambda: True,
+        ):
+            with patch(
+                'mage_ai.data_preparation.models.pipeline.project_platform_activated',
+                lambda: True,
+            ):
+                with patch(
+                    'mage_ai.orchestration.db.models.schedules.project_platform_activated',
+                    lambda: True,
+                ):
+                    settings = next(iter(self.repo_paths.values()))
+                    full_path = settings['full_path']
+                    pipeline, pipeline_callback_uuid, block_callback_uuid = (
+                        self._create_pipeline_with_callbacks(full_path)
+                    )
+
+                    pipeline_schedule = PipelineSchedule.create(
+                        name=self.faker.unique.name(),
+                        pipeline_uuid=pipeline.uuid,
+                        repo_path=full_path,
+                        schedule_type=ScheduleType.TIME,
+                    )
+                    pipeline_run = PipelineRun.create(
+                        pipeline_schedule_id=pipeline_schedule.id,
+                        pipeline_uuid=pipeline.uuid,
+                        status=PipelineRun.PipelineRunStatus.RUNNING,
+                    )
+                    for block_run in pipeline_run.block_runs:
+                        block_run.update(status=BlockRun.BlockRunStatus.COMPLETED)
+
+                    scheduler = PipelineScheduler(pipeline_run=pipeline_run)
+                    pipeline_callback = scheduler.pipeline.pipeline_callbacks_by_uuid[
+                        pipeline_callback_uuid
+                    ]
+                    block_callback = scheduler.pipeline.callbacks_by_uuid[block_callback_uuid]
+
+                    with patch.object(
+                        scheduler.notification_sender, 'send_pipeline_run_success_message',
+                    ):
+                        with patch.object(
+                            pipeline_callback, 'execute_callback',
+                        ) as mock_pipeline_callback:
+                            with patch.object(
+                                block_callback, 'execute_callback',
+                            ) as mock_block_callback:
+                                scheduler.schedule()
+
+                    self.assertEqual(
+                        PipelineRun.PipelineRunStatus.COMPLETED,
+                        pipeline_run.status,
+                    )
+                    mock_pipeline_callback.assert_called_once()
+                    self.assertEqual('on_success', mock_pipeline_callback.call_args[0][0])
+                    mock_block_callback.assert_not_called()
+
+    def test_schedule_failed_pipeline_executes_pipeline_failure_callbacks_only(self):
+        with patch(
+            'mage_ai.orchestration.pipeline_scheduler_original.project_platform_activated',
+            lambda: True,
+        ):
+            with patch(
+                'mage_ai.data_preparation.models.pipeline.project_platform_activated',
+                lambda: True,
+            ):
+                with patch(
+                    'mage_ai.orchestration.db.models.schedules.project_platform_activated',
+                    lambda: True,
+                ):
+                    settings = next(iter(self.repo_paths.values()))
+                    full_path = settings['full_path']
+                    pipeline, pipeline_callback_uuid, block_callback_uuid = (
+                        self._create_pipeline_with_callbacks(full_path)
+                    )
+
+                    pipeline_schedule = PipelineSchedule.create(
+                        name=self.faker.unique.name(),
+                        pipeline_uuid=pipeline.uuid,
+                        repo_path=full_path,
+                        schedule_type=ScheduleType.TIME,
+                    )
+                    pipeline_run = PipelineRun.create(
+                        pipeline_schedule_id=pipeline_schedule.id,
+                        pipeline_uuid=pipeline.uuid,
+                        status=PipelineRun.PipelineRunStatus.RUNNING,
+                    )
+                    failed_block_run = next(
+                        br for br in pipeline_run.block_runs if br.block_uuid == 'block1'
+                    )
+                    failed_block_run.update(status=BlockRun.BlockRunStatus.FAILED)
+
+                    scheduler = PipelineScheduler(pipeline_run=pipeline_run)
+                    pipeline_callback = scheduler.pipeline.pipeline_callbacks_by_uuid[
+                        pipeline_callback_uuid
+                    ]
+                    block_callback = scheduler.pipeline.callbacks_by_uuid[block_callback_uuid]
+
+                    with patch.object(
+                        scheduler.notification_sender, 'send_pipeline_run_failure_message',
+                    ) as mock_send_message:
+                        with patch.object(
+                            pipeline_callback, 'execute_callback',
+                        ) as mock_pipeline_callback:
+                            with patch.object(
+                                block_callback, 'execute_callback',
+                            ) as mock_block_callback:
+                                scheduler.schedule()
+
+                    self.assertEqual(
+                        PipelineRun.PipelineRunStatus.FAILED,
+                        pipeline_run.status,
+                    )
+                    mock_send_message.assert_called_once()
+                    mock_pipeline_callback.assert_called_once()
+                    self.assertEqual('on_failure', mock_pipeline_callback.call_args[0][0])
+                    self.assertIsInstance(
+                        mock_pipeline_callback.call_args[1]['callback_kwargs']['__error'],
+                        Exception,
+                    )
+                    mock_block_callback.assert_not_called()
+
+    @freeze_time('2023-05-01 01:20:33')
+    def test_pipeline_run_timeout_cancel_does_not_execute_failure_callbacks(self):
+        with patch(
+            'mage_ai.orchestration.pipeline_scheduler_original.project_platform_activated',
+            lambda: True,
+        ):
+            with patch(
+                'mage_ai.data_preparation.models.pipeline.project_platform_activated',
+                lambda: True,
+            ):
+                with patch(
+                    'mage_ai.orchestration.db.models.schedules.project_platform_activated',
+                    lambda: True,
+                ):
+                    settings = next(iter(self.repo_paths.values()))
+                    full_path = settings['full_path']
+                    pipeline, pipeline_callback_uuid, _ = (
+                        self._create_pipeline_with_callbacks(full_path)
+                    )
+
+                    pipeline_schedule = PipelineSchedule.create(
+                        name=self.faker.unique.name(),
+                        pipeline_uuid=pipeline.uuid,
+                        repo_path=full_path,
+                        schedule_type=ScheduleType.TIME,
+                        settings=dict(
+                            timeout=600,
+                            timeout_status=PipelineRun.PipelineRunStatus.CANCELLED,
+                        ),
+                    )
+                    pipeline_run = PipelineRun.create(
+                        execution_date=datetime(
+                            2023,
+                            5,
+                            1,
+                            1,
+                            10,
+                            32,
+                            tzinfo=pytz.utc,
+                        ).astimezone(),
+                        pipeline_schedule_id=pipeline_schedule.id,
+                        pipeline_uuid=pipeline.uuid,
+                        started_at=datetime(
+                            2023,
+                            5,
+                            1,
+                            1,
+                            10,
+                            32,
+                            tzinfo=pytz.utc,
+                        ).astimezone(),
+                        status=PipelineRun.PipelineRunStatus.RUNNING,
+                    )
+
+                    scheduler = PipelineScheduler(pipeline_run=pipeline_run)
+                    pipeline_callback = scheduler.pipeline.pipeline_callbacks_by_uuid[
+                        pipeline_callback_uuid
+                    ]
+
+                    with patch.object(
+                        scheduler.notification_sender, 'send_pipeline_run_failure_message',
+                    ) as mock_send_message:
+                        with patch.object(
+                            pipeline_callback, 'execute_callback',
+                        ) as mock_pipeline_callback:
+                            scheduler.schedule()
+
+                    self.assertEqual(
+                        PipelineRun.PipelineRunStatus.CANCELLED,
+                        pipeline_run.status,
+                    )
+                    mock_send_message.assert_not_called()
+                    mock_pipeline_callback.assert_not_called()
 
     @freeze_time('2023-11-11 12:30:00')
     def test_schedule_all(self):


### PR DESCRIPTION
Closes #5438

# Use Case

Block-level callbacks can fire multiple times when several blocks fail concurrently. This makes it difficult to run a single success or failure handler for the pipeline as a whole.

This change adds explicit pipeline-level callbacks so callback code can run once when a pipeline run reaches a terminal success or failure state.

# Description

This PR adds first-class `pipeline_callbacks` support to pipeline metadata and executes those callback blocks from the scheduler when a pipeline run completes or fails.

The implementation keeps pipeline-level callbacks separate from block-level callbacks:
- block callbacks remain under `callbacks`
- pipeline callbacks are stored under `pipeline_callbacks`

# The changes include

- add `pipeline_callbacks` to the pipeline model and serialization flow
- add `pipeline_callbacks_by_uuid` and explicit pipeline callback loading/saving behavior
- add API policy support for reading and writing `pipeline_callbacks`
- add a dedicated pipeline callback template
- execute pipeline-level `on_success` callbacks when a pipeline run completes
- execute pipeline-level `on_failure` callbacks when a pipeline run fails
- preserve timeout behavior so cancelled runs do not trigger failure callbacks
- add model tests for pipeline callback serialization and execution
- add scheduler tests for success, failure, and cancelled-timeout behavior
- add matching project-platform scheduler coverage

# How Has This Been Tested?

```bash
python3 -m py_compile \
  mage_ai/data_preparation/models/pipeline.py \
  mage_ai/tests/orchestration/test_pipeline_scheduler_project_platform.py
```

```bash
DEBUG=0 TZ=America/Los_Angeles poetry run pytest \
  mage_ai/tests/data_preparation/models/test_pipeline_callbacks.py \
  mage_ai/tests/orchestration/test_pipeline_scheduler.py \
  mage_ai/tests/orchestration/test_pipeline_scheduler_project_platform.py \
  -k "pipeline_callbacks or executes_pipeline_callbacks_only or executes_pipeline_failure_callbacks_only or timeout_cancel_does_not_execute_failure_callbacks"
```

Result:
- `15 passed`

