### PR TITLE
Add datetime filter for pipeline runs

### DIFF
--- a/mage_ai/api/resources/PipelineRunResource.py
+++ b/mage_ai/api/resources/PipelineRunResource.py
@@ -168,9 +168,9 @@ class PipelineRunResource(DatabaseResource):
         if statuses:
             results = results.filter(PipelineRun.status.in_(statuses))
         if start_timestamp is not None:
-            results = results.filter(PipelineRun.created_at >= start_timestamp)
+            results = results.filter(PipelineRun.started_at >= start_timestamp)
         if end_timestamp is not None:
-            results = results.filter(PipelineRun.created_at <= end_timestamp)
+            results = results.filter(PipelineRun.started_at <= end_timestamp)
 
         limit = int((meta or {}).get(META_KEY_LIMIT, self.DEFAULT_LIMIT))
 

--- a/mage_ai/api/utils.py
+++ b/mage_ai/api/utils.py
@@ -142,13 +142,13 @@ def get_query_timestamps(query_arg) -> Tuple[datetime, datetime]:
     error = ApiError.RESOURCE_INVALID.copy()
     if start_timestamp:
         try:
-            start_timestamp = datetime.utcfromtimestamp(int(start_timestamp))
+            start_timestamp = datetime.utcfromtimestamp(int(start_timestamp)).replace(tzinfo=None)
         except (ValueError, OverflowError):
             error.update(message='Value is invalid for start_timestamp.')
             raise ApiError(error)
     if end_timestamp:
         try:
-            end_timestamp = datetime.utcfromtimestamp(int(end_timestamp))
+            end_timestamp = datetime.utcfromtimestamp(int(end_timestamp)).replace(tzinfo=None)
         except (ValueError, OverflowError):
             error.update(message='Value is invalid for end_timestamp.')
             raise ApiError(error)

--- a/mage_ai/api/utils.py
+++ b/mage_ai/api/utils.py
@@ -142,15 +142,19 @@ def get_query_timestamps(query_arg) -> Tuple[datetime, datetime]:
     error = ApiError.RESOURCE_INVALID.copy()
     if start_timestamp:
         try:
-            start_timestamp = datetime.fromtimestamp(int(start_timestamp))
+            start_timestamp = datetime.utcfromtimestamp(int(start_timestamp))
         except (ValueError, OverflowError):
             error.update(message='Value is invalid for start_timestamp.')
             raise ApiError(error)
     if end_timestamp:
         try:
-            end_timestamp = datetime.fromtimestamp(int(end_timestamp))
+            end_timestamp = datetime.utcfromtimestamp(int(end_timestamp))
         except (ValueError, OverflowError):
             error.update(message='Value is invalid for end_timestamp.')
             raise ApiError(error)
+
+    if start_timestamp and end_timestamp and start_timestamp > end_timestamp:
+        error.update(message='start_timestamp must be earlier than end_timestamp.')
+        raise ApiError(error)
 
     return start_timestamp, end_timestamp

--- a/mage_ai/api/utils.py
+++ b/mage_ai/api/utils.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from mage_ai.api.errors import ApiError
 from mage_ai.orchestration.constants import Entity
@@ -131,7 +131,7 @@ def parse_cookie_header(cookies_raw):
     return cookies
 
 
-def get_query_timestamps(query_arg) -> Tuple[datetime, datetime]:
+def get_query_timestamps(query_arg) -> Tuple[Optional[datetime], Optional[datetime]]:
     start_timestamp = query_arg.get('start_timestamp', [None])
     if start_timestamp:
         start_timestamp = start_timestamp[0]

--- a/mage_ai/frontend/components/shared/Table/Toolbar/constants.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/constants.tsx
@@ -1,8 +1,11 @@
+import { TimeType } from '@oracle/components/Calendar';
 import { BORDER_RADIUS } from '@oracle/styles/units/borders';
 import { Search } from '@oracle/icons';
 import { UNIT } from '@oracle/styles/units/spacing';
 
 export const BUTTON_PADDING = `${UNIT * 1.5}px`;
+export const DATE_RANGE_BUTTON_VERTICAL_PADDING = 9;
+export const DEFAULT_TIME: TimeType = { hour: '00', minute: '00' };
 export const POPUP_MENU_WIDTH = UNIT * 40;
 export const POPUP_TOP_OFFSET = 58;
 

--- a/mage_ai/frontend/components/shared/Table/Toolbar/index.style.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/index.style.tsx
@@ -1,0 +1,134 @@
+import styled from 'styled-components';
+
+import dark from '@oracle/styles/themes/dark';
+import { BORDER_RADIUS, BORDER_STYLE, BORDER_WIDTH } from '@oracle/styles/units/borders';
+import { PADDING, UNIT } from '@oracle/styles/units/spacing';
+
+export const DateRangeContainerStyle = styled.div`
+  border-radius: ${BORDER_RADIUS}px;
+  border-style: ${BORDER_STYLE};
+  border-width: ${BORDER_WIDTH}px;
+  display: flex;
+  flex-direction: column;
+  gap: ${UNIT * 1.5}px;
+  margin-top: ${UNIT / 2}px;
+  padding: ${PADDING}px;
+  width: ${UNIT * 44}px;
+
+  ${props => `
+    background: ${(props.theme?.background || dark.background).popup};
+    border-color: ${(props.theme?.interactive || dark.interactive).defaultBorder};
+    box-shadow: ${(props.theme?.shadow || dark.shadow).popup};
+  `}
+
+  /* Uniform tile height so the Start/End labels don't push individual rows taller */
+  .react-calendar__month-view__days__day {
+    height: 52px;
+    position: relative;
+  }
+
+  /* Date range highlighting */
+  .react-calendar__tile.dr-between {
+    background: rgba(72, 119, 255, 0.12);
+    border-radius: 0;
+  }
+
+  .react-calendar__tile.dr-start:not(.dr-single)::before,
+  .react-calendar__tile.dr-end:not(.dr-single)::before {
+    bottom: 0;
+    content: '';
+    position: absolute;
+    top: 0;
+    background: rgba(72, 119, 255, 0.12);
+  }
+
+  .react-calendar__tile.dr-start:not(.dr-single)::before {
+    left: 50%;
+    right: 0;
+  }
+
+  .react-calendar__tile.dr-end:not(.dr-single)::before {
+    left: 0;
+    right: 50%;
+  }
+
+  .react-calendar__tile.dr-start abbr,
+  .react-calendar__tile.dr-end abbr {
+    align-items: center;
+    background: #4877FF;
+    border-radius: 50%;
+    color: #fff !important;
+    display: flex;
+    height: 32px;
+    justify-content: center;
+    margin: 0 auto;
+    position: relative;
+    width: 32px;
+    z-index: 1;
+  }
+
+  /* Override react-calendar default active/hover on range tiles */
+  .react-calendar__tile.dr-start:enabled:hover,
+  .react-calendar__tile.dr-start:enabled:focus,
+  .react-calendar__tile.dr-end:enabled:hover,
+  .react-calendar__tile.dr-end:enabled:focus,
+  .react-calendar__tile.dr-between:enabled:hover,
+  .react-calendar__tile.dr-between:enabled:focus {
+    background: rgba(72, 119, 255, 0.12);
+  }
+
+  .react-calendar__tile.dr-start:enabled:hover abbr,
+  .react-calendar__tile.dr-start:enabled:focus abbr,
+  .react-calendar__tile.dr-end:enabled:hover abbr,
+  .react-calendar__tile.dr-end:enabled:focus abbr {
+    background: #5982ff;
+  }
+
+  /* Date range labels — absolutely positioned so they never affect tile height */
+  .dr-label {
+    bottom: 1px;
+    color: #86E2FF;
+    font-size: 8px;
+    font-weight: 700;
+    left: 0;
+    letter-spacing: 0.02em;
+    line-height: 1;
+    position: absolute;
+    right: 0;
+    text-align: center;
+    text-transform: uppercase;
+    z-index: 1;
+  }
+`;
+
+export const DateRangeFieldsStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${UNIT / 2}px;
+`;
+
+export const DateRangeFieldRowStyle = styled.div<{ active?: boolean }>`
+  align-items: center;
+  border-radius: ${BORDER_RADIUS}px;
+  border-style: ${BORDER_STYLE};
+  border-width: ${BORDER_WIDTH}px;
+  cursor: pointer;
+  display: flex;
+  gap: ${UNIT}px;
+  padding: ${UNIT * 0.75}px ${UNIT * 1.5}px;
+
+  ${props => `
+    background: ${props.active
+      ? (props.theme?.interactive || dark.interactive).defaultBackground
+      : 'transparent'};
+    border-color: ${props.active
+      ? (props.theme?.interactive || dark.interactive).focusBorder
+      : (props.theme?.interactive || dark.interactive).defaultBorder};
+  `}
+
+  &:hover {
+    ${props => !props.active && `
+      border-color: ${(props.theme?.interactive || dark.interactive).hoverBorder};
+    `}
+  }
+`;

--- a/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
@@ -76,7 +76,7 @@ function DateRangePicker({ endTimestamp, onApply, onOpenChange, startTimestamp }
     if (!open) return;
 
     setActiveField('start');
-    if (startTimestamp) {
+    if (startTimestamp !== null && startTimestamp !== undefined) {
       const { date, time } = fromUnixTimestamp(startTimestamp);
       setStartDate(date);
       setStartTime(time);
@@ -84,7 +84,7 @@ function DateRangePicker({ endTimestamp, onApply, onOpenChange, startTimestamp }
       setStartDate(null);
       setStartTime(DEFAULT_TIME);
     }
-    if (endTimestamp) {
+    if (endTimestamp !== null && endTimestamp !== undefined) {
       const { date, time } = fromUnixTimestamp(endTimestamp);
       setEndDate(date);
       setEndTime(time);
@@ -105,19 +105,25 @@ function DateRangePicker({ endTimestamp, onApply, onOpenChange, startTimestamp }
   }, [activeField]);
 
   const handleApply = useCallback(() => {
-    let startTs: number;
-    let endTs: number;
+    let startTs: number | null = null;
+    let endTs: number | null = null;
 
-    if (!startDate || !endDate) {
+    if (!startDate && !endDate) {
       const now = new Date();
       const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
       startTs = Math.floor(todayStart.getTime() / 1000);
       endTs = Math.floor(now.getTime() / 1000);
-    } else {
+    } else if (startDate && endDate) {
       const s = toUnixTimestamp(startDate, startTime);
       const e = toUnixTimestamp(endDate, endTime);
       startTs = Math.min(s, e);
       endTs = Math.max(s, e);
+    } else if (startDate && !endDate) {
+      startTs = toUnixTimestamp(startDate, startTime);
+      endTs = null;
+    } else if (!startDate && endDate) {
+      startTs = null;
+      endTs = toUnixTimestamp(endDate, endTime);
     }
 
     onApply(startTs, endTs);
@@ -171,7 +177,7 @@ function DateRangePicker({ endTimestamp, onApply, onOpenChange, startTimestamp }
     <div style={{ display: 'inline-block', position: 'relative' }}>
       <KeyboardShortcutButton
         {...SHARED_BUTTON_PROPS}
-        afterElement={startTimestamp || endTimestamp
+        afterElement={startTimestamp != null || endTimestamp != null
           ? <Badge cyan noVerticalPadding><Text bold inverted>1</Text></Badge>
           : null
         }

--- a/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
@@ -1,8 +1,12 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 
 import AddButton from '@components/shared/AddButton';
 import Badge from '@oracle/components/Badge';
+import ReactCalendar from 'react-calendar';
+import Select from '@oracle/elements/Inputs/Select';
+import { TimeType } from '@oracle/components/Calendar';
+import { rangeSequential } from '@utils/array';
 import ClickOutside from '@oracle/components/ClickOutside';
 import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
@@ -17,18 +21,260 @@ import Tooltip from '@oracle/components/Tooltip';
 import {
   BUTTON_PADDING,
   ConfirmDialogueOpenEnum,
+  DATE_RANGE_BUTTON_VERTICAL_PADDING,
+  DEFAULT_TIME,
   POPUP_MENU_WIDTH,
   POPUP_TOP_OFFSET,
   SEARCH_INPUT_PROPS,
   SHARED_TOOLTIP_PROPS,
 } from './constants';
-import { Close, Ellipsis, Filter, Group, Trash } from '@oracle/icons';
+import { fromUnixTimestamp, toUnixTimestamp } from '@utils/date';
+import { CalendarDate, Close, Ellipsis, Filter, Group, Trash } from '@oracle/icons';
 import { FlyoutMenuItemType } from '@oracle/components/FlyoutMenu';
 import { SHARED_BUTTON_PROPS } from '@components/shared/AddButton';
 import { UNIT } from '@oracle/styles/units/spacing';
+import {
+  DateRangeContainerStyle,
+  DateRangeFieldRowStyle,
+  DateRangeFieldsStyle,
+} from './index.style';
 import { VerticalDividerStyle } from '@oracle/elements/Divider/index.style';
 import { getNestedTruthyValuesCount } from '@utils/hash';
 import { isViewer } from '@utils/session';
+
+export type DateRangePickerProps = {
+  endTimestamp?: number;
+  onApply: (startTimestamp: number | null, endTimestamp: number | null) => void;
+  onOpenChange?: (open: boolean) => void;
+  startTimestamp?: number;
+};
+
+type ActiveFieldType = 'start' | 'end';
+
+function formatDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function DateRangePicker({ endTimestamp, onApply, onOpenChange, startTimestamp }: DateRangePickerProps) {
+  const [open, setOpen] = useState<boolean>(false);
+
+  const setOpenWithCallback = useCallback((value: boolean) => {
+    setOpen(value);
+    onOpenChange?.(value);
+  }, [onOpenChange]);
+  const [activeField, setActiveField] = useState<ActiveFieldType>('start');
+  const [startDate, setStartDate] = useState<Date | null>(null);
+  const [startTime, setStartTime] = useState<TimeType>(DEFAULT_TIME);
+  const [endDate, setEndDate] = useState<Date | null>(null);
+  const [endTime, setEndTime] = useState<TimeType>(DEFAULT_TIME);
+
+  useEffect(() => {
+    if (!open) return;
+
+    setActiveField('start');
+    if (startTimestamp) {
+      const { date, time } = fromUnixTimestamp(startTimestamp);
+      setStartDate(date);
+      setStartTime(time);
+    } else {
+      setStartDate(null);
+      setStartTime(DEFAULT_TIME);
+    }
+    if (endTimestamp) {
+      const { date, time } = fromUnixTimestamp(endTimestamp);
+      setEndDate(date);
+      setEndTime(time);
+    } else {
+      setEndDate(null);
+      setEndTime(DEFAULT_TIME);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, startTimestamp, endTimestamp]);
+
+  const handleCalendarChange = useCallback((date: Date) => {
+    if (activeField === 'start') {
+      setStartDate(date);
+      setActiveField('end');
+    } else {
+      setEndDate(date);
+    }
+  }, [activeField]);
+
+  const handleApply = useCallback(() => {
+    if (!startDate || !endDate) {
+      onApply(null, null);
+    } else {
+      const startTs = toUnixTimestamp(startDate, startTime);
+      const endTs = toUnixTimestamp(endDate, endTime);
+      onApply(Math.min(startTs, endTs), Math.max(startTs, endTs));
+    }
+    setOpenWithCallback(false);
+  }, [endDate, endTime, onApply, setOpenWithCallback, startDate, startTime]);
+
+  const handleClear = useCallback(() => {
+    setStartDate(null);
+    setStartTime(DEFAULT_TIME);
+    setEndDate(null);
+    setEndTime(DEFAULT_TIME);
+    setActiveField('start');
+  }, []);
+
+  const tileClassName = useCallback(({ date, view }: { date: Date; view: string }) => {
+    if (view !== 'month' || !startDate || !endDate) return null;
+
+    const d = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+    const s = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate()).getTime();
+    const e = new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate()).getTime();
+    const [lo, hi] = s <= e ? [s, e] : [e, s];
+
+    const classes: string[] = [];
+    if (d === s) classes.push('dr-start');
+    if (d === e) classes.push('dr-end');
+    if (s === e && d === s) classes.push('dr-single');
+    if (d > lo && d < hi) classes.push('dr-between');
+
+    return classes.length ? classes.join(' ') : null;
+  }, [startDate, endDate]);
+
+  const tileContent = useCallback(({ date, view }: { date: Date; view: string }) => {
+    if (view !== 'month' || !startDate || !endDate) return null;
+
+    const d = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+    const s = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate()).getTime();
+    const e = new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate()).getTime();
+
+    if (s !== e) {
+      if (d === s) return <span className="dr-label">Start</span>;
+      if (d === e) return <span className="dr-label">End</span>;
+    }
+
+    return null;
+  }, [startDate, endDate]);
+
+  const calendarValue = (activeField === 'start' ? startDate : endDate) ?? new Date();
+
+  return (
+    <div style={{ display: 'inline-block', position: 'relative' }}>
+      <KeyboardShortcutButton
+        {...SHARED_BUTTON_PROPS}
+        afterElement={startTimestamp || endTimestamp
+          ? <Badge cyan noVerticalPadding><Text bold inverted>1</Text></Badge>
+          : null
+        }
+        beforeElement={<CalendarDate size={2 * UNIT} />}
+        onClick={() => setOpenWithCallback(!open)}
+        uuid="Table/Toolbar/DateRangeButton"
+      >
+        Date range
+      </KeyboardShortcutButton>
+
+      <ClickOutside
+        onClickOutside={() => setOpenWithCallback(false)}
+        open={open}
+        style={{ left: 0, position: 'absolute', top: '100%', zIndex: 10 }}
+      >
+        <DateRangeContainerStyle>
+          <ReactCalendar
+            onChange={handleCalendarChange}
+            tileClassName={tileClassName}
+            tileContent={tileContent}
+            value={calendarValue}
+          />
+
+          <DateRangeFieldsStyle>
+            {(['start', 'end'] as ActiveFieldType[]).map(field => {
+              const isActive = activeField === field;
+              const date = field === 'start' ? startDate : endDate;
+              const time = field === 'start' ? startTime : endTime;
+              const setTime = field === 'start' ? setStartTime : setEndTime;
+
+              return (
+                <DateRangeFieldRowStyle
+                  active={isActive}
+                  key={field}
+                  onClick={() => setActiveField(field)}
+                >
+                  <Text default small>
+                    {field === 'start' ? 'Start' : 'End'}
+                  </Text>
+                  <Flex flex={1}>
+                    <Text default muted={!date} small>{date ? formatDate(date) : 'No date selected'}</Text>
+                  </Flex>
+                  <Select
+                    compact
+                    monospace
+                    onChange={e => {
+                      e.preventDefault();
+                      setActiveField(field);
+                      setTime(prev => ({ ...prev, hour: e.target.value }));
+                    }}
+                    paddingRight={UNIT * 5}
+                    placeholder="HH"
+                    value={time.hour}
+                  >
+                    {rangeSequential(24, 0)
+                      .map(n => String(n).padStart(2, '0'))
+                      .map(h => <option key={h} value={h}>{h}</option>)
+                    }
+                  </Select>
+                  <Text bold default small>:</Text>
+                  <Select
+                    compact
+                    monospace
+                    onChange={e => {
+                      e.preventDefault();
+                      setActiveField(field);
+                      setTime(prev => ({ ...prev, minute: e.target.value }));
+                    }}
+                    paddingRight={UNIT * 5}
+                    placeholder="MM"
+                    value={time.minute}
+                  >
+                    {rangeSequential(60, 0)
+                      .map(n => String(n).padStart(2, '0'))
+                      .map(m => <option key={m} value={m}>{m}</option>)
+                    }
+                  </Select>
+                </DateRangeFieldRowStyle>
+              );
+            })}
+          </DateRangeFieldsStyle>
+
+          <FlexContainer>
+            <KeyboardShortcutButton
+              bold
+              fullWidth
+              greyBorder
+              onClick={handleClear}
+              outline
+              paddingBottom={DATE_RANGE_BUTTON_VERTICAL_PADDING}
+              paddingTop={DATE_RANGE_BUTTON_VERTICAL_PADDING}
+              uuid="Table/Toolbar/DateRangeClear"
+            >
+              Clear
+            </KeyboardShortcutButton>
+            <Spacing mr={1} />
+            <KeyboardShortcutButton
+              bold
+              fullWidth
+              onClick={handleApply}
+              paddingBottom={DATE_RANGE_BUTTON_VERTICAL_PADDING}
+              paddingTop={DATE_RANGE_BUTTON_VERTICAL_PADDING}
+              primary
+              uuid="Table/Toolbar/DateRangeApply"
+            >
+              Apply
+            </KeyboardShortcutButton>
+          </FlexContainer>
+        </DateRangeContainerStyle>
+      </ClickOutside>
+    </div>
+  );
+}
 
 type ToolbarProps = {
   addButtonProps?: {
@@ -38,6 +284,7 @@ type ToolbarProps = {
     menuItems?: FlyoutMenuItemType[];
   };
   children?: any;
+  dateRangePickerProps?: DateRangePickerProps;
   deleteRowProps?: {
     confirmationMessage: string;
     isLoading: boolean;
@@ -100,6 +347,7 @@ type ToolbarProps = {
 function Toolbar({
   addButtonProps,
   children,
+  dateRangePickerProps,
   deleteRowProps,
   extraActionButtonProps,
   filterOptions = {},
@@ -379,6 +627,12 @@ function Toolbar({
 
       {(addButtonProps || secondaryButtonProps || children) && <Spacing mr={BUTTON_PADDING} />}
       {filterButtonEl}
+
+      {dateRangePickerProps && (
+        <Spacing ml={BUTTON_PADDING}>
+          <DateRangePicker {...dateRangePickerProps} />
+        </Spacing>
+      )}
 
       {groupMenuItems?.length > 0 &&
         <Spacing ml={BUTTON_PADDING}>

--- a/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
@@ -105,13 +105,22 @@ function DateRangePicker({ endTimestamp, onApply, onOpenChange, startTimestamp }
   }, [activeField]);
 
   const handleApply = useCallback(() => {
+    let startTs: number;
+    let endTs: number;
+
     if (!startDate || !endDate) {
-      onApply(null, null);
+      const now = new Date();
+      const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
+      startTs = Math.floor(todayStart.getTime() / 1000);
+      endTs = Math.floor(now.getTime() / 1000);
     } else {
-      const startTs = toUnixTimestamp(startDate, startTime);
-      const endTs = toUnixTimestamp(endDate, endTime);
-      onApply(Math.min(startTs, endTs), Math.max(startTs, endTs));
+      const s = toUnixTimestamp(startDate, startTime);
+      const e = toUnixTimestamp(endDate, endTime);
+      startTs = Math.min(s, e);
+      endTs = Math.max(s, e);
     }
+
+    onApply(startTs, endTs);
     setOpenWithCallback(false);
   }, [endDate, endTime, onApply, setOpenWithCallback, startDate, startTime]);
 
@@ -121,7 +130,9 @@ function DateRangePicker({ endTimestamp, onApply, onOpenChange, startTimestamp }
     setEndDate(null);
     setEndTime(DEFAULT_TIME);
     setActiveField('start');
-  }, []);
+    onApply(null, null);
+    setOpenWithCallback(false);
+  }, [onApply, setOpenWithCallback]);
 
   const tileClassName = useCallback(({ date, view }: { date: Date; view: string }) => {
     if (view !== 'month' || !startDate || !endDate) return null;

--- a/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
@@ -131,8 +131,7 @@ function DateRangePicker({ endTimestamp, onApply, onOpenChange, startTimestamp }
     setEndTime(DEFAULT_TIME);
     setActiveField('start');
     onApply(null, null);
-    setOpenWithCallback(false);
-  }, [onApply, setOpenWithCallback]);
+  }, [onApply]);
 
   const tileClassName = useCallback(({ date, view }: { date: Date; view: string }) => {
     if (view !== 'month' || !startDate || !endDate) return null;

--- a/mage_ai/frontend/interfaces/PipelineRunType.ts
+++ b/mage_ai/frontend/interfaces/PipelineRunType.ts
@@ -55,11 +55,13 @@ export interface PipelineRunReqQueryParamsType {
   _limit?: number;
   _offset?: number;
   disable_retries_grouping?: boolean;
+  end_timestamp?: number;
   global_data_product_uuid?: string;
   include_all_pipeline_schedules?: boolean;
   include_pipeline_tags?: boolean;
   include_pipeline_uuids?: boolean;
   pipeline_uuid?: string;
+  start_timestamp?: number;
   status?: RunStatusEnum;
 }
 

--- a/mage_ai/frontend/oracle/components/Calendar/index.tsx
+++ b/mage_ai/frontend/oracle/components/Calendar/index.tsx
@@ -14,6 +14,7 @@ export type TimeType = {
 };
 
 type CalendarProps = {
+  inline?: boolean;
   localTime?: boolean;
   selectedDate: Date;
   selectedTime: TimeType;
@@ -23,6 +24,7 @@ type CalendarProps = {
 };
 
 function Calendar({
+  inline,
   localTime,
   selectedDate,
   selectedTime,
@@ -32,7 +34,7 @@ function Calendar({
 }: CalendarProps) {
   return (
     <DateSelectionContainer
-      absolute
+      absolute={!inline}
       topPosition={topPosition}
     >
       <ReactCalendar

--- a/mage_ai/frontend/pages/pipeline-runs/index.tsx
+++ b/mage_ai/frontend/pages/pipeline-runs/index.tsx
@@ -143,7 +143,19 @@ function RunListPage() {
         status: RUN_STATUS_TO_LABEL,
       }}
       onClickFilterDefaults={() => {
-        router.push('/pipeline-runs');
+        const updatedQuery: Record<string, unknown> = {};
+        if (startTimestamp) {
+          updatedQuery.start_timestamp = startTimestamp;
+        }
+        if (endTimestamp) {
+          updatedQuery.end_timestamp = endTimestamp;
+        }
+        const qs = queryString(updatedQuery);
+        router.push(
+          '/pipeline-runs',
+          qs ? `/pipeline-runs?${qs}` : '/pipeline-runs',
+          { shallow: true },
+        );
       }}
       query={query}
       resetPageOnFilterApply
@@ -153,8 +165,10 @@ function RunListPage() {
     // The "query" dependency is intentionally excluded to avoid the filters
     // being reset every time pipeline runs are fetched.
     dateRangePickerProps,
+    endTimestamp,
     pipelineUUIDs,
     router,
+    startTimestamp,
     tags,
   ]);
 

--- a/mage_ai/frontend/pages/pipeline-runs/index.tsx
+++ b/mage_ai/frontend/pages/pipeline-runs/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 
 import Dashboard from '@components/Dashboard';
@@ -10,7 +10,7 @@ import ProjectType, { FeatureUUIDEnum } from '@interfaces/ProjectType';
 import Spacing from '@oracle/elements/Spacing';
 import Spinner from '@oracle/components/Spinner';
 import TagType from '@interfaces/TagType';
-import Toolbar from '@components/shared/Table/Toolbar';
+import Toolbar, { DateRangePickerProps } from '@components/shared/Table/Toolbar';
 import api from '@api';
 import {
   PIPELINE_RUN_STATUSES_NO_LAST_RUN_FAILED,
@@ -41,6 +41,23 @@ function RunListPage() {
     [project?.features],
   );
 
+  const urlStartTimestamp = Number.isFinite(Number(q?.start_timestamp))
+    ? Number(q.start_timestamp)
+    : undefined;
+  const urlEndTimestamp = Number.isFinite(Number(q?.end_timestamp))
+    ? Number(q.end_timestamp)
+    : undefined;
+
+  const [startTimestamp, setStartTimestamp] = useState<number | undefined>(urlStartTimestamp);
+  const [endTimestamp, setEndTimestamp] = useState<number | undefined>(urlEndTimestamp);
+  const [datePickerOpen, setDatePickerOpen] = useState<boolean>(false);
+
+  useEffect(() => {
+    setStartTimestamp(urlStartTimestamp);
+    setEndTimestamp(urlEndTimestamp);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlStartTimestamp, urlEndTimestamp]);
+
   const pipelineRunsRequestQuery: PipelineRunReqQueryParamsType = {
     ...query,
     _limit: ROW_LIMIT,
@@ -52,13 +69,19 @@ function RunListPage() {
   if (q?.status) {
     pipelineRunsRequestQuery.status = q.status;
   }
+  if (startTimestamp) {
+    pipelineRunsRequestQuery.start_timestamp = startTimestamp;
+  }
+  if (endTimestamp) {
+    pipelineRunsRequestQuery.end_timestamp = endTimestamp;
+  }
   const {
     data: dataPipelineRuns,
     mutate: fetchPipelineRuns,
   } = api.pipeline_runs.list(
     pipelineRunsRequestQuery,
     {
-      refreshInterval: 3000,
+      refreshInterval: datePickerOpen ? 0 : 3000,
       revalidateOnFocus: true,
     },
   );
@@ -72,8 +95,41 @@ function RunListPage() {
   const totalRuns = useMemo(() => dataPipelineRuns?.metadata?.count || [], [dataPipelineRuns]);
   const pipelineUUIDs = useMemo(() => dataPipelineRuns?.metadata?.pipeline_uuids || [], [dataPipelineRuns]);
 
+  const dateRangePickerProps: DateRangePickerProps = useMemo(() => ({
+    endTimestamp,
+    onApply: (start, end) => {
+      const newStart = start || undefined;
+      const newEnd = end || undefined;
+
+      setStartTimestamp(newStart);
+      setEndTimestamp(newEnd);
+
+      const updatedQuery = { ...queryFromUrl() };
+      if (newStart) {
+        updatedQuery.start_timestamp = newStart;
+      } else {
+        delete updatedQuery.start_timestamp;
+      }
+      if (newEnd) {
+        updatedQuery.end_timestamp = newEnd;
+      } else {
+        delete updatedQuery.end_timestamp;
+      }
+      delete updatedQuery.page;
+      router.push(
+        '/pipeline-runs',
+        `/pipeline-runs?${queryString(updatedQuery)}`,
+        { shallow: true },
+      );
+    },
+    onOpenChange: setDatePickerOpen,
+    startTimestamp,
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }), [endTimestamp, startTimestamp]);
+
   const toolbarEl = useMemo(() => (
     <Toolbar
+      dateRangePickerProps={dateRangePickerProps}
       filterOptions={{
         pipeline_tag: tags.map(({ uuid }) => uuid),
         pipeline_uuid: pipelineUUIDs,
@@ -96,6 +152,7 @@ function RunListPage() {
   ), [
     // The "query" dependency is intentionally excluded to avoid the filters
     // being reset every time pipeline runs are fetched.
+    dateRangePickerProps,
     pipelineUUIDs,
     router,
     tags,
@@ -134,6 +191,7 @@ function RunListPage() {
                   router.push(
                     '/pipeline-runs',
                     `/pipeline-runs?${queryString(updatedQuery)}`,
+                    { shallow: true },
                   );
                 }}
                 page={Number(page)}

--- a/mage_ai/frontend/pages/pipeline-runs/index.tsx
+++ b/mage_ai/frontend/pages/pipeline-runs/index.tsx
@@ -69,10 +69,10 @@ function RunListPage() {
   if (q?.status) {
     pipelineRunsRequestQuery.status = q.status;
   }
-  if (startTimestamp) {
+  if (startTimestamp !== undefined) {
     pipelineRunsRequestQuery.start_timestamp = startTimestamp;
   }
-  if (endTimestamp) {
+  if (endTimestamp !== undefined) {
     pipelineRunsRequestQuery.end_timestamp = endTimestamp;
   }
   const {
@@ -98,19 +98,19 @@ function RunListPage() {
   const dateRangePickerProps: DateRangePickerProps = useMemo(() => ({
     endTimestamp,
     onApply: (start, end) => {
-      const newStart = start || undefined;
-      const newEnd = end || undefined;
+      const newStart = start ?? undefined;
+      const newEnd = end ?? undefined;
 
       setStartTimestamp(newStart);
       setEndTimestamp(newEnd);
 
       const updatedQuery = { ...queryFromUrl() };
-      if (newStart) {
+      if (newStart !== undefined) {
         updatedQuery.start_timestamp = newStart;
       } else {
         delete updatedQuery.start_timestamp;
       }
-      if (newEnd) {
+      if (newEnd !== undefined) {
         updatedQuery.end_timestamp = newEnd;
       } else {
         delete updatedQuery.end_timestamp;
@@ -144,10 +144,10 @@ function RunListPage() {
       }}
       onClickFilterDefaults={() => {
         const updatedQuery: Record<string, unknown> = {};
-        if (startTimestamp) {
+        if (startTimestamp !== null && startTimestamp !== undefined) {
           updatedQuery.start_timestamp = startTimestamp;
         }
-        if (endTimestamp) {
+        if (endTimestamp !== null && endTimestamp !== undefined) {
           updatedQuery.end_timestamp = endTimestamp;
         }
         const qs = queryString(updatedQuery);

--- a/mage_ai/frontend/tests/pipeline_runs_datetime_filter.spec.ts
+++ b/mage_ai/frontend/tests/pipeline_runs_datetime_filter.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from './base';
+
+test('date range button is visible on pipeline runs page', async ({ page }) => {
+  await page.goto('/pipeline-runs');
+
+  await page.waitForLoadState('networkidle');
+
+  await expect(page.getByRole('button', { name: /date range/i })).toBeVisible();
+});
+
+test('clicking date range button opens the date picker', async ({ page }) => {
+  await page.goto('/pipeline-runs');
+  await page.getByRole('button', { name: /date range/i }).click();
+  await expect(page.getByText('Start')).toBeVisible();
+  await expect(page.getByText('End')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Apply' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Clear' })).toBeVisible();
+});
+
+test('applying date range updates the URL with start and end timestamps', async ({ page }) => {
+  await page.goto('/pipeline-runs');
+  await page.getByRole('button', { name: /date range/i }).click();
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  await expect(page).toHaveURL(/start_timestamp=\d+/);
+  await expect(page).toHaveURL(/end_timestamp=\d+/);
+});
+
+test('active date range filter shows a badge on the date range button', async ({ page }) => {
+  await page.goto('/pipeline-runs');
+  await page.getByRole('button', { name: /date range/i }).click();
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  await expect(page.getByRole('button', { name: /date range/i }).locator('..').getByText('1')).toBeVisible();
+});
+
+test('clearing the date range filter removes timestamps from the URL', async ({ page }) => {
+  await page.goto('/pipeline-runs');
+
+  await page.getByRole('button', { name: /date range/i }).click();
+  await page.getByRole('button', { name: 'Apply' }).click();
+  await expect(page).toHaveURL(/start_timestamp=\d+/);
+
+  await page.getByRole('button', { name: /date range/i }).click();
+  await page.getByRole('button', { name: 'Clear' }).click();
+
+  await expect(page).not.toHaveURL(/start_timestamp=/);
+  await expect(page).not.toHaveURL(/end_timestamp=/);
+});
+
+test('loading pipeline runs page with timestamp params shows active filter badge', async ({ page }) => {
+  const start = 1700000000;
+  const end = 1700086400;
+  await page.goto(`/pipeline-runs?start_timestamp=${start}&end_timestamp=${end}`);
+
+  await expect(page.getByRole('button', { name: /date range/i }).locator('..').getByText('1')).toBeVisible();
+});
+
+test('closing date range picker without applying does not change the URL', async ({ page }) => {
+  await page.goto('/pipeline-runs');
+  const initialUrl = page.url();
+
+  await page.getByRole('button', { name: /date range/i }).click();
+  await expect(page.getByRole('button', { name: 'Apply' })).toBeVisible();
+
+  await page.keyboard.press('Escape');
+
+  expect(page.url()).toBe(initialUrl);
+});
+
+test('applying date range preserves existing status filter in URL', async ({ page }) => {
+  await page.goto('/pipeline-runs?status[]=completed');
+
+  await page.getByRole('button', { name: /date range/i }).click();
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  await expect(page).toHaveURL(/start_timestamp=\d+/);
+  await expect(page).toHaveURL(/status\[\]=completed/);
+});
+
+test('applying status filter preserves existing date range in URL', async ({ page }) => {
+  const start = 1700000000;
+  const end = 1700086400;
+  await page.goto(`/pipeline-runs?start_timestamp=${start}&end_timestamp=${end}`);
+
+  await page.getByRole('button', { name: /filter/i }).click();
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  await expect(page).toHaveURL(new RegExp(`start_timestamp=${start}`));
+  await expect(page).toHaveURL(new RegExp(`end_timestamp=${end}`));
+});
+
+test('date range filter persists across page navigation', async ({ page }) => {
+  await page.goto('/pipeline-runs');
+
+  await page.getByRole('button', { name: /date range/i }).click();
+  await page.getByRole('button', { name: 'Apply' }).click();
+  await expect(page).toHaveURL(/start_timestamp=\d+/);
+
+  const urlWithFilter = page.url();
+
+  const nextButton = page.getByRole('button', { name: /next/i });
+  if (await nextButton.isVisible()) {
+    await nextButton.click();
+    await expect(page).toHaveURL(/start_timestamp=\d+/);
+  } else {
+    expect(page.url()).toContain('start_timestamp');
+  }
+});

--- a/mage_ai/frontend/utils/date.ts
+++ b/mage_ai/frontend/utils/date.ts
@@ -2,6 +2,7 @@ import moment from 'moment';
 import tzMoment from 'moment-timezone';
 import 'moment-duration-format';
 
+import { TimeType } from '@oracle/components/Calendar';
 import { pluralize } from '@utils/string';
 import { rangeSequential } from '@utils/array';
 
@@ -347,4 +348,21 @@ export function convertToMillisecondsTimestamp(value: number): number {
 
 export function isDate(value: any): value is Date {
   return value instanceof Date;
+}
+
+export function toUnixTimestamp(date: Date, time: TimeType): number {
+  const d = new Date(date);
+  d.setHours(parseInt(time.hour || '0', 10), parseInt(time.minute || '0', 10), 0, 0);
+  return Math.floor(d.getTime() / 1000);
+}
+
+export function fromUnixTimestamp(ts: number): { date: Date; time: TimeType } {
+  const d = new Date(ts * 1000);
+  return {
+    date: d,
+    time: {
+      hour: String(d.getHours()).padStart(2, '0'),
+      minute: String(d.getMinutes()).padStart(2, '0'),
+    },
+  };
 }

--- a/mage_ai/tests/api/endpoints/test_pipeline_run_datetime_filter.py
+++ b/mage_ai/tests/api/endpoints/test_pipeline_run_datetime_filter.py
@@ -1,0 +1,133 @@
+from datetime import datetime, timezone
+
+from mage_ai.api.errors import ApiError
+from mage_ai.api.utils import get_query_timestamps
+from mage_ai.orchestration.db.models.schedules import PipelineRun, PipelineSchedule
+from mage_ai.tests.api.endpoints.mixins import (
+    BaseAPIEndpointTest,
+    build_list_endpoint_tests,
+)
+
+RESULT_KEYS = [
+    'backfill_id',
+    'block_runs',
+    'block_runs_count',
+    'completed_at',
+    'completed_block_runs_count',
+    'created_at',
+    'event_variables',
+    'execution_date',
+    'executor_type',
+    'id',
+    'metrics',
+    'passed_sla',
+    'pipeline_schedule_id',
+    'pipeline_schedule_name',
+    'pipeline_schedule_token',
+    'pipeline_schedule_type',
+    'pipeline_uuid',
+    'started_at',
+    'status',
+    'updated_at',
+    'variables',
+]
+
+T_EARLY = datetime(2024, 1, 15, 8, 0, 0, tzinfo=timezone.utc)
+T_MID = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+T_LATE = datetime(2024, 1, 15, 16, 0, 0, tzinfo=timezone.utc)
+
+
+class PipelineRunDatetimeFilterEndpointTest(BaseAPIEndpointTest):
+    def setUp(self):
+        super().setUp()
+        self.pipeline_schedule = PipelineSchedule.create(
+            name=self.faker.unique.name(),
+            pipeline_uuid=self.pipeline.uuid,
+        )
+        self.run_early = PipelineRun.create(
+            pipeline_schedule_id=self.pipeline_schedule.id,
+            pipeline_uuid=self.pipeline_schedule.pipeline_uuid,
+            started_at=T_EARLY,
+        )
+        self.run_mid = PipelineRun.create(
+            pipeline_schedule_id=self.pipeline_schedule.id,
+            pipeline_uuid=self.pipeline_schedule.pipeline_uuid,
+            started_at=T_MID,
+        )
+        self.run_late = PipelineRun.create(
+            pipeline_schedule_id=self.pipeline_schedule.id,
+            pipeline_uuid=self.pipeline_schedule.pipeline_uuid,
+            started_at=T_LATE,
+        )
+
+        self.t_early = T_EARLY
+        self.t_mid = T_MID
+        self.t_late = T_LATE
+
+
+build_list_endpoint_tests(
+    PipelineRunDatetimeFilterEndpointTest,
+    test_uuid='start_timestamp',
+    resource='pipeline_run',
+    list_count=2,
+    build_query=lambda self: {
+        'start_timestamp': [str(int(self.t_mid.timestamp()))],
+    },
+    result_keys_to_compare=RESULT_KEYS,
+)
+
+build_list_endpoint_tests(
+    PipelineRunDatetimeFilterEndpointTest,
+    test_uuid='end_timestamp',
+    resource='pipeline_run',
+    list_count=2,
+    build_query=lambda self: {
+        'end_timestamp': [str(int(self.t_mid.timestamp()))],
+    },
+    result_keys_to_compare=RESULT_KEYS,
+)
+
+build_list_endpoint_tests(
+    PipelineRunDatetimeFilterEndpointTest,
+    test_uuid='start_and_end_timestamp',
+    resource='pipeline_run',
+    list_count=1,
+    build_query=lambda self: {
+        'start_timestamp': [str(int(self.t_mid.timestamp()))],
+        'end_timestamp': [str(int(self.t_mid.timestamp()))],
+    },
+    result_keys_to_compare=RESULT_KEYS,
+)
+
+build_list_endpoint_tests(
+    PipelineRunDatetimeFilterEndpointTest,
+    test_uuid='no_timestamp_filter',
+    resource='pipeline_run',
+    list_count=3,
+    result_keys_to_compare=RESULT_KEYS,
+)
+
+
+class GetQueryTimestampsTest(BaseAPIEndpointTest):
+    def test_utc_conversion(self):
+        query_arg = {'start_timestamp': ['0']}
+        start, end = get_query_timestamps(query_arg)
+        self.assertEqual(start, datetime(1970, 1, 1, 0, 0, 0))
+        self.assertIsNone(end)
+
+    def test_inverted_timestamps_raises(self):
+        query_arg = {
+            'start_timestamp': [str(int(T_LATE.timestamp()))],
+            'end_timestamp': [str(int(T_EARLY.timestamp()))],
+        }
+        with self.assertRaises(ApiError) as ctx:
+            get_query_timestamps(query_arg)
+        self.assertIn('start_timestamp', ctx.exception.message)
+
+    def test_invalid_start_timestamp_raises(self):
+        with self.assertRaises(ApiError):
+            get_query_timestamps({'start_timestamp': ['not_a_number']})
+
+    def test_invalid_end_timestamp_raises(self):
+        with self.assertRaises(ApiError):
+            get_query_timestamps({'end_timestamp': ['not_a_number']})


### PR DESCRIPTION
# Description

Adds a date range filter to the Pipeline Runs page, allowing users to narrow down pipeline runs by their started_at timestamp. This addresses the inability to efficiently locate runs within a specific time window when dealing with high run volumes.
**Changes included:**

- Added a `DateRangePicker` component to the Pipeline Runs table toolbar with a calendar UI, hour/minute time selectors for both start and end bounds, and an active-filter badge indicator
- Wired `start_timestamp` and `end_timestamp` as URL query parameters so filter state persists across page refreshes and is shareable via URL
- Pauses the polling interval (normally 3s) while the date picker is open to prevent layout disruption
- Added `get_query_timestamps()` utility to `api/utils.py` to parse and validate Unix timestamp query parameters
- Applied the timestamp filter on the `PipelineRun.started_at` column in `PipelineRunResource.collection()`


# How Has This Been Tested?

- Manually verified that selecting a date range on the Pipeline Runs page updates the URL and filters the displayed runs correctly
- Confirmed that clearing the date range restores the full unfiltered list
- Confirmed that invalid or missing timestamp values are handled gracefully on the backend (ApiError is raised with a descriptive message)
- Added backend endpoint tests in `mage_ai/tests/api/endpoints/test_pipeline_run_datetime_filter.py`
- Added frontend integration tests in `mage_ai/frontend/tests/pipeline_runs_datetime_filter.spec.ts`


- [x] Test A - backend returns only runs within the specified timestamp range
- [x] Test B - frontend date picker correctly encodes timestamps into URL query params


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

# Screenshot

[**Here's the short video link**](https://www.loom.com/share/65b25265c1c44c9295f3447593a07bb8)

<img width="1527" height="895" alt="image" src="https://github.com/user-attachments/assets/4a4ce2f4-1c69-4b3e-a775-e5253f5c7851" />

cc:
@wangxiaoyou1993 