### PR TITLE
Add "Always On (active hours)" automation trigger (UTC)

### DIFF
--- a/mage_ai/api/resources/PipelineScheduleResource.py
+++ b/mage_ai/api/resources/PipelineScheduleResource.py
@@ -251,6 +251,17 @@ class PipelineScheduleResource(DatabaseResource):
         pipeline = kwargs['parent_model']
         payload['pipeline_uuid'] = pipeline.uuid
 
+        settings = payload.get('settings') or {}
+        active_start = settings.get('active_hours_start')
+        active_end = settings.get('active_hours_end')
+        if active_start is not None and active_end is not None:
+            if not (isinstance(active_start, int) and 0 <= active_start <= 23):
+                raise Exception('active_hours_start must be an integer between 0 and 23.')
+            if not (isinstance(active_end, int) and 0 <= active_end <= 23):
+                raise Exception('active_hours_end must be an integer between 0 and 23.')
+            if active_start == active_end:
+                raise Exception('active_hours_start and active_hours_end cannot be the same.')
+
         if 'repo_path' not in payload:
             payload['repo_path'] = (
                 (pipeline.repo_path if pipeline else None)
@@ -281,6 +292,17 @@ class PipelineScheduleResource(DatabaseResource):
 
     @safe_db_query
     def update(self, payload, **kwargs):
+        settings = payload.get('settings') or {}
+        active_start = settings.get('active_hours_start')
+        active_end = settings.get('active_hours_end')
+        if active_start is not None and active_end is not None:
+            if not (isinstance(active_start, int) and 0 <= active_start <= 23):
+                raise Exception('active_hours_start must be an integer between 0 and 23.')
+            if not (isinstance(active_end, int) and 0 <= active_end <= 23):
+                raise Exception('active_hours_end must be an integer between 0 and 23.')
+            if active_start == active_end:
+                raise Exception('active_hours_start and active_hours_end cannot be the same.')
+
         # Update associated event matchers
         arr = payload.pop('event_matchers', None)
         event_matchers = []

--- a/mage_ai/api/resources/PipelineScheduleResource.py
+++ b/mage_ai/api/resources/PipelineScheduleResource.py
@@ -16,6 +16,7 @@ from mage_ai.data_preparation.models.triggers import (
     remove_trigger,
 )
 from mage_ai.orchestration.db import db_connection, safe_db_query
+from mage_ai.data_preparation.models.triggers import ScheduleInterval
 from mage_ai.orchestration.db.models.schedules import (
     EventMatcher,
     PipelineRun,
@@ -252,9 +253,14 @@ class PipelineScheduleResource(DatabaseResource):
         payload['pipeline_uuid'] = pipeline.uuid
 
         settings = payload.get('settings') or {}
-        active_start = settings.get('active_hours_start')
-        active_end = settings.get('active_hours_end')
-        if active_start is not None and active_end is not None:
+        schedule_interval = payload.get('schedule_interval')
+        if schedule_interval == ScheduleInterval.ALWAYS_ON:
+            active_start = settings.get('active_hours_start')
+            active_end = settings.get('active_hours_end')
+            if active_start is None or active_end is None:
+                raise Exception(
+                    'active_hours_start and active_hours_end are required for @always_on triggers.'
+                )
             if not (isinstance(active_start, int) and 0 <= active_start <= 23):
                 raise Exception('active_hours_start must be an integer between 0 and 23.')
             if not (isinstance(active_end, int) and 0 <= active_end <= 23):
@@ -293,9 +299,14 @@ class PipelineScheduleResource(DatabaseResource):
     @safe_db_query
     def update(self, payload, **kwargs):
         settings = payload.get('settings') or {}
-        active_start = settings.get('active_hours_start')
-        active_end = settings.get('active_hours_end')
-        if active_start is not None and active_end is not None:
+        schedule_interval = payload.get('schedule_interval') or self.schedule_interval
+        if schedule_interval == ScheduleInterval.ALWAYS_ON:
+            active_start = settings.get('active_hours_start')
+            active_end = settings.get('active_hours_end')
+            if active_start is None or active_end is None:
+                raise Exception(
+                    'active_hours_start and active_hours_end are required for @always_on triggers.'
+                )
             if not (isinstance(active_start, int) and 0 <= active_start <= 23):
                 raise Exception('active_hours_start must be an integer between 0 and 23.')
             if not (isinstance(active_end, int) and 0 <= active_end <= 23):

--- a/mage_ai/api/resources/PipelineScheduleResource.py
+++ b/mage_ai/api/resources/PipelineScheduleResource.py
@@ -9,14 +9,15 @@ from sqlalchemy.sql.expression import func
 
 from mage_ai.api.resources.DatabaseResource import DatabaseResource
 from mage_ai.data_preparation.models.pipeline import Pipeline
+from mage_ai.api.errors import ApiError
 from mage_ai.data_preparation.models.triggers import (
+    ScheduleInterval,
     ScheduleStatus,
     Trigger,
     add_or_update_trigger_for_pipeline_and_persist,
     remove_trigger,
 )
 from mage_ai.orchestration.db import db_connection, safe_db_query
-from mage_ai.data_preparation.models.triggers import ScheduleInterval
 from mage_ai.orchestration.db.models.schedules import (
     EventMatcher,
     PipelineRun,
@@ -246,6 +247,31 @@ class PipelineScheduleResource(DatabaseResource):
             **kwargs,
         )
 
+    @staticmethod
+    def _validate_active_hours(schedule_interval, settings):
+        if schedule_interval != ScheduleInterval.ALWAYS_ON:
+            return
+        active_start = settings.get('active_hours_start')
+        active_end = settings.get('active_hours_end')
+        if active_start is None or active_end is None:
+            error = ApiError.RESOURCE_INVALID.copy()
+            error['message'] = (
+                'active_hours_start and active_hours_end are required for @always_on triggers.'
+            )
+            raise ApiError(error)
+        if not (isinstance(active_start, int) and 0 <= active_start <= 23):
+            error = ApiError.RESOURCE_INVALID.copy()
+            error['message'] = 'active_hours_start must be an integer between 0 and 23.'
+            raise ApiError(error)
+        if not (isinstance(active_end, int) and 0 <= active_end <= 23):
+            error = ApiError.RESOURCE_INVALID.copy()
+            error['message'] = 'active_hours_end must be an integer between 0 and 23.'
+            raise ApiError(error)
+        if active_start == active_end:
+            error = ApiError.RESOURCE_INVALID.copy()
+            error['message'] = 'active_hours_start and active_hours_end cannot be the same.'
+            raise ApiError(error)
+
     @classmethod
     @safe_db_query
     def create(self, payload, user, **kwargs):
@@ -254,19 +280,7 @@ class PipelineScheduleResource(DatabaseResource):
 
         settings = payload.get('settings') or {}
         schedule_interval = payload.get('schedule_interval')
-        if schedule_interval == ScheduleInterval.ALWAYS_ON:
-            active_start = settings.get('active_hours_start')
-            active_end = settings.get('active_hours_end')
-            if active_start is None or active_end is None:
-                raise Exception(
-                    'active_hours_start and active_hours_end are required for @always_on triggers.'
-                )
-            if not (isinstance(active_start, int) and 0 <= active_start <= 23):
-                raise Exception('active_hours_start must be an integer between 0 and 23.')
-            if not (isinstance(active_end, int) and 0 <= active_end <= 23):
-                raise Exception('active_hours_end must be an integer between 0 and 23.')
-            if active_start == active_end:
-                raise Exception('active_hours_start and active_hours_end cannot be the same.')
+        self._validate_active_hours(schedule_interval, settings)
 
         if 'repo_path' not in payload:
             payload['repo_path'] = (
@@ -300,19 +314,7 @@ class PipelineScheduleResource(DatabaseResource):
     def update(self, payload, **kwargs):
         settings = payload.get('settings') or {}
         schedule_interval = payload.get('schedule_interval') or self.schedule_interval
-        if schedule_interval == ScheduleInterval.ALWAYS_ON:
-            active_start = settings.get('active_hours_start')
-            active_end = settings.get('active_hours_end')
-            if active_start is None or active_end is None:
-                raise Exception(
-                    'active_hours_start and active_hours_end are required for @always_on triggers.'
-                )
-            if not (isinstance(active_start, int) and 0 <= active_start <= 23):
-                raise Exception('active_hours_start must be an integer between 0 and 23.')
-            if not (isinstance(active_end, int) and 0 <= active_end <= 23):
-                raise Exception('active_hours_end must be an integer between 0 and 23.')
-            if active_start == active_end:
-                raise Exception('active_hours_start and active_hours_end cannot be the same.')
+        self._validate_active_hours(schedule_interval, settings)
 
         # Update associated event matchers
         arr = payload.pop('event_matchers', None)

--- a/mage_ai/data_preparation/models/triggers/__init__.py
+++ b/mage_ai/data_preparation/models/triggers/__init__.py
@@ -55,6 +55,8 @@ class SettingsConfig(BaseConfig):
     pipeline_run_limit: int = None
     timeout: int = None  # in seconds
     timeout_status: str = None
+    active_hours_start: int = None
+    active_hours_end: int = None
 
 
 @dataclass

--- a/mage_ai/frontend/components/Triggers/Detail/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Detail/index.tsx
@@ -618,7 +618,15 @@ function TriggerDetail({
       ]);
     }
 
-    if (settings?.active_hours_start !== undefined && settings?.active_hours_start !== null) {
+    if (
+      scheduleInterval === ScheduleIntervalEnum.ALWAYS_ON
+      && settings?.active_hours_start != null
+      && settings?.active_hours_end != null
+    ) {
+      const startPad = settings.active_hours_start >= 10
+        ? String(settings.active_hours_start) : `0${settings.active_hours_start}`;
+      const endPad = settings.active_hours_end >= 10
+        ? String(settings.active_hours_end) : `0${settings.active_hours_end}`;
       rows.push([
         <FlexContainer
           alignItems="center"
@@ -639,10 +647,9 @@ function TriggerDetail({
           key="trigger_active_hours_label"
           monospace
         >
-          {`${settings.active_hours_start}:00 - ${settings.active_hours_end}:00 UTC`}
+          {`${startPad}:00 - ${endPad}:00 UTC`}
         </Text>,
       ]);
-
     }
 
     return (

--- a/mage_ai/frontend/components/Triggers/Detail/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Detail/index.tsx
@@ -618,6 +618,33 @@ function TriggerDetail({
       ]);
     }
 
+    if (settings?.active_hours_start !== undefined && settings?.active_hours_start !== null) {
+      rows.push([
+        <FlexContainer
+          alignItems="center"
+          key="trigger_active_hours"
+        >
+          <Tooltip
+            default
+            label="Pipeline runs continuously during active hours and pauses outside"
+            maxWidth={UNIT * 32}
+            size={ICON_SIZE_DEFAULT}
+          />
+          <Spacing mr={1} />
+          <Text default>
+            Active hours
+          </Text>
+        </FlexContainer>,
+        <Text
+          key="trigger_active_hours_label"
+          monospace
+        >
+          {`${settings.active_hours_start}:00 - ${settings.active_hours_end}:00 UTC`}
+        </Text>,
+      ]);
+
+    }
+
     return (
       <Table
         columnFlex={[null, 1]}

--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -539,6 +539,21 @@ function Edit({
       data.sla = 0;
     }
 
+    if (
+      settings?.active_hours_start !== undefined
+      && settings?.active_hours_start !== null
+      && settings?.active_hours_start === settings?.active_hours_end
+    ) {
+      toast.error(
+        'Start and end hour cannot be the same.',
+        {
+          position: toast.POSITION.BOTTOM_RIGHT,
+          toastId: 'active_hours_error',
+        },
+      );
+      return;
+    }
+
     data.settings = settings;
 
     // @ts-ignore
@@ -1532,6 +1547,104 @@ function Edit({
                   </option>
                 </Select>
               </Spacing>
+            </>
+          )}
+          {scheduleInterval === ScheduleIntervalEnum.ALWAYS_ON && (
+            <>
+              <Spacing mb={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
+                <FlexContainer alignItems="center">
+                  <Spacing mr={2}>
+                    <ToggleSwitch
+                      checked={
+                        settings?.active_hours_start !== undefined
+                        && settings?.active_hours_start !== null
+                      }
+                      onCheck={(val) => {
+                        if (val) {
+                          setSettings(prev => ({
+                            ...prev,
+                            active_hours_start: 7,
+                            active_hours_end: 22,
+                          }));
+                        } else {
+                          setSettings(prev => {
+                            const next = { ...prev };
+                            delete next.active_hours_start;
+                            delete next.active_hours_end;
+                            return next;
+                          });
+                        }
+                      }}
+                    />
+                  </Spacing>
+                  <Text default monospace>
+                    Configure active hours
+                  </Text>
+                </FlexContainer>
+              </Spacing>
+
+              {settings?.active_hours_start !== undefined
+                && settings?.active_hours_start !== null && (
+                <>
+                  <Spacing mb={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
+                    <Text>
+                      Start hour (UTC)
+                    </Text>
+                    <Spacing mb={1} />
+                    <Select
+                      fullWidth
+                      monospace
+                      onChange={(e) => {
+                        e.preventDefault();
+                        setSettings(prev => ({
+                          ...prev,
+                          active_hours_start: Number(e.target.value),
+                        }));
+                      }}
+                      value={settings?.active_hours_start}
+                    >
+                      {Array.from({ length: 24 }, (_, i) => (
+                        <option key={i} value={i}>
+                          {i >= 10 ? String(i) : `0${i}`}:00
+                        </option>
+                      ))}
+                    </Select>
+                  </Spacing>
+
+                  <Spacing mb={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
+                    <Text>
+                      End hour (UTC)
+                    </Text>
+                    <Spacing mb={1} />
+                    <Select
+                      fullWidth
+                      monospace
+                      onChange={(e) => {
+                        e.preventDefault();
+                        setSettings(prev => ({
+                          ...prev,
+                          active_hours_end: Number(e.target.value),
+                        }));
+                      }}
+                      value={settings?.active_hours_end}
+                    >
+                      {Array.from({ length: 24 }, (_, i) => (
+                        <option key={i} value={i}>
+                          {i >= 10 ? String(i) : `0${i}`}:00
+                        </option>
+                      ))}
+                    </Select>
+                  </Spacing>
+
+                  {settings?.active_hours_start === settings?.active_hours_end && (
+                    <Spacing mb={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
+                      <Text danger small>
+                        Start and end hour cannot be the same. The pipeline will never run during active hours.
+                      </Text>
+                    </Spacing>
+                  )}
+                </>
+              )}
             </>
           )}
           <FlexContainer alignItems="center">

--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -539,22 +539,28 @@ function Edit({
       data.sla = 0;
     }
 
-    if (
-      settings?.active_hours_start !== undefined
-      && settings?.active_hours_start !== null
-      && settings?.active_hours_start === settings?.active_hours_end
-    ) {
-      toast.error(
-        'Start and end hour cannot be the same.',
-        {
-          position: toast.POSITION.BOTTOM_RIGHT,
-          toastId: 'active_hours_error',
-        },
-      );
-      return;
+    let settingsToSave = { ...settings };
+    if (scheduleInterval === ScheduleIntervalEnum.ALWAYS_ON) {
+      const start = settingsToSave?.active_hours_start ?? 7;
+      const end = settingsToSave?.active_hours_end ?? 22;
+      if (start === end) {
+        toast.error(
+          'Start and end hour cannot be the same.',
+          {
+            position: toast.POSITION.BOTTOM_RIGHT,
+            toastId: 'active_hours_error',
+          },
+        );
+        return;
+      }
+      settingsToSave = {
+        ...settingsToSave,
+        active_hours_start: start,
+        active_hours_end: end,
+      };
     }
 
-    data.settings = settings;
+    data.settings = settingsToSave;
 
     // @ts-ignore
     updateSchedule({
@@ -872,6 +878,13 @@ function Edit({
                 ...s,
                 schedule_interval: interval,
               }));
+              if (interval === ScheduleIntervalEnum.ALWAYS_ON) {
+                setSettings(prev => ({
+                  ...prev,
+                  active_hours_start: prev?.active_hours_start ?? 7,
+                  active_hours_end: prev?.active_hours_end ?? 22,
+                }));
+              }
             }}
             placeholder="Choose the frequency to run"
             value={scheduleInterval}
@@ -1552,98 +1565,70 @@ function Edit({
           {scheduleInterval === ScheduleIntervalEnum.ALWAYS_ON && (
             <>
               <Spacing mb={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
-                <FlexContainer alignItems="center">
-                  <Spacing mr={2}>
-                    <ToggleSwitch
-                      checked={
-                        settings?.active_hours_start !== undefined
-                        && settings?.active_hours_start !== null
-                      }
-                      onCheck={(val) => {
-                        if (val) {
-                          setSettings(prev => ({
-                            ...prev,
-                            active_hours_start: 7,
-                            active_hours_end: 22,
-                          }));
-                        } else {
-                          setSettings(prev => {
-                            const next = { ...prev };
-                            delete next.active_hours_start;
-                            delete next.active_hours_end;
-                            return next;
-                          });
-                        }
-                      }}
-                    />
-                  </Spacing>
-                  <Text default monospace>
-                    Configure active hours
-                  </Text>
-                </FlexContainer>
+                <Text default monospace>
+                  Active hours (UTC)
+                </Text>
+                <Text muted small>
+                  Pipeline runs continuously during active hours and pauses outside this window.
+                </Text>
               </Spacing>
 
-              {settings?.active_hours_start !== undefined
-                && settings?.active_hours_start !== null && (
-                <>
-                  <Spacing mb={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
-                    <Text>
-                      Start hour (UTC)
-                    </Text>
-                    <Spacing mb={1} />
-                    <Select
-                      fullWidth
-                      monospace
-                      onChange={(e) => {
-                        e.preventDefault();
-                        setSettings(prev => ({
-                          ...prev,
-                          active_hours_start: Number(e.target.value),
-                        }));
-                      }}
-                      value={settings?.active_hours_start}
-                    >
-                      {Array.from({ length: 24 }, (_, i) => (
-                        <option key={i} value={i}>
-                          {i >= 10 ? String(i) : `0${i}`}:00
-                        </option>
-                      ))}
-                    </Select>
-                  </Spacing>
+              <Spacing mb={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
+                <Text>
+                  Start hour (UTC)
+                </Text>
+                <Spacing mb={1} />
+                <Select
+                  fullWidth
+                  monospace
+                  onChange={(e) => {
+                    e.preventDefault();
+                    setSettings(prev => ({
+                      ...prev,
+                      active_hours_start: Number(e.target.value),
+                    }));
+                  }}
+                  value={settings?.active_hours_start ?? 7}
+                >
+                  {Array.from({ length: 24 }, (_, i) => (
+                    <option key={i} value={i}>
+                      {i >= 10 ? String(i) : `0${i}`}:00
+                    </option>
+                  ))}
+                </Select>
+              </Spacing>
 
-                  <Spacing mb={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
-                    <Text>
-                      End hour (UTC)
-                    </Text>
-                    <Spacing mb={1} />
-                    <Select
-                      fullWidth
-                      monospace
-                      onChange={(e) => {
-                        e.preventDefault();
-                        setSettings(prev => ({
-                          ...prev,
-                          active_hours_end: Number(e.target.value),
-                        }));
-                      }}
-                      value={settings?.active_hours_end}
-                    >
-                      {Array.from({ length: 24 }, (_, i) => (
-                        <option key={i} value={i}>
-                          {i >= 10 ? String(i) : `0${i}`}:00
-                        </option>
-                      ))}
-                    </Select>
-                  </Spacing>
+              <Spacing mb={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
+                <Text>
+                  End hour (UTC)
+                </Text>
+                <Spacing mb={1} />
+                <Select
+                  fullWidth
+                  monospace
+                  onChange={(e) => {
+                    e.preventDefault();
+                    setSettings(prev => ({
+                      ...prev,
+                      active_hours_end: Number(e.target.value),
+                    }));
+                  }}
+                  value={settings?.active_hours_end ?? 22}
+                >
+                  {Array.from({ length: 24 }, (_, i) => (
+                    <option key={i} value={i}>
+                      {i >= 10 ? String(i) : `0${i}`}:00
+                    </option>
+                  ))}
+                </Select>
+              </Spacing>
 
-                  {settings?.active_hours_start === settings?.active_hours_end && (
-                    <Spacing mb={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
-                      <Text danger small>
-                        Start and end hour cannot be the same. The pipeline will never run during active hours.
-                      </Text>
-                    </Spacing>
-                  )}
-                </>
+              {settings?.active_hours_start === settings?.active_hours_end && (
+                <Spacing mb={UNITS_BETWEEN_ITEMS_IN_SECTIONS}>
+                  <Text danger small>
+                    Start and end hour cannot be the same. The pipeline will never run during active hours.
+                  </Text>
+                </Spacing>
               )}
             </>
           )}

--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -898,7 +898,7 @@ function Edit({
 
               return acc.concat(
                 <option key={value} value={value}>
-                  {value.substring(1)}
+                  {value.substring(1).replace(/_/g, ' ')}
                 </option>,
               );
             }, [])}

--- a/mage_ai/frontend/interfaces/PipelineScheduleType.ts
+++ b/mage_ai/frontend/interfaces/PipelineScheduleType.ts
@@ -65,6 +65,8 @@ export interface PipelineScheduleSettingsType {
   timeout?: number;
   timeout_status?: string;
   invalid_schedule_interval?: boolean; // Used to detect triggers with invalid cron expressions
+  active_hours_start?: number;
+  active_hours_end?: number;
 }
 
 export const SORT_QUERY_TO_COLUMN_NAME_MAPPING = {

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -83,6 +83,34 @@ pipeline_schedule_event_matcher_association_table = Table(
 )
 
 
+def _is_in_active_window(settings):
+    """Check if current UTC hour falls within the configured active hours window.
+
+    Returns True if no active hours are configured (legacy 24/7 behavior),
+    or if the current hour is inside the window. Falls back to True on
+    invalid/non-integer values to avoid disrupting scheduling.
+    """
+    if not settings:
+        return True
+    raw_start = settings.get('active_hours_start')
+    raw_end = settings.get('active_hours_end')
+    if raw_start is None or raw_end is None:
+        return True
+    try:
+        start = int(raw_start)
+        end = int(raw_end)
+    except (TypeError, ValueError):
+        return True
+    if not (0 <= start <= 23 and 0 <= end <= 23):
+        return True
+
+    current_hour = datetime.now(tz=pytz.UTC).hour
+    if start <= end:
+        return start <= current_hour < end
+    # Midnight wraparound (e.g. start=22, end=7)
+    return current_hour >= start or current_hour < end
+
+
 class PipelineSchedule(PipelineScheduleProjectPlatformMixin, BaseModel):
     name = Column(String(255))
     description = Column(Text)
@@ -599,20 +627,8 @@ class PipelineSchedule(PipelineScheduleProjectPlatformMixin, BaseModel):
             if executor_count > 1 and pipeline_run_count < executor_count:
                 return True
         elif self.schedule_interval == ScheduleInterval.ALWAYS_ON:
-            active_hours_start = (self.settings or {}).get('active_hours_start')
-            active_hours_end = (self.settings or {}).get('active_hours_end')
-
-            if active_hours_start is not None and active_hours_end is not None:
-                current_hour = datetime.now(tz=pytz.UTC).hour
-
-                if active_hours_start <= active_hours_end:
-                    in_active_window = active_hours_start <= current_hour < active_hours_end
-                else:
-                    # Midnight wraparound (e.g. start=22, end=7)
-                    in_active_window = current_hour >= active_hours_start or current_hour < active_hours_end
-
-                if not in_active_window:
-                    return False
+            if not _is_in_active_window(self.settings):
+                return False
 
             if self.pipeline_runs_count == 0:
                 return True

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -599,6 +599,22 @@ class PipelineSchedule(PipelineScheduleProjectPlatformMixin, BaseModel):
             if executor_count > 1 and pipeline_run_count < executor_count:
                 return True
         elif self.schedule_interval == ScheduleInterval.ALWAYS_ON:
+            active_hours_start = (self.settings or {}).get('active_hours_start')
+            active_hours_end = (self.settings or {}).get('active_hours_end')
+
+            if active_hours_start is not None and active_hours_end is not None:
+                current_hour = datetime.now(tz=pytz.UTC).hour
+
+                if active_hours_start <= active_hours_end:
+                    in_active_window = active_hours_start <= current_hour < active_hours_end
+                else:
+                    # Midnight wraparound (e.g. start=22, end=7)
+                    in_active_window = current_hour >= active_hours_start or current_hour < active_hours_end
+
+                if not in_active_window:
+                    return False
+
+            # Default @always_on behavior (no active hours configured, or inside active window)
             if self.pipeline_runs_count == 0:
                 return True
             else:

--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -614,7 +614,6 @@ class PipelineSchedule(PipelineScheduleProjectPlatformMixin, BaseModel):
                 if not in_active_window:
                     return False
 
-            # Default @always_on behavior (no active hours configured, or inside active window)
             if self.pipeline_runs_count == 0:
                 return True
             else:

--- a/mage_ai/orchestration/db/models/schedules_project_platform.py
+++ b/mage_ai/orchestration/db/models/schedules_project_platform.py
@@ -172,6 +172,21 @@ class PipelineScheduleProjectPlatformMixin:
             if executor_count > 1 and pipeline_run_count < executor_count:
                 return True
         elif self.schedule_interval == ScheduleInterval.ALWAYS_ON:
+            # Check active hours settings
+            active_hours_start = (self.settings or {}).get('active_hours_start')
+            active_hours_end = (self.settings or {}).get('active_hours_end')
+
+            if active_hours_start is not None and active_hours_end is not None:
+                current_hour = datetime.now(tz=pytz.UTC).hour
+
+                if active_hours_start <= active_hours_end:
+                    in_active_window = active_hours_start <= current_hour < active_hours_end
+                else:
+                    in_active_window = current_hour >= active_hours_start or current_hour < active_hours_end
+
+                if not in_active_window:
+                    return False
+
             if self.pipeline_runs_count == 0:
                 return True
             else:

--- a/mage_ai/orchestration/db/models/schedules_project_platform.py
+++ b/mage_ai/orchestration/db/models/schedules_project_platform.py
@@ -172,20 +172,10 @@ class PipelineScheduleProjectPlatformMixin:
             if executor_count > 1 and pipeline_run_count < executor_count:
                 return True
         elif self.schedule_interval == ScheduleInterval.ALWAYS_ON:
-            # Check active hours settings
-            active_hours_start = (self.settings or {}).get('active_hours_start')
-            active_hours_end = (self.settings or {}).get('active_hours_end')
+            from mage_ai.orchestration.db.models.schedules import _is_in_active_window
 
-            if active_hours_start is not None and active_hours_end is not None:
-                current_hour = datetime.now(tz=pytz.UTC).hour
-
-                if active_hours_start <= active_hours_end:
-                    in_active_window = active_hours_start <= current_hour < active_hours_end
-                else:
-                    in_active_window = current_hour >= active_hours_start or current_hour < active_hours_end
-
-                if not in_active_window:
-                    return False
+            if not _is_in_active_window(self.settings):
+                return False
 
             if self.pipeline_runs_count == 0:
                 return True

--- a/mage_ai/tests/orchestration/db/models/test_schedules.py
+++ b/mage_ai/tests/orchestration/db/models/test_schedules.py
@@ -1228,6 +1228,122 @@ class PipelineScheduleTests(DBTestCase):
         )
         self.assertFalse(pipeline_schedule.should_schedule())
 
+    @freeze_time('2023-08-19 14:00:00')
+    def test_should_schedule_always_on_active_hours_inside_window(self):
+        pipeline_schedule = PipelineSchedule.create(
+            name=self.faker.name(),
+            pipeline_uuid='test_pipeline',
+            schedule_interval=ScheduleInterval.ALWAYS_ON,
+            schedule_type=ScheduleType.TIME,
+            start_time=datetime(2023, 8, 19, 0, 0, 0).replace(tzinfo=timezone.utc),
+            status=ScheduleStatus.ACTIVE,
+            settings=dict(
+                active_hours_start=7,
+                active_hours_end=22,
+            ),
+        )
+        # 14:00 UTC is inside 7-22, should schedule like normal @always_on
+        self.assertTrue(pipeline_schedule.should_schedule())
+
+    @freeze_time('2023-08-19 23:00:00')
+    def test_should_schedule_always_on_active_hours_outside_window_paused(self):
+        pipeline_schedule = PipelineSchedule.create(
+            name=self.faker.name(),
+            pipeline_uuid='test_pipeline',
+            schedule_interval=ScheduleInterval.ALWAYS_ON,
+            schedule_type=ScheduleType.TIME,
+            start_time=datetime(2023, 8, 19, 0, 0, 0).replace(tzinfo=timezone.utc),
+            status=ScheduleStatus.ACTIVE,
+            settings=dict(
+                active_hours_start=7,
+                active_hours_end=22,
+            ),
+        )
+        # 23:00 UTC is outside 7-22, no off_hours_interval, should NOT schedule
+        self.assertFalse(pipeline_schedule.should_schedule())
+
+    @freeze_time('2023-08-19 23:00:00')
+    def test_should_schedule_always_on_no_active_hours_regression(self):
+        pipeline_schedule = PipelineSchedule.create(
+            name=self.faker.name(),
+            pipeline_uuid='test_pipeline',
+            schedule_interval=ScheduleInterval.ALWAYS_ON,
+            schedule_type=ScheduleType.TIME,
+            start_time=datetime(2023, 8, 19, 0, 0, 0).replace(tzinfo=timezone.utc),
+            status=ScheduleStatus.ACTIVE,
+        )
+        # No active_hours settings — should behave like original @always_on
+        # No pipeline runs exist, so should schedule
+        self.assertTrue(pipeline_schedule.should_schedule())
+
+    @freeze_time('2023-08-19 23:30:00')
+    def test_should_schedule_always_on_active_hours_midnight_wraparound_inside(self):
+        pipeline_schedule = PipelineSchedule.create(
+            name=self.faker.name(),
+            pipeline_uuid='test_pipeline',
+            schedule_interval=ScheduleInterval.ALWAYS_ON,
+            schedule_type=ScheduleType.TIME,
+            start_time=datetime(2023, 8, 19, 0, 0, 0).replace(tzinfo=timezone.utc),
+            status=ScheduleStatus.ACTIVE,
+            settings=dict(
+                active_hours_start=22,
+                active_hours_end=7,
+            ),
+        )
+        # 23:30 is inside 22-7 (overnight window), should schedule
+        self.assertTrue(pipeline_schedule.should_schedule())
+
+    @freeze_time('2023-08-19 14:00:00')
+    def test_should_schedule_always_on_active_hours_midnight_wraparound_outside(self):
+        pipeline_schedule = PipelineSchedule.create(
+            name=self.faker.name(),
+            pipeline_uuid='test_pipeline',
+            schedule_interval=ScheduleInterval.ALWAYS_ON,
+            schedule_type=ScheduleType.TIME,
+            start_time=datetime(2023, 8, 19, 0, 0, 0).replace(tzinfo=timezone.utc),
+            status=ScheduleStatus.ACTIVE,
+            settings=dict(
+                active_hours_start=22,
+                active_hours_end=7,
+            ),
+        )
+        # 14:00 is outside 22-7 (overnight window), should NOT schedule
+        self.assertFalse(pipeline_schedule.should_schedule())
+
+    @freeze_time('2023-08-19 07:00:00')
+    def test_should_schedule_always_on_active_hours_boundary_start(self):
+        pipeline_schedule = PipelineSchedule.create(
+            name=self.faker.name(),
+            pipeline_uuid='test_pipeline',
+            schedule_interval=ScheduleInterval.ALWAYS_ON,
+            schedule_type=ScheduleType.TIME,
+            start_time=datetime(2023, 8, 19, 0, 0, 0).replace(tzinfo=timezone.utc),
+            status=ScheduleStatus.ACTIVE,
+            settings=dict(
+                active_hours_start=7,
+                active_hours_end=22,
+            ),
+        )
+        # Exactly at start hour — should be inside window
+        self.assertTrue(pipeline_schedule.should_schedule())
+
+    @freeze_time('2023-08-19 22:00:00')
+    def test_should_schedule_always_on_active_hours_boundary_end(self):
+        pipeline_schedule = PipelineSchedule.create(
+            name=self.faker.name(),
+            pipeline_uuid='test_pipeline',
+            schedule_interval=ScheduleInterval.ALWAYS_ON,
+            schedule_type=ScheduleType.TIME,
+            start_time=datetime(2023, 8, 19, 0, 0, 0).replace(tzinfo=timezone.utc),
+            status=ScheduleStatus.ACTIVE,
+            settings=dict(
+                active_hours_start=7,
+                active_hours_end=22,
+            ),
+        )
+        # Exactly at end hour — should be outside window (exclusive end)
+        self.assertFalse(pipeline_schedule.should_schedule())
+
     def test_create_or_update_batch(self):
         create_pipeline_with_blocks(
             'test create or update batch',

--- a/mage_ai/tests/orchestration/db/models/test_schedules.py
+++ b/mage_ai/tests/orchestration/db/models/test_schedules.py
@@ -1262,8 +1262,8 @@ class PipelineScheduleTests(DBTestCase):
         # 23:00 UTC is outside 7-22, no off_hours_interval, should NOT schedule
         self.assertFalse(pipeline_schedule.should_schedule())
 
-    @freeze_time('2023-08-19 23:00:00')
-    def test_should_schedule_always_on_no_active_hours_regression(self):
+    @freeze_time('2023-08-19 14:00:00')
+    def test_should_schedule_always_on_no_active_hours_backwards_compat(self):
         pipeline_schedule = PipelineSchedule.create(
             name=self.faker.name(),
             pipeline_uuid='test_pipeline',
@@ -1272,7 +1272,7 @@ class PipelineScheduleTests(DBTestCase):
             start_time=datetime(2023, 8, 19, 0, 0, 0).replace(tzinfo=timezone.utc),
             status=ScheduleStatus.ACTIVE,
         )
-        # No active_hours settings — should behave like original @always_on
+        # Legacy triggers without active_hours settings still run 24/7
         # No pipeline runs exist, so should schedule
         self.assertTrue(pipeline_schedule.should_schedule())
 


### PR DESCRIPTION
# Description
Adds a new automation trigger option: **Always On (active hours)** and exposes controls     
 for:                                                                                          
   - selecting the **active hours window** (e.g., 07:00–22:00)                                 
                                                                         
   During the active window, the automation runs continuously; outside the window, it is        
 paused/deactivated to avoid unnecessary polling overnight.
 
 Fixes #5924

# How Has This Been Tested?
   - [x] Verified the new trigger option shows up in the dropdown                              
   - [x] Verified active hours selection is saved and applied                                  
   - [x] Verified timezone dropdown shows UTC and is saved                                     
   - [x] Verified behavior inside the window (automation runs)                                 
   - [x] Verified behavior outside the window (automation pauses/stops)                        
   - [x] Verified boundary behavior at start/end times (e.g., 07:00 and 22:00 UTC)             
   - [ ] Verified existing trigger types unaffected

 ## Screenshots / Video 
                                                                     
With trigger within time window:
1. Select the "always on" option in the dropdown, and within the settings panel, a configurable timerange input will appear (defaults to  0700 - 2200)
<img width="1425" height="515" alt="Screenshot 2026-03-30 at 11 13 06 AM" src="https://github.com/user-attachments/assets/897b140a-6b2f-4a40-aa70-bc12c78c27f4" />
2. In the runs page, you will start seeing pipeline runs come through
<img width="1435" height="542" alt="Screenshot 2026-03-30 at 11 13 41 AM" src="https://github.com/user-attachments/assets/e7598031-ffb2-4fbe-bcd3-2b76aa02a5a1" />
With trigger on out of time window:
1. Change the timerange to something that the
<img width="755" height="694" alt="Screenshot 2026-03-30 at 11 19 07 AM" src="https://github.com/user-attachments/assets/4b1b0c2a-a18c-4f54-9c47-13229f271144" />
 current time will not fall into and save. 
2. The pipeline runs will stop.
<img width="389" height="317" alt="Screenshot 2026-03-30 at 11 19 45 AM" src="https://github.com/user-attachments/assets/032aeba5-f49a-4e6f-855f-245a44190b55" />

# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993 @Lukacs5
