### PR TITLE
Interactive column filtering in Data widget 

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-${{ runner.os }}
           path: mage_ai/frontend/playwright-report/
           retention-days: 3
           overwrite: true
@@ -143,6 +143,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-${{ runner.os }}
           path: mage_ai/frontend/playwright-report/
           retention-days: 3

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/TableOutput.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/TableOutput.tsx
@@ -1,5 +1,5 @@
 import InnerHTML from 'dangerously-set-html-content';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import DataTable from '@components/DataTable';
 import FlexContainer from '@oracle/components/FlexContainer';
@@ -69,6 +69,9 @@ function TableOutput({
     [data, sampleData],
   );
 
+  // null = no active filters; number = at least one filter is active
+  const [filteredRowCount, setFilteredRowCount] = useState<number | null>(null);
+
   if (columns?.some(header => header === '')) {
     return (
       <Spacing mx={5} my={3}>
@@ -120,12 +123,24 @@ function TableOutput({
     const arr2 = [];
 
     if (shape?.length >= 1) {
-      const r = pluralize('row', shape?.[0]);
-      if (shape?.length >= 2) {
-        const c = pluralize('column', shape?.[1]);
-        arr1.push(`${r} x ${c}`);
+      const totalRows = shape[0];
+      const r = pluralize('row', totalRows);
+
+      if (shape.length >= 2) {
+        const totalCols = shape[1];
+        const c = pluralize('column', totalCols);
+
+        if (filteredRowCount !== null && filteredRowCount !== totalRows) {
+          arr1.push(`${filteredRowCount} of ${r} × ${c}`);
+        } else {
+          arr1.push(`${r} x ${c}`);
+        }
       } else {
-        arr1.push(r);
+        if (filteredRowCount !== null && filteredRowCount !== totalRows) {
+          arr1.push(`${filteredRowCount} of ${r}`);
+        } else {
+          arr1.push(r);
+        }
       }
     }
 
@@ -161,19 +176,21 @@ function TableOutput({
         </Text>
       </>
     );
-  }, [shape, resourceUsage]);
+  }, [filteredRowCount, resourceUsage, shape]);
 
   return (
     <>
       <DataTable
         columns={columns}
         disableScrolling={!selected}
-        key={`data-table-${order}`}
+        filterable
+        key={`data-table-${output?.timestamp ?? order}`}
         maxHeight={maxHeight || UNIT * 60}
         noBorderBottom
         noBorderLeft
         noBorderRight
         noBorderTop={!borderTop}
+        onFilteredCountChange={setFilteredRowCount}
         renderColumnHeaderCell={(
           { Header: columnName },
           _,

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
@@ -1317,6 +1317,7 @@ function CodeOutput(
                         <Tooltip {...SHARED_TOOLTIP_PROPS} label="Expand table">
                           <Button
                             {...SHARED_BUTTON_PROPS}
+                            aria-label="Expand table"
                             onClick={() => {
                               addDataOutputBlockUUID(pipeline?.uuid, blockUUID);
                               openSidekickView?.(ViewKeyEnum.DATA);

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/useCodeOutput.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/useCodeOutput.tsx
@@ -593,6 +593,7 @@ export default function useCodeOutput({
                   >
                     <Button
                       {...SHARED_BUTTON_PROPS}
+                      aria-label="Expand table"
                       onClick={() => {
                         addDataOutputBlockUUID(pipeline?.uuid, blockUUID);
                         openSidekickView?.(ViewKeyEnum.DATA);

--- a/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CommandButtons/index.tsx
@@ -362,6 +362,7 @@ function CommandButtons({
               widthFitContent
             >
               <Button
+                aria-label="Run block"
                 noBackground
                 noBorder
                 noPadding

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -89,7 +89,7 @@ type DataTableProps = {
   noBorderLeft?: boolean;
   noBorderRight?: boolean;
   noBorderTop?: boolean;
-  onFilteredCountChange?: (count: number) => void;
+  onFilteredCountChange?: (count: number | null) => void;
   rows: string[][] | number[][];
 } & SharedProps;
 

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -987,6 +987,10 @@ function DataTable({
             onClick={() => {
               setFilters({});
               setDebouncedFilters({});
+              if (debounceRef.current) {
+                clearTimeout(debounceRef.current);
+                debounceRef.current = null;
+              }
             }}
             small
           >

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import Link from '@oracle/elements/Link';
 import NextLink from 'next/link';
 import styled from 'styled-components';
@@ -11,6 +11,8 @@ import Text from '@oracle/elements/Text';
 import dark from '@oracle/styles/themes/dark';
 import light from '@oracle/styles/themes/light';
 import scrollbarWidth from './scrollbarWidth';
+import { DEBOUNCE_MS } from '@components/constants';
+import { ColumnDtype, parseAndApplyFilter } from '@utils/table/filterExpression';
 import { FONT_FAMILY_REGULAR, MONO_FONT_FAMILY_REGULAR } from '@oracle/styles/fonts/primary';
 import { REGULAR, REGULAR_LINE_HEIGHT, SMALL } from '@oracle/styles/fonts/sizes';
 import { ScrollbarStyledCss } from '@oracle/styles/scrollbars';
@@ -18,6 +20,7 @@ import { TAB_REPORTS } from '@components/datasets/overview/constants';
 import { ThemeContext } from 'styled-components';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { createDatasetTabRedirectLink } from '@components/utils';
+import { inferColumnDtype } from '@utils/table/inferColumnDtype';
 import { range, sum } from '@utils/array';
 import { isObject } from '@utils/hash';
 import { isJsonString } from '@utils/string';
@@ -71,16 +74,22 @@ type TableProps = {
     sticky?: string;
   }[];
   data: (string | number | { [key: string]: string | number | boolean } | (string | number)[])[][];
+  filterable?: boolean;
+  filterErrors?: { [col: string]: boolean };
+  filters?: { [col: string]: string };
   numberOfIndexes: number;
+  onFilterChange?: (col: string, value: string) => void;
 } & SharedProps;
 
 type DataTableProps = {
   columns: string[];
   disableZeroIndexRowNumber?: boolean;
+  filterable?: boolean;
   noBorderBottom?: boolean;
   noBorderLeft?: boolean;
   noBorderRight?: boolean;
   noBorderTop?: boolean;
+  onFilteredCountChange?: (count: number) => void;
   rows: string[][] | number[][];
 } & SharedProps;
 
@@ -199,6 +208,30 @@ const PreStyle = styled.pre`
   overflow: auto;
   ${ScrollbarStyledCss}
 `;
+
+const FilterInput = styled.input<{ error?: boolean }>`
+  background: ${props => (props.error ? 'rgba(255,59,48,0.05)' : 'transparent')};
+  border: 1px solid
+    ${props =>
+      props.error ? (props.theme.status || dark.status).negative : 'transparent'};
+  border-radius: 2px;
+  color: ${props => (props.theme.content || dark.content).default};
+  font-family: ${FONT_FAMILY_REGULAR};
+  font-size: ${REGULAR};
+  outline: none;
+  padding: ${UNIT * 0.5}px ${UNIT}px;
+  width: 100%;
+
+  &:focus {
+    border-color: ${props => (props.theme.interactive || dark.interactive).focusBorder};
+  }
+
+  &::placeholder {
+    color: ${props => (props.theme.content || dark.content).disabled};
+  }
+`;
+
+
 
 function estimateCellHeight({
   original,
@@ -357,11 +390,15 @@ function Table({ ...props }: TableProps) {
     columns,
     data,
     disableScrolling,
+    filterable,
+    filterErrors,
+    filters,
     height,
     index: indexProp,
     invalidValues,
     maxHeight,
     numberOfIndexes,
+    onFilterChange,
     previewIndexes,
     renderColumnHeader,
     renderColumnHeaderCell,
@@ -699,6 +736,49 @@ function Table({ ...props }: TableProps) {
               })}
             </div>
           ))}
+
+          {filterable && (
+            <div
+              className="tr"
+              style={{
+                display: 'flex',
+                width: headerGroups[0]?.getHeaderGroupProps()?.style?.width,
+              }}
+            >
+              {columns.map((column, idx) => {
+                const isIndexCol = idx <= numberOfIndexes - 1;
+                const filterCellStyle: React.CSSProperties = {
+                  flexShrink: 0,
+                  overflow: 'visible',
+                  padding: `${UNIT * 0.5}px`,
+                  position: 'relative',
+                  width: isIndexCol ? maxWidthOfIndexColumns[idx] : defaultColumn.width,
+                };
+
+                if (isIndexCol) {
+                  filterCellStyle.left = 0;
+                  filterCellStyle.position = 'sticky';
+                }
+
+                const colName = column.Header as string;
+
+                return (
+                  <div className="th" key={`filter-${idx}`} style={filterCellStyle}>
+                    {!isIndexCol && (
+                      <FilterInput
+                        aria-label={`Filter ${colName} column`}
+                        autoComplete="off"
+                        error={!!filterErrors?.[colName]}
+                        onChange={e => onFilterChange?.(colName, e.target.value)}
+                        placeholder="filter..."
+                        value={filters?.[colName] ?? ''}
+                      />
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
 
         {variableListMemo}
@@ -712,6 +792,7 @@ function DataTable({
   columns: columnsProp,
   disableScrolling,
   disableZeroIndexRowNumber,
+  filterable,
   height,
   index,
   invalidValues,
@@ -720,12 +801,102 @@ function DataTable({
   noBorderLeft,
   noBorderRight,
   noBorderTop,
+  onFilteredCountChange,
   previewIndexes,
   renderColumnHeader,
   renderColumnHeaderCell,
   rows: rowsProp,
   width,
 }: DataTableProps) {
+  // ---------------------------------------------------------------------------
+  // Filter state
+  // ---------------------------------------------------------------------------
+
+  // `filters` drives FilterInput values immediately (no lag on typing).
+  // `debouncedFilters` drives filteredRows memo (updates 200ms after typing stops).
+  // Two separate states are intentional — do not merge them.
+  const [filters, setFilters] = useState<{ [col: string]: string }>({});
+  const [debouncedFilters, setDebouncedFilters] = useState<{ [col: string]: string }>({});
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Debounce cleanup on unmount — prevents timer firing after component is gone.
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const handleFilterChange = useCallback((col: string, value: string) => {
+    setFilters(prev => ({ ...prev, [col]: value }));
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setDebouncedFilters(prev => ({ ...prev, [col]: value }));
+    }, DEBOUNCE_MS);
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Column dtype inference — memoised per column, runs once per dataset change.
+  // ---------------------------------------------------------------------------
+
+  const columnDtypes = useMemo<{ [col: string]: ColumnDtype }>(() => {
+    if (!filterable || !columnsProp || !rowsProp) return {};
+    return Object.fromEntries(
+      columnsProp.map((col, i) => [
+        col,
+        inferColumnDtype((rowsProp as (string | number)[][]).slice(0, 20).map(row => row[i])),
+      ]),
+    );
+  }, [filterable, columnsProp, rowsProp]);
+
+  // ---------------------------------------------------------------------------
+  // Filtered rows + errors — single pure memo, no setState side-effects.
+  //
+  // filterErrors is derived here rather than held in useState. Calling setState
+  // inside useMemo is a React anti-pattern (side-effect during render) that can
+  // trigger render loops. Deriving both values together keeps the memo pure.
+  // ---------------------------------------------------------------------------
+
+  const { filterErrors, filteredRows } = useMemo(() => {
+    const errors: { [col: string]: boolean } = {};
+
+    if (!filterable || !columnsProp || !rowsProp) {
+      return { filterErrors: errors, filteredRows: rowsProp ?? [] };
+    }
+
+    const activeEntries = columnsProp
+      .map((col, idx) => ({ col, expr: debouncedFilters[col]?.trim() ?? '', idx }))
+      .filter(({ expr }) => expr.length > 0);
+
+    if (activeEntries.length === 0) {
+      return { filterErrors: errors, filteredRows: rowsProp };
+    }
+
+    const filtered = (rowsProp as (string | number)[][]).filter(row =>
+      activeEntries.every(({ col, expr, idx }) => {
+        const result = parseAndApplyFilter(row[idx], expr, columnDtypes[col] ?? 'unknown');
+        if (result.hint) {
+          errors[col] = true;
+        }
+        return result.match;
+      }),
+    );
+
+    return { filterErrors: errors, filteredRows: filtered };
+  }, [columnDtypes, columnsProp, debouncedFilters, filterable, rowsProp]);
+
+  // ---------------------------------------------------------------------------
+  // Notify parent of filtered row count whenever it changes.
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    const hasActiveFilters = Object.values(debouncedFilters).some(v => v?.trim().length > 0);
+    onFilteredCountChange?.(hasActiveFilters ? filteredRows.length : null);
+  }, [debouncedFilters, filteredRows.length, onFilteredCountChange]);
+
+  // ---------------------------------------------------------------------------
+  // Existing derived state (unchanged)
+  // ---------------------------------------------------------------------------
+
   const columnHeadersContainEmptyString = useMemo(
     () => columnsProp?.some(header => header === ''),
     [columnsProp],
@@ -759,13 +930,17 @@ function DataTable({
         <Table
           columnHeaderHeight={columnHeaderHeight}
           columns={columns}
-          data={rowsProp}
+          data={filteredRows}
           disableScrolling={disableScrolling}
+          filterable={filterable}
+          filterErrors={filterErrors}
+          filters={filters}
           height={height}
           index={index}
           invalidValues={invalidValues}
           maxHeight={maxHeight}
           numberOfIndexes={numberOfIndexes}
+          onFilterChange={handleFilterChange}
           previewIndexes={previewIndexes}
           renderColumnHeader={renderColumnHeader}
           renderColumnHeaderCell={renderColumnHeaderCell}
@@ -776,8 +951,12 @@ function DataTable({
       columnHeaderHeight,
       columnHeadersContainEmptyString,
       columns,
-      rowsProp,
       disableScrolling,
+      filterable,
+      filterErrors,
+      filters,
+      filteredRows,
+      handleFilterChange,
       height,
       index,
       invalidValues,
@@ -802,6 +981,19 @@ function DataTable({
       noBorderTop={noBorderTop}
     >
       {!columnHeadersContainEmptyString && table}
+      {filterable && Object.values(filters).some(v => v.trim().length > 0) && (
+        <div style={{ display: 'flex', justifyContent: 'flex-end', padding: `${UNIT * 0.5}px ${UNIT}px` }}>
+          <Link
+            onClick={() => {
+              setFilters({});
+              setDebouncedFilters({});
+            }}
+            small
+          >
+            ✕ Clear filters
+          </Link>
+        </div>
+      )}
     </Styles>
   );
 }

--- a/mage_ai/frontend/components/DataTable/index.tsx
+++ b/mage_ai/frontend/components/DataTable/index.tsx
@@ -231,8 +231,6 @@ const FilterInput = styled.input<{ error?: boolean }>`
   }
 `;
 
-
-
 function estimateCellHeight({
   original,
   values,

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -56,6 +56,8 @@ import { LOCAL_STORAGE_KEY_PIPELINE_EXECUTION_HIDDEN, get } from '@storage/local
 import { OpenDataIntegrationModalType } from '@components/DataIntegrationModal/constants';
 import { OUTPUT_HEIGHT } from '@components/PipelineDetail/PipelineExecution/index.style';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
+import { REGULAR_LINE_HEIGHT } from '@oracle/styles/fonts/sizes';
+import { pluralize } from '@utils/string';
 import {
   SidekickContainerStyle,
   TABLE_COLUMN_HEADER_HEIGHT,
@@ -402,6 +404,25 @@ function Sidekick({
     textareaFocused,
   ]);
 
+  const [filteredRowCount, setFilteredRowCount] = useState<number | null>(null);
+  const handleFilteredCountChange = useCallback((count: number) => {
+    setFilteredRowCount(count);
+  }, []);
+
+  const dataStatusBar = useMemo(() => {
+    if (!columns.length) return null;
+    const totalRows = rows.length;
+    const totalCols = columns.length;
+    const label = (filteredRowCount !== null && filteredRowCount !== totalRows)
+      ? `${filteredRowCount} of ${pluralize('row', totalRows)} × ${pluralize('column', totalCols)}`
+      : `${pluralize('row', totalRows)} x ${pluralize('column', totalCols)}`;
+    return (
+      <Spacing pb={1} px={PADDING_UNITS}>
+        <Text monospace muted small>{label}</Text>
+      </Spacing>
+    );
+  }, [columns.length, filteredRowCount, rows.length]);
+
   const dataMemo = useMemo(() => columns.length > 0 && (
     <DataTable
       columnHeaderHeight={
@@ -412,11 +433,13 @@ function Sidekick({
         : TABLE_COLUMN_HEADER_HEIGHT
       }
       columns={columns}
-      height={heightWindow - heightOffset - ASIDE_SUBHEADER_HEIGHT}
+      filterable
+      height={heightWindow - heightOffset - ASIDE_SUBHEADER_HEIGHT - (UNIT * 2 + REGULAR_LINE_HEIGHT)}
       noBorderBottom
       noBorderLeft
       noBorderRight
       noBorderTop
+      onFilteredCountChange={handleFilteredCountChange}
       renderColumnHeader={renderColumnHeader}
       rows={rows}
       width={afterWidth}
@@ -425,6 +448,7 @@ function Sidekick({
     afterWidth,
     columnTypes,
     columns,
+    handleFilteredCountChange,
     heightOffset,
     heightWindow,
     insightsByFeatureUUID,
@@ -660,6 +684,7 @@ function Sidekick({
         }
 
         {activeView === ViewKeyEnum.DATA && dataMemo}
+        {activeView === ViewKeyEnum.DATA && dataStatusBar}
 
         {ViewKeyEnum.SECRETS === activeView && secretsMemo}
 

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -405,9 +405,6 @@ function Sidekick({
   ]);
 
   const [filteredRowCount, setFilteredRowCount] = useState<number | null>(null);
-  const handleFilteredCountChange = useCallback((count: number) => {
-    setFilteredRowCount(count);
-  }, []);
 
   const dataStatusBar = useMemo(() => {
     if (!columns.length) return null;
@@ -434,12 +431,12 @@ function Sidekick({
       }
       columns={columns}
       filterable
-      height={heightWindow - heightOffset - ASIDE_SUBHEADER_HEIGHT - (UNIT * 2 + REGULAR_LINE_HEIGHT)}
+      height={heightWindow - heightOffset - ASIDE_SUBHEADER_HEIGHT - (UNIT * 7 + REGULAR_LINE_HEIGHT)}
       noBorderBottom
       noBorderLeft
       noBorderRight
       noBorderTop
-      onFilteredCountChange={handleFilteredCountChange}
+      onFilteredCountChange={setFilteredRowCount}
       renderColumnHeader={renderColumnHeader}
       rows={rows}
       width={afterWidth}
@@ -448,13 +445,13 @@ function Sidekick({
     afterWidth,
     columnTypes,
     columns,
-    handleFilteredCountChange,
     heightOffset,
     heightWindow,
     insightsByFeatureUUID,
     insightsOverview,
     renderColumnHeader,
     rows,
+    setFilteredRowCount,
   ]);
 
   const chartsMemo = useMemo(() => widgets.length > 0 && (

--- a/mage_ai/frontend/components/constants.ts
+++ b/mage_ai/frontend/components/constants.ts
@@ -15,6 +15,8 @@ import {
 import { ColumnTypeEnum } from '@interfaces/FeatureType';
 import { UNIT } from '@oracle/styles/units/spacing';
 
+export const DEBOUNCE_MS = 200;
+
 export const HEADER_HEIGHT_UNITS = 7;
 export const HEADER_HEIGHT = UNIT * HEADER_HEIGHT_UNITS;
 export const HEADER_Z_INDEX = 22;

--- a/mage_ai/frontend/tests/dataTable/columnFilter.spec.ts
+++ b/mage_ai/frontend/tests/dataTable/columnFilter.spec.ts
@@ -1,4 +1,3 @@
-import { DEBOUNCE_MS } from '@components/constants';
 import { expect, test } from '../base';
 
 const PIPELINE_URL = '/pipelines/example_pipeline/edit';
@@ -15,10 +14,9 @@ test('filters data table rows by column value', async ({ page }) => {
 
   // 2. User types a value — matching rows shown, non-matching hidden.
   await nameFilter.fill('Braund, Mr. Owen Harris');
-  await page.waitForTimeout(DEBOUNCE_MS + 150);
 
-  // 3. Row count updates.
-  await expect(page.getByText('1 of 891 rows × 12 columns').first()).toBeVisible();
+  // 3. Row count updates — Playwright retries until debounce fires and UI settles.
+  await expect(page.getByText('1 of 891 rows × 12 columns').first()).toBeVisible({ timeout: 5_000 });
 
   // 4. User clears filters — full dataset restored.
   await page.getByText('✕ Clear filters').first().click();

--- a/mage_ai/frontend/tests/dataTable/columnFilter.spec.ts
+++ b/mage_ai/frontend/tests/dataTable/columnFilter.spec.ts
@@ -6,7 +6,10 @@ const PIPELINE_URL = '/pipelines/example_pipeline/edit';
 test('filters data table rows by column value', async ({ page }) => {
   await page.goto(PIPELINE_URL);
 
-  // 1. Filter inputs are visible below column headers.
+  // Run the first block to generate the data table output.
+  await page.getByLabel('Run block').first().click();
+
+  // 1. Filter inputs are visible below column headers (waits for block to finish).
   const nameFilter = page.getByLabel('Filter Name column').first();
   await expect(nameFilter).toBeVisible({ timeout: 30_000 });
 

--- a/mage_ai/frontend/tests/dataTable/columnFilter.spec.ts
+++ b/mage_ai/frontend/tests/dataTable/columnFilter.spec.ts
@@ -14,7 +14,7 @@ test('filters data table rows by column value', async ({ page }) => {
   await expect(nameFilter).toBeVisible({ timeout: 30_000 });
 
   // 2. User types a value — matching rows shown, non-matching hidden.
-  await nameFilter.fill('Owen');
+  await nameFilter.fill('Braund, Mr. Owen Harris');
   await page.waitForTimeout(DEBOUNCE_MS + 150);
 
   // 3. Row count updates.

--- a/mage_ai/frontend/tests/dataTable/columnFilter.spec.ts
+++ b/mage_ai/frontend/tests/dataTable/columnFilter.spec.ts
@@ -1,0 +1,23 @@
+import { DEBOUNCE_MS } from '@components/constants';
+import { expect, test } from '../base';
+
+const PIPELINE_URL = '/pipelines/example_pipeline/edit';
+
+test('filters data table rows by column value', async ({ page }) => {
+  await page.goto(PIPELINE_URL);
+
+  // 1. Filter inputs are visible below column headers.
+  const nameFilter = page.getByLabel('Filter Name column').first();
+  await expect(nameFilter).toBeVisible({ timeout: 30_000 });
+
+  // 2. User types a value — matching rows shown, non-matching hidden.
+  await nameFilter.fill('Owen');
+  await page.waitForTimeout(DEBOUNCE_MS + 150);
+
+  // 3. Row count updates.
+  await expect(page.getByText('1 of 891 rows × 12 columns').first()).toBeVisible();
+
+  // 4. User clears filters — full dataset restored.
+  await page.getByText('✕ Clear filters').first().click();
+  await expect(page.getByText('891 rows x 12 columns').first()).toBeVisible();
+});

--- a/mage_ai/frontend/utils/table/filterExpression.ts
+++ b/mage_ai/frontend/utils/table/filterExpression.ts
@@ -85,7 +85,8 @@ function applyStringFilter(
 
   // None-check mode (all dtypes)
   if (value.toLowerCase() === 'none') {
-    const isNone = cell == null || cellStr.trim() === '';
+    // Also treat the string "null" as None — the table renderer displays it as "None".
+    const isNone = cell == null || cellStr.trim() === '' || cellStr.toLowerCase() === 'null';
     if (operator === '!=') {
       return { match: !isNone };
     }

--- a/mage_ai/frontend/utils/table/filterExpression.ts
+++ b/mage_ai/frontend/utils/table/filterExpression.ts
@@ -1,0 +1,273 @@
+export type ColumnDtype = 'string' | 'numeric' | 'datetime' | 'unknown';
+
+export type FilterResult = {
+  hint?: string;
+  match: boolean;
+};
+
+/**
+ * Word-alias → canonical operator map.
+ * Exact set — no additions, no omissions.
+ */
+export const OPERATOR_ALIASES: { [alias: string]: string } = {
+  eq: '=',
+  ge: '>=',
+  gt: '>',
+  le: '<=',
+  lt: '<',
+  ne: '!=',
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+interface ParsedExpression {
+  operator: string;
+  value: string;
+}
+
+/**
+ * Resolve the operator and operand value from a raw expression string.
+ *
+ * Parsing order:
+ *   1. Word aliases (whole-word match at start of string, e.g. "gt 500")
+ *   2. Word operators: "contains", "datestartswith"
+ *   3. Symbol operators, longest-first to avoid partial matches
+ *      (>= <= != before > < =)
+ *   4. No recognisable operator → operator is '' (caller uses dtype default)
+ */
+function parseExpression(expression: string): ParsedExpression {
+  const trimmed = expression.trim();
+
+  // 1. Word aliases — must be followed by whitespace (whole-word boundary)
+  for (const [alias, canonical] of Object.entries(OPERATOR_ALIASES)) {
+    const re = new RegExp(`^${alias}(?:\\s+|$)`, 'i');
+    if (re.test(trimmed)) {
+      return { operator: canonical, value: trimmed.slice(alias.length).trim() };
+    }
+  }
+
+  // 2. Word operators
+  const wordOps = ['datestartswith', 'contains'];
+  for (const op of wordOps) {
+    const re = new RegExp(`^${op}(?:\\s+|$)`, 'i');
+    if (re.test(trimmed)) {
+      return { operator: op.toLowerCase(), value: trimmed.slice(op.length).trim() };
+    }
+  }
+
+  // 3. Symbol operators — longest first to prevent partial matches
+  const symbolOps = ['>=', '<=', '!=', '>', '<', '='];
+  for (const op of symbolOps) {
+    if (trimmed.startsWith(op)) {
+      return { operator: op, value: trimmed.slice(op.length).trim() };
+    }
+  }
+
+  // 4. No operator recognised — plain value, caller applies dtype default
+  return { operator: '', value: trimmed };
+}
+
+// ---------------------------------------------------------------------------
+// Per-dtype filter applicators
+// ---------------------------------------------------------------------------
+
+function applyStringFilter(
+  cell: string | number | null | undefined,
+  operator: string,
+  value: string,
+): FilterResult {
+  // Case-insensitive by design: prioritises exploration UX over strict Dash convention parity.
+  // Dash DataTable uses case-sensitive contains/= for string columns; we do not.
+
+  const cellStr = cell == null ? '' : String(cell);
+
+  // None-check mode (all dtypes)
+  if (value.toLowerCase() === 'none') {
+    const isNone = cell == null || cellStr.trim() === '';
+    if (operator === '!=') {
+      return { match: !isNone };
+    }
+    return { match: isNone };
+  }
+
+  const cellLower = cellStr.toLowerCase();
+  const valueLower = value.toLowerCase();
+
+  switch (operator) {
+    case 'contains':
+      return { match: cellLower.includes(valueLower) };
+    case '=':
+      return { match: cellLower === valueLower };
+    case '!=':
+      return { match: cellLower !== valueLower };
+    case '>':
+      return { match: cellLower > valueLower };
+    case '>=':
+      return { match: cellLower >= valueLower };
+    case '<':
+      return { match: cellLower < valueLower };
+    case '<=':
+      return { match: cellLower <= valueLower };
+    default:
+      return { hint: 'Unknown operator. Try: contains, =, >=', match: true };
+  }
+}
+
+function applyNumericFilter(
+  cell: string | number | null | undefined,
+  operator: string,
+  value: string,
+): FilterResult {
+  // None-check mode
+  if (value.toLowerCase() === 'none') {
+    const cellNum = Number(cell);
+    const isNone = cell == null || isNaN(cellNum);
+    if (operator === '!=') {
+      return { match: !isNone };
+    }
+    return { match: isNone };
+  }
+
+  // Disallow text-only operators that make no sense for numeric columns
+  if (operator === 'contains' || operator === 'datestartswith') {
+    return { hint: 'Invalid for numeric column. Try: > 1000', match: true };
+  }
+
+  // Validate that the expression value is actually numeric
+  const numValue = Number(value);
+  if (value === '' || isNaN(numValue)) {
+    if (value === '') {
+      return { hint: 'Incomplete expression. Try: > 0', match: true };
+    }
+    return { hint: 'Invalid for numeric column. Try: > 1000', match: true };
+  }
+
+  const cellNum = Number(cell);
+
+  switch (operator) {
+    case '=':
+      return { match: cellNum === numValue };
+    case '!=':
+      return { match: cellNum !== numValue };
+    case '>':
+      return { match: cellNum > numValue };
+    case '>=':
+      return { match: cellNum >= numValue };
+    case '<':
+      return { match: cellNum < numValue };
+    case '<=':
+      return { match: cellNum <= numValue };
+    default:
+      return { hint: 'Unknown operator. Try: contains, =, >=', match: true };
+  }
+}
+
+function applyDatetimeFilter(
+  cell: string | number | null | undefined,
+  operator: string,
+  value: string,
+): FilterResult {
+  // None-check mode
+  if (value.toLowerCase() === 'none') {
+    const isNone = cell == null || isNaN(new Date(String(cell)).getTime());
+    if (operator === '!=') {
+      return { match: !isNone };
+    }
+    return { match: isNone };
+  }
+
+  switch (operator) {
+    case 'datestartswith':
+      return { match: String(cell).startsWith(value) };
+
+    case 'contains':
+      // Delegate to string contains — not an error for datetime columns
+      return { match: String(cell).toLowerCase().includes(value.toLowerCase()) };
+
+    case '=':
+    case '!=':
+    case '>':
+    case '>=':
+    case '<':
+    case '<=': {
+      const cellDate = new Date(String(cell));
+      const valueDate = new Date(value);
+      if (isNaN(cellDate.getTime()) || isNaN(valueDate.getTime())) {
+        return { hint: 'Invalid date. Try: datestartswith 2023', match: true };
+      }
+      const cellMs = cellDate.getTime();
+      const valueMs = valueDate.getTime();
+      switch (operator) {
+        case '=':
+          return { match: cellMs === valueMs };
+        case '!=':
+          return { match: cellMs !== valueMs };
+        case '>':
+          return { match: cellMs > valueMs };
+        case '>=':
+          return { match: cellMs >= valueMs };
+        case '<':
+          return { match: cellMs < valueMs };
+        case '<=':
+          return { match: cellMs <= valueMs };
+        default:
+          return { match: true };
+      }
+    }
+
+    default:
+      return { hint: 'Unknown operator. Try: contains, =, >=', match: true };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a filter expression string and test it against a single cell value.
+ *
+ * Never throws — every code path returns a FilterResult.
+ * Invalid expressions return { match: true, hint: '...' } so the table stays
+ * in its pre-filter state rather than silently removing rows.
+ *
+ * @param cellValue  The value from the table cell (may be null/undefined).
+ * @param expression The raw expression typed by the user.
+ * @param dtype      The inferred column data type.
+ */
+export function parseAndApplyFilter(
+  cellValue: string | number | null | undefined,
+  expression: string,
+  dtype: ColumnDtype,
+): FilterResult {
+  // Empty / whitespace-only expression → no filter applied
+  if (expression.trim() === '') {
+    return { match: true };
+  }
+
+  const { operator, value } = parseExpression(expression);
+
+  switch (dtype) {
+    case 'numeric': {
+      // Default operator for numeric columns is '='
+      const resolvedOp = operator === '' ? '=' : operator;
+      return applyNumericFilter(cellValue, resolvedOp, value);
+    }
+
+    case 'datetime': {
+      // Default operator for datetime columns is 'datestartswith'
+      const resolvedOp = operator === '' ? 'datestartswith' : operator;
+      return applyDatetimeFilter(cellValue, resolvedOp, value);
+    }
+
+    case 'string':
+    case 'unknown':
+    default: {
+      // Default operator for string (and unknown) columns is 'contains'
+      const resolvedOp = operator === '' ? 'contains' : operator;
+      return applyStringFilter(cellValue, resolvedOp, value);
+    }
+  }
+}

--- a/mage_ai/frontend/utils/table/filterExpression.ts
+++ b/mage_ai/frontend/utils/table/filterExpression.ts
@@ -9,7 +9,7 @@ export type FilterResult = {
  * Word-alias → canonical operator map.
  * Exact set — no additions, no omissions.
  */
-export const OPERATOR_ALIASES: { [alias: string]: string } = {
+const OPERATOR_ALIASES: { [alias: string]: string } = {
   eq: '=',
   ge: '>=',
   gt: '>',
@@ -103,7 +103,7 @@ function applyStringFilter(
       return { match: cellLower === valueLower };
     case '!=':
       return { match: cellLower !== valueLower };
-    case '>':
+    case '>': // Note: > and < do lexicographic string comparison, not numeric
       return { match: cellLower > valueLower };
     case '>=':
       return { match: cellLower >= valueLower };
@@ -213,8 +213,6 @@ function applyDatetimeFilter(
           return { match: cellMs < valueMs };
         case '<=':
           return { match: cellMs <= valueMs };
-        default:
-          return { match: true };
       }
     }
 

--- a/mage_ai/frontend/utils/table/filterExpression.ts
+++ b/mage_ai/frontend/utils/table/filterExpression.ts
@@ -161,7 +161,7 @@ function applyNumericFilter(
     case '<=':
       return { match: cellNum <= numValue };
     default:
-      return { hint: 'Unknown operator. Try: contains, =, >=', match: true };
+      return { hint: 'Unknown operator. Try one of: =, !=, >, >=, <, <=', match: true };
   }
 }
 

--- a/mage_ai/frontend/utils/table/inferColumnDtype.ts
+++ b/mage_ai/frontend/utils/table/inferColumnDtype.ts
@@ -11,7 +11,7 @@ import { ColumnDtype } from './filterExpression';
  * runs first in the detection priority — so ["2023","2022"] → 'numeric', not 'datetime'.
  * This is intentional: numeric detection takes precedence over datetime detection for 4-digit year strings.
  */
-const ISO_DATE_RE = /^\d{4}(-\d{2}(-\d{2}(T[\d:.Z+-]+)?)?)?$/;
+const ISO_DATE_RE = /^\d{4}(-\d{2}(-\d{2}([T ][\d:.Z+-]+)?)?)?$/;
 
 /**
  * Infer the data type of a column from a sample of its values.

--- a/mage_ai/frontend/utils/table/inferColumnDtype.ts
+++ b/mage_ai/frontend/utils/table/inferColumnDtype.ts
@@ -22,7 +22,7 @@ const ISO_DATE_RE = /^\d{4}(-\d{2}(-\d{2}([T ][\d:.Z+-]+)?)?)?$/;
  *   3. Otherwise → 'string'
  *   4. No non-null samples at all → 'unknown'
  *
- * @param samples  Up to ~20 representative values from the column.
+ * @param samples  A representative sample of values (caller is responsible for limiting size).
  *                 Null / undefined entries are filtered out before analysis.
  */
 export function inferColumnDtype(

--- a/mage_ai/frontend/utils/table/inferColumnDtype.ts
+++ b/mage_ai/frontend/utils/table/inferColumnDtype.ts
@@ -9,7 +9,7 @@ import { ColumnDtype } from './filterExpression';
  *
  * Note: numeric years such as "2023" satisfy this regex, but the numeric check
  * runs first in the detection priority — so ["2023","2022"] → 'numeric', not 'datetime'.
- * This is intentional (see architecture Decision 4).
+ * This is intentional: numeric detection takes precedence over datetime detection for 4-digit year strings.
  */
 const ISO_DATE_RE = /^\d{4}(-\d{2}(-\d{2}(T[\d:.Z+-]+)?)?)?$/;
 

--- a/mage_ai/frontend/utils/table/inferColumnDtype.ts
+++ b/mage_ai/frontend/utils/table/inferColumnDtype.ts
@@ -1,0 +1,56 @@
+import { ColumnDtype } from './filterExpression';
+
+/**
+ * ISO-8601 prefix regex — matches:
+ *   YYYY
+ *   YYYY-MM
+ *   YYYY-MM-DD
+ *   YYYY-MM-DDTHH:MM... (any valid datetime suffix)
+ *
+ * Note: numeric years such as "2023" satisfy this regex, but the numeric check
+ * runs first in the detection priority — so ["2023","2022"] → 'numeric', not 'datetime'.
+ * This is intentional (see architecture Decision 4).
+ */
+const ISO_DATE_RE = /^\d{4}(-\d{2}(-\d{2}(T[\d:.Z+-]+)?)?)?$/;
+
+/**
+ * Infer the data type of a column from a sample of its values.
+ *
+ * Detection priority (first match wins):
+ *   1. All non-null samples parse as finite numbers → 'numeric'
+ *   2. All non-null samples match the ISO-8601 prefix AND produce a valid Date → 'datetime'
+ *   3. Otherwise → 'string'
+ *   4. No non-null samples at all → 'unknown'
+ *
+ * @param samples  Up to ~20 representative values from the column.
+ *                 Null / undefined entries are filtered out before analysis.
+ */
+export function inferColumnDtype(
+  samples: (string | number | null | undefined)[],
+): ColumnDtype {
+  const nonNull = samples.filter(
+    (v): v is string | number => v !== null && v !== undefined,
+  );
+
+  if (nonNull.length === 0) {
+    return 'unknown';
+  }
+
+  // 1. Numeric check
+  if (nonNull.every(v => String(v).trim() !== '' && isFinite(Number(v)))) {
+    return 'numeric';
+  }
+
+  // 2. Datetime check — ISO prefix regex AND valid Date construction
+  if (
+    nonNull.every(v => {
+      const s = String(v);
+      return ISO_DATE_RE.test(s) && !isNaN(new Date(s).getTime());
+    })
+  ) {
+    return 'datetime';
+  }
+
+  // 3. Fall through → string
+  return 'string';
+}


### PR DESCRIPTION
## Use Case

This PR adds an interactive, client-side column filter directly to the Data widget so users can explore subsets of their data instantly without writing code or hitting the backend.

Closes #4143

## Description

Adds interactive column filtering to the `DataTable` component (used in the inline Block Output and the expanded Sidekick panel). 

<img width="1236" height="677" alt="Screenshot 2026-03-19 at 2 11 32 PM" src="https://github.com/user-attachments/assets/31f98df4-784c-4f4e-a818-50a6d1c2a972" />
<img width="1421" height="482" alt="Screenshot 2026-03-19 at 2 14 48 PM" src="https://github.com/user-attachments/assets/cbafa632-8c6d-4df8-b73f-2993e06bc508" />

**Key Technical & Product Notes:**
- **Performance:** Block outputs are hard-capped at 1,000 rows (`DATAFRAME_SAMPLE_COUNT`), so filtering is handled synchronously on the main thread with a 200ms debounce.
- **Exploration UX:** All string comparisons (including `>`, `<`, `=`) are intentionally case-insensitive to make searching easier.
- **State Management:** `filterErrors` is computed as a derived value within a single pure `useMemo` alongside `filteredRows` to avoid React `setState` render loops.

## The changes include

- client-side type inference (numeric, datetime, string) sampling the first 20 rows
- type-aware operators matching Dash syntax (`>`, `<=`, `contains`, `datestartswith`, `= None`, etc.)
- visual error validation (red borders) for invalid filter expressions
- dynamic row count indicator (`filtered of total rows × total columns`) 
- `filterable` prop to enable the filter row on both inline block outputs and Sidekick

## Also the following things have been changed

- **Header vs. Body Alignment:** There is a pre-existing layout bug in the inline Block Output where column headers misalign with data cells on wide tables. The new filter row successfully aligns with the headers, but fixing the underlying header-body mismatch was left out of scope to avoid a risky layout refactor.

## How Has This Been Tested?

- [x] Tested manually in the browser (both inline 10-row limit and Sidekick 1,000-row surfaces).
- [x] Added 1 Playwright E2E test (`columnFilter.spec.ts`) covering the core happy path.
- **Note on Unit Tests:** The expression parser (`filterExpression.ts`) is a pure function. Since no frontend unit testing infra (Jest/Vitest) exists in the project yet, it was verified via local Node.js smoke tests instead.

## Checklist

- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
[wangxiaoyou1993](https://github.com/wangxiaoyou1993)
