### PR TITLE
fix: issue-5480

### DIFF
--- a/mage_ai/data_preparation/models/block/__init__.py
+++ b/mage_ai/data_preparation/models/block/__init__.py
@@ -4294,14 +4294,17 @@ class SensorBlock(Block):
             has_kwargs = any([p.kind == p.VAR_KEYWORD for p in sig.parameters.values()])
             use_global_vars = has_kwargs and global_vars is not None and len(global_vars) != 0
             args = input_vars if has_args else []
+            poll_interval_seconds = int(
+                (self.configuration or {}).get('poll_interval_seconds', 60)
+            )
             while True:
                 condition = (
                     block_function(*args, **global_vars) if use_global_vars else block_function()
                 )
                 if condition:
                     break
-                print('Sensor sleeping for 1 minute...')
-                time.sleep(60)
+                print(f'Sensor sleeping for {poll_interval_seconds} seconds...')
+                time.sleep(poll_interval_seconds)
             return []
 
 

--- a/mage_ai/tests/data_preparation/models/test_block.py
+++ b/mage_ai/tests/data_preparation/models/test_block.py
@@ -395,6 +395,61 @@ def sensor(*args):
         output = block2.execute_sync(from_notebook=True)
         self.assertEqual(output['output'][0], True)
 
+    @patch('time.sleep')
+    def test_sensor_block_default_poll_interval(self, mock_sleep):
+        pipeline = Pipeline.create(
+            'test pipeline sensor default interval',
+            repo_path=self.repo_path,
+        )
+        block = Block.create(
+            'test_sensor_default_interval',
+            'sensor',
+            self.repo_path,
+            pipeline=pipeline,
+        )
+        # Write a sensor that fails once then succeeds, to trigger sleep
+        with open(block.file_path, 'w') as file:
+            file.write("""if 'sensor' not in globals():
+    from mage_ai.data_preparation.decorators import sensor
+
+_attempt = [0]
+
+@sensor
+def check_condition():
+    _attempt[0] += 1
+    return _attempt[0] > 1
+""")
+        block.execute_sync()
+        mock_sleep.assert_any_call(60)
+
+    @patch('time.sleep')
+    def test_sensor_block_custom_poll_interval(self, mock_sleep):
+        pipeline = Pipeline.create(
+            'test pipeline sensor custom interval',
+            repo_path=self.repo_path,
+        )
+        block = Block.create(
+            'test_sensor_custom_interval',
+            'sensor',
+            self.repo_path,
+            pipeline=pipeline,
+            configuration={'poll_interval_seconds': 5},
+        )
+        # Write a sensor that fails once then succeeds, to trigger sleep
+        with open(block.file_path, 'w') as file:
+            file.write("""if 'sensor' not in globals():
+    from mage_ai.data_preparation.decorators import sensor
+
+_attempt = [0]
+
+@sensor
+def check_condition():
+    _attempt[0] += 1
+    return _attempt[0] > 1
+""")
+        block.execute_sync()
+        mock_sleep.assert_any_call(5)
+
     @patch('builtins.print')
     def test_execute_with_callback_success(self, mock_print):
         pipeline = Pipeline.create(


### PR DESCRIPTION
I have successfully implemented the requested change to allow configurable polling intervals in Sensor blocks.

**Core Logic Update:**
In block/init.py, I modified theSensorBlock.execute_block_functionto readpoll_interval_secondsfrom the block's configuration.

```
# Before
print('Sensor sleeping for 1 minute...')
time.sleep(60)

# After
poll_interval_seconds = int(
    (self.configuration or {}).get('poll_interval_seconds', 60)
)
...
print(f'Sensor sleeping for {poll_interval_seconds} seconds...')
time.sleep(poll_interval_seconds)
```

**Unit Tests:**
I added two new tests to test_block.py as requested:

test_sensor_block_default_poll_interval: Verifies that the sensor sleeps for 60 seconds by default when no configuration is provided.
test_sensor_block_custom_poll_interval: Verifies that the sensor sleeps for the custom duration (e.g., 5 seconds) specified in the configuration.

**Verification:**
Automated Tests:
The new tests use unittest.mock.patch on time.sleep to verify the exact sleep duration without actually waiting.

I have successfully executed the automated tests inside my running Docker container. All tests passed, confirming that the configurable sensor polling interval works as expected.

**Test Results:**
test_sensor_block_default_poll_interval: PASSED (Verified 60s sleep)
test_sensor_block_custom_poll_interval: PASSED (Verified 5s sleep)
test_sensor_block_args_execution: PASSED (Mage default test)

Manual Verification (via Docker):
Since I'm running the project via Docker:

Creating a Sensor block.
Clicking on the block Settings/Configuration.
Adding "poll_interval_seconds": 300 (or any value) to the configuration JSON.
Running the block and checking the terminal/logs for the message: Sensor sleeping for 300 seconds....