### PR TITLE
[cb] Let users filter pipeline runs by date time. ckabiroan/master/issue-6062 to mage-ai/master

### DIFF
--- a/docs/orchestration/pipeline-runs/overview.mdx
+++ b/docs/orchestration/pipeline-runs/overview.mdx
@@ -77,11 +77,13 @@ The pipeline run list page provides comprehensive filtering options:
 - **Pipeline UUID** - Filter by specific pipeline identifiers
 - **Status** - Filter by run status (Cancelled, Done, Failed, Last run failed, Ready, Running)
 - **Pipeline Tag** - Filter by pipeline tags
+- **Date Time** – Filter by fixed ranges or by a custom date/time range with configurable start and end timestamps
 - **Search** - Text search across pipeline runs (Mage Pro only)
 
 **Filter Actions:**
 - **Apply filters** - Apply selected filter criteria
 - **Reset filters** - Clear all filters and return to defaults
+- **Filter** - Apply the Date Time filter
 
 <Info>
   **Mage OSS vs Pro**: 

--- a/docs/orchestration/pipeline-runs/overview.mdx
+++ b/docs/orchestration/pipeline-runs/overview.mdx
@@ -83,7 +83,7 @@ The pipeline run list page provides comprehensive filtering options:
 **Filter Actions:**
 - **Apply filters** - Apply selected filter criteria
 - **Reset filters** - Clear all filters and return to defaults
-- **Filter** - Apply the Date Time filter
+- **Filter** - Apply the selected Date Time filter only
 
 <Info>
   **Mage OSS vs Pro**: 

--- a/mage_ai/api/resources/PipelineRunResource.py
+++ b/mage_ai/api/resources/PipelineRunResource.py
@@ -168,10 +168,10 @@ class PipelineRunResource(DatabaseResource):
         if statuses:
             results = results.filter(PipelineRun.status.in_(statuses))
         if start_timestamp is not None:
-            # Filter by created_at to include runs that have yet to started
+            # Filter by created_at to include runs that have not started
             results = results.filter(PipelineRun.created_at >= start_timestamp)
         if end_timestamp is not None:
-            # Filter by created_at to include runs that have yet to started
+            # Filter by created_at to include runs that have not started
             results = results.filter(PipelineRun.created_at <= end_timestamp)
 
         limit = int((meta or {}).get(META_KEY_LIMIT, self.DEFAULT_LIMIT))

--- a/mage_ai/api/resources/PipelineRunResource.py
+++ b/mage_ai/api/resources/PipelineRunResource.py
@@ -168,9 +168,9 @@ class PipelineRunResource(DatabaseResource):
         if statuses:
             results = results.filter(PipelineRun.status.in_(statuses))
         if start_timestamp is not None:
-            results = results.filter(PipelineRun.started_at >= start_timestamp)
+            results = results.filter(PipelineRun.created_at >= start_timestamp)
         if end_timestamp is not None:
-            results = results.filter(PipelineRun.started_at <= end_timestamp)
+            results = results.filter(PipelineRun.created_at <= end_timestamp)
 
         limit = int((meta or {}).get(META_KEY_LIMIT, self.DEFAULT_LIMIT))
 

--- a/mage_ai/api/resources/PipelineRunResource.py
+++ b/mage_ai/api/resources/PipelineRunResource.py
@@ -170,7 +170,7 @@ class PipelineRunResource(DatabaseResource):
         if start_timestamp is not None:
             results = results.filter(PipelineRun.started_at >= start_timestamp)
         if end_timestamp is not None:
-            results = results.filter(PipelineRun.completed_at <= end_timestamp)
+            results = results.filter(PipelineRun.started_at <= end_timestamp)
 
         limit = int((meta or {}).get(META_KEY_LIMIT, self.DEFAULT_LIMIT))
 

--- a/mage_ai/api/resources/PipelineRunResource.py
+++ b/mage_ai/api/resources/PipelineRunResource.py
@@ -168,8 +168,10 @@ class PipelineRunResource(DatabaseResource):
         if statuses:
             results = results.filter(PipelineRun.status.in_(statuses))
         if start_timestamp is not None:
+            # Filter by created_at to include runs that have yet to started
             results = results.filter(PipelineRun.created_at >= start_timestamp)
         if end_timestamp is not None:
+            # Filter by created_at to include runs that have yet to started
             results = results.filter(PipelineRun.created_at <= end_timestamp)
 
         limit = int((meta or {}).get(META_KEY_LIMIT, self.DEFAULT_LIMIT))

--- a/mage_ai/api/resources/PipelineRunResource.py
+++ b/mage_ai/api/resources/PipelineRunResource.py
@@ -168,9 +168,9 @@ class PipelineRunResource(DatabaseResource):
         if statuses:
             results = results.filter(PipelineRun.status.in_(statuses))
         if start_timestamp is not None:
-            results = results.filter(PipelineRun.created_at >= start_timestamp)
+            results = results.filter(PipelineRun.started_at >= start_timestamp)
         if end_timestamp is not None:
-            results = results.filter(PipelineRun.created_at <= end_timestamp)
+            results = results.filter(PipelineRun.completed_at <= end_timestamp)
 
         limit = int((meta or {}).get(META_KEY_LIMIT, self.DEFAULT_LIMIT))
 

--- a/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
+++ b/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
@@ -91,6 +91,8 @@ function DateTimeRange({ timestamps, setSelectedRange, selectedRange }) {
                             {
                                 [DateTimeRangeQueryEnum.START]: startTimestamp,
                                 [DateTimeRangeQueryEnum.END]: null,
+                                page: null,
+                                offset: null,
                             },
                         );
                     }
@@ -175,6 +177,8 @@ function DateTimeRange({ timestamps, setSelectedRange, selectedRange }) {
                                 goToWithQuery({
                                     [DateTimeRangeQueryEnum.START]: unixTimestampFromDate(start),
                                     [DateTimeRangeQueryEnum.END]: unixTimestampFromDate(end),
+                                    page: null,
+                                    offset: null,
                                 });
                             }}
                             padding={`${UNIT / 2}px`}

--- a/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
+++ b/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
@@ -1,0 +1,164 @@
+import { useState } from 'react';
+
+import Button from '@oracle/elements/Button';
+import Calendar, { TimeType } from '@oracle/components/Calendar';
+import ClickOutside from '@oracle/components/ClickOutside';
+import Select from '@oracle/elements/Inputs/Select';
+import Spacing from '@oracle/elements/Spacing';
+import Text from '@oracle/elements/Text';
+import TextInput from '@oracle/elements/Inputs/TextInput';
+import { LogRangeEnum } from '@interfaces/LogType';
+
+import { UNIT } from '@oracle/styles/units/spacing';
+import { calculateStartTimestamp } from '@utils/number';
+import {
+    isoDateFormatFromDateParts,
+    padTime,
+    unixTimestampFromDate,
+    utcDateFromDateAndTime,
+} from '@utils/date';
+import { goToWithQuery } from '@utils/routing';
+import FlexContainer from '@oracle/components/FlexContainer';
+
+enum RangeQueryEnum {
+    START = 'start_timestamp',
+    END = 'end_timestamp',
+}
+
+const RANGES = [
+    LogRangeEnum.LAST_HOUR,
+    LogRangeEnum.LAST_DAY,
+    LogRangeEnum.LAST_WEEK,
+    LogRangeEnum.LAST_30_DAYS,
+];
+
+const RANGE_SECOND_INTERVAL_MAPPING = {
+    [LogRangeEnum.LAST_HOUR]: 3600,
+    [LogRangeEnum.LAST_DAY]: 86400,
+    [LogRangeEnum.LAST_WEEK]: 604800,
+    [LogRangeEnum.LAST_30_DAYS]: 2592000,
+};
+
+function DateTimeRange({ setSelectedRange, selectedRange }) {
+    const [showCalendarIndex, setShowCalendarIndex] = useState<number>(null);
+    const [startDate, setStartDate] = useState<Date>(null);
+    const [startTime, setStartTime] = useState<TimeType>({ hour: '00', minute: '00' });
+    const [endDate, setEndDate] = useState<Date>(new Date());
+    const [endTime, setEndTime] = useState<TimeType>({
+        hour: padTime(String(new Date().getUTCHours())),
+        minute: padTime(String(new Date().getUTCMinutes())),
+    });
+
+    return (
+        <FlexContainer alignItems="center">
+            <Select
+                compact
+                defaultColor
+                onChange={e => {
+                    e.preventDefault();
+                    const range = e.target.value;
+                    setSelectedRange(range);
+                    if (RANGES.includes(range)) {
+                        const startTimestamp = calculateStartTimestamp(RANGE_SECOND_INTERVAL_MAPPING[range]);
+                        goToWithQuery(
+                            {
+                                [RangeQueryEnum.START]: startTimestamp,
+                                [RangeQueryEnum.END]: null,
+                            },
+                        );
+                    }
+                }}
+                paddingRight={UNIT * 4}
+                placeholder="Select time range"
+                value={selectedRange}
+            >
+                {Object.values(LogRangeEnum).map(range => (
+                    <option key={range} value={range}>
+                        {range}
+                    </option>
+                ))}
+            </Select>
+
+            <Spacing mr={1} />
+
+            {
+                selectedRange === LogRangeEnum.CUSTOM_RANGE && (
+                    <>
+                        <TextInput
+                            compact
+                            defaultColor
+                            onClick={() => setShowCalendarIndex(0)}
+                            paddingRight={0}
+                            placeholder="Start"
+                            value={startDate
+                                ? utcDateFromDateAndTime(startDate, startTime?.hour, startTime?.minute)
+                                : ''
+                            }
+                        />
+                        <ClickOutside
+                            onClickOutside={() => setShowCalendarIndex(null)}
+                            open={showCalendarIndex === 0}
+                            style={{ position: 'relative' }}
+                        >
+                            <Calendar
+                                selectedDate={startDate}
+                                selectedTime={startTime}
+                                setSelectedDate={setStartDate}
+                                setSelectedTime={setStartTime}
+                            />
+                        </ClickOutside>
+
+                        <Spacing px={1}>
+                            <Text>
+                                to
+                            </Text>
+                        </Spacing>
+
+                        <TextInput
+                            compact
+                            defaultColor
+                            onClick={() => setShowCalendarIndex(1)}
+                            paddingRight={0}
+                            placeholder="End"
+                            value={endDate
+                                ? utcDateFromDateAndTime(endDate, endTime?.hour, endTime?.minute)
+                                : ''
+                            }
+                        />
+                        <ClickOutside
+                            onClickOutside={() => setShowCalendarIndex(null)}
+                            open={showCalendarIndex === 1}
+                            style={{ position: 'relative' }}
+                        >
+                            <Calendar
+                                selectedDate={endDate}
+                                selectedTime={endTime}
+                                setSelectedDate={setEndDate}
+                                setSelectedTime={setEndTime}
+                            />
+                        </ClickOutside>
+
+                        <Spacing mr={1} />
+
+                        <Button
+                            borderRadius={`${UNIT / 2}px`}
+                            onClick={() => {
+                                const start = isoDateFormatFromDateParts(startDate, startTime.hour, startTime.minute);
+                                const end = isoDateFormatFromDateParts(endDate, endTime.hour, endTime.minute);
+                                goToWithQuery({
+                                    [RangeQueryEnum.START]: unixTimestampFromDate(start),
+                                    [RangeQueryEnum.END]: unixTimestampFromDate(end),
+                                });
+                            }}
+                            padding={`${UNIT / 2}px`}
+                            primary
+                        >
+                            Filter
+                        </Button>
+                    </>
+                )
+            }
+        </FlexContainer>)
+};
+
+export default DateTimeRange;

--- a/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
+++ b/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import Button from '@oracle/elements/Button';
 import Calendar, { TimeType } from '@oracle/components/Calendar';
@@ -11,6 +11,7 @@ import TextInput from '@oracle/elements/Inputs/TextInput';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { calculateStartTimestamp } from '@utils/number';
 import {
+    getDatePartsFromUnixTimestamp,
     isoDateFormatFromDateParts,
     padTime,
     unixTimestampFromDate,
@@ -19,8 +20,10 @@ import {
 import { goToWithQuery } from '@utils/routing';
 import FlexContainer from '@oracle/components/FlexContainer';
 import { DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING, DATE_TIME_RANGES, DateTimeRangeEnum, DateTimeRangeQueryEnum } from '@interfaces/DateTimeRangeType';
+import { queryFromUrl } from '@utils/url';
 
 function DateTimeRange({ setSelectedRange, selectedRange }) {
+    const q = queryFromUrl();
     const [showCalendarIndex, setShowCalendarIndex] = useState<number>(null);
     const [startDate, setStartDate] = useState<Date>(null);
     const [startTime, setStartTime] = useState<TimeType>({ hour: '00', minute: '00' });
@@ -29,6 +32,44 @@ function DateTimeRange({ setSelectedRange, selectedRange }) {
         hour: padTime(String(new Date().getUTCHours())),
         minute: padTime(String(new Date().getUTCMinutes())),
     });
+
+    useEffect(() => {
+        const {
+            start_timestamp: initialStart,
+            end_timestamp: initialEnd,
+        } = q;
+
+        if (initialStart) {
+            const {
+                date: initialStartDate,
+                hour: initialStartHour,
+                minute: initialStartMinute,
+            } = getDatePartsFromUnixTimestamp(initialStart);
+            setStartDate(initialStartDate);
+            setStartTime({
+                hour: padTime(initialStartHour),
+                minute: padTime(initialStartMinute),
+            });
+
+            const secondsAgo = (Math.ceil(Date.now() / 1000) - initialStart);
+            if (Math.abs(secondsAgo - DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING[DateTimeRangeEnum.LAST_DAY]) <= 60) {
+                setSelectedRange(DateTimeRangeEnum.LAST_DAY);
+            }
+        }
+
+        if (initialEnd) {
+            const {
+                date: initialEndDate,
+                hour: initialEndHour,
+                minute: initialEndMinute,
+            } = getDatePartsFromUnixTimestamp(initialEnd);
+            setEndDate(initialEndDate);
+            setEndTime({
+                hour: padTime(initialEndHour),
+                minute: padTime(initialEndMinute),
+            });
+        }
+    }, []);
 
     return (
         <FlexContainer alignItems="center">

--- a/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
+++ b/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
@@ -11,189 +11,194 @@ import TextInput from '@oracle/elements/Inputs/TextInput';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { calculateStartTimestamp } from '@utils/number';
 import {
-    getDatePartsFromUnixTimestamp,
-    isoDateFormatFromDateParts,
-    padTime,
-    unixTimestampFromDate,
-    utcDateFromDateAndTime,
+  getDatePartsFromUnixTimestamp,
+  isoDateFormatFromDateParts,
+  padTime,
+  unixTimestampFromDate,
+  utcDateFromDateAndTime,
 } from '@utils/date';
 import { goToWithQuery } from '@utils/routing';
 import FlexContainer from '@oracle/components/FlexContainer';
-import { DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING, DATE_TIME_RANGES, DateTimeRangeEnum, DateTimeRangeQueryEnum } from '@interfaces/DateTimeRangeType';
+import {
+  DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING,
+  DATE_TIME_RANGES,
+  DateTimeRangeEnum,
+  DateTimeRangeProps,
+  DateTimeRangeQueryEnum,
+} from '@interfaces/DateTimeRangeType';
 
-function DateTimeRange({ timestamps, setSelectedRange, selectedRange }) {
-    const [showCalendarIndex, setShowCalendarIndex] = useState<number>(null);
-    const [startDate, setStartDate] = useState<Date>(null);
-    const [startTime, setStartTime] = useState<TimeType>({ hour: '00', minute: '00' });
-    const [endDate, setEndDate] = useState<Date>(new Date());
-    const [endTime, setEndTime] = useState<TimeType>({
-        hour: padTime(String(new Date().getUTCHours())),
-        minute: padTime(String(new Date().getUTCMinutes())),
-    });
+function DateTimeRange({ timestamps, setSelectedRange, selectedRange }: DateTimeRangeProps) {
+  const [showCalendarIndex, setShowCalendarIndex] = useState<number>(null);
+  const [startDate, setStartDate] = useState<Date>(null);
+  const [startTime, setStartTime] = useState<TimeType>({ hour: '00', minute: '00' });
+  const [endDate, setEndDate] = useState<Date>(new Date());
+  const [endTime, setEndTime] = useState<TimeType>({
+    hour: padTime(String(new Date().getUTCHours())),
+    minute: padTime(String(new Date().getUTCMinutes())),
+  });
 
-    useEffect(() => {
+  useEffect(
+    () => {
+      const { start_timestamp: initialStart, end_timestamp: initialEnd } = timestamps;
+
+      if (initialStart) {
         const {
-            start_timestamp: initialStart,
-            end_timestamp: initialEnd,
-        } = timestamps;
+          date: initialStartDate,
+          hour: initialStartHour,
+          minute: initialStartMinute,
+        } = getDatePartsFromUnixTimestamp(initialStart);
+        setStartDate(initialStartDate);
+        setStartTime({
+          hour: padTime(initialStartHour),
+          minute: padTime(initialStartMinute),
+        });
 
-        if (initialStart) {
-            const {
-                date: initialStartDate,
-                hour: initialStartHour,
-                minute: initialStartMinute,
-            } = getDatePartsFromUnixTimestamp(initialStart);
-            setStartDate(initialStartDate);
-            setStartTime({
-                hour: padTime(initialStartHour),
-                minute: padTime(initialStartMinute),
-            });
-
-            const secondsAgo = (Math.ceil(Date.now() / 1000) - initialStart);
-            if (Math.abs(secondsAgo - DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING[DateTimeRangeEnum.LAST_DAY]) <= 60) {
-                setSelectedRange(DateTimeRangeEnum.LAST_DAY);
-            }
-            else if (Math.abs(secondsAgo - DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING[DateTimeRangeEnum.LAST_HOUR]) <= 3600) {
-                setSelectedRange(DateTimeRangeEnum.LAST_HOUR);
-            }
+        const secondsAgo = Math.ceil(Date.now() / 1000) - initialStart;
+        if (
+          Math.abs(
+            secondsAgo - DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING[DateTimeRangeEnum.LAST_DAY],
+          ) <= 60
+        ) {
+          setSelectedRange(DateTimeRangeEnum.LAST_DAY);
+        } else if (
+          Math.abs(
+            secondsAgo - DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING[DateTimeRangeEnum.LAST_HOUR],
+          ) <= 3600
+        ) {
+          setSelectedRange(DateTimeRangeEnum.LAST_HOUR);
         }
+      }
 
-        if (initialEnd) {
-            const {
-                date: initialEndDate,
-                hour: initialEndHour,
-                minute: initialEndMinute,
-            } = getDatePartsFromUnixTimestamp(initialEnd);
-            setEndDate(initialEndDate);
-            setEndTime({
-                hour: padTime(initialEndHour),
-                minute: padTime(initialEndMinute),
-            });
-        }
+      if (initialEnd) {
+        const {
+          date: initialEndDate,
+          hour: initialEndHour,
+          minute: initialEndMinute,
+        } = getDatePartsFromUnixTimestamp(initialEnd);
+        setEndDate(initialEndDate);
+        setEndTime({
+          hour: padTime(initialEndHour),
+          minute: padTime(initialEndMinute),
+        });
+      }
 
-        if (initialStart && initialEnd) {
-            setSelectedRange(DateTimeRangeEnum.CUSTOM_RANGE);
-        }
+      if (initialStart && initialEnd) {
+        setSelectedRange(DateTimeRangeEnum.CUSTOM_RANGE);
+      }
     },
-        // Initialize state from URL params on mount.
-        // Avoid re-running on query changes to prevent overwriting user input.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        []);
+    // Initialize state from URL params on mount.
+    // Avoid re-running on query changes to prevent overwriting user input.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
 
-    return (
-        <FlexContainer alignItems="center">
-            <Select
-                compact
-                defaultColor
-                onChange={e => {
-                    e.preventDefault();
-                    const range = e.target.value;
-                    setSelectedRange(range);
-                    if (DATE_TIME_RANGES.includes(range)) {
-                        const startTimestamp = calculateStartTimestamp(DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING[range]);
-                        goToWithQuery(
-                            {
-                                [DateTimeRangeQueryEnum.START]: startTimestamp,
-                                [DateTimeRangeQueryEnum.END]: null,
-                                page: null,
-                                offset: null,
-                            },
-                        );
-                    }
-                }}
-                paddingRight={UNIT * 4}
-                placeholder="Select time range"
-                value={selectedRange}
-            >
-                {Object.values(DateTimeRangeEnum).map(range => (
-                    <option key={range} value={range}>
-                        {range}
-                    </option>
-                ))}
-            </Select>
+  return (
+    <FlexContainer alignItems='center'>
+      <Select
+        compact
+        defaultColor
+        onChange={e => {
+          e.preventDefault();
+          const range = e.target.value;
+          setSelectedRange(range);
+          if (DATE_TIME_RANGES.includes(range)) {
+            const startTimestamp = calculateStartTimestamp(
+              DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING[range],
+            );
+            goToWithQuery({
+              [DateTimeRangeQueryEnum.START]: startTimestamp,
+              [DateTimeRangeQueryEnum.END]: null,
+              offset: null,
+              page: null,
+            });
+          }
+        }}
+        paddingRight={UNIT * 4}
+        placeholder='Select time range'
+        value={selectedRange}
+      >
+        {Object.values(DateTimeRangeEnum).map(range => (
+          <option key={range} value={range}>
+            {range}
+          </option>
+        ))}
+      </Select>
 
-            <Spacing mr={1} />
+      <Spacing mr={1} />
 
-            {
-                selectedRange === DateTimeRangeEnum.CUSTOM_RANGE && (
-                    <>
-                        <TextInput
-                            compact
-                            defaultColor
-                            onClick={() => setShowCalendarIndex(0)}
-                            paddingRight={0}
-                            placeholder="Start"
-                            value={startDate
-                                ? utcDateFromDateAndTime(startDate, startTime?.hour, startTime?.minute)
-                                : ''
-                            }
-                        />
-                        <ClickOutside
-                            onClickOutside={() => setShowCalendarIndex(null)}
-                            open={showCalendarIndex === 0}
-                            style={{ position: 'relative' }}
-                        >
-                            <Calendar
-                                selectedDate={startDate}
-                                selectedTime={startTime}
-                                setSelectedDate={setStartDate}
-                                setSelectedTime={setStartTime}
-                            />
-                        </ClickOutside>
-
-                        <Spacing px={1}>
-                            <Text>
-                                to
-                            </Text>
-                        </Spacing>
-
-                        <TextInput
-                            compact
-                            defaultColor
-                            onClick={() => setShowCalendarIndex(1)}
-                            paddingRight={0}
-                            placeholder="End"
-                            value={endDate
-                                ? utcDateFromDateAndTime(endDate, endTime?.hour, endTime?.minute)
-                                : ''
-                            }
-                        />
-                        <ClickOutside
-                            onClickOutside={() => setShowCalendarIndex(null)}
-                            open={showCalendarIndex === 1}
-                            style={{ position: 'relative' }}
-                        >
-                            <Calendar
-                                selectedDate={endDate}
-                                selectedTime={endTime}
-                                setSelectedDate={setEndDate}
-                                setSelectedTime={setEndTime}
-                            />
-                        </ClickOutside>
-
-                        <Spacing mr={1} />
-
-                        <Button
-                            borderRadius={`${UNIT / 2}px`}
-                            onClick={() => {
-                                const start = isoDateFormatFromDateParts(startDate, startTime.hour, startTime.minute);
-                                const end = isoDateFormatFromDateParts(endDate, endTime.hour, endTime.minute);
-                                goToWithQuery({
-                                    [DateTimeRangeQueryEnum.START]: unixTimestampFromDate(start),
-                                    [DateTimeRangeQueryEnum.END]: unixTimestampFromDate(end),
-                                    page: null,
-                                    offset: null,
-                                });
-                            }}
-                            padding={`${UNIT / 2}px`}
-                            primary
-                        >
-                            Filter
-                        </Button>
-                    </>
-                )
+      {selectedRange === DateTimeRangeEnum.CUSTOM_RANGE && (
+        <>
+          <TextInput
+            compact
+            defaultColor
+            onClick={() => setShowCalendarIndex(0)}
+            paddingRight={0}
+            placeholder='Start'
+            value={
+              startDate ? utcDateFromDateAndTime(startDate, startTime?.hour, startTime?.minute) : ''
             }
-        </FlexContainer>)
-};
+          />
+          <ClickOutside
+            onClickOutside={() => setShowCalendarIndex(null)}
+            open={showCalendarIndex === 0}
+            style={{ position: 'relative' }}
+          >
+            <Calendar
+              selectedDate={startDate}
+              selectedTime={startTime}
+              setSelectedDate={setStartDate}
+              setSelectedTime={setStartTime}
+            />
+          </ClickOutside>
+
+          <Spacing px={1}>
+            <Text>to</Text>
+          </Spacing>
+
+          <TextInput
+            compact
+            defaultColor
+            onClick={() => setShowCalendarIndex(1)}
+            paddingRight={0}
+            placeholder='End'
+            value={endDate ? utcDateFromDateAndTime(endDate, endTime?.hour, endTime?.minute) : ''}
+          />
+          <ClickOutside
+            onClickOutside={() => setShowCalendarIndex(null)}
+            open={showCalendarIndex === 1}
+            style={{ position: 'relative' }}
+          >
+            <Calendar
+              selectedDate={endDate}
+              selectedTime={endTime}
+              setSelectedDate={setEndDate}
+              setSelectedTime={setEndTime}
+            />
+          </ClickOutside>
+
+          <Spacing mr={1} />
+
+          <Button
+            borderRadius={`${UNIT / 2}px`}
+            onClick={() => {
+              const start = isoDateFormatFromDateParts(startDate, startTime.hour, startTime.minute);
+              const end = isoDateFormatFromDateParts(endDate, endTime.hour, endTime.minute);
+              goToWithQuery({
+                [DateTimeRangeQueryEnum.START]: unixTimestampFromDate(start),
+                [DateTimeRangeQueryEnum.END]: unixTimestampFromDate(end),
+                offset: null,
+                page: null,
+              });
+            }}
+            padding={`${UNIT / 2}px`}
+            primary
+          >
+            Filter
+          </Button>
+        </>
+      )}
+    </FlexContainer>
+  );
+}
 
 export default DateTimeRange;

--- a/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
+++ b/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
@@ -20,10 +20,8 @@ import {
 import { goToWithQuery } from '@utils/routing';
 import FlexContainer from '@oracle/components/FlexContainer';
 import { DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING, DATE_TIME_RANGES, DateTimeRangeEnum, DateTimeRangeQueryEnum } from '@interfaces/DateTimeRangeType';
-import { queryFromUrl } from '@utils/url';
 
-function DateTimeRange({ setSelectedRange, selectedRange }) {
-    const q = queryFromUrl();
+function DateTimeRange({ timestamps, setSelectedRange, selectedRange }) {
     const [showCalendarIndex, setShowCalendarIndex] = useState<number>(null);
     const [startDate, setStartDate] = useState<Date>(null);
     const [startTime, setStartTime] = useState<TimeType>({ hour: '00', minute: '00' });
@@ -37,7 +35,7 @@ function DateTimeRange({ setSelectedRange, selectedRange }) {
         const {
             start_timestamp: initialStart,
             end_timestamp: initialEnd,
-        } = q;
+        } = timestamps;
 
         if (initialStart) {
             const {

--- a/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
+++ b/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
@@ -55,6 +55,9 @@ function DateTimeRange({ setSelectedRange, selectedRange }) {
             if (Math.abs(secondsAgo - DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING[DateTimeRangeEnum.LAST_DAY]) <= 60) {
                 setSelectedRange(DateTimeRangeEnum.LAST_DAY);
             }
+            else if (Math.abs(secondsAgo - DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING[DateTimeRangeEnum.LAST_HOUR]) <= 3600) {
+                setSelectedRange(DateTimeRangeEnum.LAST_HOUR);
+            }
         }
 
         if (initialEnd) {
@@ -68,6 +71,10 @@ function DateTimeRange({ setSelectedRange, selectedRange }) {
                 hour: padTime(initialEndHour),
                 minute: padTime(initialEndMinute),
             });
+        }
+
+        if (initialStart && initialEnd) {
+            setSelectedRange(DateTimeRangeEnum.CUSTOM_RANGE);
         }
     }, []);
 

--- a/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
+++ b/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
@@ -89,10 +89,8 @@ function DateTimeRange({ timestamps, setSelectedRange, selectedRange }: DateTime
         setSelectedRange(DateTimeRangeEnum.CUSTOM_RANGE);
       }
     },
-    // Initialize state from URL params on mount.
-    // Avoid re-running on query changes to prevent overwriting user input.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
+    [timestamps],
   );
 
   return (

--- a/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
+++ b/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
@@ -7,7 +7,6 @@ import Select from '@oracle/elements/Inputs/Select';
 import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
 import TextInput from '@oracle/elements/Inputs/TextInput';
-import { LogRangeEnum } from '@interfaces/LogType';
 
 import { UNIT } from '@oracle/styles/units/spacing';
 import { calculateStartTimestamp } from '@utils/number';
@@ -19,25 +18,7 @@ import {
 } from '@utils/date';
 import { goToWithQuery } from '@utils/routing';
 import FlexContainer from '@oracle/components/FlexContainer';
-
-enum RangeQueryEnum {
-    START = 'start_timestamp',
-    END = 'end_timestamp',
-}
-
-const RANGES = [
-    LogRangeEnum.LAST_HOUR,
-    LogRangeEnum.LAST_DAY,
-    LogRangeEnum.LAST_WEEK,
-    LogRangeEnum.LAST_30_DAYS,
-];
-
-const RANGE_SECOND_INTERVAL_MAPPING = {
-    [LogRangeEnum.LAST_HOUR]: 3600,
-    [LogRangeEnum.LAST_DAY]: 86400,
-    [LogRangeEnum.LAST_WEEK]: 604800,
-    [LogRangeEnum.LAST_30_DAYS]: 2592000,
-};
+import { DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING, DATE_TIME_RANGES, DateTimeRangeEnum, DateTimeRangeQueryEnum } from '@interfaces/DateTimeRangeType';
 
 function DateTimeRange({ setSelectedRange, selectedRange }) {
     const [showCalendarIndex, setShowCalendarIndex] = useState<number>(null);
@@ -58,12 +39,12 @@ function DateTimeRange({ setSelectedRange, selectedRange }) {
                     e.preventDefault();
                     const range = e.target.value;
                     setSelectedRange(range);
-                    if (RANGES.includes(range)) {
-                        const startTimestamp = calculateStartTimestamp(RANGE_SECOND_INTERVAL_MAPPING[range]);
+                    if (DATE_TIME_RANGES.includes(range)) {
+                        const startTimestamp = calculateStartTimestamp(DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING[range]);
                         goToWithQuery(
                             {
-                                [RangeQueryEnum.START]: startTimestamp,
-                                [RangeQueryEnum.END]: null,
+                                [DateTimeRangeQueryEnum.START]: startTimestamp,
+                                [DateTimeRangeQueryEnum.END]: null,
                             },
                         );
                     }
@@ -72,7 +53,7 @@ function DateTimeRange({ setSelectedRange, selectedRange }) {
                 placeholder="Select time range"
                 value={selectedRange}
             >
-                {Object.values(LogRangeEnum).map(range => (
+                {Object.values(DateTimeRangeEnum).map(range => (
                     <option key={range} value={range}>
                         {range}
                     </option>
@@ -82,7 +63,7 @@ function DateTimeRange({ setSelectedRange, selectedRange }) {
             <Spacing mr={1} />
 
             {
-                selectedRange === LogRangeEnum.CUSTOM_RANGE && (
+                selectedRange === DateTimeRangeEnum.CUSTOM_RANGE && (
                     <>
                         <TextInput
                             compact
@@ -146,8 +127,8 @@ function DateTimeRange({ setSelectedRange, selectedRange }) {
                                 const start = isoDateFormatFromDateParts(startDate, startTime.hour, startTime.minute);
                                 const end = isoDateFormatFromDateParts(endDate, endTime.hour, endTime.minute);
                                 goToWithQuery({
-                                    [RangeQueryEnum.START]: unixTimestampFromDate(start),
-                                    [RangeQueryEnum.END]: unixTimestampFromDate(end),
+                                    [DateTimeRangeQueryEnum.START]: unixTimestampFromDate(start),
+                                    [DateTimeRangeQueryEnum.END]: unixTimestampFromDate(end),
                                 });
                             }}
                             padding={`${UNIT / 2}px`}

--- a/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
+++ b/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
@@ -74,7 +74,11 @@ function DateTimeRange({ timestamps, setSelectedRange, selectedRange }) {
         if (initialStart && initialEnd) {
             setSelectedRange(DateTimeRangeEnum.CUSTOM_RANGE);
         }
-    }, []);
+    },
+        // Initialize state from URL params on mount.
+        // Avoid re-running on query changes to prevent overwriting user input.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        []);
 
     return (
         <FlexContainer alignItems="center">

--- a/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
+++ b/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
@@ -93,7 +93,7 @@ function DateTimeRange({ timestamps, setSelectedRange, selectedRange }: DateTime
   );
 
   return (
-    <FlexContainer alignItems='center'>
+    <FlexContainer alignItems="center">
       <Select
         compact
         defaultColor
@@ -114,7 +114,7 @@ function DateTimeRange({ timestamps, setSelectedRange, selectedRange }: DateTime
           }
         }}
         paddingRight={UNIT * 4}
-        placeholder='Select time range'
+        placeholder="Select time range"
         value={selectedRange}
       >
         {Object.values(DateTimeRangeEnum).map(range => (
@@ -133,7 +133,7 @@ function DateTimeRange({ timestamps, setSelectedRange, selectedRange }: DateTime
             defaultColor
             onClick={() => setShowCalendarIndex(0)}
             paddingRight={0}
-            placeholder='Start'
+            placeholder="Start"
             value={
               startDate ? utcDateFromDateAndTime(startDate, startTime?.hour, startTime?.minute) : ''
             }
@@ -160,7 +160,7 @@ function DateTimeRange({ timestamps, setSelectedRange, selectedRange }: DateTime
             defaultColor
             onClick={() => setShowCalendarIndex(1)}
             paddingRight={0}
-            placeholder='End'
+            placeholder="End"
             value={endDate ? utcDateFromDateAndTime(endDate, endTime?.hour, endTime?.minute) : ''}
           />
           <ClickOutside

--- a/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
+++ b/mage_ai/frontend/components/shared/DateTimeRange/index.tsx
@@ -54,18 +54,21 @@ function DateTimeRange({ timestamps, setSelectedRange, selectedRange }: DateTime
         });
 
         const secondsAgo = Math.ceil(Date.now() / 1000) - initialStart;
-        if (
-          Math.abs(
-            secondsAgo - DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING[DateTimeRangeEnum.LAST_DAY],
-          ) <= 60
-        ) {
-          setSelectedRange(DateTimeRangeEnum.LAST_DAY);
-        } else if (
-          Math.abs(
-            secondsAgo - DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING[DateTimeRangeEnum.LAST_HOUR],
-          ) <= 3600
-        ) {
-          setSelectedRange(DateTimeRangeEnum.LAST_HOUR);
+        const presets = [
+          DateTimeRangeEnum.LAST_HOUR,
+          DateTimeRangeEnum.LAST_DAY,
+          DateTimeRangeEnum.LAST_WEEK,
+          DateTimeRangeEnum.LAST_30_DAYS,
+        ];
+
+        for (const preset of presets) {
+          const targetSeconds = DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING[preset];
+          if (typeof targetSeconds === 'number'
+            && Math.abs(secondsAgo - targetSeconds) <= 60
+          ) {
+            setSelectedRange(preset);
+            break;
+          }
         }
       }
 

--- a/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
@@ -97,6 +97,12 @@ type ToolbarProps = {
   selectedRowId?: string | number;
   setSelectedRow?: (row: any) => void;
   showDivider?: boolean;
+  dateTimeRangeProps?: {
+    timestamps: {
+      start_timestamp?: number;
+      end_timestamp?: number;
+    }
+  }
 };
 
 function Toolbar({
@@ -118,6 +124,7 @@ function Toolbar({
   selectedRowId,
   setSelectedRow,
   showDivider,
+  dateTimeRangeProps,
 }: ToolbarProps) {
   const router = useRouter();
   const isViewerRole = isViewer(router?.basePath);
@@ -383,12 +390,15 @@ function Toolbar({
       {(addButtonProps || secondaryButtonProps || children) && <Spacing mr={BUTTON_PADDING} />}
       {filterButtonEl}
 
-      <Spacing ml={BUTTON_PADDING}>
-        <DateTimeRange
-          timestamps={query}
-          selectedRange={selectedRange}
-          setSelectedRange={setSelectedRange}></DateTimeRange>
-      </Spacing>
+      {dateTimeRangeProps && (
+        <Spacing ml={BUTTON_PADDING}>
+          <DateTimeRange
+            timestamps={dateTimeRangeProps.timestamps}
+            selectedRange={selectedRange}
+            setSelectedRange={setSelectedRange}
+          />
+        </Spacing>
+      )}
 
       {groupMenuItems?.length > 0 &&
         <Spacing ml={BUTTON_PADDING}>

--- a/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import AddButton from '@components/shared/AddButton';
 import Badge from '@oracle/components/Badge';
 import ClickOutside from '@oracle/components/ClickOutside';
+import DateTimeRange from '@components/shared/DateTimeRange';
 import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
 import FlyoutMenuWrapper from '@oracle/components/FlyoutMenu/FlyoutMenuWrapper';
@@ -29,6 +30,7 @@ import { UNIT } from '@oracle/styles/units/spacing';
 import { VerticalDividerStyle } from '@oracle/elements/Divider/index.style';
 import { getNestedTruthyValuesCount } from '@utils/hash';
 import { isViewer } from '@utils/session';
+import { DateTimeRangeEnum } from '@interfaces/DateTimeRangeType';
 
 type ToolbarProps = {
   addButtonProps?: {
@@ -129,6 +131,7 @@ function Toolbar({
   const [filterButtonMenuOpen, setFilterButtonMenuOpen] = useState<boolean>(false);
   const [groupButtonMenuOpen, setGroupButtonMenuOpen] = useState<boolean>(false);
   const [moreActionsMenuOpen, setMoreActionsMenuOpen] = useState<boolean>(false);
+  const [selectedRange, setSelectedRange] = useState<DateTimeRangeEnum>(null);
   const [confirmationDialogueOpenIdx, setConfirmationDialogueOpenIdx] = useState<number>(null);
   const disabledActions = !selectedRowId;
 
@@ -264,11 +267,11 @@ function Toolbar({
         {...SHARED_BUTTON_PROPS}
         afterElement={filtersAppliedCount > 0
           ?
-            <Badge cyan noVerticalPadding>
-              <Text bold inverted>
-                {filtersAppliedCount}
-              </Text>
-            </Badge>
+          <Badge cyan noVerticalPadding>
+            <Text bold inverted>
+              {filtersAppliedCount}
+            </Text>
+          </Badge>
           : null
         }
         beforeElement={<Filter size={2 * UNIT} />}
@@ -379,6 +382,12 @@ function Toolbar({
 
       {(addButtonProps || secondaryButtonProps || children) && <Spacing mr={BUTTON_PADDING} />}
       {filterButtonEl}
+
+      <Spacing ml={BUTTON_PADDING}>
+        <DateTimeRange
+          selectedRange={selectedRange}
+          setSelectedRange={setSelectedRange}></DateTimeRange>
+      </Spacing>
 
       {groupMenuItems?.length > 0 &&
         <Spacing ml={BUTTON_PADDING}>

--- a/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
@@ -385,6 +385,7 @@ function Toolbar({
 
       <Spacing ml={BUTTON_PADDING}>
         <DateTimeRange
+          timestamps={query}
           selectedRange={selectedRange}
           setSelectedRange={setSelectedRange}></DateTimeRange>
       </Spacing>

--- a/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
@@ -274,11 +274,11 @@ function Toolbar({
         {...SHARED_BUTTON_PROPS}
         afterElement={filtersAppliedCount > 0
           ?
-          <Badge cyan noVerticalPadding>
-            <Text bold inverted>
-              {filtersAppliedCount}
-            </Text>
-          </Badge>
+            <Badge cyan noVerticalPadding>
+              <Text bold inverted>
+                {filtersAppliedCount}
+              </Text>
+            </Badge>
           : null
         }
         beforeElement={<Filter size={2 * UNIT} />}
@@ -393,9 +393,9 @@ function Toolbar({
       {dateTimeRangeProps && (
         <Spacing ml={BUTTON_PADDING}>
           <DateTimeRange
-            timestamps={dateTimeRangeProps.timestamps}
             selectedRange={selectedRange}
             setSelectedRange={setSelectedRange}
+            timestamps={dateTimeRangeProps.timestamps}
           />
         </Spacing>
       )}

--- a/mage_ai/frontend/interfaces/DateTimeRangeType.ts
+++ b/mage_ai/frontend/interfaces/DateTimeRangeType.ts
@@ -1,0 +1,28 @@
+export enum DateTimeRangeQueryEnum {
+    START = 'start_timestamp',
+    END = 'end_timestamp',
+}
+
+export enum DateTimeRangeEnum {
+  LAST_HOUR = 'Last hour',
+  LAST_DAY = 'Last day',
+  LAST_WEEK = 'Last week',
+  LAST_30_DAYS = 'Last 30 days',
+  CUSTOM_RANGE = 'Custom range',
+}
+
+export const DATE_TIME_RANGES = [
+    DateTimeRangeEnum.LAST_HOUR,
+    DateTimeRangeEnum.LAST_DAY,
+    DateTimeRangeEnum.LAST_WEEK,
+    DateTimeRangeEnum.LAST_30_DAYS,
+];
+
+export const DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING = {
+    [DateTimeRangeEnum.LAST_HOUR]: 3600,
+    [DateTimeRangeEnum.LAST_DAY]: 86400,
+    [DateTimeRangeEnum.LAST_WEEK]: 604800,
+    [DateTimeRangeEnum.LAST_30_DAYS]: 2592000,
+};
+
+

--- a/mage_ai/frontend/interfaces/DateTimeRangeType.ts
+++ b/mage_ai/frontend/interfaces/DateTimeRangeType.ts
@@ -24,3 +24,14 @@ export const DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING = {
     [DateTimeRangeEnum.LAST_WEEK]: 604800,
     [DateTimeRangeEnum.LAST_30_DAYS]: 2592000,
 };
+
+export type DateTimeRangeTimeStamps = {
+    start_timestamp?: number;
+    end_timestamp?: number;
+}
+
+export type DateTimeRangeProps = {
+    timestamps: DateTimeRangeTimeStamps,
+    selectedRange: DateTimeRangeEnum;
+    setSelectedRange: (range: DateTimeRangeEnum) => void;
+};

--- a/mage_ai/frontend/interfaces/DateTimeRangeType.ts
+++ b/mage_ai/frontend/interfaces/DateTimeRangeType.ts
@@ -1,37 +1,37 @@
 export enum DateTimeRangeQueryEnum {
-    START = 'start_timestamp',
-    END = 'end_timestamp',
+  START = 'start_timestamp',
+  END = 'end_timestamp',
 }
 
 export enum DateTimeRangeEnum {
-    LAST_HOUR = 'Last hour',
-    LAST_DAY = 'Last day',
-    LAST_WEEK = 'Last week',
-    LAST_30_DAYS = 'Last 30 days',
-    CUSTOM_RANGE = 'Custom range',
+  LAST_HOUR = 'Last hour',
+  LAST_DAY = 'Last day',
+  LAST_WEEK = 'Last week',
+  LAST_30_DAYS = 'Last 30 days',
+  CUSTOM_RANGE = 'Custom range',
 }
 
 export const DATE_TIME_RANGES = [
-    DateTimeRangeEnum.LAST_HOUR,
-    DateTimeRangeEnum.LAST_DAY,
-    DateTimeRangeEnum.LAST_WEEK,
-    DateTimeRangeEnum.LAST_30_DAYS,
+  DateTimeRangeEnum.LAST_HOUR,
+  DateTimeRangeEnum.LAST_DAY,
+  DateTimeRangeEnum.LAST_WEEK,
+  DateTimeRangeEnum.LAST_30_DAYS,
 ];
 
 export const DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING = {
-    [DateTimeRangeEnum.LAST_HOUR]: 3600,
-    [DateTimeRangeEnum.LAST_DAY]: 86400,
-    [DateTimeRangeEnum.LAST_WEEK]: 604800,
-    [DateTimeRangeEnum.LAST_30_DAYS]: 2592000,
+  [DateTimeRangeEnum.LAST_HOUR]: 3600,
+  [DateTimeRangeEnum.LAST_DAY]: 86400,
+  [DateTimeRangeEnum.LAST_WEEK]: 604800,
+  [DateTimeRangeEnum.LAST_30_DAYS]: 2592000,
 };
 
 export type DateTimeRangeTimeStamps = {
-    start_timestamp?: number;
-    end_timestamp?: number;
-}
+  start_timestamp?: number;
+  end_timestamp?: number;
+};
 
 export type DateTimeRangeProps = {
-    timestamps: DateTimeRangeTimeStamps,
-    selectedRange: DateTimeRangeEnum;
-    setSelectedRange: (range: DateTimeRangeEnum) => void;
+  timestamps: DateTimeRangeTimeStamps;
+  selectedRange: DateTimeRangeEnum;
+  setSelectedRange: (range: DateTimeRangeEnum) => void;
 };

--- a/mage_ai/frontend/interfaces/DateTimeRangeType.ts
+++ b/mage_ai/frontend/interfaces/DateTimeRangeType.ts
@@ -4,11 +4,11 @@ export enum DateTimeRangeQueryEnum {
 }
 
 export enum DateTimeRangeEnum {
-  LAST_HOUR = 'Last hour',
-  LAST_DAY = 'Last day',
-  LAST_WEEK = 'Last week',
-  LAST_30_DAYS = 'Last 30 days',
-  CUSTOM_RANGE = 'Custom range',
+    LAST_HOUR = 'Last hour',
+    LAST_DAY = 'Last day',
+    LAST_WEEK = 'Last week',
+    LAST_30_DAYS = 'Last 30 days',
+    CUSTOM_RANGE = 'Custom range',
 }
 
 export const DATE_TIME_RANGES = [
@@ -24,5 +24,3 @@ export const DATE_TIME_RANGE_SECOND_INTERVAL_MAPPING = {
     [DateTimeRangeEnum.LAST_WEEK]: 604800,
     [DateTimeRangeEnum.LAST_30_DAYS]: 2592000,
 };
-
-

--- a/mage_ai/frontend/interfaces/PipelineRunType.ts
+++ b/mage_ai/frontend/interfaces/PipelineRunType.ts
@@ -61,12 +61,16 @@ export interface PipelineRunReqQueryParamsType {
   include_pipeline_uuids?: boolean;
   pipeline_uuid?: string;
   status?: RunStatusEnum;
+  start_timestamp?: number;
+  end_timestamp?: number;
 }
 
 export enum PipelineRunFilterQueryEnum {
   PIPELINE_UUID = 'pipeline_uuid[]',
   STATUS = 'status[]',
   TAG = 'pipeline_tag[]',
+  START_TIMESTAMP = 'start_timestamp',
+  END_TIMESTAMP = 'end_timestamp',
 }
 
 interface Obj {

--- a/mage_ai/frontend/pages/pipeline-runs/index.tsx
+++ b/mage_ai/frontend/pages/pipeline-runs/index.tsx
@@ -43,6 +43,16 @@ function RunListPage() {
     [project?.features],
   );
 
+  const start = query?.[PipelineRunFilterQueryEnum.START_TIMESTAMP];
+  const end = query?.[PipelineRunFilterQueryEnum.END_TIMESTAMP];
+
+  const dateTimeRangeProps = {
+    timestamps: {
+      start_timestamp: start ? Number(start) : undefined,
+      end_timestamp: end ? Number(end) : undefined,
+    },
+  };
+
   const pipelineRunsRequestQuery: PipelineRunReqQueryParamsType = {
     ...query,
     _limit: ROW_LIMIT,
@@ -93,6 +103,7 @@ function RunListPage() {
       }}
       query={query}
       resetPageOnFilterApply
+      dateTimeRangeProps={dateTimeRangeProps}
     />
   // eslint-disable-next-line react-hooks/exhaustive-deps
   ), [

--- a/mage_ai/frontend/pages/pipeline-runs/index.tsx
+++ b/mage_ai/frontend/pages/pipeline-runs/index.tsx
@@ -32,6 +32,8 @@ function RunListPage() {
     PipelineRunFilterQueryEnum.PIPELINE_UUID,
     PipelineRunFilterQueryEnum.STATUS,
     PipelineRunFilterQueryEnum.TAG,
+    PipelineRunFilterQueryEnum.START_TIMESTAMP,
+    PipelineRunFilterQueryEnum.END_TIMESTAMP,
   ]), [q]);
 
   const { data: dataProjects } = api.projects.list();

--- a/mage_ai/frontend/tests/pipeline_runs.spec.ts
+++ b/mage_ai/frontend/tests/pipeline_runs.spec.ts
@@ -23,36 +23,47 @@ test('ensure pipeline "example_pipeline" runs successfully', async ({ page }) =>
   await expect(page.locator('#pipeline-triggers-row-0')).toContainText('completed');
 });
 
-test('updates URL when filtering pipeline runs by a custom date range', async ({ page }) => {
-  await page.goto('/pipeline-runs');
-
-  await page
-    .locator('select[placeholder="Select time range"]')
-    .selectOption({ label: 'Custom range' });
-
-  await selectDateTime(page, 'Start', '.react-calendar__tile--now', '10', '05');
-  await selectDateTime(page, 'End', '.react-calendar__tile--now', '17', '30');
-
-  await page.getByRole('button', { name: /^Filter$/i }).last().click();
-
-  await expect(page).toHaveURL(/start_timestamp=.*end_timestamp=.*/);
-});
-
-const cases = [
-  { label: 'Last hour' },
-  { label: 'Last day' },
-  { label: 'Last week' },
-  { label: 'Last 30 days' },
+const dateTimeRangeCases = [
+  { url: '/pipeline-runs' },
+  { url: '/pipeline-runs?page=7&offset=300' }
 ];
 
-for (const { label } of cases) {
-  test(`updates URL for ${label} filter`, async ({ page }) => {
-    await page.goto('/pipeline-runs');
+for (const { url } of dateTimeRangeCases) {
+  test(`updates URL ${url} when filtering pipeline runs by a custom date range`, async ({ page }) => {
+    await page.goto(url);
 
     await page
       .locator('select[placeholder="Select time range"]')
-      .selectOption({ label });
+      .selectOption({ label: 'Custom range' });
 
-    await expect(page).toHaveURL(/start_timestamp=.*/);
+    await selectDateTime(page, 'Start', '.react-calendar__tile--now', '10', '05');
+    await selectDateTime(page, 'End', '.react-calendar__tile--now', '17', '30');
+
+    await page.getByRole('button', { name: /^Filter$/i }).last().click();
+
+    await expect(page).toHaveURL(/start_timestamp=.*end_timestamp=.*/);
+    await expect(page).not.toHaveURL(/[?&]page=/);
+    await expect(page).not.toHaveURL(/[?&]offset=/);
   });
+
+  const fixedRangeCases = [
+    { label: 'Last hour' },
+    { label: 'Last day' },
+    { label: 'Last week' },
+    { label: 'Last 30 days' },
+  ];
+
+  for (const { label } of fixedRangeCases) {
+    test(`updates URL ${url} for ${label} filter`, async ({ page }) => {
+      await page.goto(url);
+
+      await page
+        .locator('select[placeholder="Select time range"]')
+        .selectOption({ label });
+
+      await expect(page).toHaveURL(/start_timestamp=.*/);
+      await expect(page).not.toHaveURL(/[?&]page=/);
+      await expect(page).not.toHaveURL(/[?&]offset=/);
+    });
+  }
 }

--- a/mage_ai/frontend/tests/pipeline_runs.spec.ts
+++ b/mage_ai/frontend/tests/pipeline_runs.spec.ts
@@ -23,7 +23,7 @@ test('ensure pipeline "example_pipeline" runs successfully', async ({ page }) =>
   await expect(page.locator('#pipeline-triggers-row-0')).toContainText('completed');
 });
 
-test('filters pipeline runs using custom date ranges in the URL', async ({ page }) => {
+test('updates URL when filtering pipeline runs by a custom date range', async ({ page }) => {
   await page.goto('/pipeline-runs');
 
   await page
@@ -37,3 +37,22 @@ test('filters pipeline runs using custom date ranges in the URL', async ({ page 
 
   await expect(page).toHaveURL(/start_timestamp=.*end_timestamp=.*/);
 });
+
+const cases = [
+  { label: 'Last hour' },
+  { label: 'Last day' },
+  { label: 'Last week' },
+  { label: 'Last 30 days' },
+];
+
+for (const { label } of cases) {
+  test(`updates URL for ${label} filter`, async ({ page }) => {
+    await page.goto('/pipeline-runs');
+
+    await page
+      .locator('select[placeholder="Select time range"]')
+      .selectOption({ label });
+
+    await expect(page).toHaveURL(/start_timestamp=.*/);
+  });
+}

--- a/mage_ai/frontend/tests/pipeline_runs.spec.ts
+++ b/mage_ai/frontend/tests/pipeline_runs.spec.ts
@@ -25,11 +25,13 @@ test('ensure pipeline "example_pipeline" runs successfully', async ({ page }) =>
 
 const dateTimeRangeCases = [
   { url: '/pipeline-runs' },
-  { url: '/pipeline-runs?page=7&offset=300' }
+  { url: '/pipeline-runs?page=7&offset=300' },
 ];
 
 for (const { url } of dateTimeRangeCases) {
-  test(`updates URL ${url} when filtering pipeline runs by a custom date range`, async ({ page }) => {
+  test(`updates URL ${url} when filtering pipeline runs by a custom date range`, async ({
+    page,
+  }) => {
     await page.goto(url);
 
     await page
@@ -39,7 +41,10 @@ for (const { url } of dateTimeRangeCases) {
     await selectDateTime(page, 'Start', '.react-calendar__tile--now', '10', '05');
     await selectDateTime(page, 'End', '.react-calendar__tile--now', '17', '30');
 
-    await page.getByRole('button', { name: /^Filter$/i }).last().click();
+    await page
+      .getByRole('button', { name: /^Filter$/i })
+      .last()
+      .click();
 
     await expect(page).toHaveURL(/start_timestamp=.*end_timestamp=.*/);
     await expect(page).not.toHaveURL(/[?&]page=/);
@@ -66,4 +71,32 @@ for (const { url } of dateTimeRangeCases) {
       await expect(page).not.toHaveURL(/[?&]offset=/);
     });
   }
+}
+
+const INTERVALS = {
+  LAST_30_DAYS: 2592000,
+  LAST_WEEK: 604800,
+  LAST_DAY: 86400,
+  LAST_HOUR: 3600,
+};
+
+const shareUrlCases = [
+  { interval: INTERVALS.LAST_30_DAYS, label: 'Last 30 days' },
+  { interval: INTERVALS.LAST_WEEK, label: 'Last week' },
+  { interval: INTERVALS.LAST_DAY, label: 'Last day' },
+  { interval: INTERVALS.LAST_HOUR, label: 'Last hour' },
+];
+
+for (const { interval, label } of shareUrlCases) {
+  test(`initializes date time range to ${label} when URL has corresponding start_timestamp`, async ({
+    page,
+  }) => {
+    const now = Math.floor(Date.now() / 1000);
+    const startTimestamp = now - interval;
+
+    await page.goto(`/pipeline-runs?start_timestamp=${startTimestamp}`);
+
+    const select = await page.locator('select[placeholder="Select time range"]');
+    await expect(select).toHaveValue(label);
+  });
 }

--- a/mage_ai/frontend/tests/pipeline_runs.spec.ts
+++ b/mage_ai/frontend/tests/pipeline_runs.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from './base';
+import { selectDateTime } from './utils';
 
 test('ensure pipeline "example_pipeline" runs successfully', async ({ page }) => {
   // This test assumes the "example_pipeline" pipeline exists in a new project.
@@ -20,4 +21,19 @@ test('ensure pipeline "example_pipeline" runs successfully', async ({ page }) =>
   // Go back to pipeline's trigger page.
   await page.getByRole('link', { name: 'example_pipeline' }).click();
   await expect(page.locator('#pipeline-triggers-row-0')).toContainText('completed');
+});
+
+test('filters pipeline runs using custom date ranges in the URL', async ({ page }) => {
+  await page.goto('/pipeline-runs');
+
+  await page
+    .locator('select[placeholder="Select time range"]')
+    .selectOption({ label: 'Custom range' });
+
+  await selectDateTime(page, 'Start', '.react-calendar__tile--now', '10', '05');
+  await selectDateTime(page, 'End', '.react-calendar__tile--now', '17', '30');
+
+  await page.getByRole('button', { name: /^Filter$/i }).last().click();
+
+  await expect(page).toHaveURL(/start_timestamp=.*end_timestamp=.*/);
 });

--- a/mage_ai/frontend/tests/utils.ts
+++ b/mage_ai/frontend/tests/utils.ts
@@ -20,7 +20,7 @@ function getSettingsToEnable(
     'DBT_V2',
     'GLOBAL_HOOKS',
     'NOTEBOOK_BLOCK_OUTPUT_SPLIT_VIEW',
-]);
+  ]);
 
   for (const feature in featuresFiltered) {
     if (!settingFeaturesToDisable[
@@ -68,4 +68,23 @@ export async function enableSettings(
   }
 
   await page.getByRole('button', { name: 'Save project settings' }).click();
+}
+
+export async function selectDateTime(
+  page,
+  placeholder,
+  daySelector,
+  hour,
+  minute,
+) {
+  await page.locator(`input[placeholder="${placeholder}"]`).click();
+
+  const calendar = page.locator('.react-calendar');
+  await calendar.locator(daySelector).click();
+
+  const selects = page.locator('select:visible');
+  const count = await selects.count();
+
+  await selects.nth(count - 2).selectOption(hour);
+  await selects.nth(count - 1).selectOption(minute);
 }


### PR DESCRIPTION
# Description
- Implements #6062

## Demo video
https://www.youtube.com/live/BuBMlwMHgXg

## Frontend changes
- Adds date/time range filtering to the pipeline runs toolbar, letting users to scope results to specific time windows
- Aligns UX with existing **Logs filtering UX**  to maintain consistency across the product
- Synchronizes selected range with the URL, allowing filters to be shared via URL while persisting across refreshes
- Supports both predefined ranges (e.g., last hour, last day) and custom start/end times
- Introduces a reusable DateTimeRange component for broader use across the application

## Backend changes
- Behavior unchanged
- Clarified datetime filtering edge cases in PipelineRunResource.py comments

## Design considerations
- Chose to integrate within the existing filter UI rather than introduce a new panel to preserve current user workflows
- Prioritized consistency with existing Mage patterns over expanding UI surface area
- Structured component to allow future extension (e.g., presets, alternate layouts)

# How Has This Been Tested?
- [x] Test A - Automated Playwright tests for fixed ranges and URL-based filtering.
- [x] Test B - Manual testing in Chrome and Edge.

## Verified
- Date/time selection correctly filters pipeline runs
- URL updates reflect selected range
- Shared URLs reproduce the same filtered view across browser sessions


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993 
