### PR TITLE
Improve dbt pipeline error notifications with specific model/test failure details

### DIFF
--- a/mage_ai/data_preparation/models/block/dbt/block_sql.py
+++ b/mage_ai/data_preparation/models/block/dbt/block_sql.py
@@ -415,7 +415,7 @@ class DBTBlockSQL(DBTBlock, ProjectPlatformAccessible):
                 res = cli.invoke([task] + args)
                 success = res.success
                 if not success:
-                    raise Exception(str(res.exception))
+                    raise Exception(self.__get_dbt_error_message(res))
             # run show task, to get data for preview or downstream usage
             # test task does not have any data
             #
@@ -611,3 +611,45 @@ class DBTBlockSQL(DBTBlock, ProjectPlatformAccessible):
                 return file_path
 
         return self.configuration.get('file_path')
+
+    @staticmethod
+    def __get_dbt_error_message(res) -> str:
+        """
+        Build a detailed error message from a failed dbt run result.
+
+        Extracts individual model/test failures from res.result.results so that
+        notifications show exactly which dbt models or tests caused the failure,
+        rather than only a generic exception string.
+        """
+        base_msg = str(res.exception) if res.exception else 'dbt run failed'
+
+        failed_nodes = []
+        try:
+            if res.result and hasattr(res.result, 'results'):
+                for run_result in res.result.results:
+                    status = str(run_result.status)
+                    # RunStatus values that represent failures: 'error' (model errors),
+                    # 'fail' (test failures), 'runtime error'
+                    if status in ('error', 'fail', 'runtime error'):
+                        node = run_result.node
+                        resource_type = (
+                            node.resource_type.value
+                            if hasattr(node.resource_type, 'value')
+                            else str(node.resource_type)
+                        )
+                        node_name = node.name
+                        message = run_result.message or ''
+                        failed_nodes.append(
+                            f'  - {resource_type} "{node_name}": {message}'
+                        )
+        except Exception:
+            pass
+
+        if failed_nodes:
+            return (
+                f'{base_msg}\n\n'
+                f'Failed dbt models/tests:\n'
+                + '\n'.join(failed_nodes)
+            )
+
+        return base_msg

--- a/tests/test_dbt_error_message.py
+++ b/tests/test_dbt_error_message.py
@@ -113,9 +113,65 @@ def test_result_attribute_missing():
     print('PASSED')
 
 
+def test_with_real_dbt_enums():
+    """
+    Verify the helper works with the *actual* dbt SDK types — not just string mocks.
+
+    Uses the real RunStatus, TestStatus, and NodeType enums from dbt-core so the
+    test proves that str(RunStatus.Error) == 'error', str(TestStatus.Fail) == 'fail',
+    and NodeType.*.value returns the expected resource-type strings.
+    """
+    try:
+        from dbt.contracts.results import RunStatus, TestStatus
+        from dbt.node_types import NodeType
+    except ImportError:
+        print('\n--- test_with_real_dbt_enums ---')
+        print('SKIPPED (dbt-core not installed)')
+        return
+
+    def make_node(name, resource_type):
+        node = MagicMock()
+        node.name = name
+        node.resource_type = resource_type
+        return node
+
+    res = MagicMock()
+    res.exception = None
+    res.result.results = [
+        MagicMock(
+            status=RunStatus.Error,
+            node=make_node('stg_orders', NodeType.Model),
+            message='column "status" does not exist',
+        ),
+        MagicMock(
+            status=TestStatus.Fail,
+            node=make_node('not_null_orders_id', NodeType.Test),
+            message='Got 3 results, configured to fail if != 0',
+        ),
+        MagicMock(
+            status=RunStatus.Success,
+            node=make_node('dim_customers', NodeType.Model),
+            message=None,
+        ),
+    ]
+
+    msg = get_dbt_error_message(res)
+    print('\n--- test_with_real_dbt_enums ---')
+    print(msg)
+
+    assert 'Failed dbt models/tests:' in msg
+    assert 'model "stg_orders"' in msg
+    assert 'column "status" does not exist' in msg
+    assert 'test "not_null_orders_id"' in msg
+    assert 'Got 3 results' in msg
+    assert 'dim_customers' not in msg   # successful node excluded
+    print('PASSED')
+
+
 if __name__ == '__main__':
     test_failed_model_and_test()
     test_python_exception_fallback()
     test_no_failures_in_results()
     test_result_attribute_missing()
+    test_with_real_dbt_enums()
     print('\nAll tests passed.')

--- a/tests/test_dbt_error_message.py
+++ b/tests/test_dbt_error_message.py
@@ -1,0 +1,121 @@
+from unittest.mock import MagicMock
+
+
+def get_dbt_error_message(res) -> str:
+    """Copy of DBTBlockSQL.__get_dbt_error_message for isolated testing."""
+    base_msg = str(res.exception) if res.exception else 'dbt run failed'
+
+    failed_nodes = []
+    try:
+        if res.result and hasattr(res.result, 'results'):
+            for run_result in res.result.results:
+                status = str(run_result.status)
+                if status in ('error', 'fail', 'runtime error'):
+                    node = run_result.node
+                    resource_type = (
+                        node.resource_type.value
+                        if hasattr(node.resource_type, 'value')
+                        else str(node.resource_type)
+                    )
+                    node_name = node.name
+                    message = run_result.message or ''
+                    failed_nodes.append(
+                        f'  - {resource_type} "{node_name}": {message}'
+                    )
+    except Exception:
+        pass
+
+    if failed_nodes:
+        return (
+            f'{base_msg}\n\n'
+            f'Failed dbt models/tests:\n'
+            + '\n'.join(failed_nodes)
+        )
+
+    return base_msg
+
+
+def make_node(name, resource_type_value):
+    node = MagicMock()
+    node.name = name
+    node.resource_type.value = resource_type_value
+    return node
+
+
+def test_failed_model_and_test():
+    """Both a model error and a test failure should appear in the message."""
+    res = MagicMock()
+    res.exception = None
+    res.result.results = [
+        MagicMock(status='error', node=make_node('stg_orders', 'model'),
+                  message='column "status" does not exist'),
+        MagicMock(status='fail',  node=make_node('not_null_orders_id', 'test'),
+                  message='Got 3 results, configured to fail if != 0'),
+        MagicMock(status='pass',  node=make_node('unique_orders_id', 'test'),
+                  message=None),   # passing test — should NOT appear
+    ]
+
+    msg = get_dbt_error_message(res)
+    print('\n--- test_failed_model_and_test ---')
+    print(msg)
+
+    assert 'Failed dbt models/tests:' in msg
+    assert 'model "stg_orders"' in msg
+    assert 'column "status" does not exist' in msg
+    assert 'test "not_null_orders_id"' in msg
+    assert 'Got 3 results' in msg
+    assert 'unique_orders_id' not in msg   # passing test excluded
+    print('PASSED')
+
+
+def test_python_exception_fallback():
+    """When dbt itself throws a Python exception, show that instead."""
+    res = MagicMock()
+    res.exception = RuntimeError('Connection refused')
+    res.result.results = []
+
+    msg = get_dbt_error_message(res)
+    print('\n--- test_python_exception_fallback ---')
+    print(msg)
+
+    assert 'Connection refused' in msg
+    assert 'Failed dbt models/tests' not in msg
+    print('PASSED')
+
+
+def test_no_failures_in_results():
+    """All nodes passed — message should be the base dbt run failed string."""
+    res = MagicMock()
+    res.exception = None
+    res.result.results = [
+        MagicMock(status='pass', node=make_node('my_model', 'model'), message=None),
+    ]
+
+    msg = get_dbt_error_message(res)
+    print('\n--- test_no_failures_in_results ---')
+    print(msg)
+
+    assert msg == 'dbt run failed'
+    assert 'Failed dbt models/tests' not in msg
+    print('PASSED')
+
+
+def test_result_attribute_missing():
+    """If res.result has no 'results' attr, fall back gracefully."""
+    res = MagicMock(spec=['exception'])
+    res.exception = None
+
+    msg = get_dbt_error_message(res)
+    print('\n--- test_result_attribute_missing ---')
+    print(msg)
+
+    assert msg == 'dbt run failed'
+    print('PASSED')
+
+
+if __name__ == '__main__':
+    test_failed_model_and_test()
+    test_python_exception_fallback()
+    test_no_failures_in_results()
+    test_result_attribute_missing()
+    print('\nAll tests passed.')


### PR DESCRIPTION
# Description
Fixes #5185

Currently, when a dbt pipeline block fails, notifications only indicate
which block encountered an error. This change extends the error message
to include the specific dbt models and tests that failed, along with
their individual error messages.

Changes made in `mage_ai/data_preparation/models/block/dbt/block_sql.py`:
- Added `__get_dbt_error_message()` helper that inspects `dbtRunnerResult.results`
  and collects every node with status `error`, `fail`, or `runtime error`
- Each failed node is reported with its resource type (model/test), name,
  and error message
- Falls back to the original behavior if no node-level results are available



# How Has This Been Tested?
- [ ] Unit tested with 4 cases using Python's unittest.mock:
  1. Failed model + failed test both appear in message, passing nodes excluded
  2. Python-level exception (e.g. DB connection error) falls back gracefully
  3. All nodes passed but dbt returned failure — generic message shown
  4. Result object missing `.results` attribute — no crash, graceful fallback

Run with:
  python tests/test_dbt_error_message.py


# Checklist
- [x] The PR is tagged with proper labels (enhancement)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective
- [x] I have commented my code, particularly in hard-to-understand areas

cc:
@tommydangerous 
