### PR TITLE
Image output types

### DIFF
--- a/mage_ai/data_preparation/models/block/outputs.py
+++ b/mage_ai/data_preparation/models/block/outputs.py
@@ -38,12 +38,23 @@ from mage_ai.data_preparation.models.variables.constants import VariableType
 from mage_ai.server.kernel_output_parser import DataType
 from mage_ai.settings.server import MEMORY_MANAGER_V2
 from mage_ai.shared.hash import merge_dict
+from mage_ai.shared.image_output_detect import (
+    try_image_payload_from_bytes,
+    try_image_payload_from_string,
+)
 from mage_ai.shared.parsers import (
     convert_matrix_to_dataframe,
     encode_complex,
     has_to_dict,
 )
 from mage_ai.shared.strings import is_json
+
+_MIME_TO_OUTPUT_TYPE = {
+    'image/png': DataType.IMAGE_PNG,
+    'image/jpeg': DataType.IMAGE_JPEG,
+    'image/gif': DataType.IMAGE_GIF,
+    'image/webp': DataType.IMAGE_WEBP,
+}
 
 
 def format_output_data(
@@ -369,6 +380,16 @@ df = get_variable('{block.pipeline.uuid}', '{block.uuid}', 'df')
             variable_uuid=variable_uuid,
         )
         return data, False
+    elif isinstance(data, (bytes, bytearray)):
+        img = try_image_payload_from_bytes(bytes(data))
+        if img:
+            mime, b64 = img
+            data = dict(
+                text_data=b64,
+                type=_MIME_TO_OUTPUT_TYPE.get(mime, DataType.IMAGE_PNG),
+                variable_uuid=variable_uuid,
+            )
+            return data, False
     elif is_primitive(data):
         json_data = is_json(data)
         if json_data:
@@ -381,11 +402,21 @@ df = get_variable('{block.pipeline.uuid}', '{block.uuid}', 'df')
                 variable_uuid=variable_uuid,
             )
         else:
-            data = dict(
-                text_data=str(data),
-                type=DataType.TEXT,
-                variable_uuid=variable_uuid,
-            )
+            text = str(data)
+            img = try_image_payload_from_string(text)
+            if img:
+                mime, b64 = img
+                data = dict(
+                    text_data=b64,
+                    type=_MIME_TO_OUTPUT_TYPE.get(mime, DataType.IMAGE_PNG),
+                    variable_uuid=variable_uuid,
+                )
+            else:
+                data = dict(
+                    text_data=text,
+                    type=DataType.TEXT,
+                    variable_uuid=variable_uuid,
+                )
         return data, False
     elif basic_iterable:
         data = dict(

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/ImageOutput.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/ImageOutput.tsx
@@ -5,10 +5,18 @@ import { UNIT } from '@oracle/styles/units/spacing';
 interface ImageOutputProps {
   data: string;
   height?: number;
+  mimeType?: string;
   uuid?: string;
 }
 
-function ImageOutput({ data, height = UNIT * 60, uuid }: ImageOutputProps): JSX.Element {
+function ImageOutput({
+  data,
+  height = UNIT * 60,
+  mimeType = 'image/png',
+  uuid,
+}: ImageOutputProps): JSX.Element {
+  const src = `data:${mimeType};base64,${data.replace(/^\s+|\s+$/g, '')}`;
+
   return (
     <div
       style={{
@@ -21,7 +29,8 @@ function ImageOutput({ data, height = UNIT * 60, uuid }: ImageOutputProps): JSX.
       <Image
         alt={`Image ${uuid ? `${uuid} ` : ''}from code output`}
         layout="fill"
-        src={`data:image/png;base64, ${data}`}
+        src={src}
+        unoptimized
       />
     </div>
   );

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/OutputRenderer.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/OutputRenderer.tsx
@@ -17,6 +17,7 @@ import { PADDING_UNITS } from '@oracle/styles/units/spacing';
 import { TabType } from '@oracle/components/Tabs/ButtonTabs';
 import { getColorsForBlockType } from '../index.style';
 import { ignoreKeys, isObject } from '@utils/hash';
+import { imageMimeTypeForDataType, isImageOutputDataType } from '@utils/imageOutput';
 
 type OutputRendererProps = {
   block: BlockType;
@@ -142,8 +143,10 @@ function OutputRenderer({
         selected={selected}
       />
     );
-  } else if (DataTypeEnum.IMAGE_PNG === dataType) {
-    return <ImageOutput data={textValue} />;
+  } else if (isImageOutputDataType(dataType)) {
+    return (
+      <ImageOutput data={textValue} mimeType={imageMimeTypeForDataType(dataType)} />
+    );
   } else {
     const objectData = [data || textData]?.find(obj => obj && isObject(obj));
 

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/index.tsx
@@ -75,6 +75,7 @@ import {
 } from '@utils/string';
 import { onSuccess } from '@api/utils/response';
 import { ignoreKeys, isObject } from '@utils/hash';
+import { imageMimeTypeForDataType, isImageOutputDataType } from '@utils/imageOutput';
 import { range } from '@utils/array';
 import TextOutput from './TextOutput';
 import ImageOutput from './ImageOutput';
@@ -889,9 +890,14 @@ function CodeOutput(
                     displayElement = tableEl;
                   }
                 }
-              } else if (DataTypeEnum.IMAGE_PNG === typeDisplay && textData) {
+              } else if (isImageOutputDataType(typeDisplay) && textData) {
                 displayElement = (
-                  <ImageOutput data={textData} height={UNIT * 60} uuid={String(idxInner)} />
+                  <ImageOutput
+                    data={textData}
+                    height={UNIT * 60}
+                    mimeType={imageMimeTypeForDataType(typeDisplay)}
+                    uuid={String(idxInner)}
+                  />
                 );
               }
             }
@@ -998,10 +1004,14 @@ function CodeOutput(
           if (data) {
             displayElement = buildDisplayForHTMLOutput(data, outputRowSharedProps);
           }
-        } else if (dataTypeInner === DataTypeEnum.IMAGE_PNG && data?.length >= 1) {
+        } else if (isImageOutputDataType(dataTypeInner) && data?.length >= 1) {
+          const mime = imageMimeTypeForDataType(dataTypeInner);
           displayElement = (
             <div style={{ overflow: 'auto', backgroundColor: 'white', maxHeight: UNIT * 60 }}>
-              <img alt={`Image ${idx} from code output`} src={`data:image/png;base64, ${data}`} />
+              <img
+                alt={`Image ${idx} from code output`}
+                src={`data:${mime};base64,${String(data).replace(/^\s+|\s+$/g, '')}`}
+              />
             </div>
           );
         } else if (dataTypeInner === DataTypeEnum.PROGRESS) {

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/useCodeOutput.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/useCodeOutput.tsx
@@ -29,6 +29,7 @@ import Text from '@oracle/elements/Text';
 import Tooltip from '@oracle/components/Tooltip';
 import api from '@api';
 import usePrevious from '@utils/usePrevious';
+import { imageMimeTypeForDataType, isImageOutputDataType } from '@utils/imageOutput';
 import { BorderColorShareProps } from '../index.style';
 import { Check, ChevronDown, ChevronUp, Expand, Save } from '@oracle/icons';
 import {
@@ -438,12 +439,13 @@ export default function useCodeOutput({
               </OutputRowStyle>
             );
           }
-        } else if (dataType === DataTypeEnum.IMAGE_PNG && data?.length >= 1) {
+        } else if (isImageOutputDataType(dataType) && data?.length >= 1) {
+          const mime = imageMimeTypeForDataType(dataType);
           displayElement = (
             <div style={{ backgroundColor: 'white' }}>
               <img
                 alt={`Image ${idx} from code output`}
-                src={`data:image/png;base64, ${data}`}
+                src={`data:${mime};base64,${String(data).replace(/^\s+|\s+$/g, '')}`}
               />
             </div>
           );

--- a/mage_ai/frontend/components/PipelineDetail/BlockRuns/buildTableSidekick.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/BlockRuns/buildTableSidekick.tsx
@@ -18,6 +18,7 @@ import { PADDING_UNITS } from '@oracle/styles/units/spacing';
 import { TABLE_COLUMN_HEADER_HEIGHT } from '@components/Sidekick/index.style';
 import { TABS_HEIGHT_OFFSET } from '@components/PipelineRun/shared/buildTableSidekick';
 import { createBlockStatus } from '@components/Triggers/utils';
+import { imageMimeTypeForDataType, isImageOutputDataType } from '@utils/imageOutput';
 import { alphabet, hashCode, isJsonString } from '@utils/string';
 import { indexBy, sortByKey } from '@utils/array';
 
@@ -157,7 +158,8 @@ export default function ({
             } else {
               el = emptyOutputMessageEl;
             }
-          } else if (DataTypeEnum.IMAGE_PNG === dataType && textData) {
+          } else if (isImageOutputDataType(dataType) && textData) {
+            const mime = imageMimeTypeForDataType(dataType);
             el = (
               <div
                 style={{
@@ -166,7 +168,10 @@ export default function ({
                   overflow: 'auto',
                 }}
               >
-                <img alt="Image from code output" src={`data:image/png;base64, ${textData}`} />
+                <img
+                  alt="Image from code output"
+                  src={`data:${mime};base64,${String(textData).replace(/^\s+|\s+$/g, '')}`}
+                />
               </div>
             );
           } else if (DataTypeEnum.TEXT_HTML === dataType && textData) {

--- a/mage_ai/frontend/components/PipelineDetail/PipelineExecution/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/PipelineExecution/index.tsx
@@ -25,6 +25,7 @@ import { UNIT } from '@oracle/styles/units/spacing';
 import { removeKeyboardFocus } from '@context/shared/utils';
 import { SampleDataType } from '@interfaces/BlockType';
 import Image from 'next/image';
+import { imageMimeTypeForDataType, isImageOutputDataType } from '@utils/imageOutput';
 
 export type PipelineExecutionProps = {
   cancelPipeline: () => void;
@@ -180,13 +181,15 @@ function PipelineExecution({
                         </Text>
                       </OutputRowStyle>
                     );
-                  } else if (dataType === DataTypeEnum.IMAGE_PNG) {
+                  } else if (isImageOutputDataType(dataType)) {
+                    const mime = imageMimeTypeForDataType(dataType);
                     displayElement = (
                       <div style={{ backgroundColor: 'white' }}>
                         <Image
                           alt={`Image ${idx} from code output`}
                           layout="responsive"
-                          src={`data:image/png;base64, ${data}`}
+                          src={`data:${mime};base64,${String(data).replace(/^\s+|\s+$/g, '')}`}
+                          unoptimized
                         />
                       </div>
                     );

--- a/mage_ai/frontend/interfaces/KernelOutputType.ts
+++ b/mage_ai/frontend/interfaces/KernelOutputType.ts
@@ -3,7 +3,7 @@ import { BlockTypeEnum, SampleDataType } from './BlockType';
 export enum ExecutionStateEnum {
   BUSY = 'busy', // Code is being executed
   IDLE = 'idle', // Nothing is being done
-  QUEUED = 'queued', // Block is being attempted to run but another block is still busy
+  QUEUED = 'queued', // The block is being attempted to run but another block is still busy
 }
 
 export enum MsgTypeEnum {
@@ -13,6 +13,9 @@ export enum MsgTypeEnum {
 export enum DataTypeEnum {
   GROUP = 'group',
   IMAGE_PNG = 'image/png',
+  IMAGE_JPEG = 'image/jpeg',
+  IMAGE_GIF = 'image/gif',
+  IMAGE_WEBP = 'image/webp',
   OBJECT = 'object',
   PROGRESS = 'progress', // Deprecated; can come from Great Expectations
   PROGRESS_STATUS = 'progress_status',

--- a/mage_ai/frontend/utils/imageOutput.ts
+++ b/mage_ai/frontend/utils/imageOutput.ts
@@ -1,0 +1,25 @@
+import { DataTypeEnum } from '@interfaces/KernelOutputType';
+
+export const IMAGE_OUTPUT_DATA_TYPES: DataTypeEnum[] = [
+  DataTypeEnum.IMAGE_PNG,
+  DataTypeEnum.IMAGE_JPEG,
+  DataTypeEnum.IMAGE_GIF,
+  DataTypeEnum.IMAGE_WEBP,
+];
+
+export function isImageOutputDataType(t: DataTypeEnum): boolean {
+  return IMAGE_OUTPUT_DATA_TYPES.includes(t);
+}
+
+export function imageMimeTypeForDataType(t: DataTypeEnum): string {
+  if (t === DataTypeEnum.IMAGE_JPEG) {
+    return 'image/jpeg';
+  }
+  if (t === DataTypeEnum.IMAGE_GIF) {
+    return 'image/gif';
+  }
+  if (t === DataTypeEnum.IMAGE_WEBP) {
+    return 'image/webp';
+  }
+  return 'image/png';
+}

--- a/mage_ai/server/kernel_output_parser.py
+++ b/mage_ai/server/kernel_output_parser.py
@@ -5,6 +5,9 @@ from mage_ai.shared.enum import StrEnum
 class DataType(StrEnum):
     DATA_FRAME = 'data_frame'
     IMAGE_PNG = 'image/png'
+    IMAGE_JPEG = 'image/jpeg'
+    IMAGE_GIF = 'image/gif'
+    IMAGE_WEBP = 'image/webp'
     PROGRESS = 'progress'  # Deprecated; can come from Great Expectations
     PROGRESS_STATUS = 'progress_status'  # Comes from execute_custom_code.py
     GROUP = 'group'
@@ -43,6 +46,9 @@ def parse_output_message(message: dict) -> dict:
     text_html = data.get('text/html')
     code = data.get('code')
     image = data.get('image/png')
+    image_jpeg = data.get('image/jpeg')
+    image_gif = data.get('image/gif')
+    image_webp = data.get('image/webp')
 
     if content.get('name') in ['stdout', 'stderr']:
         text_stdout = content.get('text')
@@ -54,6 +60,15 @@ def parse_output_message(message: dict) -> dict:
     elif image:
         data_content = image
         data_type = DataType.IMAGE_PNG
+    elif image_jpeg:
+        data_content = image_jpeg
+        data_type = DataType.IMAGE_JPEG
+    elif image_gif:
+        data_content = image_gif
+        data_type = DataType.IMAGE_GIF
+    elif image_webp:
+        data_content = image_webp
+        data_type = DataType.IMAGE_WEBP
     elif traceback:
         data_content = [line for line in traceback]
         data_type = DataType.TEXT

--- a/mage_ai/shared/image_output_detect.py
+++ b/mage_ai/shared/image_output_detect.py
@@ -1,0 +1,94 @@
+import base64
+import binascii
+import re
+from typing import Optional, Tuple
+
+from mage_ai.settings.server import MAX_OUTPUT_IMAGE_PREVIEW_SIZE
+
+_DATA_URL_RE = re.compile(
+    r'^data:(image/[a-zA-Z0-9.+-]+);base64,([\s\S]+)$',
+    re.IGNORECASE,
+)
+
+
+def sniff_image_mime(raw: bytes) -> Optional[str]:
+    if not raw or len(raw) < 12:
+        return None
+    if raw.startswith(b'\x89PNG\r\n\x1a\n'):
+        return 'image/png'
+    if raw.startswith(b'\xff\xd8\xff'):
+        return 'image/jpeg'
+    if raw.startswith(b'GIF87a') or raw.startswith(b'GIF89a'):
+        return 'image/gif'
+    if raw.startswith(b'RIFF') and len(raw) >= 12 and raw[8:12] == b'WEBP':
+        return 'image/webp'
+    return None
+
+
+def _normalize_jpeg_mime(mime: str) -> str:
+    if mime.lower() in ('image/jpg', 'image/jpeg'):
+        return 'image/jpeg'
+    return mime.lower()
+
+
+def try_image_payload_from_data_url(s: str) -> Optional[Tuple[str, str]]:
+    s = s.strip()
+    m = _DATA_URL_RE.match(s)
+    if not m:
+        return None
+    mime = _normalize_jpeg_mime(m.group(1))
+    if not mime.startswith('image/') or mime == 'image/svg+xml':
+        return None
+    b64_part = re.sub(r'\s+', '', m.group(2))
+    if not b64_part:
+        return None
+    try:
+        raw = base64.b64decode(b64_part, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+    if len(raw) > MAX_OUTPUT_IMAGE_PREVIEW_SIZE:
+        return None
+    sniffed = sniff_image_mime(raw)
+    if sniffed:
+        mime = sniffed
+    elif mime not in ('image/png', 'image/jpeg', 'image/gif', 'image/webp'):
+        return None
+    payload = base64.b64encode(raw).decode('ascii')
+    return mime, payload
+
+
+def try_image_payload_from_plain_base64(s: str) -> Optional[Tuple[str, str]]:
+    cleaned = re.sub(r'\s+', '', s.strip())
+    if len(cleaned) < 32:
+        return None
+    try:
+        raw = base64.b64decode(cleaned, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+    if len(raw) > MAX_OUTPUT_IMAGE_PREVIEW_SIZE:
+        return None
+    mime = sniff_image_mime(raw)
+    if not mime:
+        return None
+    return mime, cleaned
+
+
+def try_image_payload_from_string(s: str) -> Optional[Tuple[str, str]]:
+    if not s or not isinstance(s, str):
+        return None
+    from_data = try_image_payload_from_data_url(s)
+    if from_data:
+        return from_data
+    return try_image_payload_from_plain_base64(s)
+
+
+def try_image_payload_from_bytes(data: bytes) -> Optional[Tuple[str, str]]:
+    if not data:
+        return None
+    if len(data) > MAX_OUTPUT_IMAGE_PREVIEW_SIZE:
+        return None
+    mime = sniff_image_mime(data)
+    if not mime:
+        return None
+    payload = base64.b64encode(data).decode('ascii')
+    return mime, payload

--- a/mage_ai/tests/shared/test_image_output_detect.py
+++ b/mage_ai/tests/shared/test_image_output_detect.py
@@ -1,0 +1,84 @@
+import base64
+from unittest.mock import MagicMock
+
+from mage_ai.server.kernel_output_parser import DataType
+from mage_ai.shared.image_output_detect import (
+    sniff_image_mime,
+    try_image_payload_from_bytes,
+    try_image_payload_from_plain_base64,
+    try_image_payload_from_string,
+)
+
+# 1x1 transparent PNG
+TINY_PNG_B64 = (
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+)
+
+
+def test_sniff_image_mime_png():
+    raw = base64.b64decode(TINY_PNG_B64)
+    assert sniff_image_mime(raw) == 'image/png'
+
+
+def test_try_image_payload_from_plain_base64_png():
+    result = try_image_payload_from_plain_base64(TINY_PNG_B64)
+    assert result is not None
+    mime, payload = result
+    assert mime == 'image/png'
+    assert payload == TINY_PNG_B64
+
+
+def test_try_image_payload_from_string_plain():
+    result = try_image_payload_from_string(f'  {TINY_PNG_B64}  \n')
+    assert result is not None
+    assert result[0] == 'image/png'
+
+
+def test_try_image_payload_from_string_data_url():
+    result = try_image_payload_from_string(f'data:image/png;base64,{TINY_PNG_B64}')
+    assert result is not None
+    mime, payload = result
+    assert mime == 'image/png'
+    assert base64.b64decode(payload) == base64.b64decode(TINY_PNG_B64)
+
+
+def test_try_image_payload_from_bytes():
+    raw = base64.b64decode(TINY_PNG_B64)
+    result = try_image_payload_from_bytes(raw)
+    assert result is not None
+    mime, payload = result
+    assert mime == 'image/png'
+    assert base64.b64decode(payload) == raw
+
+
+def test_try_image_payload_from_string_not_image():
+    assert try_image_payload_from_string('hello world') is None
+    assert try_image_payload_from_string('YQ==') is None  # decodes to b'a'
+
+
+def _mock_block():
+    block = MagicMock()
+    block.uuid = 'block_uuid'
+    block.configuration = None
+    block.upstream_blocks = []
+    block.is_dynamic_v2 = False
+    block.pipeline.variable_manager = MagicMock()
+    block.pipeline.uuid = 'pipeline_uuid'
+    return block
+
+
+def test_format_output_data_base64_string():
+    from mage_ai.data_preparation.models.block.outputs import format_output_data
+
+    out, _ = format_output_data(_mock_block(), TINY_PNG_B64, 'output_0')
+    assert out['type'] == DataType.IMAGE_PNG
+    assert out['text_data'] == TINY_PNG_B64
+
+
+def test_format_output_data_png_bytes():
+    from mage_ai.data_preparation.models.block.outputs import format_output_data
+
+    raw = base64.b64decode(TINY_PNG_B64)
+    out, _ = format_output_data(_mock_block(), raw, 'output_0')
+    assert out['type'] == DataType.IMAGE_PNG
+    assert base64.b64decode(out['text_data']) == raw


### PR DESCRIPTION
# Support multiple image MIME types (PNG/JPEG/GIF/WEBP) in code output — parsing, formatting, and UI

**Commits:** `793bbe3e9a13aafa3411be74094ddb11914c471e`, `e836486c35dc57cdbde61811213f0d236b097977`

## Description

This PR adds end-to-end support for **image outputs** beyond PNG alone, so kernel/code results can be classified, formatted, and rendered correctly for **PNG, JPEG, GIF, and WEBP**.

### Commit `793bbe3` — CodeBlock & UI

- Extends **`ImageOutput`** with a **`mimeType`** prop (default `image/png`) so **`data:image/<type>;base64,...`** URLs use the right type.
- Wires **`mimeType`** through **`OutputRenderer`**, **`CodeOutput`**, and **`useCodeOutput`**.
- Aligns **`buildTableSidekick`** and **`PipelineExecution`** with the same image rendering behavior.
- Updates **`KernelOutputType`** so the frontend can represent the additional image data types.
- Adds **`mage_ai/tests/shared/test_image_output_detect.py`** for shared image-detection / parsing behavior.

### Commit `e836486` — Backend formatting & parsing

- Adds **`mage_ai/shared/image_output_detect.py`** to detect image types from bytes, parse data URLs, and normalize MIME types (with size limits via existing server settings).
- Updates **`outputs.py`** to detect and process image payloads from bytes/strings when building block outputs.
- Extends **`kernel_output_parser.py`** **`DataType`** and parsing so **JPEG / GIF / WEBP** are handled consistently with PNG.
- Adds **`frontend/utils/imageOutput.ts`** for shared MIME/data-URL helpers on the client.

## How Has This Been Tested?

### Automated

```bash
pytest mage_ai/tests/shared/test_image_output_detect.py -v
```

### Manual

1. **Code block output** — Run code that displays images (e.g. matplotlib `plt.show()` or `IPython.display`). Verify **PNG** and, if possible, **JPEG / GIF / WEBP** or data URLs render in the CodeBlock output area.
2. **Pipeline run views** — Run a pipeline whose blocks emit image output; confirm **Pipeline execution** and **block run / sidekick** views show image previews consistently.
3. **Regression** — Run blocks that only emit **text**, **HTML**, or **tables**; confirm behavior is unchanged and there are no new console errors.

## Checklist

- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

---

*Copy the sections you need into the GitHub PR description field. You can delete this file after opening the PR if you prefer not to keep it in the repo.*
