### PR TITLE
feat: add truncate_before_full_table_sync option to full table sync

### DIFF
--- a/mage_integrations/mage_integrations/destinations/base.py
+++ b/mage_integrations/mage_integrations/destinations/base.py
@@ -189,8 +189,25 @@ class Destination(ABC):
     def after_process(self) -> None:    # noqa: B027
         pass
 
-    def export_batch_data(self, record_data: List[Dict], stream: str, tags: Dict = None) -> None:
-        raise NotImplementedError('Subclasses must implement the export_batch_data method.')
+    def export_batch_data(self, stream, schema, records, replication_method=None, **kwargs):
+        REPLICATION_METHOD_FULL_TABLE = 'FULL_TABLE'
+
+        truncate_enabled = self.config.get('truncate_before_full_table_sync', False)
+        is_full_table = replication_method == REPLICATION_METHOD_FULL_TABLE
+
+        if not hasattr(self, '_truncated_streams'):
+            self._truncated_streams = set()
+
+        if truncate_enabled and is_full_table and stream not in self._truncated_streams:
+            self.logger.info(
+                f'truncate_before_full_table_sync=true: truncating stream {stream}'
+            )
+            self.truncate_table(stream, schema)
+            self._truncated_streams.add(stream)
+    
+    def truncate_table(self, stream: str, schema: dict) -> None:
+        pass
+    
 
     def export_data(
         self,

--- a/mage_integrations/mage_integrations/destinations/sql/base.py
+++ b/mage_integrations/mage_integrations/destinations/sql/base.py
@@ -86,6 +86,32 @@ class Destination(BaseDestination):
 
         # Create schema if not exists. Only run this command for the first batch.
         # Pass if user decides to skip it
+
+        # Truncate table before first batch if config option is enabled
+        if not hasattr(self, '_truncated_streams'):
+            self._truncated_streams = set()
+
+        replication_method = self.replication_methods.get(stream)
+        truncate_enabled = self.config.get('truncate_before_full_table_sync', False)
+
+        if (
+            truncate_enabled
+            and replication_method == REPLICATION_METHOD_FULL_TABLE
+            and stream not in self._truncated_streams
+        ):
+            self.logger.info(
+                f'truncate_before_full_table_sync=true: truncating table for stream {stream}',
+                tags=tags,
+            )
+            self.truncate_table(
+                database_name=database_name,
+                schema_name=schema_name,
+                table_name=table_name,
+            )
+            self._truncated_streams.add(stream)
+        
+
+
         if tags.get('batch') == 0:
             if self.skip_schema_creation:
                 # User decided not to run CREATE SCHEMA command
@@ -317,6 +343,25 @@ class Destination(BaseDestination):
                 results += self.build_connection().execute(query_strings, commit=True)
 
         return results
+
+    def truncate_table(
+        self,
+        table_name: str,
+        schema_name: str = None,
+        database_name: str = None,
+    ) -> None:
+        """
+        Truncates the destination table before a FULL_TABLE sync.
+        Only runs when truncate_before_full_table_sync=true in config.
+        """
+        parts = [x for x in [database_name, schema_name, table_name] if x]
+        full_table = '.'.join([self._wrap_with_quotes(p) for p in parts])
+
+        sql = f'TRUNCATE TABLE {full_table};'
+        self.logger.info(f'Executing: {sql}')
+        self.build_connection().execute([sql], commit=True)
+        self.logger.info(f'Table {full_table} truncated successfully.')
+
 
     def build_connection(self):
         raise Exception('Subclasses must implement the build_connection method.')


### PR DESCRIPTION
Fixes #4708

Added a new config option `truncate_before_full_table_sync` to data integration 
SQL destination blocks (PostgreSQL, MySQL, and other SQL destinations).

When set to `true`, the destination table is truncated once before the first 
batch is written during a FULL_TABLE sync. This ensures stale or duplicate 
records are removed before a full reload.

Previously, users had to manually run a separate block to truncate the table 
before running the integration pipeline. This change makes that a first-class 
config option.

## Usage
Add to your destination config YAML:
    truncate_before_full_table_sync: true
    
- Manually tested by running a FULL_TABLE sync with truncate_before_full_table_sync: true
  and verifying the table was truncated before new records were inserted.

- Verified that existing pipelines without the flag are unaffected (defaults to false).

- Verified that truncation only happens once per stream per run, even when 
  multiple batches are processed.