### PR TITLE
Implementation for change request Enhanced Notification for dbt Pipelines #5185

### DIFF
--- a/mage_ai/data_preparation/models/block/dbt/block_sql.py
+++ b/mage_ai/data_preparation/models/block/dbt/block_sql.py
@@ -415,7 +415,8 @@ class DBTBlockSQL(DBTBlock, ProjectPlatformAccessible):
                 res = cli.invoke([task] + args)
                 success = res.success
                 if not success:
-                    raise Exception(str(res.exception))
+                    error_details = self.__build_dbt_error_detail(task, res)
+                    raise Exception(error_details)  # was raise Exception(str(res.exception))
             # run show task, to get data for preview or downstream usage
             # test task does not have any data
             #
@@ -611,3 +612,34 @@ class DBTBlockSQL(DBTBlock, ProjectPlatformAccessible):
                 return file_path
 
         return self.configuration.get('file_path')
+
+    @staticmethod
+    def __build_dbt_error_detail(task: str, res) -> str:
+        """
+        Parse dbtRunnerResult to extract per-model/test failure details.
+        Returns an error string listing the specific failed models/tests encountered errors.
+        """
+        failed_lines = []
+        try:
+            if res.result and hasattr(res.result, 'results'):
+                for node_result in res.result.results:
+                    status = str(getattr(node_result, 'status', '')).lower()
+                    if status in ('error', 'fail'):
+                        node = getattr(node_result, 'node', None)
+                        node_name = node.name if node else 'unknown'
+                        resource_type = (
+                            node.resource_type.value
+                            if node and hasattr(node.resource_type, 'value')
+                            else 'node'
+                        )
+                        message = getattr(node_result, 'message', None) or status
+                        failed_lines.append(f'  [{resource_type}] {node_name}: {message}')
+        except Exception:
+            pass  # fall back to generic error
+
+        if failed_lines:
+            return (
+                f'dbt {task} failed. The following models/tests encountered errors:\n'
+                + '\n'.join(failed_lines)
+            )
+        return str(res.exception)

--- a/mage_ai/data_preparation/models/block/dbt/block_sql.py
+++ b/mage_ai/data_preparation/models/block/dbt/block_sql.py
@@ -616,7 +616,7 @@ class DBTBlockSQL(DBTBlock, ProjectPlatformAccessible):
     @staticmethod
     def __build_dbt_error_detail(task: str, res) -> str:
         """
-        Parse dbtRunnerResult to extract per-model/test failure details.
+        Parse res as dbtRunnerResult to extract per-model/test failure details.
         Returns an error string listing the specific failed models/tests encountered errors.
         """
         failed_lines = []

--- a/mage_ai/data_preparation/models/block/dbt/block_sql.py
+++ b/mage_ai/data_preparation/models/block/dbt/block_sql.py
@@ -415,10 +415,7 @@ class DBTBlockSQL(DBTBlock, ProjectPlatformAccessible):
                 res = cli.invoke([task] + args)
                 success = res.success
                 if not success:
-                    print("Exception:")
-                    print(f'[BEFORE] str(res.exception): {str(res.exception)}.')
                     error_details = self._build_dbt_error_detail(task, res)
-                    print(f'[AFTER] error_details: {error_details}.')
                     raise Exception(error_details)  # was raise Exception(str(res.exception))
             # run show task, to get data for preview or downstream usage
             # test task does not have any data

--- a/mage_ai/data_preparation/models/block/dbt/block_sql.py
+++ b/mage_ai/data_preparation/models/block/dbt/block_sql.py
@@ -415,7 +415,10 @@ class DBTBlockSQL(DBTBlock, ProjectPlatformAccessible):
                 res = cli.invoke([task] + args)
                 success = res.success
                 if not success:
-                    error_details = self.__build_dbt_error_detail(task, res)
+                    print("Exception:")
+                    print(f'[BEFORE] str(res.exception): {str(res.exception)}.')
+                    error_details = self._build_dbt_error_detail(task, res)
+                    print(f'[AFTER] error_details: {error_details}.')
                     raise Exception(error_details)  # was raise Exception(str(res.exception))
             # run show task, to get data for preview or downstream usage
             # test task does not have any data
@@ -614,17 +617,22 @@ class DBTBlockSQL(DBTBlock, ProjectPlatformAccessible):
         return self.configuration.get('file_path')
 
     @staticmethod
-    def __build_dbt_error_detail(task: str, res) -> str:
+    def _build_dbt_error_detail(task: str, res, max_nodes: int = 20) -> str:
         """
         Parse res as dbtRunnerResult to extract per-model/test failure details.
         Returns an error string listing the specific failed models/tests encountered errors.
+        Caps output at max_nodes to avoid exceeding notification channel limits.
         """
         failed_lines = []
+        total_failures = 0
         try:
             if res.result and hasattr(res.result, 'results'):
                 for node_result in res.result.results:
                     status = str(getattr(node_result, 'status', '')).lower()
                     if status in ('error', 'fail'):
+                        total_failures += 1
+                        if len(failed_lines) >= max_nodes:
+                            continue
                         node = getattr(node_result, 'node', None)
                         node_name = node.name if node else 'unknown'
                         resource_type = (
@@ -638,8 +646,13 @@ class DBTBlockSQL(DBTBlock, ProjectPlatformAccessible):
             pass  # fall back to generic error
 
         if failed_lines:
-            return (
+            detail = (
                 f'dbt {task} failed. The following models/tests encountered errors:\n'
                 + '\n'.join(failed_lines)
             )
+            if total_failures > max_nodes:
+                detail += (
+                    f'\n  ... and {total_failures - max_nodes} more failure(s) omitted.'
+                )
+            return detail
         return str(res.exception)

--- a/mage_ai/orchestration/notification/sender.py
+++ b/mage_ai/orchestration/notification/sender.py
@@ -29,7 +29,7 @@ DEFAULT_MESSAGES = dict(
         summary=(
             'Failed to run Pipeline `{pipeline_uuid}` with Trigger {pipeline_schedule_id} '
             '`{pipeline_schedule_name}` at execution time `{execution_time}`. '
-            'Error: {error}'
+            'Error: {error}\n{stacktrace}'
         ),
     ),
     passed_sla=dict(
@@ -59,6 +59,7 @@ class NotificationSender:
             summary (str, optional): Mid-length sentences, used as the summary of the message.
             details (str, optional): Long message, used as the body of the message (e.g. Email body)
         """
+
         if summary is None:
             return
         if self.config.slack_config is not None and self.config.slack_config.is_valid:
@@ -174,14 +175,14 @@ class NotificationSender:
         if text is None or pipeline is None or pipeline_run is None:
             return text
         return text.format(
-            error=error,
+            error=error or '',
             execution_time=pipeline_run.execution_date,
             pipeline_run_url=self.__pipeline_run_url(pipeline, pipeline_run),
             pipeline_schedule_id=pipeline_run.pipeline_schedule.id,
             pipeline_schedule_name=pipeline_run.pipeline_schedule.name,
             pipeline_schedule_description=pipeline_run.pipeline_schedule.description,
             pipeline_uuid=pipeline.uuid,
-            stacktrace=stacktrace,
+            stacktrace=stacktrace or ''
         )
 
     def __send_pipeline_run_message(

--- a/mage_ai/orchestration/notification/sender.py
+++ b/mage_ai/orchestration/notification/sender.py
@@ -29,7 +29,7 @@ DEFAULT_MESSAGES = dict(
         summary=(
             'Failed to run Pipeline `{pipeline_uuid}` with Trigger {pipeline_schedule_id} '
             '`{pipeline_schedule_name}` at execution time `{execution_time}`. '
-            'Error: {error}\n{stacktrace}'
+            'Error: {error}{stacktrace}'
         ),
     ),
     passed_sla=dict(
@@ -175,14 +175,14 @@ class NotificationSender:
         if text is None or pipeline is None or pipeline_run is None:
             return text
         return text.format(
-            error=error or '',
+            error=error,
             execution_time=pipeline_run.execution_date,
             pipeline_run_url=self.__pipeline_run_url(pipeline, pipeline_run),
             pipeline_schedule_id=pipeline_run.pipeline_schedule.id,
             pipeline_schedule_name=pipeline_run.pipeline_schedule.name,
             pipeline_schedule_description=pipeline_run.pipeline_schedule.description,
             pipeline_uuid=pipeline.uuid,
-            stacktrace=stacktrace or ''
+            stacktrace=f'\n{stacktrace}' if stacktrace else ''
         )
 
     def __send_pipeline_run_message(

--- a/mage_ai/orchestration/pipeline_scheduler_original.py
+++ b/mage_ai/orchestration/pipeline_scheduler_original.py
@@ -346,18 +346,28 @@ class PipelineScheduler:
             failed_block_runs = self.pipeline_run.failed_block_runs
             stacktrace = None
             for br in failed_block_runs:
-                if br.metrics:
-                    message = br.metrics.get('error', {}).get('message')
-                    if message:
-                        message_split = message.split('\n')
-                        # Truncate the error message if it has too many lines, set max
-                        # lines at 50
-                        if len(message_split) > 50:
-                            message_split = message_split[-50:]
-                            message_split.insert(0, '... (error truncated)')
-                        message = '\n'.join(message_split)
-                        stacktrace = f'Error for block {br.block_uuid}:\n{message}'
-                        break
+                error_entry = br.metrics.get('error', {})
+                # The 'error' key holds the exception message (may contain dbt model details)
+                error_str = error_entry.get('error', '')
+                message = error_entry.get('message', '')
+
+                parts = []
+                # Include the exception message first — for dbt blocks this contains
+                # the per-model/test failure summary built in block_sql.py
+                if error_str:
+                    parts.append(error_str)
+
+                # Append truncated traceback for further debugging context
+                if message:
+                    message_split = message.split('\n')
+                    if len(message_split) > 50:
+                        message_split = message_split[-50:]
+                        message_split.insert(0, '... (traceback truncated)')
+                    parts.append('\n'.join(message_split))
+
+                if parts:
+                    stacktrace = f'Error for block {br.block_uuid}:\n' + '\n\n'.join(parts)
+                    break
 
             self.notification_sender.send_pipeline_run_failure_message(
                 pipeline=self.pipeline,

--- a/mage_ai/orchestration/pipeline_scheduler_original.py
+++ b/mage_ai/orchestration/pipeline_scheduler_original.py
@@ -357,7 +357,11 @@ class PipelineScheduler:
                 # Include the exception message first — for dbt blocks this contains
                 # the per-model/test failure summary built in block_sql.py
                 if error_str:
-                    parts.append(error_str)
+                    error_str_lines = error_str.split('\n')
+                    if len(error_str_lines) > 50:
+                        error_str_lines = error_str_lines[:50]
+                        error_str_lines.append('... (error details truncated)')
+                    parts.append('\n'.join(error_str_lines))
 
                 # Append truncated traceback for further debugging context
                 if message:

--- a/mage_ai/orchestration/pipeline_scheduler_original.py
+++ b/mage_ai/orchestration/pipeline_scheduler_original.py
@@ -346,6 +346,8 @@ class PipelineScheduler:
             failed_block_runs = self.pipeline_run.failed_block_runs
             stacktrace = None
             for br in failed_block_runs:
+                if not br.metrics:
+                    continue
                 error_entry = br.metrics.get('error', {})
                 # The 'error' key holds the exception message (may contain dbt model details)
                 error_str = error_entry.get('error', '')

--- a/mage_ai/tests/data_preparation/models/block/dbt/test_block_sql.py
+++ b/mage_ai/tests/data_preparation/models/block/dbt/test_block_sql.py
@@ -26,9 +26,8 @@ def _make_res(node_results, exception_str='some dbt exception'):
     return res
 
 
-# Helper to call the name-mangled private static method
 def _build(task, res):
-    return DBTBlockSQL._DBTBlockSQL__build_dbt_error_detail(task, res)
+    return DBTBlockSQL._build_dbt_error_detail(task, res)
 
 
 class DBTBlockSQLBuildErrorDetailTest(TestCase):
@@ -129,3 +128,20 @@ class DBTBlockSQLBuildErrorDetailTest(TestCase):
 
         self.assertIn('node', result)
         self.assertIn('my_model', result)
+
+    def test_output_is_capped_at_max_nodes(self):
+        """When more nodes fail than max_nodes, output is truncated with a notice."""
+        nodes = [
+            _make_node_result('error', _make_node(f'model_{i}', 'model'), f'Error {i}')
+            for i in range(30)
+        ]
+        res = _make_res(nodes)
+
+        # Use max_nodes=10 to test capping
+        result = DBTBlockSQL._build_dbt_error_detail('build', res, max_nodes=10)
+
+        # First 10 should appear, rest should not
+        self.assertIn('[model] model_0', result)
+        self.assertIn('[model] model_9', result)
+        self.assertNotIn('[model] model_10', result)
+        self.assertIn('20 more failure(s) omitted', result)

--- a/mage_ai/tests/data_preparation/models/block/dbt/test_block_sql.py
+++ b/mage_ai/tests/data_preparation/models/block/dbt/test_block_sql.py
@@ -1,329 +1,131 @@
-# import asyncio
-# import json
-# import os
-# from pathlib import Path
-# from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock
 
-# from dbt.cli.main import dbtRunnerResult
-
-# from mage_ai.data_preparation.models.block.dbt.block import DBTBlock
-# from mage_ai.data_preparation.models.block.dbt.block_sql import DBTBlockSQL
-# from mage_ai.data_preparation.models.constants import BlockLanguage, BlockType
-# from mage_ai.settings.utils import base_repo_path
-# from mage_ai.tests.base_test import TestCase
-# from mage_ai.tests.data_preparation.models.block.platform.test_mixins import (
-#     BlockWithProjectPlatformShared,
-# )
-# from mage_ai.tests.shared.mixins import ProjectPlatformMixin
+from mage_ai.data_preparation.models.block.dbt.block_sql import DBTBlockSQL
+from mage_ai.tests.base_test import TestCase
 
 
-# def build_block():
-#     pipeline = MagicMock()
-#     pipeline.uuid = 'test'
-#     pipeline.repo_path = 'test_repo_path'
-#     pipeline.get_block.return_value = None
-
-#     return DBTBlock.create(
-#         name='test_dbt_block_sql',
-#         uuid='test_dbt_block_sql',
-#         block_type=BlockType.DBT,
-#         language=BlockLanguage.SQL,
-#         pipeline=pipeline,
-#         configuration={
-#             'dbt_profile_target': 'test',
-#             'file_path': str(Path('test_project_name/test_models/model.sql')),
-#             'dbt': {
-#                 'command': 'build',
-#                 'disable_tests': True
-#             }
-#         }
-#     )
+def _make_node(name, resource_type_value):
+    node = MagicMock()
+    node.name = name
+    node.resource_type.value = resource_type_value
+    return node
 
 
-# class DBTBlockSQLTest(TestCase):
-#     @classmethod
-#     def setUpClass(self):
-#         super().setUpClass()
-#         self.dbt_block = build_block()
-
-#     @classmethod
-#     def tearDownClass(self):
-#         super().tearDownClass()
-
-#     def test_file_path(self):
-#         self.assertEqual(
-#             self.dbt_block.file_path,
-#             str(Path('test_repo_path/dbt/test_project_name/test_models/model.sql'))
-#         )
-
-#     @patch('mage_ai.data_preparation.models.block.dbt.block_sql.Profiles')
-#     @patch('mage_ai.data_preparation.models.block.dbt.block_sql.Project')
-#     def test_metadata_async(self, Project: MagicMock, Profiles: MagicMock):
-#         Project.return_value.local_packages = ['test_project_name']
-#         Project.return_value.project = {
-#             'name': 'test_project_name',
-#             'profile': 'test_project_name'
-#         }
-#         Profiles.return_value.profiles = {
-#             'test_project_name': {
-#                 'target': 'test',
-#                 'outputs': {
-#                     'test': None,
-#                     'dev': None,
-#                     'prod': None
-#                 }
-#             }
-#         }
-
-#         metadata = asyncio.run(self.dbt_block.metadata_async())
-
-#         self.assertEqual(
-#             metadata,
-#             {
-#                 'dbt': {
-#                     'block': {'snapshot': False},
-#                     'project': 'test_project_name',
-#                     'projects': {
-#                         'test_project_name': {
-#                             'target': 'test',
-#                             'targets': ['dev', 'prod', 'test']
-#                         }
-#                     }
-#                 }
-#             }
-#         )
-
-#     @patch('mage_ai.data_preparation.models.block.dbt.block_sql.Project')
-#     def test_tags(self, Project: MagicMock):
-#         Project.return_value.project = {
-#             'model-paths': ['models', 'test_models']
-#         }
-#         self.assertEqual(
-#             self.dbt_block.tags(),
-#             []
-#         )
-
-#     def test_project_path(self):
-#         self.assertEqual(
-#             self.dbt_block.project_path,
-#             str(Path('test_repo_path/dbt/test_project_name'))
-#         )
-
-#     @patch('mage_ai.data_preparation.models.block.dbt.block_sql.DBTCli.invoke')
-#     @patch('mage_ai.data_preparation.models.block.dbt.block_sql.Project')
-#     @patch('mage_ai.data_preparation.models.block.dbt.block_sql.Profiles')
-#     def test_execute_block(
-#         self,
-#         Profiles: MagicMock,
-#         Project: MagicMock,
-#         mock_invoke: MagicMock,
-#     ):
-#         mock_invoke.return_value = dbtRunnerResult(True)
-#         Profiles.return_value.__enter__.return_value.profiles_dir = 'test_profiles_dir'
-#         Project.return_value.project = {
-#             'model-paths': ['models', 'test_models']
-#         }
-
-#         self.dbt_block._execute_block(
-#             {},
-#             from_notebook=False,
-#             runtime_arguments={
-#                 '__mage_variables': {
-#                     'blocks': {
-#                         'test_dbt_block_sql': {
-#                             'configuration': {
-#                                 'flags': ['--full-refresh'],
-#                                 'suffix': '+'
-#                             }
-#                         }
-#                     }
-#                 }
-#             },
-#             global_vars={}
-#         )
-
-#         self.assertEqual(mock_invoke.mock_calls[0], call([
-#             'deps',
-#             '--project-dir', str(Path('test_repo_path/dbt/test_project_name')),
-#             '--full-refresh',
-#             '--select', 'model+',
-#             '--vars', '{}',
-#             '--target', 'test',
-#             '--profiles-dir', 'test_profiles_dir'
-#         ]))
-#         self.assertEqual(mock_invoke.mock_calls[1], call([
-#             'run',
-#             '--project-dir', str(Path('test_repo_path/dbt/test_project_name')),
-#             '--full-refresh',
-#             '--select', 'model+',
-#             '--vars', '{}',
-#             '--target', 'test',
-#             '--profiles-dir', 'test_profiles_dir'
-#         ]))
-
-#     @patch('mage_ai.data_preparation.models.block.dbt.block_sql.Project')
-#     @patch('mage_ai.data_preparation.models.block.dbt.block_sql.Path.open')
-#     @patch('mage_ai.data_preparation.models.block.dbt.block_sql.Path.exists')
-#     def test_content_compiled(self, exists: MagicMock, open: MagicMock, Project: MagicMock):
-#         Project.return_value.project = {
-#             'model-paths': ['models', 'test_models']
-#         }
-#         open.return_value.__enter__.return_value.read.return_value = 'SELECT * FROM test'
-#         exists.return_value = True
-
-#         self.assertEqual(
-#             self.dbt_block.content_compiled,
-#             'SELECT * FROM test'
-#         )
-
-#     @patch('mage_ai.data_preparation.models.block.dbt.block_sql.DBTCli.invoke')
-#     @patch('mage_ai.data_preparation.models.block.dbt.block_sql.Profiles')
-#     def test_upstream_dbt_blocks(
-#         self,
-#         Profiles: MagicMock,
-#         mock_invoke: MagicMock,
-#     ):
-#         Profiles.return_value.__enter__.return_value.profiles_dir = 'test_profiles_dir'
-#         mock_invoke.return_value = dbtRunnerResult(
-#             success=True,
-#             exception=None,
-#             result=[
-#                 '{"unique_id":"test1", "original_file_path":"test1_file_path.sql", ' +
-#                 '"depends_on": {"nodes":[]}}',
-#                 '{"unique_id":"test2", "original_file_path":"test2_file_path.sql", ' +
-#                 '"depends_on": {"nodes":["test1"]}}'
-#             ],
-#         )
-
-#         blocks = [block.to_dict() for block in self.dbt_block.upstream_dbt_blocks()].__iter__()
-
-#         mock_invoke.assert_called_once_with([
-#             'list',
-#             '--project-dir', str(Path('test_repo_path/dbt/test_project_name')),
-#             '--profiles-dir', 'test_profiles_dir',
-#             '--select', '+model',
-#             '--output', 'json',
-#             '--output-keys', 'unique_id original_file_path depends_on',
-#             '--resource-type', 'model',
-#             '--resource-type', 'snapshot',
-#         ])
-
-#         block = next(blocks)
-#         self.assertDictContainsSubset(
-#             {
-#                 'configuration': {
-#                     'file_path': str(Path('test_project_name/test1_file_path.sql'))
-#                 },
-#                 'downstream_blocks': [str(Path('test_project_name/test2_file_path'))],
-#                 'name': str(Path('test_project_name/test1_file_path')),
-#                 'language': 'sql',
-#                 'type': 'dbt',
-#                 'upstream_blocks': [],
-#                 'uuid': str(Path('test_project_name/test1_file_path'))
-#             },
-#             block
-#         )
-
-#         block = next(blocks)
-#         self.assertDictContainsSubset(
-#             {
-#                 'configuration': {
-#                     'file_path': str(Path('test_project_name/test2_file_path.sql'))
-#                 },
-#                 'downstream_blocks': [],
-#                 'name': str(Path('test_project_name/test2_file_path')),
-#                 'language': 'sql',
-#                 'type': 'dbt',
-#                 'upstream_blocks': [str(Path('test_project_name/test1_file_path'))],
-#                 'uuid': str(Path('test_project_name/test2_file_path'))
-#             },
-#             block
-#         )
+def _make_node_result(status, node, message=None):
+    nr = MagicMock()
+    nr.status = status
+    nr.node = node
+    nr.message = message
+    return nr
 
 
-# @patch(
-#     'mage_ai.data_preparation.models.block.platform.mixins.project_platform_activated',
-#     lambda: True,
-# )
-# @patch(
-#     'mage_ai.data_preparation.models.block.platform.utils.project_platform_activated',
-#     lambda: True,
-# )
-# @patch('mage_ai.settings.platform.project_platform_activated', lambda: True)
-# class DBTBlockSQLProjectPlatformTest(ProjectPlatformMixin, BlockWithProjectPlatformShared):
-#     def test_file_path(self):
-#         block = build_block()
-#         block.configuration['file_source'] = dict(path='mage_data/dbt/demo/models/fire.sql')
-#         self.assertEqual(block.file_path, 'mage_data/dbt/demo/models/fire.sql')
+def _make_res(node_results, exception_str='some dbt exception'):
+    res = MagicMock()
+    res.result.results = node_results
+    res.exception = exception_str
+    return res
 
-#     def test_project_path(self):
-#         block = build_block()
-#         block.configuration['file_source'] = dict(
-#             path='mage_data/dbt/demo/models/fire.sql',
-#             project_path='mage_data/dbt/demo',
-#         )
-#         self.assertEqual(block.project_path, os.path.join(base_repo_path(), 'mage_data/dbt/demo'))
 
-#     @patch('mage_ai.data_preparation.models.block.dbt.block_sql.DBTCli.invoke')
-#     @patch('mage_ai.data_preparation.models.block.dbt.block_sql.Profiles')
-#     def test_upstream_dbt_blocks(self, Profiles, mock_invoke):
-#         mock_invoke.return_value = dbtRunnerResult(success=True, result=[
-#             json.dumps(dict(
-#                 depends_on=dict(nodes=[]),
-#                 original_file_path='models/water.sql',
-#                 unique_id='water',
-#             )),
-#             json.dumps(dict(
-#                 depends_on=dict(nodes=['water']),
-#                 original_file_path='models/ice.sql',
-#                 unique_id='ice',
-#             )),
-#         ])
-#         Profiles.return_value.__enter__.return_value.profiles_dir = 'test_profiles_dir'
+# Helper to call the name-mangled private static method
+def _build(task, res):
+    return DBTBlockSQL._DBTBlockSQL__build_dbt_error_detail(task, res)
 
-#         os.makedirs(os.path.join(base_repo_path(), 'mage_data/dbt/demo/models'), exist_ok=True)
-#         for key in [
-#             'fire',
-#             'ice',
-#             'water',
-#         ]:
-#             with open(
-#                 os.path.join(base_repo_path(), f'mage_data/dbt/demo/models/{key}.sql'),
-#                 'w',
-#             ) as f:
-#                 f.write('')
-#         with open(os.path.join(base_repo_path(), 'mage_data/dbt/dbt_project.yml'), 'w') as f:
-#             f.write('')
 
-#         block = build_block()
-#         block.configuration['file_source'] = dict(
-#             path='mage_data/dbt/demo/models/fire.sql',
-#             project_path='mage_data/dbt/demo',
-#         )
-#         blocks = block.upstream_dbt_blocks()
+class DBTBlockSQLBuildErrorDetailTest(TestCase):
 
-#         self.assertEqual(len(blocks), 2)
+    def test_model_error_is_formatted(self):
+        """A failed model node produces [model] name: message format."""
+        node = _make_node('my_model', 'model')
+        res = _make_res([_make_node_result('error', node, 'Database Error\n  bad SQL')])
 
-#         block1, block2 = blocks
-#         self.assertTrue(isinstance(block1, DBTBlockSQL))
-#         self.assertEqual(block1.type, BlockType.DBT)
-#         self.assertEqual(block1.configuration, dict(
-#             file_path='mage_data/dbt/demo/models/water.sql',
-#             file_source=dict(
-#                 path='mage_data/dbt/demo/models/water.sql',
-#                 project_path='mage_data/dbt',
-#             ),
-#         ))
-#         self.assertEqual(block1.language, BlockLanguage.SQL)
+        result = _build('run', res)
 
-#         self.assertTrue(isinstance(block2, DBTBlockSQL))
-#         self.assertEqual(block2.type, BlockType.DBT)
-#         self.assertEqual(block2.configuration, dict(
-#             file_path='mage_data/dbt/demo/models/ice.sql',
-#             file_source=dict(
-#                 path='mage_data/dbt/demo/models/ice.sql',
-#                 project_path='mage_data/dbt',
-#             ),
-#         ))
-#         self.assertEqual(block2.language, BlockLanguage.SQL)
-#         self.assertEqual(block2.upstream_blocks, [block1])
+        self.assertIn('dbt run failed', result)
+        self.assertIn('[model] my_model', result)
+        self.assertIn('Database Error', result)
+
+    def test_test_fail_is_formatted(self):
+        """A failed dbt test node (status=fail) produces [test] name: message format."""
+        node = _make_node('not_null_orders_id', 'test')
+        res = _make_res([_make_node_result('fail', node, 'Got 3 results')])
+
+        result = _build('test', res)
+
+        self.assertIn('dbt test failed', result)
+        self.assertIn('[test] not_null_orders_id', result)
+        self.assertIn('Got 3 results', result)
+
+    def test_multiple_failures_all_listed(self):
+        """All failed nodes are listed, not just the first."""
+        node_a = _make_node('model_a', 'model')
+        node_b = _make_node('model_b', 'model')
+        res = _make_res([
+            _make_node_result('error', node_a, 'Error A'),
+            _make_node_result('error', node_b, 'Error B'),
+        ])
+
+        result = _build('build', res)
+
+        self.assertIn('[model] model_a', result)
+        self.assertIn('[model] model_b', result)
+
+    def test_passing_nodes_are_excluded(self):
+        """Nodes with status 'success' or 'pass' do not appear in the output."""
+        passing_node = _make_node('good_model', 'model')
+        failing_node = _make_node('bad_model', 'model')
+        res = _make_res([
+            _make_node_result('success', passing_node, None),
+            _make_node_result('error', failing_node, 'Error'),
+        ])
+
+        result = _build('run', res)
+
+        self.assertNotIn('good_model', result)
+        self.assertIn('bad_model', result)
+
+    def test_no_failed_nodes_falls_back_to_exception(self):
+        """When all nodes pass, falls back to str(res.exception)."""
+        node = _make_node('good_model', 'model')
+        res = _make_res([_make_node_result('success', node, None)], exception_str='original error')
+
+        result = _build('run', res)
+
+        self.assertEqual(result, 'original error')
+
+    def test_none_result_falls_back_to_exception(self):
+        """When res.result is None, falls back to str(res.exception)."""
+        res = MagicMock()
+        res.result = None
+        res.exception = 'fallback error'
+
+        result = _build('run', res)
+
+        self.assertEqual(result, 'fallback error')
+
+    def test_node_is_none_uses_unknown(self):
+        """When node attribute is None, node name falls back to 'unknown'."""
+        nr = _make_node_result('error', None, 'some error')
+        res = _make_res([nr])
+
+        result = _build('run', res)
+
+        self.assertIn('unknown', result)
+
+    def test_resource_type_without_value_attr_uses_node(self):
+        """When resource_type has no .value, resource type label falls back to 'node'."""
+        # Use spec= to create a resource_type object that has no .value attribute
+        resource_type = MagicMock(spec=[])  # empty spec → no attributes including .value
+        node = MagicMock(spec=['name', 'resource_type'])
+        node.name = 'my_model'
+        node.resource_type = resource_type
+
+        nr = MagicMock()
+        nr.status = 'error'
+        nr.node = node
+        nr.message = 'err'
+        res = _make_res([nr])
+
+        result = _build('run', res)
+
+        self.assertIn('node', result)
+        self.assertIn('my_model', result)

--- a/mage_ai/tests/orchestration/notification/test_sender.py
+++ b/mage_ai/tests/orchestration/notification/test_sender.py
@@ -167,3 +167,92 @@ class NotificationSenderTests(DBTestCase):
             message=ANY,
             description=ANY,
         )
+
+
+class NotificationSenderStacktraceTests(DBTestCase):
+    """Tests for the enhanced failure message: stacktrace in template, None-guarding."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.pipeline = create_pipeline('test_stacktrace_pipeline', cls.repo_path)
+        cls.pipeline_run = create_pipeline_run_with_schedule(
+            pipeline_uuid='test_stacktrace_pipeline'
+        )
+
+    @patch('mage_ai.orchestration.notification.sender.send_slack_message')
+    def test_stacktrace_appears_in_slack_message(self, mock_send_slack):
+        """When stacktrace is provided, it is included in the Slack notification body."""
+        notification_config = NotificationConfig.load(config=SLACK_NOTIFICATION_CONFIG)
+        sender = NotificationSender(config=notification_config)
+        pipeline_run = self.__class__.pipeline_run
+
+        dbt_stacktrace = (
+            'Error for block my_block:\n'
+            'dbt build failed. The following models/tests encountered errors:\n'
+            '  [model] my_model: Database Error\n    syntax error'
+        )
+        sender.send_pipeline_run_failure_message(
+            self.__class__.pipeline,
+            pipeline_run,
+            error='Failed blocks: my_block',
+            stacktrace=dbt_stacktrace,
+        )
+
+        call_args = mock_send_slack.call_args
+        sent_message = call_args[0][1]  # positional: (config, message, title)
+        self.assertIn('[model] my_model', sent_message)
+        self.assertIn('syntax error', sent_message)
+
+    @patch('mage_ai.orchestration.notification.sender.send_slack_message')
+    def test_none_stacktrace_does_not_produce_literal_none(self, mock_send_slack):
+        """When stacktrace=None, the word 'None' must not appear in the message."""
+        notification_config = NotificationConfig.load(config=SLACK_NOTIFICATION_CONFIG)
+        sender = NotificationSender(config=notification_config)
+        pipeline_run = self.__class__.pipeline_run
+
+        sender.send_pipeline_run_failure_message(
+            self.__class__.pipeline,
+            pipeline_run,
+            error='some error',
+            stacktrace=None,
+        )
+
+        sent_message = mock_send_slack.call_args[0][1]
+        # The literal string 'None' must not appear as a value
+        self.assertNotIn('\nNone', sent_message)
+
+    @patch('mage_ai.orchestration.notification.sender.send_slack_message')
+    def test_none_stacktrace_adds_no_extra_blank_line(self, mock_send_slack):
+        """When stacktrace=None, no extra blank line is added after the error."""
+        notification_config = NotificationConfig.load(config=SLACK_NOTIFICATION_CONFIG)
+        sender = NotificationSender(config=notification_config)
+        pipeline_run = self.__class__.pipeline_run
+
+        sender.send_pipeline_run_failure_message(
+            self.__class__.pipeline,
+            pipeline_run,
+            error='some error',
+            stacktrace=None,
+        )
+
+        sent_message = mock_send_slack.call_args[0][1]
+        self.assertNotIn('some error\n\n', sent_message)
+
+    @patch('mage_ai.orchestration.notification.sender.send_slack_message')
+    def test_stacktrace_and_error_both_appear(self, mock_send_slack):
+        """Both the error summary and the dbt stacktrace detail appear in the message."""
+        notification_config = NotificationConfig.load(config=SLACK_NOTIFICATION_CONFIG)
+        sender = NotificationSender(config=notification_config)
+        pipeline_run = self.__class__.pipeline_run
+
+        sender.send_pipeline_run_failure_message(
+            self.__class__.pipeline,
+            pipeline_run,
+            error='Failed blocks: my_dbt_block',
+            stacktrace='Error for block my_dbt_block:\ndbt run failed.\n  [model] orders: OOM',
+        )
+
+        sent_message = mock_send_slack.call_args[0][1]
+        self.assertIn('Failed blocks: my_dbt_block', sent_message)
+        self.assertIn('[model] orders', sent_message)

--- a/mage_ai/tests/orchestration/test_pipeline_scheduler.py
+++ b/mage_ai/tests/orchestration/test_pipeline_scheduler.py
@@ -1119,3 +1119,171 @@ class PipelineSchedulerTests(DBTestCase):
         PipelineScheduler(pipeline_run=pipeline_run2).schedule()
         self.assertEqual(block_run.status, BlockRun.BlockRunStatus.FAILED)
         self.assertEqual(block_run2.status, BlockRun.BlockRunStatus.RUNNING)
+
+
+class PipelineSchedulerOnFailureTests(DBTestCase):
+    """Tests for on_pipeline_run_failure stacktrace construction (enhanced dbt notifications)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.pipeline = create_pipeline_with_blocks('test_failure_pipeline', cls.repo_path)
+
+    def _make_scheduler_with_failed_block(self, error_str=None, message=None, metrics=None):
+        """
+        Create a PipelineScheduler with one failed block run whose metrics
+        contain the given error_str and message.
+        """
+        pipeline_run = create_pipeline_run_with_schedule(
+            pipeline_uuid='test_failure_pipeline',
+        )
+        pipeline_run.update(status=PipelineRun.PipelineRunStatus.RUNNING)
+
+        block_run = pipeline_run.block_runs[0]
+
+        if metrics is not None:
+            block_run.update(
+                status=BlockRun.BlockRunStatus.FAILED,
+                metrics=metrics,
+            )
+        else:
+            block_metrics = {}
+            if error_str is not None or message is not None:
+                block_metrics['error'] = {}
+                if error_str is not None:
+                    block_metrics['error']['error'] = error_str
+                if message is not None:
+                    block_metrics['error']['message'] = message
+            block_run.update(
+                status=BlockRun.BlockRunStatus.FAILED,
+                metrics=block_metrics,
+            )
+
+        return PipelineScheduler(pipeline_run=pipeline_run), pipeline_run
+
+    def test_error_str_appears_in_stacktrace(self):
+        """The exception message (error_str from metrics) is included in the stacktrace."""
+        dbt_detail = (
+            'dbt build failed. The following models/tests encountered errors:\n'
+            '  [model] my_model: Database Error\n    bad SQL'
+        )
+        scheduler, pipeline_run = self._make_scheduler_with_failed_block(
+            error_str=dbt_detail,
+        )
+
+        captured = {}
+        with patch.object(
+            scheduler.notification_sender,
+            'send_pipeline_run_failure_message',
+        ) as mock_send:
+            mock_send.side_effect = lambda **kw: captured.update(kw)
+            with patch(
+                'mage_ai.orchestration.pipeline_scheduler_original.cancel_block_runs_and_jobs'
+            ):
+                with patch(
+                    'mage_ai.orchestration.pipeline_scheduler_original'
+                    '.UsageStatisticLogger'
+                ):
+                    scheduler.on_pipeline_run_failure(error_msg='block failed')
+
+        stacktrace = captured.get('stacktrace', '')
+        self.assertIn(dbt_detail, stacktrace)
+
+    def test_both_error_str_and_traceback_present(self):
+        """When both error_str and message exist, they both appear separated by blank line."""
+        error_str = 'dbt build failed.\n  [model] bad_model: syntax error'
+        traceback_msg = 'Traceback (most recent call last):\n  File "block.py", line 10\nException'
+        scheduler, _ = self._make_scheduler_with_failed_block(
+            error_str=error_str,
+            message=traceback_msg,
+        )
+
+        captured = {}
+        with patch.object(
+            scheduler.notification_sender,
+            'send_pipeline_run_failure_message',
+        ) as mock_send:
+            mock_send.side_effect = lambda **kw: captured.update(kw)
+            with patch(
+                'mage_ai.orchestration.pipeline_scheduler_original.cancel_block_runs_and_jobs'
+            ):
+                with patch(
+                    'mage_ai.orchestration.pipeline_scheduler_original'
+                    '.UsageStatisticLogger'
+                ):
+                    scheduler.on_pipeline_run_failure(error_msg='block failed')
+
+        stacktrace = captured.get('stacktrace', '')
+        self.assertIn(error_str, stacktrace)
+        self.assertIn(traceback_msg, stacktrace)
+        # The two parts are separated by a blank line
+        self.assertIn('\n\n', stacktrace)
+
+    def test_long_traceback_is_truncated(self):
+        """Tracebacks longer than 50 lines are truncated and prefixed with a notice."""
+        long_message = '\n'.join([f'line {i}' for i in range(100)])
+        scheduler, _ = self._make_scheduler_with_failed_block(message=long_message)
+
+        captured = {}
+        with patch.object(
+            scheduler.notification_sender,
+            'send_pipeline_run_failure_message',
+        ) as mock_send:
+            mock_send.side_effect = lambda **kw: captured.update(kw)
+            with patch(
+                'mage_ai.orchestration.pipeline_scheduler_original.cancel_block_runs_and_jobs'
+            ):
+                with patch(
+                    'mage_ai.orchestration.pipeline_scheduler_original'
+                    '.UsageStatisticLogger'
+                ):
+                    scheduler.on_pipeline_run_failure(error_msg='block failed')
+
+        stacktrace = captured.get('stacktrace', '')
+        self.assertIn('... (traceback truncated)', stacktrace)
+        # Should end with the last few original lines, not line 0
+        self.assertIn('line 99', stacktrace)
+        self.assertNotIn('line 0\n', stacktrace)
+
+    def test_empty_metrics_does_not_crash(self):
+        """When block run metrics is an empty dict, stacktrace stays None (no crash)."""
+        scheduler, _ = self._make_scheduler_with_failed_block(metrics={})
+
+        captured = {}
+        with patch.object(
+            scheduler.notification_sender,
+            'send_pipeline_run_failure_message',
+        ) as mock_send:
+            mock_send.side_effect = lambda **kw: captured.update(kw)
+            with patch(
+                'mage_ai.orchestration.pipeline_scheduler_original.cancel_block_runs_and_jobs'
+            ):
+                with patch(
+                    'mage_ai.orchestration.pipeline_scheduler_original'
+                    '.UsageStatisticLogger'
+                ):
+                    scheduler.on_pipeline_run_failure(error_msg='block failed')
+
+        self.assertIsNone(captured.get('stacktrace'))
+
+    def test_none_metrics_does_not_crash(self):
+        """When block run metrics is None, the loop skips it without crashing."""
+        scheduler, _ = self._make_scheduler_with_failed_block(metrics=None)
+
+        captured = {}
+        with patch.object(
+            scheduler.notification_sender,
+            'send_pipeline_run_failure_message',
+        ) as mock_send:
+            mock_send.side_effect = lambda **kw: captured.update(kw)
+            with patch(
+                'mage_ai.orchestration.pipeline_scheduler_original.cancel_block_runs_and_jobs'
+            ):
+                with patch(
+                    'mage_ai.orchestration.pipeline_scheduler_original'
+                    '.UsageStatisticLogger'
+                ):
+                    # Should not raise AttributeError
+                    scheduler.on_pipeline_run_failure(error_msg='block failed')
+
+        self.assertIsNone(captured.get('stacktrace'))

--- a/mage_ai/tests/orchestration/test_pipeline_scheduler.py
+++ b/mage_ai/tests/orchestration/test_pipeline_scheduler.py
@@ -1287,3 +1287,29 @@ class PipelineSchedulerOnFailureTests(DBTestCase):
                     scheduler.on_pipeline_run_failure(error_msg='block failed')
 
         self.assertIsNone(captured.get('stacktrace'))
+
+    def test_long_error_str_is_truncated(self):
+        """error_str longer than 50 lines is truncated, keeping the first 50 lines."""
+        long_error = '\n'.join([f'  [model] model_{i}: Error {i}' for i in range(100)])
+        scheduler, _ = self._make_scheduler_with_failed_block(error_str=long_error)
+
+        captured = {}
+        with patch.object(
+            scheduler.notification_sender,
+            'send_pipeline_run_failure_message',
+        ) as mock_send:
+            mock_send.side_effect = lambda **kw: captured.update(kw)
+            with patch(
+                'mage_ai.orchestration.pipeline_scheduler_original.cancel_block_runs_and_jobs'
+            ):
+                with patch(
+                    'mage_ai.orchestration.pipeline_scheduler_original'
+                    '.UsageStatisticLogger'
+                ):
+                    scheduler.on_pipeline_run_failure(error_msg='block failed')
+
+        stacktrace = captured.get('stacktrace', '')
+        self.assertIn('... (error details truncated)', stacktrace)
+        # Should keep the first lines (model names), not the last
+        self.assertIn('model_0', stacktrace)
+        self.assertNotIn('model_99', stacktrace)


### PR DESCRIPTION
# Description
The PR includes implementation for change request **[Enhanced Notification for dbt Pipelines](https://github.com/mage-ai/mage-ai/issues/5185)**. It extends the current notification payload to include details about the specific models and tests that are in error. Also it displays this detailed error information in the notification message sent to the user.

# What Has This Been Changed?
**mage_ai/data_preparation/models/block/dbt/block_sql.py**
Added `__build_dbt_error_detail()` static method that parses `dbtRunnerResult.result.results `to extract the specific models and tests that failed, formatting each as `[resource_type] node_name: error_message`. Called when a dbt block fails instead of raising a generic `str(res.exception)`.

**mage_ai/orchestration/pipeline_scheduler_original.py**
Updated `on_pipeline_run_failure()` to read `metrics['error']['error']` (the exception message containing dbt model/test details) in addition to the raw traceback. Previously only the traceback was forwarded, so the dbt-specific detail was silently dropped. Also restored a missing` if not br.metrics: continue` guard.

**mage_ai/orchestration/notification/sender.py**
Added `{stacktrace} `to the default failure message template so that per-model/test error details are included in notification messages sent to all channels (Slack, Teams, Email, etc.). The stacktrace is conditionally appended only when present, preserving existing behaviour for non-dbt pipelines.

# How Has This Been Tested?
## Run unit tests:
```
docker exec {mage-ai-server-container-name} python -m unittest mage_ai.tests.data_preparation.models.block.dbt.test_block_sql -v
docker exec {mage-ai-server-container-name} python -m unittest mage_ai.tests.orchestration.notification.test_sender -v
docker exec {mage-ai-server-container-name} python -m unittest mage_ai.tests.orchestration.notification.test_sender.NotificationSenderStacktraceTests -v
```
Verified all tests passed.

## Integration test(with frontend using real DBT model):
- Create a new pipeline
- Edit the pipeline with adding a DBT model
- Edit the related model SQL file with making SQL query to wrong syntax: changing `select * from source_data` to `select * form source_data`
- Run the pipeline
- Verified running the pipeline Failed along with exception logs including detail error on per-model or test as follows:
```
error_details: dbt build failed. The following models/tests encountered errors:
  [model] my_first_dbt_model: Runtime Error in model my_first_dbt_model (models/example/my_first_dbt_model.sql)
  Parser Error: syntax error at or near "source_data"
  LINE 30: form source_data
```

## Inline test:
In mage_ai\orchestration\notification\sender.py, added the first line inside the send method in class NotificationSender:
`print(f'[NOTIFICATION PAYLOAD]\ntitle: {title}\nsummary: {summary}\n')`

In case of running the test pipeline failed, the printed result included detail errors on per-model/test level.

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (see Section What Has This Been Changed?) 

cc:
@wangxiaoyou1993