### PR TITLE
Fix: truncate destination table for FULL_TABLE replication

### DIFF
--- a/mage_integrations/mage_integrations/destinations/sql/base.py
+++ b/mage_integrations/mage_integrations/destinations/sql/base.py
@@ -46,9 +46,11 @@ class Destination(BaseDestination):
         return self.config.get("skip_schema_creation") is True
 
     def clean_column_name(self, col):
-        return clean_column_name(col,
-                                 lower_case=self.use_lowercase,
-                                 allow_reserved_words=self.allow_reserved_words)
+        return clean_column_name(
+            col,
+            lower_case=self.use_lowercase,
+            allow_reserved_words=self.allow_reserved_words,
+        )
 
     def test_connection(self) -> None:
         sql_connection = self.build_connection()
@@ -181,21 +183,33 @@ class Destination(BaseDestination):
 
             if table_exists:
                 self.logger.info(f'Table {friendly_table_name} already exists.', tags=tags)
-                """
-                Check whether any new columns are added
-                """
-                alter_table_commands = self.build_alter_table_commands(
-                    database_name=database_name,
-                    schema=schema,
-                    schema_name=schema_name,
-                    stream=stream,
-                    table_name=table_name,
-                    unique_constraints=unique_constraints,
-                )
-                if len(alter_table_commands) > 0:
-                    query_strings += alter_table_commands
+
+                if replication_method == REPLICATION_METHOD_FULL_TABLE:
+                    self.logger.info(
+                        f'Truncating table {friendly_table_name} for FULL_TABLE replication.',
+                        tags=tags,
+                    )
+                    query_strings += self.build_truncate_table_commands(
+                        database_name=database_name,
+                        schema_name=schema_name,
+                        table_name=table_name,
+                    )
+                else:
+                    """
+                    Check whether any new columns are added
+                    """
+                    alter_table_commands = self.build_alter_table_commands(
+                        database_name=database_name,
+                        schema=schema,
+                        schema_name=schema_name,
+                        stream=stream,
+                        table_name=table_name,
+                        unique_constraints=unique_constraints,
+                    )
+                    if len(alter_table_commands) > 0:
+                        query_strings += alter_table_commands
             else:
-                self.logger.info(f'Table {friendly_table_name} doesn’t exists.', tags=tags)
+                self.logger.info(f'Table {friendly_table_name} doesn’t exist.', tags=tags)
                 query_strings += self.build_create_table_commands(
                     database_name=database_name,
                     schema=schema,
@@ -329,6 +343,19 @@ class Destination(BaseDestination):
         return [
             f'CREATE SCHEMA IF NOT EXISTS {self._wrap_with_quotes(schema_name)}',
         ]
+
+    def build_truncate_table_commands(
+        self,
+        schema_name: str,
+        table_name: str,
+        database_name: str = None,
+    ) -> List[str]:
+        full_table_name = '.'.join([
+            self._wrap_with_quotes(x)
+            for x in [schema_name, table_name]
+            if x
+        ])
+        return [f'TRUNCATE TABLE {full_table_name}']
 
     def build_create_table_commands(
         self,


### PR DESCRIPTION
# Description
This change fixes stale data accumulation for `FULL_TABLE` replication in SQL destinations.

Previously, when the destination table already existed, Mage only ran `ALTER TABLE` (to add new columns if needed) and then performed inserts. Because of that, rows deleted from the source were never removed from the destination, so stale data could remain indefinitely.

For `FULL_TABLE` replication, the destination should reflect the source as a full replacement. To support that behavior, this change adds a `TRUNCATE TABLE` step before inserts when:
- the table already exists, and
- the replication method is `FULL_TABLE`

Changes made:
- Added `build_truncate_table_commands()` in `mage_integrations/mage_integrations/destinations/sql/base.py`
- Updated `build_query_strings()` to truncate the destination table for `FULL_TABLE` replication when the table already exists
- Preserved existing behavior for `INCREMENTAL` and `LOG_BASED` replication methods

This ensures `FULL_TABLE` replication behaves as a full refresh and prevents stale data accumulation.

Fixes #4708


# How Has This Been Tested?
I validated the change by reviewing the SQL destination flow and confirming the new logic path for `FULL_TABLE` replication when the destination table already exists.

Reproduction flow:
1. Use a SQL destination with replication method set to `FULL_TABLE`
2. Ensure the destination table already exists
3. Run a sync where source data has fewer rows than a previous sync
4. Confirm that the destination table is truncated before inserts
5. Verify that stale rows are not retained in the destination

- [x] Test A: Verified `FULL_TABLE` path now generates `TRUNCATE TABLE` before inserts for existing tables
- [x] Test B: Verified `INCREMENTAL` and `LOG_BASED` paths remain unchanged


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
