### PR TITLE
feat(terminal): xterm + correct PTY size for tab completion (#3499).

### DIFF
--- a/mage_ai/frontend/components/Terminal/index.style.tsx
+++ b/mage_ai/frontend/components/Terminal/index.style.tsx
@@ -25,7 +25,8 @@ export const ContainerStyle = styled.div<{
   ${ScrollbarStyledCss}
 
   height: 100%;
-  overflow: auto;
+  /* xterm viewport scrolls; outer scroll breaks PTY width vs grid alignment */
+  overflow: hidden;
   position: absolute;
 
   ${props => `
@@ -46,13 +47,17 @@ export const XTermHost = styled.div<{
   ${SHARED_STYLES}
   box-sizing: border-box;
   flex: 1;
+  height: 100%;
   min-height: 0;
   min-width: 0;
   padding: ${PADDING_UNITS * UNIT}px;
+  position: relative;
+  width: 100%;
 
   .xterm {
     height: 100%;
     padding: 0;
+    width: 100%;
   }
 
   .xterm-viewport {

--- a/mage_ai/frontend/components/Terminal/index.style.tsx
+++ b/mage_ai/frontend/components/Terminal/index.style.tsx
@@ -50,7 +50,9 @@ export const XTermHost = styled.div<{
   height: 100%;
   min-height: 0;
   min-width: 0;
-  padding: ${PADDING_UNITS * UNIT}px;
+  /* xterm should occupy the full measured area; padding shrinks PTY cols/lines and
+   * causes premature wrapping. */
+  padding: 0;
   position: relative;
   width: 100%;
 

--- a/mage_ai/frontend/components/Terminal/index.style.tsx
+++ b/mage_ai/frontend/components/Terminal/index.style.tsx
@@ -39,6 +39,27 @@ export const InnerStyle = styled.div`
   padding: ${PADDING_UNITS * UNIT}px;
 `;
 
+/** Fills parent; xterm FitAddon measures this element. */
+export const XTermHost = styled.div<{
+  width?: number;
+}>`
+  ${SHARED_STYLES}
+  box-sizing: border-box;
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  padding: ${PADDING_UNITS * UNIT}px;
+
+  .xterm {
+    height: 100%;
+    padding: 0;
+  }
+
+  .xterm-viewport {
+    border-radius: 0;
+  }
+`;
+
 export const LineStyle = styled.div`
   height: ${ROW_HEIGHT}px;
 `;

--- a/mage_ai/frontend/components/Terminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/index.tsx
@@ -142,94 +142,120 @@ function Terminal({
       return undefined;
     }
 
-    const term = new XTerm({
-      cursorBlink: true,
-      fontFamily: 'Menlo, Monaco, "Courier New", monospace',
-      fontSize: 13,
-      overviewRuler: { width: 0 },
-      scrollback: 5000,
-      theme: {
-        background: bg,
-        cursor: cursor,
-        foreground: fg,
-      },
-    });
-    const fitAddon = new FitAddon();
-    term.loadAddon(fitAddon);
-    term.open(refHost.current);
-    termRef.current = term;
-    fitAddonRef.current = fitAddon;
+    let term: XTerm | null = null;
+    let fitAddon: FitAddon | null = null;
+    let onWindowResize: (() => void) | null = null;
+    let ro: ResizeObserver | null = null;
 
-    term.onData((data) => {
-      sendPayload(['stdin', data]);
-    });
+    try {
+      term = new XTerm({
+        cursorBlink: true,
+        fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+        fontSize: 13,
+        overviewRuler: { width: 0 },
+        scrollback: 5000,
+        theme: {
+          background: bg,
+          cursor: cursor,
+          foreground: fg,
+        },
+      });
 
-    term.attachCustomKeyEventHandler((domEvent) => {
-      if (domEvent.metaKey && domEvent.key.toLowerCase() === 'k') {
-        domEvent.preventDefault();
-        clearScreen();
-        return false;
-      }
-      const ext = externalShortcutsRef.current;
-      if (ext) {
-        const keyMapping: Record<string, boolean> = {
-          Meta: domEvent.metaKey,
-          Control: domEvent.ctrlKey,
-          Shift: domEvent.shiftKey,
-          Alt: domEvent.altKey,
-        };
-        if (ext(domEvent, keyMapping, [])) {
+      fitAddon = new FitAddon();
+      term.loadAddon(fitAddon);
+      term.open(refHost.current);
+      termRef.current = term;
+      fitAddonRef.current = fitAddon;
+
+      term.onData((data) => {
+        sendPayload(['stdin', data]);
+      });
+
+      term.attachCustomKeyEventHandler((domEvent) => {
+        if (domEvent.metaKey && domEvent.key.toLowerCase() === 'k') {
           domEvent.preventDefault();
+          clearScreen();
           return false;
         }
-      }
-      return true;
-    });
+        const ext = externalShortcutsRef.current;
+        if (ext) {
+          const keyMapping: Record<string, boolean> = {
+            Meta: domEvent.metaKey,
+            Control: domEvent.ctrlKey,
+            Shift: domEvent.shiftKey,
+            Alt: domEvent.altKey,
+          };
+          if (ext(domEvent, keyMapping, [])) {
+            domEvent.preventDefault();
+            return false;
+          }
+        }
+        return true;
+      });
 
-    const scheduleDebouncedFit = () => {
-      if (resizeDebounceRef.current) {
-        window.clearTimeout(resizeDebounceRef.current);
-      }
-      resizeDebounceRef.current = window.setTimeout(() => {
-        resizeDebounceRef.current = null;
-        fitAndNotifySize();
-      }, 50);
-    };
+      const scheduleDebouncedFit = () => {
+        if (resizeDebounceRef.current) {
+          window.clearTimeout(resizeDebounceRef.current);
+        }
+        resizeDebounceRef.current = window.setTimeout(() => {
+          resizeDebounceRef.current = null;
+          fitAndNotifySize();
+        }, 50);
+      };
 
-    const refitUntilStable = () => {
-      fitAndNotifySize();
-      requestAnimationFrame(() => {
+      const refitUntilStable = () => {
         fitAndNotifySize();
         requestAnimationFrame(() => {
           fitAndNotifySize();
+          requestAnimationFrame(() => {
+            fitAndNotifySize();
+          });
         });
+        window.setTimeout(() => fitAndNotifySize(), 50);
+        window.setTimeout(() => fitAndNotifySize(), 200);
+      };
+
+      refitUntilStable();
+
+      // Guard for environments where the Font Loading API may not exist.
+      const fontsReadyThen = (document as any)?.fonts?.ready?.then;
+      if (typeof fontsReadyThen === 'function') {
+        void (document as any).fonts.ready.then(() => {
+          fitAndNotifySize();
+          window.setTimeout(() => fitAndNotifySize(), 100);
+        });
+      } else {
+        fitAndNotifySize();
+      }
+
+      onWindowResize = () => scheduleDebouncedFit();
+      window.addEventListener('resize', onWindowResize);
+
+      ro = new ResizeObserver(() => {
+        scheduleDebouncedFit();
       });
-      window.setTimeout(() => fitAndNotifySize(), 50);
-      window.setTimeout(() => fitAndNotifySize(), 200);
-    };
-    refitUntilStable();
-    void document.fonts.ready.then(() => {
-      fitAndNotifySize();
-      window.setTimeout(() => fitAndNotifySize(), 100);
-    });
-
-    const onWindowResize = () => scheduleDebouncedFit();
-    window.addEventListener('resize', onWindowResize);
-
-    const ro = new ResizeObserver(() => {
-      scheduleDebouncedFit();
-    });
-    ro.observe(refHost.current);
-    resizeObserverRef.current = ro;
+      ro.observe(refHost.current);
+      resizeObserverRef.current = ro;
+    } catch (err) {
+      // If xterm fails to initialize, avoid breaking the whole page load.
+      // This helps keep non-terminal UI elements (like page breadcrumbs) visible.
+      // eslint-disable-next-line no-console
+      console.error('Mage terminal init failed:', err);
+      return undefined;
+    }
 
     return () => {
-      window.removeEventListener('resize', onWindowResize);
-      ro.disconnect();
-      resizeObserverRef.current = null;
+      if (onWindowResize) {
+        window.removeEventListener('resize', onWindowResize);
+      }
+      if (ro) {
+        ro.disconnect();
+        resizeObserverRef.current = null;
+      }
       if (resizeDebounceRef.current) {
         window.clearTimeout(resizeDebounceRef.current);
       }
-      term.dispose();
+      term?.dispose();
       termRef.current = null;
       fitAddonRef.current = null;
     };

--- a/mage_ai/frontend/components/Terminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/index.tsx
@@ -1,5 +1,6 @@
-import { FitAddon } from '@xterm/addon-fit';
 import { Terminal as XTerm } from '@xterm/xterm';
+
+import { FitAddon } from './xtermFitAddon';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTheme } from 'styled-components';
 
@@ -118,7 +119,8 @@ function Terminal({
     }
     const { cols, rows } = term;
     if (cols > 0 && rows > 0) {
-      sendPayload(['set_size', cols, rows]);
+      // terminado: self.size = command[1:3] then rows, cols = client.size → expect [rows, cols]
+      sendPayload(['set_size', rows, cols]);
     }
   }, [sendPayload]);
 
@@ -144,6 +146,7 @@ function Terminal({
       cursorBlink: true,
       fontFamily: 'Menlo, Monaco, "Courier New", monospace',
       fontSize: 13,
+      overviewRuler: { width: 0 },
       scrollback: 5000,
       theme: {
         background: bg,
@@ -183,23 +186,44 @@ function Terminal({
       return true;
     });
 
-    requestAnimationFrame(() => {
-      fitAndNotifySize();
-    });
-
-    const ro = new ResizeObserver(() => {
+    const scheduleDebouncedFit = () => {
       if (resizeDebounceRef.current) {
         window.clearTimeout(resizeDebounceRef.current);
       }
       resizeDebounceRef.current = window.setTimeout(() => {
         resizeDebounceRef.current = null;
         fitAndNotifySize();
-      }, 100);
+      }, 50);
+    };
+
+    const refitUntilStable = () => {
+      fitAndNotifySize();
+      requestAnimationFrame(() => {
+        fitAndNotifySize();
+        requestAnimationFrame(() => {
+          fitAndNotifySize();
+        });
+      });
+      window.setTimeout(() => fitAndNotifySize(), 50);
+      window.setTimeout(() => fitAndNotifySize(), 200);
+    };
+    refitUntilStable();
+    void document.fonts.ready.then(() => {
+      fitAndNotifySize();
+      window.setTimeout(() => fitAndNotifySize(), 100);
+    });
+
+    const onWindowResize = () => scheduleDebouncedFit();
+    window.addEventListener('resize', onWindowResize);
+
+    const ro = new ResizeObserver(() => {
+      scheduleDebouncedFit();
     });
     ro.observe(refHost.current);
     resizeObserverRef.current = ro;
 
     return () => {
+      window.removeEventListener('resize', onWindowResize);
       ro.disconnect();
       resizeObserverRef.current = null;
       if (resizeDebounceRef.current) {

--- a/mage_ai/frontend/components/Terminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/index.tsx
@@ -1,51 +1,26 @@
-import Ansi from 'ansi-to-react';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal as XTerm } from '@xterm/xterm';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTheme } from 'styled-components';
 
 import AuthToken from '@api/utils/AuthToken';
 import ClickOutside from '@oracle/components/ClickOutside';
-import KernelOutputType, {
-  DataTypeEnum,
-  DATA_TYPE_TEXTLIKE,
-} from '@interfaces/KernelOutputType';
-import Text from '@oracle/elements/Text';
-import {
-  CharacterStyle,
-  ContainerStyle,
-  InnerStyle,
-  InputStyle,
-  LineStyle,
-} from './index.style';
-import {
-  KEY_CODE_ARROW_DOWN,
-  KEY_CODE_ARROW_LEFT,
-  KEY_CODE_ARROW_RIGHT,
-  KEY_CODE_ARROW_UP,
-  KEY_CODE_BACKSPACE,
-  KEY_CODE_C,
-  KEY_CODE_CONTROL,
-  KEY_CODE_ENTER,
-  KEY_CODE_META,
-  KEY_CODE_V,
-} from '@utils/hooks/keyboardShortcuts/constants';
 import { OAUTH2_APPLICATION_CLIENT_ID } from '@api/constants';
-import { keysPresentAndKeysRecent, onlyKeysPresent } from '@utils/hooks/keyboardShortcuts/utils';
-import { pauseEvent } from '@utils/events';
 import { useKeyboardContext } from '@context/Keyboard';
+import dark from '@oracle/styles/themes/dark';
+import { ContainerStyle, XTermHost } from './index.style';
 
 export const DEFAULT_TERMINAL_UUID = 'terminal';
-// Limit the number of lines for the terminal output; otherwise, typing in the terminal can become laggy.
-const TERMINAL_OUTPUT_LIMIT = 2500;
 
 type TerminalProps = {
+  /** @deprecated Line buffer removed; xterm streams to PTY. */
   command?: string;
   commandHistory?: string[];
   commandIndex?: number;
   cursorIndex?: number;
   externalKeyboardShortcuts?: (
-    event: any,
-    keyMapping: {
-      [key: string]: boolean;
-    },
+    event: KeyboardEvent,
+    keyMapping: Record<string, boolean>,
     keyHistory: number[],
   ) => boolean;
   focus?: boolean;
@@ -55,7 +30,8 @@ type TerminalProps = {
     token: string;
   };
   onFocus?: () => void;
-  outputs?: KernelOutputType[];
+  /** @deprecated Output is rendered by xterm only. */
+  outputs?: unknown;
   sendMessage: (message: string, keep?: boolean) => void;
   setCommand?: (prev: (value: string) => string) => void;
   setCommandHistory?: (prev: (value: string[]) => string[]) => void;
@@ -69,476 +45,250 @@ type TerminalProps = {
 };
 
 function Terminal({
-  command: commandProp,
-  commandHistory: commandHistoryProp,
-  commandIndex: commandIndexProp,
-  cursorIndex: cursorIndexProp,
   externalKeyboardShortcuts,
   focus: focusProp,
   lastMessage,
   oauthWebsocketData: oauthWebsocketDataProp,
   onFocus,
-  outputs,
   sendMessage,
-  setCommand: setCommandProp,
-  setCommandHistory: setCommandHistoryProp,
-  setCommandIndex: setCommandIndexProp,
-  setCursorIndex: setCursorIndexProp,
   setFocus: setFocusProp,
-  setStdout: setStdoutProp,
-  stdout: stdoutProp,
-  uuid: terminalUUID = DEFAULT_TERMINAL_UUID,
+  uuid: _uuid = DEFAULT_TERMINAL_UUID,
   width,
 }: TerminalProps) {
-  const refContainer = useRef(null);
-  const refInner = useRef(null);
+  const refContainer = useRef<HTMLDivElement>(null);
+  const refHost = useRef<HTMLDivElement>(null);
+  const termRef = useRef<XTerm | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const resizeDebounceRef = useRef<number | null>(null);
 
-  const [commandState, setCommandState] = useState<string>('');
-  const setCommand = useCallback((prev) => {
-    if (setCommandProp) {
-      return setCommandProp?.(prev);
-    }
-
-    return setCommandState(prev);
-  }, [setCommandProp]);
-  const command = useMemo(() => typeof commandProp !== 'undefined'
-    ? commandProp
-    : commandState
-  , [commandProp, commandState]);
-  const [commandHistoryState, setCommandHistoryState] = useState<string[]>([]);
-  const setCommandHistory = useCallback((prev) => {
-    if (setCommandHistoryProp) {
-      return setCommandHistoryProp?.(prev);
-    }
-
-    return setCommandHistoryState(prev);
-  }, [setCommandHistoryProp]);
-  const commandHistory = useMemo(() => typeof commandHistoryProp !== 'undefined'
-    ? commandHistoryProp
-    : commandHistoryState
-  , [commandHistoryProp, commandHistoryState]);
-  const [commandIndexState, setCommandIndexState] = useState<number>(0);
-  const setCommandIndex = useCallback((prev) => {
-    if (setCommandIndexProp) {
-      return setCommandIndexProp?.(prev);
-    }
-
-    return setCommandIndexState(prev);
-  }, [setCommandIndexProp]);
-  const commandIndex = useMemo(() => typeof commandIndexProp !== 'undefined'
-    ? commandIndexProp
-    : commandIndexState
-  , [commandIndexProp, commandIndexState]);
-  const [cursorIndexState, setCursorIndexState] = useState<number>(0);
-  const setCursorIndex = useCallback((prev) => {
-    if (setCursorIndexProp) {
-      return setCursorIndexProp?.(prev);
-    }
-
-    return setCursorIndexState(prev);
-  }, [setCursorIndexProp]);
-  const cursorIndex = useMemo(() => typeof cursorIndexProp !== 'undefined'
-    ? cursorIndexProp
-    : cursorIndexState
-  , [cursorIndexProp, cursorIndexState]);
-  const [focusState, setFocusState] = useState<boolean>(false);
-  const setFocus = useCallback((prev) => {
-    if (setFocusProp) {
-      return setFocusProp?.(prev);
-    }
-
-    return setFocusState(prev);
-  }, [setFocusProp]);
-  const focus = useMemo(() => typeof focusProp !== 'undefined'
-    ? focusProp
-    : focusState
-  , [focusProp, focusState]);
-  const [stdoutState, setStdoutState] = useState<string>();
-  const setStdout = useCallback((prev) => {
-    if (setStdoutProp) {
-      return setStdoutProp?.(prev);
-    }
-
-    return setStdoutState(prev);
-  }, [setStdoutProp]);
-  const stdout = useMemo(() => typeof stdoutProp !== 'undefined'
-    ? stdoutProp
-    : stdoutState
-  , [stdoutProp, stdoutState]);
-
-  const token = useMemo(() => new AuthToken(), []);
-  const oauthWebsocketData = useMemo(() => oauthWebsocketDataProp || ({
-    api_key: OAUTH2_APPLICATION_CLIENT_ID,
-    token: token.decodedToken.token,
-  }), [
-    oauthWebsocketDataProp,
-    token,
-  ]);
-
-  useEffect(() => {
-    if (lastMessage) {
-      const msg = JSON.parse(lastMessage.data);
-
-      setStdout(prev => {
-        const p = prev || '';
-        if (msg[0] === 'stdout') {
-          const out = msg[1];
-          return p + out;
-        }
-        return p;
-      });
-    }
-  }, [
-    lastMessage,
-    setStdout,
-  ]);
-
-  const kernelOutputsUpdated: KernelOutputType[] = useMemo(() => {
-    if (typeof outputs !== 'undefined') {
-      return (outputs || []).slice(-TERMINAL_OUTPUT_LIMIT);
-    }
-
-    if (!stdout) {
-      return [];
-    }
-
-    // Filter out commands to configure settings
-    const splitStdout =
-      stdout
-        .split('\n')
-        .slice(-TERMINAL_OUTPUT_LIMIT)
-        .filter(d => !d.includes('# Mage terminal settings command'));
-
-    return splitStdout.map(d => ({
-      data: d,
-      execution_state: null,
-      type: DataTypeEnum.TEXT,
-    }));
-  }, [outputs, stdout]);
-
-  useEffect(() => {
-    if (refContainer.current && refInner.current) {
-      const height = refInner.current.getBoundingClientRect().height;
-      refContainer.current.scrollTo(0, height);
-    }
-  }, [
-    command,
-    kernelOutputsUpdated,
-    refContainer,
-    refInner,
-  ]);
-
-  const {
-    registerOnKeyDown,
-    setDisableGlobalKeyboardShortcuts,
-    unregisterOnKeyDown,
-  } = useKeyboardContext();
-
-  useEffect(() => () => {
-    unregisterOnKeyDown(terminalUUID);
-  }, [unregisterOnKeyDown, terminalUUID]);
-
-  function decreaseCursorIndex() {
-    return setCursorIndex(currIdx => currIdx > 0 ? currIdx - 1 : currIdx);
-  }
-  const increaseCursorIndex = useCallback(() => {
-    setCursorIndex(currIdx => (currIdx < command.length) ? currIdx + 1 : currIdx);
-  }, [command, setCursorIndex]);
-
-  const sendCommand = useCallback((cmd) => {
-    sendMessage(JSON.stringify({
-      ...oauthWebsocketData,
-      command: ['stdin', cmd],
-    }));
-    sendMessage(JSON.stringify({
-      ...oauthWebsocketData,
-      command: ['stdin', '\r'],
-    }));
-    if (cmd?.length >= 2) {
-      setCommandIndex(commandHistory.length + 1);
-      setCommandHistory(prev => prev.concat(cmd));
-      setCursorIndex(0);
-    }
-    setCommand('');
-  }, [
-    commandHistory,
-    sendMessage,
-    setCommand,
-    oauthWebsocketData,
-    setCommandHistory,
-    setCommandIndex,
-    setCursorIndex,
-  ]);
-
-  const handleCopiedText = useCallback((clipText) => {
-    const lines = clipText?.split(/\n/) || [];
-    if (lines.length > 1) {
-      const enteredLines = lines.slice(0, -1);
-      sendCommand(command + enteredLines.join('\n'));
-      const currentCommand = (lines.slice(-1)[0] || '').trim();
-      setCommand(currentCommand);
-      setCursorIndex(currentCommand.length);
-    } else {
-      setCommand(prev => prev + clipText);
-      setCursorIndex(command.length + clipText.length);
-    }
-  }, [
-    command,
-    sendCommand,
-    setCommand,
-    setCursorIndex,
-  ]);
-
-  registerOnKeyDown(
-    terminalUUID,
-    (event, keyMapping, keyHistory) => {
-      const {
-        code,
-        key,
-      } = event;
-
-      if (focus) {
-        if (externalKeyboardShortcuts && externalKeyboardShortcuts(event, keyMapping, keyHistory)) {
-          return;
-        } else {
-          pauseEvent(event);
-        }
-
-        if (onlyKeysPresent([KEY_CODE_CONTROL, KEY_CODE_C], keyMapping)) {
-          if (command?.length >= 0) {
-            sendMessage(JSON.stringify({
-              ...oauthWebsocketData,
-              command: ['stdin', command],
-            }));
-            sendMessage(JSON.stringify({
-              ...oauthWebsocketData,
-              command: ['stdin', '\x03'],
-            }));
-            setCursorIndex(0);
-          }
-          setCommand('');
-        } else {
-          if (KEY_CODE_BACKSPACE === code && !keyMapping[KEY_CODE_META]) {
-            const minIdx = Math.max(0, cursorIndex - 1);
-            setCommand(prev => prev.slice(0, minIdx) + prev.slice(cursorIndex));
-            setCursorIndex(currIdx => Math.max(0, currIdx - 1));
-          } else if (onlyKeysPresent([KEY_CODE_ARROW_LEFT], keyMapping)) {
-            decreaseCursorIndex();
-          } else if (onlyKeysPresent([KEY_CODE_ARROW_RIGHT], keyMapping)) {
-            increaseCursorIndex();
-          } else if (keysPresentAndKeysRecent([KEY_CODE_ARROW_UP], [KEY_CODE_ARROW_UP], keyMapping, keyHistory)) {
-            if (commandHistory.length >= 1) {
-              const idx = Math.max(0, commandIndex - 1);
-              setCommand(commandHistory[idx]);
-              setCommandIndex(idx);
-              setCursorIndex(commandHistory[idx]?.length || 0);
-            }
-          } else if (keysPresentAndKeysRecent([KEY_CODE_ARROW_DOWN], [KEY_CODE_ARROW_DOWN], keyMapping, keyHistory)) {
-            if (commandHistory.length >= 1) {
-              const idx = Math.min(commandHistory.length, commandIndex + 1);
-              const nextCommand = commandHistory[idx] || '';
-              setCommand(nextCommand);
-              setCommandIndex(idx);
-              setCursorIndex(nextCommand.length);
-            }
-          } else if (onlyKeysPresent([KEY_CODE_ENTER], keyMapping)) {
-            sendCommand(command);
-          } else if (onlyKeysPresent([KEY_CODE_META, KEY_CODE_C], keyMapping)) {
-            navigator.clipboard.writeText(window.getSelection().toString());
-          } else if (onlyKeysPresent([KEY_CODE_META, KEY_CODE_V], keyMapping)
-            || onlyKeysPresent([KEY_CODE_CONTROL, KEY_CODE_V], keyMapping)) {
-            if (typeof navigator?.clipboard === 'undefined') {
-              alert('Clipboard pasting is not allowed in insecure contexts. If your Mage '
-                + 'deployment is not secure but you still want to use clipboard paste, you '
-                + 'can override this setting (which should only be done temporarily) '
-                + 'on Chrome browsers by going to '
-                + '"chrome://flags/#unsafely-treat-insecure-origin-as-secure", '
-                + 'adding your origin to "Insecure origins treated as secure", '
-                + 'and enabling that setting.');
-            } else if (navigator?.clipboard?.readText) {
-              navigator.clipboard.readText()
-                .then(handleCopiedText)
-                .catch(err => alert(`${err}
-    For Chrome, users need to allow clipboard permissions for this site under \
-"Privacy and security" -> "Site settings".
-    For Safari, users need to allow the clipboard paste by clicking "Paste" \
-in the context menu that appears.`),
-                );
-            } else if (navigator?.clipboard?.read) {
-              navigator.clipboard.read()
-                .then(clipboardItems => {
-                  for (const clipboardItem of clipboardItems) {
-                    for (const type of clipboardItem.types) {
-                      if (type === 'text/plain') {
-                        return clipboardItem.getType(type);
-                      }
-                    }
-                  }
-                }).then(blob => blob.text())
-                .then(handleCopiedText)
-                .catch(err => alert(`${err}
-    For Firefox, users need to allow clipboard paste by setting the "dom.events.asyncClipboard.read" \
-preference in "about:config" to "true" and clicking "Paste" in the context menu that appears.`),
-                );
-            } else {
-              alert(`If pasting is not working properly, you may need to adjust some settings in your browser.
-
-    For Firefox, users need to allow clipboard paste by setting both the "dom.events.asyncClipboard.clipboardItem" \
-and "dom.events.asyncClipboard.read" preferences in "about:config" to "true" and clicking "Paste" in the context \
-menu that appears.
-    For Chrome, users need to allow clipboard permissions for this site under \
-"Privacy and security" -> "Site settings".
-    For Safari, users need to allow the clipboard paste by clicking "Paste" \
-in the context menu that appears.
-`);
-            }
-          } else if (!keyMapping[KEY_CODE_META] && !keyMapping[KEY_CODE_CONTROL] && key.length === 1) {
-            setCommand(prev => prev?.slice(0, cursorIndex) + key + prev?.slice(cursorIndex));
-            setCursorIndex(currIdx => currIdx + 1);
-          }
-        }
+  const [focusState, setFocusState] = useState(false);
+  const applyFocus = useCallback(
+    (next: boolean) => {
+      if (setFocusProp) {
+        setFocusProp(() => next);
+      } else {
+        setFocusState(next);
       }
     },
-    [
-      command,
-      commandHistory,
-      commandIndex,
-      externalKeyboardShortcuts,
-      focus,
-      kernelOutputsUpdated,
-      setCommand,
-      setCommandHistory,
-      setCommandIndex,
-      terminalUUID,
-    ],
+    [setFocusProp],
+  );
+  const focus = useMemo(
+    () => (typeof focusProp !== 'undefined' ? focusProp : focusState),
+    [focusProp, focusState],
   );
 
-  const lastCommand = useMemo(
-    () => kernelOutputsUpdated[kernelOutputsUpdated.length - 1]?.data,
-    [kernelOutputsUpdated],
+  const theme = useTheme() as typeof dark;
+  const bg = theme?.background?.blackTransparentDark || dark.background.blackTransparentDark;
+  const fg = theme?.content?.default || dark.content.default;
+  const cursor = theme?.accent?.yellow || dark.accent.yellow;
+
+  const token = useMemo(() => new AuthToken(), []);
+  const oauthWebsocketData = useMemo(
+    () =>
+      oauthWebsocketDataProp || {
+        api_key: OAUTH2_APPLICATION_CLIENT_ID,
+        token: token.decodedToken.token,
+      },
+    [oauthWebsocketDataProp, token],
   );
+
+  const sendPayload = useCallback(
+    (command: (string | number)[]) => {
+      sendMessage(
+        JSON.stringify({
+          ...oauthWebsocketData,
+          command,
+        }),
+      );
+    },
+    [oauthWebsocketData, sendMessage],
+  );
+
+  const fitAndNotifySize = useCallback(() => {
+    const term = termRef.current;
+    const fitAddon = fitAddonRef.current;
+    if (!term || !fitAddon) {
+      return;
+    }
+    try {
+      fitAddon.fit();
+    } catch {
+      return;
+    }
+    const { cols, rows } = term;
+    if (cols > 0 && rows > 0) {
+      sendPayload(['set_size', cols, rows]);
+    }
+  }, [sendPayload]);
+
+  const clearScreen = useCallback(() => {
+    termRef.current?.clear();
+    sendPayload(['stdin', '__CLEAR_OUTPUT__']);
+    sendPayload(['stdin', '\r']);
+  }, [sendPayload]);
+
+  const {
+    setDisableGlobalKeyboardShortcuts,
+  } = useKeyboardContext();
+
+  const externalShortcutsRef = useRef(externalKeyboardShortcuts);
+  externalShortcutsRef.current = externalKeyboardShortcuts;
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !refHost.current) {
+      return undefined;
+    }
+
+    const term = new XTerm({
+      cursorBlink: true,
+      fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+      fontSize: 13,
+      scrollback: 5000,
+      theme: {
+        background: bg,
+        cursor: cursor,
+        foreground: fg,
+      },
+    });
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
+    term.open(refHost.current);
+    termRef.current = term;
+    fitAddonRef.current = fitAddon;
+
+    term.onData((data) => {
+      sendPayload(['stdin', data]);
+    });
+
+    term.attachCustomKeyEventHandler((domEvent) => {
+      if (domEvent.metaKey && domEvent.key.toLowerCase() === 'k') {
+        domEvent.preventDefault();
+        clearScreen();
+        return false;
+      }
+      const ext = externalShortcutsRef.current;
+      if (ext) {
+        const keyMapping: Record<string, boolean> = {
+          Meta: domEvent.metaKey,
+          Control: domEvent.ctrlKey,
+          Shift: domEvent.shiftKey,
+          Alt: domEvent.altKey,
+        };
+        if (ext(domEvent, keyMapping, [])) {
+          domEvent.preventDefault();
+          return false;
+        }
+      }
+      return true;
+    });
+
+    requestAnimationFrame(() => {
+      fitAndNotifySize();
+    });
+
+    const ro = new ResizeObserver(() => {
+      if (resizeDebounceRef.current) {
+        window.clearTimeout(resizeDebounceRef.current);
+      }
+      resizeDebounceRef.current = window.setTimeout(() => {
+        resizeDebounceRef.current = null;
+        fitAndNotifySize();
+      }, 100);
+    });
+    ro.observe(refHost.current);
+    resizeObserverRef.current = ro;
+
+    return () => {
+      ro.disconnect();
+      resizeObserverRef.current = null;
+      if (resizeDebounceRef.current) {
+        window.clearTimeout(resizeDebounceRef.current);
+      }
+      term.dispose();
+      termRef.current = null;
+      fitAddonRef.current = null;
+    };
+    // Theme is applied in a separate effect; do not depend on colors here or the PTY session resets.
+  }, [sendPayload, clearScreen]);
+
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) {
+      return;
+    }
+    term.options.theme = {
+      background: bg,
+      cursor: cursor,
+      foreground: fg,
+    };
+  }, [bg, cursor, fg]);
+
+  useEffect(() => {
+    const term = termRef.current;
+    if (!lastMessage || !term) {
+      return;
+    }
+    let msg: unknown;
+    try {
+      msg = JSON.parse(lastMessage.data);
+    } catch {
+      return;
+    }
+    if (!Array.isArray(msg) || typeof msg[0] !== 'string') {
+      return;
+    }
+    if (msg[0] === 'stdout' && typeof msg[1] === 'string') {
+      term.write(msg[1]);
+    } else if (msg[0] === 'disconnect') {
+      term.write('\r\n\x1b[33m[Disconnected]\x1b[0m\r\n');
+    }
+  }, [lastMessage]);
+
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) {
+      return;
+    }
+    if (focus) {
+      term.focus();
+    } else {
+      term.blur();
+    }
+  }, [focus]);
 
   return (
     <ContainerStyle
       ref={refContainer}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
       width={width}
     >
       <ClickOutside
         isOpen
         onClick={() => {
           onFocus?.();
-          setFocus(true);
+          applyFocus(true);
           setDisableGlobalKeyboardShortcuts(true);
+          termRef.current?.focus();
         }}
         onClickOutside={() => {
-          setFocus(false);
+          applyFocus(false);
           setDisableGlobalKeyboardShortcuts(false);
+          termRef.current?.blur();
         }}
         style={{
-          minHeight: '100%',
+          display: 'flex',
+          flex: 1,
+          flexDirection: 'column',
+          minHeight: 0,
+          minWidth: 0,
         }}
       >
-        <InnerStyle
-          ref={refInner}
-          width={width}
-        >
-          {kernelOutputsUpdated?.reduce((acc, kernelOutput: {
-            command?: string;
-            data: string;
-            type: DataTypeEnum;
-          }, idx: number) => {
-            if (idx == kernelOutputsUpdated.length - 1) {
-              return acc;
-            }
-            const {
-              command,
-              data: dataInit,
-              type: dataType,
-            } = kernelOutput || {};
-
-            let dataArray: string[] = [];
-            if (Array.isArray(dataInit)) {
-              dataArray = dataInit;
-            } else {
-              dataArray = [dataInit];
-            }
-            dataArray = dataArray.filter(d => d);
-
-            const arr = [];
-
-            dataArray.forEach((data: string, idxInner: number) => {
-              let displayElement;
-              if (DATA_TYPE_TEXTLIKE.includes(dataType)) {
-                // Replace difficult-to-read blue font with cyan font
-                const dataReplacedBlueFont = (data || '').replaceAll('[34;', '[36;');
-                displayElement = (
-                  <Text
-                    monospace
-                    preWrap
-                    // This used to be a no wrap Text component, but changing it
-                    // to no wrap for now. Please change it back if you see any issues.
-                  >
-                    {data && (
-                      <Ansi>
-                        {dataReplacedBlueFont}
-                      </Ansi>
-                    )}
-                  </Text>
-                );
-              }
-
-              if (displayElement) {
-                const key = `command-${idx}-${idxInner}-${data}`;
-
-                if (!command) {
-                  arr.push(
-                    // <LineStyle key={key}>
-                    <div key={key}>
-                      {displayElement}
-                    </div>,
-                    // </LineStyle>,
-                  );
-                }
-              }
-            });
-
-            return acc.concat(arr);
-          }, [])}
-
-          {(
-            <InputStyle
-              focused={focus
-                && (command?.length === 0)}
-            >
-              <Text monospace>
-                <Text inline monospace>
-                  {lastCommand
-                    && ((Array.isArray(lastCommand) && lastCommand?.length >= 1 && typeof lastCommand?.[0] === 'string') || typeof lastCommand === 'string')
-                    && (
-                    <Ansi>
-                      {Array.isArray(lastCommand) ? lastCommand.join('\n') : lastCommand}
-                    </Ansi>
-                  )}
-                </Text>
-                {command?.split('').map(((char: string, idx: number, arr: string[]) => (
-                  <CharacterStyle
-                    focusBeginning={focus && cursorIndex === 0 && idx === 0}
-                    focused={
-                      focus &&
-                        (cursorIndex === idx + 1 ||
-                          cursorIndex >= arr.length && idx === arr.length - 1)
-                    }
-                    key={`command-${idx}-${char}`}
-                  >
-                    {char === ' ' && <>&nbsp;</>}
-                    {char === '\n' && <br />}
-                    {char !== ' ' && char}
-                  </CharacterStyle>
-                )))}
-              </Text>
-            </InputStyle>
-          )}
-        </InnerStyle>
+        <XTermHost ref={refHost} width={width} />
       </ClickOutside>
     </ContainerStyle>
   );

--- a/mage_ai/frontend/components/Terminal/useTerminal/index.tsx
+++ b/mage_ai/frontend/components/Terminal/useTerminal/index.tsx
@@ -7,7 +7,6 @@ import FileEditorHeader from '@components/FileEditor/Header';
 import FileTabsScroller from '@components/FileTabsScroller';
 import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
-import KernelOutputType, { DataTypeEnum } from '@interfaces/KernelOutputType';
 import Spacing from '@oracle/elements/Spacing';
 import Terminal from '@components/Terminal';
 import useContextMenu from '@utils/useContextMenu';
@@ -16,7 +15,6 @@ import { CachedItemType } from './constants';
 import { ApplicationExpansionUUIDEnum, CommandCenterStateEnum } from '@interfaces/CommandCenterType';
 import { CUSTOM_EVENT_NAME_APPLICATION_STATE_CHANGED } from '@utils/events/constants';
 import { CUSTOM_EVENT_NAME_COMMAND_CENTER_STATE_CHANGED } from '@utils/events/constants';
-import { KEY_CODE_K, KEY_CODE_META } from '@utils/hooks/keyboardShortcuts/constants';
 import { OAUTH2_APPLICATION_CLIENT_ID } from '@api/constants';
 import { StatusEnum } from '@storage/ApplicationManager/constants';
 import { Terminal as TerminalIcon } from '@oracle/icons';
@@ -24,7 +22,6 @@ import { UNIT } from '@oracle/styles/units/spacing';
 import { cleanName, randomNameGenerator } from '@utils/string';
 import { getItems, setItems } from './storage';
 import { getWebSocket } from '@api/utils/url';
-import { keysPresentAndKeysRecent } from '@utils/hooks/keyboardShortcuts/utils';
 import { pushAtIndex } from '@utils/array';
 import { useFileTabs } from '@components/PipelineDetail/FileTabs';
 
@@ -61,77 +58,12 @@ export default function useTerminal({
   const selectedItem: CachedItemType =
     useMemo(() => items?.find(item => item?.selected) || items?.[0], [items]);
 
-  const [command, setCommandState] = useState<{
-    [uuid: string]: string;
-  }>({});
-  const [commandHistory, setCommandHistoryState] = useState<{
-    [uuid: string]: string[];
-  }>({});
-  const [commandIndex, setCommandIndexState] = useState<{
-    [uuid: string]: number;
-  }>({});
-  const [cursorIndex, setCursorIndexState] = useState<{
-    [uuid: string]: number;
-  }>({});
   const [focus, setFocusState] = useState<{
     [uuid: string]: boolean;
   }>({});
-  const [stdout, setStdoutState] = useState<{
-    [uuid: string]: string;
-  }>({});
 
-  const setCommand = useCallback(({ uuid }: CachedItemType, prev0) => {
-    setCommandState((prev1) => {
-      const value = typeof prev0 === 'function' ? prev0(prev1?.[uuid] || '') : prev0;
-
-      return {
-        ...prev1,
-        [uuid]: value,
-      };
-    });
-  }, []);
-  const setCommandHistory = useCallback(({ uuid }: CachedItemType, prev0) => {
-    setCommandHistoryState((prev1) => {
-      const value = typeof prev0 === 'function' ? prev0(prev1?.[uuid] || []) : prev0;
-
-      return {
-        ...prev1,
-        [uuid]: value,
-      };
-    });
-  }, []);
-  const setCommandIndex = useCallback(({ uuid }: CachedItemType, prev0) => {
-    setCommandIndexState((prev1) => {
-      const value = typeof prev0 === 'function' ? prev0(prev1?.[uuid] || 0) : prev0;
-
-      return {
-        ...prev1,
-        [uuid]: value,
-      };
-    });
-  }, []);
-  const setCursorIndex = useCallback(({ uuid }: CachedItemType, prev0) => {
-    setCursorIndexState((prev1) => {
-      const value = typeof prev0 === 'function' ? prev0(prev1?.[uuid] || 0) : prev0;
-
-      return {
-        ...prev1,
-        [uuid]: value,
-      };
-    });
-  }, []);
   const setFocus = useCallback(({ uuid }: CachedItemType, prev0) => {
     setFocusState((prev1) => {
-      const value = typeof prev0 === 'function' ? prev0(prev1?.[uuid]) : prev0;
-
-      return {
-        ...prev1,
-        [uuid]: value,
-      };
-    });
-  }, []);
-  const setStdout = useCallback(({ uuid }: CachedItemType, prev0) => {
-    setStdoutState((prev1) => {
       const value = typeof prev0 === 'function' ? prev0(prev1?.[uuid]) : prev0;
 
       return {
@@ -235,120 +167,40 @@ export default function useTerminal({
 
   const {
     lastMessage,
-    readyState,
     sendMessage,
   } = useWebSocket(getWebSocket(selectedItem ? 'terminal' : null), {
     queryParams: {
       term_name: `${user?.id}--${uuidTerminalController}--${selectedItem?.uuid}`,
     },
-    // shouldReconnect: (data) => {
-    //   return false;
-    // },
-    // onOpen
-    // onMessage
   }, !!selectedItem);
-
-  useEffect(() => {
-    if (lastMessage) {
-      const msg = JSON.parse(lastMessage.data);
-
-      setStdout(selectedItem, (prev: string) => {
-        const p = prev || '';
-        if (msg[0] === 'stdout') {
-          const out = msg[1];
-          return p + out;
-        }
-        return p;
-      });
-    }
-  }, [lastMessage, selectedItem, setStdout]);
 
   const setSelectedItemUUID = useCallback((uuidSelected: string) => {
     updateItems(items?.map(item => ({ ...item, selected: item?.uuid === uuidSelected })));
   }, [items, selectedItem]);
-
-  const stdoutSelected = useMemo(() => stdout?.[selectedItem?.uuid], [selectedItem, stdout]);
-  const outputs: KernelOutputType[] = useMemo(() => {
-    if (!stdoutSelected) {
-      return [];
-    }
-
-    // Filter out commands to configure settings
-    const splitStdout = stdoutSelected
-      .split('\n')
-      .filter(d => !d.includes('# Mage terminal settings command'));
-
-    return splitStdout.map(d => ({
-      data: d,
-      type: DataTypeEnum.TEXT,
-    }));
-  }, [selectedItem, stdoutSelected]);
-
-  const externalKeyboardShortcuts = useCallback((event, keyMapping, keyHistory) => {
-    if (!selectedItem) {
-      return;
-    }
-
-    if (keysPresentAndKeysRecent([KEY_CODE_META], [KEY_CODE_K], keyMapping, keyHistory)) {
-      sendMessage(JSON.stringify({
-        ...oauthWebsocketData,
-        command: ['stdin', '__CLEAR_OUTPUT__'],
-      }));
-      sendMessage(JSON.stringify({
-        ...oauthWebsocketData,
-        command: ['stdin', '\r'],
-      }));
-      setStdout(selectedItem, null);
-
-      return true;
-    }
-
-    return false;
-  }, [oauthWebsocketData, sendMessage, selectedItem, setStdout]);
 
   const terminal = useMemo(() => {
     if (!items?.length) {
       return null;
     }
 
-
     return (
       <Terminal
-        command={command?.[selectedItem?.uuid] || ''}
-        commandHistory={commandHistory?.[selectedItem?.uuid] || []}
-        commandIndex={commandIndex?.[selectedItem?.uuid] || 0}
-        cursorIndex={cursorIndex?.[selectedItem?.uuid] || 0}
-        externalKeyboardShortcuts={externalKeyboardShortcuts}
+        key={selectedItem?.uuid}
         focus={focus?.[selectedItem?.uuid] || false}
         lastMessage={lastMessage}
         oauthWebsocketData={oauthWebsocketData}
-        outputs={outputs}
         sendMessage={sendMessage}
-        setCommand={prev => setCommand(selectedItem, prev)}
-        setCommandHistory={prev => setCommandHistory(selectedItem, prev)}
-        setCommandIndex={prev => setCommandIndex(selectedItem, prev)}
-        setCursorIndex={prev => setCursorIndex(selectedItem, prev)}
         setFocus={prev => setFocus(selectedItem, prev)}
         uuid={uuidTerminalController}
       />
     );
   }, [
-    command,
-    commandHistory,
-    commandIndex,
-    cursorIndex,
-    externalKeyboardShortcuts,
     focus,
     items,
     lastMessage,
     oauthWebsocketData,
-    outputs,
     selectedItem,
     sendMessage,
-    setCommand,
-    setCommandHistory,
-    setCommandIndex,
-    setCursorIndex,
     setFocus,
     uuidTerminalController,
   ]);

--- a/mage_ai/frontend/components/Terminal/xtermFitAddon.ts
+++ b/mage_ai/frontend/components/Terminal/xtermFitAddon.ts
@@ -1,0 +1,103 @@
+/**
+ * FitAddon based on @xterm/addon-fit (MIT). Uses getBoundingClientRect for the
+ * xterm parent so cols/rows match the visible area in flex layouts; stock addon
+ * uses getComputedStyle height/width which is often wrong (auto/NaN), causing
+ * shell wrap width to disagree with xterm and “same-line” redraw glitches.
+ */
+import type { ITerminalAddon, Terminal } from '@xterm/xterm';
+
+const MINIMUM_COLS = 2;
+const MINIMUM_ROWS = 1;
+
+type TerminalWithCore = Terminal & {
+  _core: {
+    _renderService: {
+      clear(): void;
+      dimensions: {
+        css: { cell: { width: number; height: number } };
+      };
+    };
+  };
+};
+
+function overviewRulerReserve(terminal: Terminal): number {
+  if (terminal.options.scrollback === 0) {
+    return 0;
+  }
+  const w = terminal.options.overviewRuler?.width;
+  return typeof w === 'number' ? w : 14;
+}
+
+export class FitAddon implements ITerminalAddon {
+  private _terminal?: Terminal;
+
+  public activate(terminal: Terminal): void {
+    this._terminal = terminal;
+  }
+
+  public dispose(): void {}
+
+  public fit(): void {
+    const dims = this.proposeDimensions();
+    if (!dims || !this._terminal || Number.isNaN(dims.cols) || Number.isNaN(dims.rows)) {
+      return;
+    }
+    const term = this._terminal as TerminalWithCore;
+    const core = term._core;
+    if (this._terminal.rows !== dims.rows || this._terminal.cols !== dims.cols) {
+      core._renderService.clear();
+      this._terminal.resize(dims.cols, dims.rows);
+    }
+  }
+
+  public proposeDimensions(): { cols: number; rows: number } | undefined {
+    if (!this._terminal?.element?.parentElement) {
+      return undefined;
+    }
+    const term = this._terminal as TerminalWithCore;
+    const renderDims = term._core._renderService.dimensions;
+    if (renderDims.css.cell.width === 0 || renderDims.css.cell.height === 0) {
+      return undefined;
+    }
+
+    const parent = this._terminal.element.parentElement;
+    const rect = parent.getBoundingClientRect();
+    let parentWidth = rect.width;
+    let parentHeight = rect.height;
+    if (!parentWidth || !parentHeight) {
+      parentWidth = parent.clientWidth;
+      parentHeight = parent.clientHeight;
+    }
+    if (!parentWidth || !parentHeight) {
+      return undefined;
+    }
+
+    const ruler = overviewRulerReserve(this._terminal);
+    const elStyle = window.getComputedStyle(this._terminal.element);
+    const padding = {
+      top: parseInt(elStyle.getPropertyValue('padding-top'), 10) || 0,
+      bottom: parseInt(elStyle.getPropertyValue('padding-bottom'), 10) || 0,
+      right: parseInt(elStyle.getPropertyValue('padding-right'), 10) || 0,
+      left: parseInt(elStyle.getPropertyValue('padding-left'), 10) || 0,
+    };
+    const verticalPadding = padding.top + padding.bottom;
+    const horizontalPadding = padding.right + padding.left;
+    const availableHeight = parentHeight - verticalPadding;
+    const availableWidth = parentWidth - horizontalPadding - ruler;
+
+    if (availableWidth <= 0 || availableHeight <= 0) {
+      return undefined;
+    }
+
+    return {
+      cols: Math.max(
+        MINIMUM_COLS,
+        Math.floor(availableWidth / renderDims.css.cell.width),
+      ),
+      rows: Math.max(
+        MINIMUM_ROWS,
+        Math.floor(availableHeight / renderDims.css.cell.height),
+      ),
+    };
+  }
+}

--- a/mage_ai/frontend/components/VersionControl/GitActions.tsx
+++ b/mage_ai/frontend/components/VersionControl/GitActions.tsx
@@ -206,6 +206,7 @@ function GitActions({
     lastMessage,
     sendMessage,
   } = useWebSocket(getWebSocket('terminal'), {
+    queryParams: sharedWebsocketData,
     shouldReconnect: () => true,
   }, 'cwd' in sharedWebsocketData);
 

--- a/mage_ai/frontend/package.json
+++ b/mage_ai/frontend/package.json
@@ -43,7 +43,6 @@
     "@visx/threshold": "2.12.2",
     "@visx/tooltip": "2.16.0",
     "@visx/voronoi": "2.10.0",
-    "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "add": "^2.0.6",
     "ansi-to-react": "^6.1.6",

--- a/mage_ai/frontend/package.json
+++ b/mage_ai/frontend/package.json
@@ -43,6 +43,8 @@
     "@visx/threshold": "2.12.2",
     "@visx/tooltip": "2.16.0",
     "@visx/voronoi": "2.10.0",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "add": "^2.0.6",
     "ansi-to-react": "^6.1.6",
     "axios": "^0.27.2",

--- a/mage_ai/frontend/pages/_app.tsx
+++ b/mage_ai/frontend/pages/_app.tsx
@@ -10,6 +10,7 @@ import { createRoot } from 'react-dom/client';
 
 import 'react-toastify/dist/ReactToastify.min.css';
 import '@styles/globals.css';
+import '@xterm/xterm/css/xterm.css';
 import '@styles/scss/main.scss';
 import '@styles/scss/themes/dark.scss';
 import '@styles/scss/themes/light.scss';

--- a/mage_ai/frontend/yarn.lock
+++ b/mage_ai/frontend/yarn.lock
@@ -4366,6 +4366,16 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
   integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
 
+"@xterm/addon-fit@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-fit/-/addon-fit-0.11.0.tgz#ba4778b69fcc9044a060c2176bbe077657d7b37e"
+  integrity sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==
+
+"@xterm/xterm@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@xterm/xterm/-/xterm-6.0.0.tgz#93637b0f2ee3a70718b5746a27c9c506af16745b"
+  integrity sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"

--- a/mage_ai/frontend/yarn.lock
+++ b/mage_ai/frontend/yarn.lock
@@ -4366,11 +4366,6 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
   integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
 
-"@xterm/addon-fit@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@xterm/addon-fit/-/addon-fit-0.11.0.tgz#ba4778b69fcc9044a060c2176bbe077657d7b37e"
-  integrity sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==
-
 "@xterm/xterm@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@xterm/xterm/-/xterm-6.0.0.tgz#93637b0f2ee3a70718b5746a27c9c506af16745b"


### PR DESCRIPTION
# Description
This PR implements shell-style tab completion and correct line wrapping in the Mage UI terminal ([#3499](https://github.com/mage-ai/mage-ai/issues/3499)) by replacing the previous line-buffered input with xterm.js, so every keystroke (including Tab) is sent to the PTY via the existing terminado WebSocket.

# How Has This Been Tested?
Manual checks in a local Mage dev session (frontend + server):
 
- [Open Terminal: onfirm the shell receives input and completes Commands]
- [ Type a long line; wrapping follows the visible width of the panel] 
- [Resize the panel / window; prompt and input reflow without column drift]
- [⌘+K (or equivalent clear shortcut) still clears as expected.]

FYI: https://www.loom.com/share/ddf928266ee84950b55646925caca6f8

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [ ] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

