### PR TITLE
Extend filter to allow date range filtering, add execution date filter to pipeline runs (#6062)

### DIFF
--- a/mage_ai/api/policies/PipelineRunPolicy.py
+++ b/mage_ai/api/policies/PipelineRunPolicy.py
@@ -101,6 +101,8 @@ PipelineRunPolicy.allow_query([
     'backfill_id',
     'disable_retries_grouping',
     'end_timestamp',
+    'execution_date_end',
+    'execution_date_start',
     'global_data_product_uuid',
     'include_all_pipeline_schedules',
     'include_pipeline_tags',

--- a/mage_ai/api/resources/PipelineRunResource.py
+++ b/mage_ai/api/resources/PipelineRunResource.py
@@ -42,6 +42,12 @@ class PipelineRunResource(DatabaseResource):
             pipeline_schedule_id = parent_model.id
 
         start_timestamp, end_timestamp = get_query_timestamps(query_arg)
+        execution_date_start, execution_date_end = get_query_timestamps(
+            query_arg,
+            start_key='execution_date_start',
+            end_key='execution_date_end',
+        )
+
         backfill_id = query_arg.get('backfill_id', [None])
         if backfill_id:
             backfill_id = backfill_id[0]
@@ -171,6 +177,10 @@ class PipelineRunResource(DatabaseResource):
             results = results.filter(PipelineRun.created_at >= start_timestamp)
         if end_timestamp is not None:
             results = results.filter(PipelineRun.created_at <= end_timestamp)
+        if execution_date_start is not None:
+            results = results.filter(PipelineRun.execution_date >= execution_date_start)
+        if execution_date_end is not None:
+            results = results.filter(PipelineRun.execution_date <= execution_date_end)
 
         limit = int((meta or {}).get(META_KEY_LIMIT, self.DEFAULT_LIMIT))
 

--- a/mage_ai/api/utils.py
+++ b/mage_ai/api/utils.py
@@ -131,26 +131,32 @@ def parse_cookie_header(cookies_raw):
     return cookies
 
 
-def get_query_timestamps(query_arg) -> Tuple[datetime, datetime]:
-    start_timestamp = query_arg.get('start_timestamp', [None])
+def get_query_timestamps(
+    query_arg,
+    start_key: str = 'start_timestamp',
+    end_key: str = 'end_timestamp',
+) -> Tuple[datetime, datetime]:
+    start_timestamp = query_arg.get(start_key, [None])
     if start_timestamp:
         start_timestamp = start_timestamp[0]
-    end_timestamp = query_arg.get('end_timestamp', [None])
+    end_timestamp = query_arg.get(end_key, [None])
     if end_timestamp:
         end_timestamp = end_timestamp[0]
 
+    # TODO: Consider gracefully handling invalid timestamps (e.g. skip filtering)
+    # instead of raising an error. Keeping existing behavior unchanged for now.
     error = ApiError.RESOURCE_INVALID.copy()
     if start_timestamp:
         try:
             start_timestamp = datetime.fromtimestamp(int(start_timestamp))
         except (ValueError, OverflowError):
-            error.update(message='Value is invalid for start_timestamp.')
+            error.update(message=f'Value {start_timestamp} is invalid for {start_key}.')
             raise ApiError(error)
     if end_timestamp:
         try:
             end_timestamp = datetime.fromtimestamp(int(end_timestamp))
         except (ValueError, OverflowError):
-            error.update(message='Value is invalid for end_timestamp.')
+            error.update(message=f'Value {end_timestamp} is invalid for {end_key}.')
             raise ApiError(error)
 
     return start_timestamp, end_timestamp

--- a/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/shared/Table/Toolbar/index.tsx
@@ -12,7 +12,7 @@ import PopupMenu from '@oracle/components/PopupMenu';
 import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
 import TextInput from '@oracle/elements/Inputs/TextInput';
-import ToggleMenu from '@oracle/components/ToggleMenu';
+import ToggleMenu, { DateRangeOptionType } from '@oracle/components/ToggleMenu';
 import Tooltip from '@oracle/components/Tooltip';
 import {
   BUTTON_PADDING,
@@ -27,7 +27,6 @@ import { FlyoutMenuItemType } from '@oracle/components/FlyoutMenu';
 import { SHARED_BUTTON_PROPS } from '@components/shared/AddButton';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { VerticalDividerStyle } from '@oracle/elements/Divider/index.style';
-import { getNestedTruthyValuesCount } from '@utils/hash';
 import { isViewer } from '@utils/session';
 
 type ToolbarProps = {
@@ -56,7 +55,7 @@ type ToolbarProps = {
     tooltip?: string;
   };
   filterOptions?: {
-    [keyof: string]: string[];
+    [keyof: string]: string[] | DateRangeOptionType;
   };
   filterValueLabelMapping?: {
     [keyof: string]: {
@@ -162,12 +161,20 @@ function Toolbar({
   } = searchProps || {};
 
   const filterOptionsEnabledMapping = useMemo(() => (
-    Object.entries(filterOptions).reduce((mapping, [filterKey, values]) => {
-      mapping[filterKey] = {};
-      values.forEach(value => {
-        const filterValueEnabled = query[`${filterKey}[]`]?.includes(value) || false;
-        mapping[filterKey][value] = filterValueEnabled;
-      });
+    Object.entries(filterOptions).reduce((mapping, [filterKey, value]) => {
+      if (Array.isArray(value)) {
+        mapping[filterKey] = {};
+        value.forEach(v => {
+          const filterValueEnabled = query[`${filterKey}[]`]?.includes(v) || false;
+          mapping[filterKey][v] = filterValueEnabled;
+        });
+      } else {
+        mapping[filterKey] = {
+          ...value,
+          startValue: query[value.startKey] || null,
+          endValue: query[value.endKey] || null,
+        };
+      }
 
       return mapping;
     }, {})
@@ -234,10 +241,20 @@ function Toolbar({
     secondaryButtonTooltip,
   ]);
 
-  const filtersAppliedCount = useMemo(
-    () => getNestedTruthyValuesCount(filterOptionsEnabledMapping),
-    [filterOptionsEnabledMapping],
-  );
+  const filtersAppliedCount = useMemo(() => {
+    let count = 0;
+    Object.entries(filterOptionsEnabledMapping).forEach(([, value]) => {
+      if (value && (value as DateRangeOptionType).type === 'date_range') {
+        const { startKey, endKey } = value as DateRangeOptionType;
+        if (query[startKey] || query[endKey]) {
+          count += 1;
+        }
+      } else if (value && typeof value === 'object') {
+        count += Object.values(value).filter(v => !!v).length;
+      }
+    });
+    return count;
+  }, [filterOptionsEnabledMapping, query]);
   const filterButtonEl = useMemo(() => (
     <ToggleMenu
       compact

--- a/mage_ai/frontend/interfaces/PipelineRunType.ts
+++ b/mage_ai/frontend/interfaces/PipelineRunType.ts
@@ -55,6 +55,8 @@ export interface PipelineRunReqQueryParamsType {
   _limit?: number;
   _offset?: number;
   disable_retries_grouping?: boolean;
+  execution_date_end?: number;
+  execution_date_start?: number;
   global_data_product_uuid?: string;
   include_all_pipeline_schedules?: boolean;
   include_pipeline_tags?: boolean;
@@ -64,6 +66,8 @@ export interface PipelineRunReqQueryParamsType {
 }
 
 export enum PipelineRunFilterQueryEnum {
+  EXECUTION_DATE_END = 'execution_date_end',
+  EXECUTION_DATE_START = 'execution_date_start',
   PIPELINE_UUID = 'pipeline_uuid[]',
   STATUS = 'status[]',
   TAG = 'pipeline_tag[]',

--- a/mage_ai/frontend/oracle/components/ToggleMenu/index.style.ts
+++ b/mage_ai/frontend/oracle/components/ToggleMenu/index.style.ts
@@ -14,6 +14,7 @@ const CONTAINER_MIN_WIDTH = UNIT * 74;
 const MAIN_HEIGHT = UNIT * 48;
 
 export const ContainerStyle = styled.div<{
+  allowOverflow?: boolean;
   compact?: boolean;
   display?: boolean;
   left?: number;
@@ -29,6 +30,10 @@ export const ContainerStyle = styled.div<{
     background-color: ${(props.theme || dark).background.panel};
     border: ${BORDER_WIDTH_THICK}px ${BORDER_STYLE} ${(props.theme || dark).interactive.defaultBackground};
     box-shadow: ${(props.theme.shadow || dark.shadow).window};
+  `}
+
+  ${props => props.allowOverflow && `
+    overflow: visible;
   `}
 
   ${props => props.display && `
@@ -49,6 +54,7 @@ export const ContainerStyle = styled.div<{
 `;
 
 export const MainStyle = styled.div<{
+  allowOverflow?: boolean;
   compact?: boolean;
 }>`
   display: flex;
@@ -59,6 +65,10 @@ export const MainStyle = styled.div<{
   ${props => `
     background-color: ${(props.theme || dark).background.content};
     border: ${BORDER_WIDTH}px ${BORDER_STYLE} ${(props.theme || dark).interactive.defaultBackground};
+  `}
+
+  ${props => props.allowOverflow && `
+    overflow: visible;
   `}
 
   ${props => props.compact && `
@@ -76,10 +86,16 @@ export const BeforeStyle = styled.aside`
   `}
 `;
 
-export const ContentStyle = styled.div`
+export const ContentStyle = styled.div<{
+  allowOverflow?: boolean;
+}>`
   width: 100%;
   overflow: auto;
   ${ScrollbarStyledCss}
+
+  ${props => props.allowOverflow && `
+    overflow: visible;
+  `}
 `;
 
 const SHARED_STYLES = css`

--- a/mage_ai/frontend/oracle/components/ToggleMenu/index.tsx
+++ b/mage_ai/frontend/oracle/components/ToggleMenu/index.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
 
 import Button from '@oracle/elements/Button';
+import Calendar, { TimeType } from '@oracle/components/Calendar';
 import ClickOutside from '@oracle/components/ClickOutside';
 import Flex from '@oracle/components/Flex';
 import FlexContainer from '@oracle/components/FlexContainer';
 import Spacing from '@oracle/elements/Spacing';
 import Text from '@oracle/elements/Text';
+import TextInput from '@oracle/elements/Inputs/TextInput';
 import ToggleSwitch from '@oracle/elements/Inputs/ToggleSwitch';
 import {
   BeforeStyle,
@@ -15,11 +17,202 @@ import {
   OptionStyle,
   ToggleValueStyle,
 } from './index.style';
-import { ChevronRight } from '@oracle/icons';
-import { GoToWithFiltersProps, goToWithFilters } from '@utils/routing';
+import { ChevronRight, Close } from '@oracle/icons';
+import { goToWithMixedFilters } from '@utils/routing';
 import { MetaQueryEnum } from '@api/constants';
 import { ROW_LIMIT } from '@components/shared/Paginate';
+import {
+  getDatePartsFromUnixTimestamp,
+  isoDateFormatFromDateParts,
+  padTime,
+  unixTimestampFromDate,
+  utcDateFromDateAndTime,
+} from '@utils/date';
 import { capitalize, removeUnderscore } from '@utils/string';
+
+export type DateRangeOptionType = {
+  type: 'date_range';
+  startKey: string;
+  endKey: string;
+  startValue?: string | null;
+  endValue?: string | null;
+};
+
+type ToggleOptionType = {
+  [keyof: string]: boolean;
+};
+
+type FilterOptionType = ToggleOptionType | DateRangeOptionType;
+
+function isDateRangeOption(option: FilterOptionType): option is DateRangeOptionType {
+  return option && (option as DateRangeOptionType).type === 'date_range';
+}
+
+const DEFAULT_START_TIME: TimeType = { hour: '00', minute: '00' };
+const DEFAULT_END_TIME: TimeType = { hour: '23', minute: '59' };
+
+type DateRangeStateType = {
+  startDate: Date | null;
+  startTime: TimeType;
+  endDate: Date | null;
+  endTime: TimeType;
+};
+
+type ToggleListProps = {
+  optionKey: string;
+  options: ToggleOptionType;
+  setFilterState: React.Dispatch<React.SetStateAction<{
+    [key: string]: ToggleOptionType | DateRangeStateType;
+  }>>;
+  toggleValueMapping?: {
+    [keyof: string]: string | (() => string);
+  };
+};
+
+function ToggleList({
+  optionKey,
+  options,
+  setFilterState,
+  toggleValueMapping,
+}: ToggleListProps) {
+  return (
+    <>
+      {Object.entries(options || {}).map(([value, enabled]) => {
+        const optionValue = (typeof toggleValueMapping?.[value] === 'function'
+          // @ts-ignore
+          ? capitalize(toggleValueMapping?.[value]?.())
+          : toggleValueMapping?.[value]
+        ) || value;
+
+        return (
+          <ToggleValueStyle key={value}>
+            <Text
+              title={!toggleValueMapping ? optionValue : null}
+              width={200}
+            >
+              {optionValue}
+            </Text>
+            <ToggleSwitch
+              checked={enabled}
+              onCheck={() => setFilterState(prevState => ({
+                ...prevState,
+                [optionKey]: {
+                  ...prevState?.[optionKey],
+                  [value]: !enabled,
+                },
+              }))}
+            />
+          </ToggleValueStyle>
+        );
+      })}
+    </>
+  );
+}
+
+type DateRangePickerProps = {
+  dateRange: DateRangeStateType;
+  optionKey: string;
+  setFilterState: React.Dispatch<React.SetStateAction<{
+    [key: string]: ToggleOptionType | DateRangeStateType;
+  }>>;
+  showCalendarIndex: number | null;
+  setShowCalendarIndex: (idx: number | null) => void;
+};
+
+// TODO: Closing calendar on date selection would be better UX, but
+//  keeping it open for consistency with calendar behavior elsewhere in the app.
+// TODO: Validate that start date is not after end date and vice versa, showing an inline error message.
+function DateRangePicker({
+  dateRange,
+  optionKey,
+  setFilterState,
+  showCalendarIndex,
+  setShowCalendarIndex,
+}: DateRangePickerProps) {
+  return (
+    <Spacing p={2}>
+      {[
+        {
+          label: 'Start',
+          dateKey: 'startDate' as const,
+          timeKey: 'startTime' as const,
+          defaultTime: DEFAULT_START_TIME,
+          placeholder: 'Select start date',
+        },
+        {
+          label: 'End',
+          dateKey: 'endDate' as const,
+          timeKey: 'endTime' as const,
+          defaultTime: DEFAULT_END_TIME,
+          placeholder: 'Select end date',
+        },
+      ].map(({ label, dateKey, timeKey, defaultTime, placeholder }, idx) => (
+        <Spacing key={label} mb={1}>
+          <Text bold default small>
+            {label}
+          </Text>
+          <Spacing mt={1}>
+            <div style={{ position: 'relative' }}>
+              <TextInput
+                afterIcon={dateRange?.[dateKey] ? <Close /> : null}
+                afterIconClick={dateRange?.[dateKey]
+                  ? () => setFilterState(prev => ({
+                    ...prev,
+                    [optionKey]: {
+                      ...(prev[optionKey] as DateRangeStateType),
+                      [dateKey]: null,
+                      [timeKey]: defaultTime,
+                    },
+                  }))
+                  : null
+                }
+                compact
+                defaultColor
+                onClick={() => setShowCalendarIndex(idx)}
+                placeholder={placeholder}
+                value={dateRange?.[dateKey]
+                  ? utcDateFromDateAndTime(
+                      dateRange[dateKey],
+                      dateRange[timeKey]?.hour,
+                      dateRange[timeKey]?.minute,
+                    )
+                  : ''
+                }
+              />
+              <ClickOutside
+                onClickOutside={() => setShowCalendarIndex(null)}
+                open={showCalendarIndex === idx}
+                style={{ position: 'relative' }}
+              >
+                <Calendar
+                  selectedDate={dateRange?.[dateKey]}
+                  selectedTime={dateRange?.[timeKey]}
+                  setSelectedDate={(d) => setFilterState(prev => ({
+                    ...prev,
+                    [optionKey]: {
+                      ...(prev[optionKey] as DateRangeStateType),
+                      [dateKey]: d,
+                    },
+                  }))}
+                  setSelectedTime={(t) => setFilterState(prev => {
+                    const prevTime = (prev[optionKey] as DateRangeStateType)?.[timeKey];
+                    return {
+                      ...prev,
+                      [optionKey]: {
+                        ...(prev[optionKey] as DateRangeStateType),
+                        [timeKey]: t(prevTime),
+                      },
+                    };
+                  })}
+                />
+              </ClickOutside>
+            </div>
+          </Spacing>
+        </Spacing>
+      ))}
+    </Spacing>
+  );
+}
 
 type ToggleMenuProps = {
   children: any;
@@ -33,9 +226,7 @@ type ToggleMenuProps = {
   onSecondaryClick: () => void;
   open: boolean;
   options: {
-    [keyof: string]: {
-      [keyof: string]: boolean;
-    };
+    [keyof: string]: FilterOptionType;
   };
   parentRef: React.RefObject<any>;
   query: { [keyof: string]: string[] };
@@ -49,6 +240,7 @@ type ToggleMenuProps = {
   };
 };
 
+// TODO: Rename ToggleMenu to FilterMenu since it now supports both toggle and date range filter types.
 function ToggleMenu({
   children,
   compact,
@@ -65,17 +257,101 @@ function ToggleMenu({
   toggleValueMapping,
 }: ToggleMenuProps) {
   const [highlightedOptionKey, setHighlightedOptionKey] = useState<string>(null);
-  const [optionsState, setOptionsState] = useState(options);
+  const [showCalendarIndex, setShowCalendarIndex] = useState<number>(null);
+  const [filterState, setFilterState] = useState<{
+    [key: string]: ToggleOptionType | DateRangeStateType;
+  }>({});
 
   useEffect(() => {
-    setOptionsState(options);
+    const state: { [key: string]: ToggleOptionType | DateRangeStateType } = {};
+
+    Object.entries(options).forEach(([key, value]) => {
+      if (isDateRangeOption(value)) {
+        const entry: DateRangeStateType = {
+          startDate: null,
+          startTime: DEFAULT_START_TIME,
+          endDate: null,
+          endTime: DEFAULT_END_TIME,
+        };
+        if (value.startValue) {
+          const { date, hour, minute } = getDatePartsFromUnixTimestamp(value.startValue);
+          entry.startDate = date;
+          entry.startTime = { hour: padTime(hour), minute: padTime(minute) };
+        }
+        if (value.endValue) {
+          const { date, hour, minute } = getDatePartsFromUnixTimestamp(value.endValue);
+          entry.endDate = date;
+          entry.endTime = { hour: padTime(hour), minute: padTime(minute) };
+        }
+        state[key] = entry;
+      } else {
+        state[key] = value as ToggleOptionType;
+      }
+    });
+
+    setFilterState(state);
   }, [options]);
 
   const {
     top = 0,
   } = parentRef?.current?.getBoundingClientRect?.() || {};
   const optionKeys = Object.keys(options);
+  const highlightedIsDateRange = highlightedOptionKey
+    && isDateRangeOption(options[highlightedOptionKey]);
+  const currentDateRange = highlightedIsDateRange
+    ? filterState[highlightedOptionKey] as DateRangeStateType
+    : null;
 
+  const handleApply = () => {
+    const updatedQuery = Object.entries(filterState)
+      .reduce((acc, [optionKey, stateValue]) => {
+        if (!isDateRangeOption(options[optionKey])) {
+          const filteredValues = [];
+          Object.entries(stateValue as ToggleOptionType)
+            .forEach(([value, enabled]) => enabled && filteredValues.push(value));
+          acc[optionKey] = filteredValues;
+        }
+
+        return acc;
+      }, {});
+
+    // Build date range query params (scalar, not array)
+    const dateRangeQuery: Record<string, number | null> = {};
+    Object.entries(options).forEach(([key, value]) => {
+      if (isDateRangeOption(value)) {
+        const dr = filterState[key] as DateRangeStateType;
+        [
+          { dateKey: 'startDate', timeKey: 'startTime', queryKey: 'startKey' },
+          { dateKey: 'endDate', timeKey: 'endTime', queryKey: 'endKey' },
+        ].forEach(({ dateKey, timeKey, queryKey }) => {
+          if (dr?.[dateKey]) {
+            const iso = isoDateFormatFromDateParts(
+              dr[dateKey], dr[timeKey].hour, dr[timeKey].minute,
+            );
+            dateRangeQuery[value[queryKey]] = unixTimestampFromDate(iso);
+          } else {
+            dateRangeQuery[value[queryKey]] = null;
+          }
+        });
+      }
+    });
+
+    onClickCallback?.(
+      query,
+      { ...updatedQuery, ...dateRangeQuery },
+    );
+
+    goToWithMixedFilters(query, updatedQuery, dateRangeQuery, {
+      itemsPerPage: resetLimitOnApply
+        ? (query?.[MetaQueryEnum.LIMIT]
+          ? +query[MetaQueryEnum.LIMIT]
+          : ROW_LIMIT)
+        : undefined,
+      pushHistory: true,
+      resetLimitParams: resetLimitOnApply,
+      resetPage: resetPageOnApply,
+    });
+  };
 
   return (
     <ClickOutside
@@ -86,18 +362,22 @@ function ToggleMenu({
         {children}
       </div>
       <ContainerStyle
+        allowOverflow={showCalendarIndex !== null}
         compact={compact}
         display={open}
         top={top - 5}
       >
-        <MainStyle compact={compact}>
+        <MainStyle allowOverflow={showCalendarIndex !== null} compact={compact}>
           <Flex flex="1">
             <BeforeStyle>
               {optionKeys.map(optionKey => (
                 <OptionStyle
                   highlighted={highlightedOptionKey === optionKey}
                   key={optionKey}
-                  onMouseEnter={() => setHighlightedOptionKey(optionKey)}
+                  onMouseEnter={() => {
+                    setHighlightedOptionKey(optionKey);
+                    setShowCalendarIndex(null);
+                  }}
                 >
                   <Text>
                     {removeUnderscore(capitalize(optionKey))}
@@ -108,84 +388,35 @@ function ToggleMenu({
             </BeforeStyle>
           </Flex>
           <Flex flex="2">
-            <ContentStyle>
-              {highlightedOptionKey && (
-                Object.entries((optionsState || options)?.[highlightedOptionKey] || {}).map(([value, enabled]) => {
-                  const valueMapping = toggleValueMapping?.[highlightedOptionKey];
-                  const optionValue = (typeof valueMapping?.[value] === 'function'
-                    // @ts-ignore
-                    ? capitalize(valueMapping?.[value]?.())
-                    : valueMapping?.[value]
-                  ) || value;
-
-                  return (
-                    <ToggleValueStyle key={value}>
-                      <Text
-                        title={!valueMapping ? optionValue : null}
-                        width={200}
-                      >
-                        {optionValue}
-                      </Text>
-                      <ToggleSwitch
-                        checked={enabled}
-                        onCheck={() => setOptionsState(prevState => ({
-                          ...prevState,
-                          [highlightedOptionKey]: {
-                            ...prevState?.[highlightedOptionKey],
-                            [value]: !enabled,
-                          },
-                        }))}
-                      />
-                    </ToggleValueStyle>
-                  );
-                })
+            <ContentStyle allowOverflow={showCalendarIndex !== null}>
+              {highlightedOptionKey && (highlightedIsDateRange
+                ? <DateRangePicker
+                    dateRange={currentDateRange}
+                    optionKey={highlightedOptionKey}
+                    setFilterState={setFilterState}
+                    setShowCalendarIndex={setShowCalendarIndex}
+                    showCalendarIndex={showCalendarIndex}
+                  />
+                : <ToggleList
+                    optionKey={highlightedOptionKey}
+                    options={(filterState || options)?.[highlightedOptionKey] as ToggleOptionType}
+                    setFilterState={setFilterState}
+                    toggleValueMapping={toggleValueMapping?.[highlightedOptionKey]}
+                  />
               )}
             </ContentStyle>
           </Flex>
         </MainStyle>
         <Spacing m={1}>
           <FlexContainer>
-            <Button
-              onClick={() => {
-                const updatedQuery = Object.entries(optionsState)
-                  .reduce((query, [optionKey, enabledValueMapping]) => {
-                    const filteredValues = [];
-                    Object.entries(enabledValueMapping)
-                      .forEach(([value, enabled]) => enabled && filteredValues.push(value));
-                    query[optionKey] = filteredValues;
-
-                    return query;
-                  }, {});
-
-                onClickCallback?.(
-                  query,
-                  updatedQuery,
-                );
-
-                const filterQueryOptions: GoToWithFiltersProps = {
-                  addingMultipleValues: true,
-                  itemsPerPage: ROW_LIMIT,
-                  pushHistory: true,
-                  resetLimitParams: resetLimitOnApply,
-                  resetPage: resetPageOnApply,
-                };
-                if (query?.[MetaQueryEnum.LIMIT]) {
-                  filterQueryOptions.itemsPerPage = +query?.[MetaQueryEnum.LIMIT];
-                }
-                goToWithFilters(
-                  query,
-                  updatedQuery,
-                  filterQueryOptions,
-                );
-              }}
-              secondary
-            >
+            <Button onClick={handleApply} secondary>
               Apply
             </Button>
             <Spacing mr={1} />
             <Button
               noBackground
               onClick={() => {
+                setFilterState({});
                 setOpen(false);
                 onSecondaryClick?.();
               }}

--- a/mage_ai/frontend/pages/manage/pipeline-runs/index.tsx
+++ b/mage_ai/frontend/pages/manage/pipeline-runs/index.tsx
@@ -31,6 +31,8 @@ function RunListPage() {
   const q = queryFromUrl();
   const page = q?.page ? q.page : 0;
   const query = useMemo(() => filterQuery(q, [
+    PipelineRunFilterQueryEnum.EXECUTION_DATE_END,
+    PipelineRunFilterQueryEnum.EXECUTION_DATE_START,
     PipelineRunFilterQueryEnum.PIPELINE_UUID,
     PipelineRunFilterQueryEnum.STATUS,
     PipelineRunFilterQueryEnum.TAG,
@@ -71,6 +73,11 @@ function RunListPage() {
     <Toolbar
       filterOptions={{
         status: PIPELINE_RUN_STATUSES_NO_LAST_RUN_FAILED,
+        execution_date: {
+          type: 'date_range',
+          startKey: PipelineRunFilterQueryEnum.EXECUTION_DATE_START,
+          endKey: PipelineRunFilterQueryEnum.EXECUTION_DATE_END,
+        },
       }}
       filterValueLabelMapping={{
         status: RUN_STATUS_TO_LABEL,

--- a/mage_ai/frontend/pages/pipeline-runs/index.tsx
+++ b/mage_ai/frontend/pages/pipeline-runs/index.tsx
@@ -29,6 +29,8 @@ function RunListPage() {
   const q = queryFromUrl();
   const page = q?.page ? q.page : 0;
   const query = useMemo(() => filterQuery(q, [
+    PipelineRunFilterQueryEnum.EXECUTION_DATE_END,
+    PipelineRunFilterQueryEnum.EXECUTION_DATE_START,
     PipelineRunFilterQueryEnum.PIPELINE_UUID,
     PipelineRunFilterQueryEnum.STATUS,
     PipelineRunFilterQueryEnum.TAG,
@@ -78,6 +80,11 @@ function RunListPage() {
         pipeline_tag: tags.map(({ uuid }) => uuid),
         pipeline_uuid: pipelineUUIDs,
         status: PIPELINE_RUN_STATUSES_NO_LAST_RUN_FAILED,
+        execution_date: {
+          type: 'date_range',
+          startKey: PipelineRunFilterQueryEnum.EXECUTION_DATE_START,
+          endKey: PipelineRunFilterQueryEnum.EXECUTION_DATE_END,
+        },
       }}
       filterValueLabelMapping={{
         pipeline_tag: tags.reduce((acc, { uuid }) => ({

--- a/mage_ai/frontend/utils/hash.ts
+++ b/mage_ai/frontend/utils/hash.ts
@@ -24,19 +24,6 @@ export function selectEntriesWithValues(
   return finalObj;
 }
 
-export function getNestedTruthyValuesCount(obj) {
-  return Object.entries(obj).reduce((count, [key, cv]) => {
-    if (cv !== null && typeof cv === 'object' && !Array.isArray(cv)) {
-      const additionalCount = Object.values(cv).filter(v => !!v).length;
-      count += additionalCount;
-    } else {
-      count += !!cv ? 1 : 0;
-    }
-
-    return count;
-  }, 0);
-}
-
 export function ignoreKeys(d, keys) {
   const copy = { ...d };
 

--- a/mage_ai/frontend/utils/routing.ts
+++ b/mage_ai/frontend/utils/routing.ts
@@ -71,7 +71,6 @@ export function goToWithQuery(query, opts: GoToWithQueryProps = {}) {
 }
 
 export type GoToWithFiltersProps = {
-  addingMultipleValues?: boolean;
   isList?: boolean,
   itemsPerPage?: number,
   pushHistory?: boolean,
@@ -79,17 +78,41 @@ export type GoToWithFiltersProps = {
   resetPage?: boolean,
 };
 
+// Legacy wrapper used by Logs/Filter. Prefer goToWithMixedFilters for new code.
 export function goToWithFilters(
   query: any,
   additionalQuery: any,
   {
-    addingMultipleValues,
-    isList,
     itemsPerPage,
     pushHistory = false,
     resetLimitParams = false,
     resetPage = false,
   }: GoToWithFiltersProps,
+) {
+  goToWithMixedFilters(query, {}, {}, {
+    itemsPerPage, listFilters: additionalQuery, pushHistory, resetLimitParams, resetPage,
+  });
+}
+
+export type GoToWithMixedFiltersProps = {
+  itemsPerPage?: number;
+  listFilters?: { [key: string]: any };
+  pushHistory?: boolean;
+  resetLimitParams?: boolean;
+  resetPage?: boolean;
+};
+
+export function goToWithMixedFilters(
+  query: any,
+  arrayFilters: { [key: string]: any[] },
+  scalarFilters: { [key: string]: any },
+  {
+    itemsPerPage,
+    listFilters,
+    pushHistory = false,
+    resetLimitParams = false,
+    resetPage = false,
+  }: GoToWithMixedFiltersProps,
 ) {
   let updatedQuery = { ...query };
 
@@ -97,35 +120,34 @@ export function goToWithFilters(
     updatedQuery.page = 0;
   }
 
-  if (addingMultipleValues) {
-    Object.entries(additionalQuery).forEach(([k1, v]) => {
-      if (Array.isArray(v)) {
-        const k2 = `${k1}[]`;
-        updatedQuery[k2] = v.map(String);
-      }
-    });
-  } else if (isList) {
-    Object.entries(additionalQuery).forEach(([k1, v]) => {
+  Object.entries(arrayFilters).forEach(([k, v]) => {
+    if (Array.isArray(v)) {
+      updatedQuery[`${k}[]`] = v.map(String);
+    }
+  });
+
+  // Toggle individual values in/out of existing arrays
+  if (listFilters) {
+    Object.entries(listFilters).forEach(([k, v]) => {
       const value = String(v);
-      const k2 = `${k1}[]`;
-      let arr = updatedQuery[k2];
+      const arrKey = `${k}[]`;
+      let arr = updatedQuery[arrKey];
       if (arr && Array.isArray(arr)) {
         arr = arr.map(String);
         if (arr.includes(value)) {
-          updatedQuery[k2] = remove(arr, val => val === value);
+          updatedQuery[arrKey] = remove(arr, val => val === value);
         } else {
-          updatedQuery[k2] = arr.concat(value);
+          updatedQuery[arrKey] = arr.concat(value);
         }
       } else {
-        updatedQuery[k2] = [value];
+        updatedQuery[arrKey] = [value];
       }
     });
-  } else {
-    updatedQuery = {
-      ...updatedQuery,
-      ...additionalQuery,
-    };
   }
+
+  Object.entries(scalarFilters).forEach(([k, v]) => {
+    updatedQuery[k] = v;
+  });
 
   if (resetLimitParams) {
     updatedQuery[MetaQueryEnum.LIMIT] = itemsPerPage || ITEMS_PER_PAGE;


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
                                                                                                                                                                                                                                    
  Seamlessly integrates date range filtering into the existing filter menu for pipeline runs (#6062). Execution date was chosen as the filter field because it best fits the task requirements and is already visible as a column in the table, making the filter immediately verifiable by users.
                                                                                                                                                                                                                                    
  ## Approach     

  Instead of adding a separate date picker button, the date range filter lives inside the existing filter menu. Users get one filter entry point — no extra buttons, no new interaction patterns to learn. An alternative design with a separate date picker button was considered but rejected to avoid a fragmented filtering experience with multiple entry points.
                                                                                                                                                                                                                                    
  The implementation is generic: any page using the shared ToggleMenu/Toolbar can add date range filtering by passing a config object. Multiple date range filters can coexist alongside toggle filters in the same menu.

  ## Test plan

  - [ ] Filter by start date, end date, and both — verify results match                                                                                                                                                             
  - [ ] Clear dates with X button, change time values — verify URL updates
  - [ ] Confirm existing toggle filters still work alongside date filters                                                                                                                                                           
  - [ ] Verify applied filter count badge is correct (includes date range filters)
  - [ ] Verify "Defaults" button resets date range filters
  - [ ] Verify on both `/pipeline-runs` and `/manage/pipeline-runs`                                                                                                                                                                 
   
  ## Notes                                                                                                                                                                                                                          
                  
  - Start/end date validation (start < end) can be added as a polish pass.
  - ToggleMenu could be renamed to FilterMenu to reflect its expanded scope.
  - Calendar stays open after date selection for consistency with calendar behavior elsewhere in the app.