### PR TITLE
Fix: Add description field to Trigger initialization

### DIFF
--- a/mage_ai/api/resources/PipelineScheduleResource.py
+++ b/mage_ai/api/resources/PipelineScheduleResource.py
@@ -420,6 +420,7 @@ class PipelineScheduleResource(DatabaseResource):
         pipeline = Pipeline.get(updated_model.pipeline_uuid, repo_path=repo_path)
         if pipeline:
             trigger = Trigger(
+                description=updated_model.description,
                 last_enabled_at=updated_model.last_enabled_at,
                 name=updated_model.name,
                 pipeline_uuid=updated_model.pipeline_uuid,

--- a/mage_ai/api/resources/PipelineTriggerResource.py
+++ b/mage_ai/api/resources/PipelineTriggerResource.py
@@ -42,6 +42,7 @@ class PipelineTriggerResource(GenericResource):
         if pipeline_schedule_id:
             pipeline_schedule = PipelineSchedule.query.get(pipeline_schedule_id)
             trigger = Trigger(
+                description=pipeline_schedule.description,
                 last_enabled_at=pipeline_schedule.last_enabled_at,
                 name=pipeline_schedule.name,
                 pipeline_uuid=pipeline_schedule.pipeline_uuid,


### PR DESCRIPTION
Fixes bug where trigger descriptions were reset to null when activating or updating pipeline triggers from the UI. Now properly preserves the description field from `PipelineSchedule` when constructing `Trigger` objects.

# Description

When a user activates (or otherwise updates) a pipeline trigger from the Mage UI, the `description` field in the pipeline's `triggers.yaml` was being reset to `null`, wiping out any description that was previously set.

**Example diff previously seen in `triggers.yaml` after clicking "activate":**

```diff
-- description: Test description
+- description: null
-  status: inactive
+  status: active
```

### Root Cause

In the API resources that persist a `Trigger` to `triggers.yaml`, the `Trigger(...)` dataclass was being constructed without passing `description`. Since `Trigger.description` defaults to `None`, `to_dict()` then wrote `description: null` to the yaml file, overwriting the existing description.

`PipelineSchedule` already has a `description` column and the `Trigger` dataclass already serializes `description` in `to_dict()` — the field was simply never forwarded between them at these two call sites. Other call sites (e.g. `add_or_update_trigger_for_pipeline_and_persist`) pass the already-loaded `trigger_config` through, so they preserve the description correctly.

# What Has Been Changed?

Added `description=<source>.description` to the `Trigger(...)` constructor call in two files (2 files, 2 lines added):

1. **`mage_ai/api/resources/PipelineScheduleResource.py`** — `update()` method:

```diff
 trigger = Trigger(
+    description=updated_model.description,
     last_enabled_at=updated_model.last_enabled_at,
     name=updated_model.name,
     ...
 )
```

2. **`mage_ai/api/resources/PipelineTriggerResource.py`** — `create()` classmethod, `if pipeline_schedule_id:` branch:

```diff
 trigger = Trigger(
+    description=pipeline_schedule.description,
     last_enabled_at=pipeline_schedule.last_enabled_at,
     name=pipeline_schedule.name,
     ...
 )
```

# How Has This Been Tested?

Manually verified end-to-end against a local Mage instance running in Docker.

**Reproducing on `master`:** Set up a trigger with a non-empty description in `triggers.yaml`, activated it via the UI, and observed the `description` was reset to `null` in `triggers.yaml` — confirming the bug.

**Verifying on this branch:** Restored the description, rebuilt the container with the fix, and activated the trigger again. The `description` was preserved; only `status` and `last_enabled_at` changed, matching the expected behavior.

- [x] Reproduced the bug on master (`description: null` after activation)
- [x] Verified the fix preserves the description on activation

# Checklist

- [x] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
