### PR TITLE
Support image previews in output block

### DIFF
--- a/mage_ai/data_preparation/models/block/outputs.py
+++ b/mage_ai/data_preparation/models/block/outputs.py
@@ -43,10 +43,7 @@ from mage_ai.shared.parsers import (
     encode_complex,
     has_to_dict,
 )
-from mage_ai.shared.strings import (
-    is_json,
-    is_image
-)
+from mage_ai.shared.strings import is_image, is_json
 
 
 def format_output_data(

--- a/mage_ai/data_preparation/models/block/outputs.py
+++ b/mage_ai/data_preparation/models/block/outputs.py
@@ -43,7 +43,10 @@ from mage_ai.shared.parsers import (
     encode_complex,
     has_to_dict,
 )
-from mage_ai.shared.strings import is_json
+from mage_ai.shared.strings import (
+    is_json,
+    is_image
+)
 
 
 def format_output_data(
@@ -371,6 +374,7 @@ df = get_variable('{block.pipeline.uuid}', '{block.uuid}', 'df')
         return data, False
     elif is_primitive(data):
         json_data = is_json(data)
+        img_format, img_data = is_image(data)
         if json_data:
             text_data = json_data.get('data') or ''
             if isinstance(text_data, list):
@@ -378,6 +382,19 @@ df = get_variable('{block.pipeline.uuid}', '{block.uuid}', 'df')
             data = dict(
                 text_data=text_data,
                 type=DataType.TEXT_PLAIN,
+                variable_uuid=variable_uuid,
+            )
+        elif img_data:
+            FORMAT_TO_DATA_TYPE = {
+                'PNG': DataType.IMAGE_PNG,
+                'JPEG': DataType.IMAGE_JPEG,
+                'GIF': DataType.IMAGE_GIF,
+                'WebP': DataType.IMAGE_WEBP,
+            }
+            mime_type = FORMAT_TO_DATA_TYPE.get(img_format, DataType.IMAGE_PNG)
+            data = dict(
+                text_data=str(data),
+                type=mime_type,
                 variable_uuid=variable_uuid,
             )
         else:

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/ImageOutput.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/ImageOutput.tsx
@@ -5,10 +5,11 @@ import { UNIT } from '@oracle/styles/units/spacing';
 interface ImageOutputProps {
   data: string;
   height?: number;
+  mimeType?: string;
   uuid?: string;
 }
 
-function ImageOutput({ data, height = UNIT * 60, uuid }: ImageOutputProps): JSX.Element {
+function ImageOutput({ data, height = UNIT * 60, mimeType = 'image/png', uuid }: ImageOutputProps): JSX.Element {
   return (
     <div
       style={{
@@ -21,7 +22,7 @@ function ImageOutput({ data, height = UNIT * 60, uuid }: ImageOutputProps): JSX.
       <Image
         alt={`Image ${uuid ? `${uuid} ` : ''}from code output`}
         layout="fill"
-        src={`data:image/png;base64, ${data}`}
+        src={`data:${mimeType};base64, ${data}`}
       />
     </div>
   );

--- a/mage_ai/frontend/components/CodeBlock/CodeOutput/OutputRenderer.tsx
+++ b/mage_ai/frontend/components/CodeBlock/CodeOutput/OutputRenderer.tsx
@@ -142,8 +142,15 @@ function OutputRenderer({
         selected={selected}
       />
     );
-  } else if (DataTypeEnum.IMAGE_PNG === dataType) {
-    return <ImageOutput data={textValue} />;
+  } else if (
+      [
+        DataTypeEnum.IMAGE_PNG,
+        DataTypeEnum.IMAGE_JPEG,
+        DataTypeEnum.IMAGE_GIF,
+        DataTypeEnum.IMAGE_WEBP,
+      ].includes(dataType)
+  ) {
+    return <ImageOutput data={textValue} mimeType={dataType} />;
   } else {
     const objectData = [data || textData]?.find(obj => obj && isObject(obj));
 

--- a/mage_ai/frontend/interfaces/KernelOutputType.ts
+++ b/mage_ai/frontend/interfaces/KernelOutputType.ts
@@ -13,6 +13,9 @@ export enum MsgTypeEnum {
 export enum DataTypeEnum {
   GROUP = 'group',
   IMAGE_PNG = 'image/png',
+  IMAGE_JPEG = 'image/jpeg',
+  IMAGE_GIF = 'image/gif',
+  IMAGE_WEBP = 'image/webp',
   OBJECT = 'object',
   PROGRESS = 'progress', // Deprecated; can come from Great Expectations
   PROGRESS_STATUS = 'progress_status',

--- a/mage_ai/server/kernel_output_parser.py
+++ b/mage_ai/server/kernel_output_parser.py
@@ -5,6 +5,9 @@ from mage_ai.shared.enum import StrEnum
 class DataType(StrEnum):
     DATA_FRAME = 'data_frame'
     IMAGE_PNG = 'image/png'
+    IMAGE_JPEG = 'image/jpeg'
+    IMAGE_GIF = 'image/gif'
+    IMAGE_WEBP = 'image/webp'
     PROGRESS = 'progress'  # Deprecated; can come from Great Expectations
     PROGRESS_STATUS = 'progress_status'  # Comes from execute_custom_code.py
     GROUP = 'group'

--- a/mage_ai/shared/strings.py
+++ b/mage_ai/shared/strings.py
@@ -21,7 +21,7 @@ def is_image(img):
     try:
         # Strip metadata header if present (e.g., "data:image/png;base64,")
         if "," in img:
-            image_string = img.split(",")[1]
+            img = img.split(",")[1]
 
         img_data = base64.b64decode(img, validate=True)
 

--- a/mage_ai/shared/strings.py
+++ b/mage_ai/shared/strings.py
@@ -1,8 +1,11 @@
+import base64
+import io
 import json
 import re
 from typing import List
 
 import inflection
+from PIL import Image
 
 
 def is_json(myjson):
@@ -14,6 +17,19 @@ def is_json(myjson):
     except Exception:
         return False
 
+def is_image(img):
+    try:
+        # Strip metadata header if present (e.g., "data:image/png;base64,")
+        if "," in img:
+            image_string = img.split(",")[1]
+
+        img_data = base64.b64decode(img, validate=True)
+
+        with Image.open(io.BytesIO(img_data)) as img:
+            img.verify()
+            return img.format, True
+    except Exception:
+        return '', False
 
 def camel_to_snake_case(name):
     name = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)


### PR DESCRIPTION
# Description
* Added support for previewing `image/png`, `image/jpeg`, `image/gif`, and `image/webp` in block outputs.
* Added optional `mimeType` prop to `ImageOutput` component
* Added required data types for `jpeg`, `gif`, and `webp`.
* Utilized existing Pillow dependency for checking image validity and format.

Closes mage-ai/mage-ai#6073


# How Has This Been Tested?
* Code block output: Run code that displays images in different formats
* Pipelines: Run a pipeline with blocks emitting image output.  Then, confirm pipeline runs as expected.
* Regression:  Ensure other block types run as expected


# Checklist
- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
@wangxiaoyou1993
