### PR TITLE
Add Backblaze B2 storage class subclassing S3

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -811,6 +811,7 @@
                   "integrations/databases/Athena",
                   "integrations/databases/AzureBlobStorage",
                   "integrations/databases/AzureDataLakeStorage",
+                  "integrations/databases/BackblazeB2",
                   "integrations/databases/BigQuery",
                   "integrations/databases/Chroma",
                   "integrations/databases/ClickHouse",

--- a/docs/integrations/databases/BackblazeB2.mdx
+++ b/docs/integrations/databases/BackblazeB2.mdx
@@ -1,0 +1,116 @@
+---
+title: "Backblaze B2"
+---
+
+## Prerequisites
+
+Backblaze B2 uses Mage's S3-compatible client, which depends on `boto3`. Docker
+and full dev installs already include it. If you installed Mage with a plain
+`pip install mage-ai`, install the `s3` extra so the dependency is present:
+
+```bash
+pip install "mage-ai[s3]"
+```
+
+## Add credentials
+
+1. Create a new pipeline or open an existing pipeline.
+2. Expand the left side of your screen to view the file browser.
+3. Scroll down and click on a file named `io_config.yaml`.
+4. Enter the following keys and values under the key named `default` (you can
+   have multiple profiles, add it under whichever is relevant to you)
+   ```yaml
+   version: 0.1.1
+   default:
+     B2_APPLICATION_KEY_ID: ...
+     B2_APPLICATION_KEY: ...
+     # Optional. Defaults to us-west-004. If your bucket is in another region,
+     # uncomment and set this to that region's endpoint (shown on the B2 bucket
+     # page), e.g. us-west-001, us-east-005, eu-central-003:
+     # B2_ENDPOINT_URL: https://s3.us-east-005.backblazeb2.com
+   ```
+
+   For backwards compatibility, the loader also falls back to
+   `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_ENDPOINT` (for the
+   endpoint URL) when the corresponding `B2_*` keys are not set.
+
+<br />
+
+## Using Python block
+
+1. Create a new pipeline or open an existing pipeline.
+2. Add a data loader or transformer block (the code snippet below is for a data
+   loader).
+3. Select `Generic (no template)`.
+4. Enter this code snippet (note: change the `config_profile` from `default` if
+   you have a different profile):
+
+   ```python
+   from mage_ai.settings.repo import get_repo_path
+   from mage_ai.io.config import ConfigFileLoader
+   from mage_ai.io.backblaze_b2 import BackblazeB2
+   from os import path
+   from pandas import DataFrame
+
+   if 'data_loader' not in globals():
+       from mage_ai.data_preparation.decorators import data_loader
+
+
+   @data_loader
+   def load_from_backblaze_b2(**kwargs) -> DataFrame:
+       config_path = path.join(get_repo_path(), 'io_config.yaml')
+       config_profile = 'default'
+
+       bucket_name = '...'  # Change to your B2 bucket name
+       object_key = '...'   # Change to your object key
+
+       return BackblazeB2.with_config(ConfigFileLoader(config_path, config_profile)).load(
+           bucket_name,
+           object_key,
+       )
+   ```
+
+5. Run the block.
+
+### Endpoint override
+
+The default endpoint is `https://s3.us-west-004.backblazeb2.com`. If your
+bucket lives in another B2 region, add:
+
+```yaml
+default:
+  B2_ENDPOINT_URL: https://s3.us-east-005.backblazeb2.com
+```
+
+under your profile in the `io_config.yaml` file. `AWS_ENDPOINT` is honored as a fallback.
+
+### Errors
+
+<b>B2 connection endpoint URL error</b>
+
+Open the `io_config.yaml` file at the root of your project (e.g.
+`default_repo/io_config.yaml`) and confirm that `B2_ENDPOINT_URL` (if set)
+matches the region of your B2 bucket.
+
+## Permissions
+
+Ensure the [application key](https://www.backblaze.com/docs/cloud-storage-create-and-manage-app-keys)
+you create in the Backblaze B2 console grants the following capabilities on
+your bucket:
+
+- `readFiles`
+- `writeFiles`
+- `listFiles`
+
+These permissions are required to:
+- Read data from B2 (e.g. `.csv`, `.parquet`, `.json`)
+- Write query results or transformed data to B2
+- List contents of a bucket when needed
+
+<Note>
+  Two common Backblaze B2 gotchas:
+  - The **master application key** is not S3-compatible. Create a standard
+    (non-master) application key for use with Mage.
+  - App keys restricted to a single bucket may also need the
+    `listAllBucketNames` capability for S3 SDK/integration compatibility.
+</Note>

--- a/mage_ai/io/backblaze_b2.py
+++ b/mage_ai/io/backblaze_b2.py
@@ -1,0 +1,124 @@
+from functools import lru_cache
+from importlib.metadata import PackageNotFoundError, version
+
+from botocore.config import Config
+
+from mage_ai.io.config import BaseConfigLoader, ConfigKey
+from mage_ai.io.s3 import S3
+
+DEFAULT_B2_ENDPOINT_URL = 'https://s3.us-west-004.backblazeb2.com'
+
+
+@lru_cache(maxsize=1)
+def _user_agent_extra() -> str:
+    """`b2ai-mage-ai/<version>` user agent, resolved once on first use."""
+    try:
+        pkg_version = version('mage-ai')
+    except PackageNotFoundError:  # source checkout without installed dist metadata
+        pkg_version = 'dev'
+    return f'b2ai-mage-ai/{pkg_version}'
+
+
+class BackblazeB2(S3):
+    """
+    Handles data transfer between a Backblaze B2 bucket and the Mage app. Supports
+    loading files of any of the following types:
+    - ".csv"
+    - ".json"
+    - ".parquet"
+    - ".hdf5"
+
+    Backblaze B2 exposes an S3-compatible API, so this class is a thin subclass of
+    `S3` that defaults the endpoint URL to a Backblaze B2 region endpoint. Use the
+    factory method `with_config` to construct the data loader using a B2
+    application key.
+    """
+
+    def __init__(
+        self,
+        verbose: bool = False,
+        endpoint_url: str = DEFAULT_B2_ENDPOINT_URL,
+        **kwargs,
+    ) -> None:
+        """
+        Initializes data loader from a Backblaze B2 bucket. By default the loader
+        targets the `us-west-004` region; specify:
+        - `endpoint_url` - B2 S3-compatible endpoint URL for your bucket's region
+        - `aws_access_key_id` - your B2 Application Key ID
+        - `aws_secret_access_key` - your B2 Application Key
+
+        The `b2ai-mage-ai/<version>` user agent is always sent. Any caller-provided
+        `user_agent_extra` (passed directly and/or via a botocore `Config`) is
+        appended to it rather than replacing it, and other settings on a caller
+        `Config` are preserved.
+        """
+        caller_config = kwargs.pop('config', None)
+
+        # Base UA first, then any extras the caller supplied via either channel.
+        user_agent_parts = [_user_agent_extra()]
+        config_extra = (
+            getattr(caller_config, 'user_agent_extra', None)
+            if caller_config is not None
+            else None
+        )
+        if config_extra:
+            user_agent_parts.append(config_extra)
+        kwarg_extra = kwargs.pop('user_agent_extra', None)
+        if kwarg_extra:
+            user_agent_parts.append(kwarg_extra)
+
+        client_config = Config(user_agent_extra=' '.join(user_agent_parts))
+        if caller_config is not None:
+            # Keep the caller's other Config settings; our (appended) UA wins.
+            client_config = caller_config.merge(client_config)
+
+        super().__init__(
+            verbose=verbose, endpoint_url=endpoint_url, config=client_config, **kwargs,
+        )
+
+    @classmethod
+    def with_config(
+        cls,
+        config: BaseConfigLoader,
+        **kwargs,
+    ) -> 'BackblazeB2':
+        """
+        Initializes a Backblaze B2 client from a configuration loader. This client
+        accepts the following B2 credentials and settings:
+        - Application Key ID
+        - Application Key
+        - Endpoint URL
+
+        Falls back to the equivalent AWS keys (`AWS_ACCESS_KEY_ID`,
+        `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT`) when a B2 key is not present.
+
+        Args:
+            config (BaseConfigLoader): Configuration loader object
+        """
+        return cls(
+            aws_access_key_id=(
+                kwargs.pop('aws_access_key_id', None)
+                or config[ConfigKey.B2_APPLICATION_KEY_ID]
+                or config[ConfigKey.AWS_ACCESS_KEY_ID]
+            ),
+            aws_secret_access_key=(
+                kwargs.pop('aws_secret_access_key', None)
+                or config[ConfigKey.B2_APPLICATION_KEY]
+                or config[ConfigKey.AWS_SECRET_ACCESS_KEY]
+            ),
+            # B2 S3 auth is application key id + key only; it does not support
+            # session tokens. Do not inherit AWS_SESSION_TOKEN from a shared
+            # profile; honor a token only when the caller passes one explicitly.
+            aws_session_token=kwargs.pop('aws_session_token', None),
+            region_name=(
+                kwargs.pop('region_name', None)
+                or config[ConfigKey.AWS_REGION]
+            ),
+            endpoint_url=(
+                kwargs.pop('endpoint_url', None)
+                or config[ConfigKey.B2_ENDPOINT_URL]
+                or config[ConfigKey.AWS_ENDPOINT]
+                or DEFAULT_B2_ENDPOINT_URL
+            ),
+            **kwargs,
+        )

--- a/mage_ai/io/config.py
+++ b/mage_ai/io/config.py
@@ -33,6 +33,10 @@ class ConfigKey(StrEnum):
     AZURE_STORAGE_ACCOUNT_NAME = 'AZURE_STORAGE_ACCOUNT_NAME'
     AZURE_TENANT_ID = 'AZURE_TENANT_ID'
 
+    B2_APPLICATION_KEY_ID = 'B2_APPLICATION_KEY_ID'
+    B2_APPLICATION_KEY = 'B2_APPLICATION_KEY'
+    B2_ENDPOINT_URL = 'B2_ENDPOINT_URL'
+
     CHROMA_COLLECTION = 'CHROMA_COLLECTION'
     CHROMA_PATH = 'CHROMA_PATH'
 
@@ -345,6 +349,7 @@ class VerboseConfigKey(StrEnum):
     AIRTABLE = 'Airtable'
     ALGOLIA = 'Algolia'
     AWS = 'AWS'
+    BACKBLAZE_B2 = 'Backblaze B2'
     BIGQUERY = 'BigQuery'
     CHROMA = 'Chroma'
     CLICKHOUSE = 'ClickHouse'
@@ -372,6 +377,9 @@ class ConfigFileLoader(BaseConfigLoader):
         ConfigKey.AWS_REGION: (VerboseConfigKey.AWS, 'region'),
         ConfigKey.AWS_SECRET_ACCESS_KEY: (VerboseConfigKey.AWS, 'secret_access_key'),
         ConfigKey.AWS_SESSION_TOKEN: (VerboseConfigKey.AWS, 'session_token'),
+        ConfigKey.B2_APPLICATION_KEY_ID: (VerboseConfigKey.BACKBLAZE_B2, 'application_key_id'),
+        ConfigKey.B2_APPLICATION_KEY: (VerboseConfigKey.BACKBLAZE_B2, 'application_key'),
+        ConfigKey.B2_ENDPOINT_URL: (VerboseConfigKey.BACKBLAZE_B2, 'endpoint_url'),
         ConfigKey.GOOGLE_LOCATION: (VerboseConfigKey.BIGQUERY, 'location'),
         ConfigKey.GOOGLE_SERVICE_ACC_KEY: (VerboseConfigKey.BIGQUERY, 'credentials_mapping'),
         ConfigKey.GOOGLE_SERVICE_ACC_KEY_FILEPATH: (

--- a/mage_ai/tests/io/test_backblaze_b2.py
+++ b/mage_ai/tests/io/test_backblaze_b2.py
@@ -1,0 +1,245 @@
+from unittest import mock
+
+from mage_ai.io.backblaze_b2 import DEFAULT_B2_ENDPOINT_URL, BackblazeB2
+from mage_ai.io.config import BaseConfigLoader, ConfigKey, VerboseConfigKey
+from mage_ai.tests.base_test import TestCase
+
+
+class _DictConfigLoader(BaseConfigLoader):
+    """Minimal in-memory config loader for testing ``with_config``."""
+
+    def __init__(self, values):
+        self._values = values
+
+    def contains(self, key, **kwargs):
+        return key in self._values and self._values[key] is not None
+
+    def get(self, key, **kwargs):
+        return self._values.get(key)
+
+
+class BackblazeB2ConfigKeyTests(TestCase):
+    def test_b2_config_keys_exist_with_expected_values(self):
+        self.assertEqual(ConfigKey.B2_APPLICATION_KEY_ID.value, 'B2_APPLICATION_KEY_ID')
+        self.assertEqual(ConfigKey.B2_APPLICATION_KEY.value, 'B2_APPLICATION_KEY')
+        self.assertEqual(ConfigKey.B2_ENDPOINT_URL.value, 'B2_ENDPOINT_URL')
+
+    def test_backblaze_b2_verbose_config_key_exists(self):
+        self.assertEqual(VerboseConfigKey.BACKBLAZE_B2.value, 'Backblaze B2')
+
+
+class BackblazeB2ConstructorTests(TestCase):
+    @mock.patch('mage_ai.io.s3.boto3.client')
+    def test_default_endpoint_url_is_b2(self, mock_boto_client):
+        BackblazeB2()
+        mock_boto_client.assert_called_once()
+        args, kwargs = mock_boto_client.call_args
+        self.assertEqual(args[0], 's3')
+        self.assertEqual(kwargs.get('endpoint_url'), DEFAULT_B2_ENDPOINT_URL)
+
+    @mock.patch('mage_ai.io.s3.boto3.client')
+    def test_user_agent_extra_is_versioned(self, mock_boto_client):
+        BackblazeB2()
+        _, kwargs = mock_boto_client.call_args
+        user_agent_extra = kwargs['config'].user_agent_extra
+        self.assertTrue(user_agent_extra.startswith('b2ai-mage-ai/'))
+
+    @mock.patch('mage_ai.io.s3.boto3.client')
+    def test_user_agent_extra_appends_caller_value(self, mock_boto_client):
+        BackblazeB2(user_agent_extra='custom-app/1.0')
+        _, kwargs = mock_boto_client.call_args
+        user_agent_extra = kwargs['config'].user_agent_extra
+        # Base UA is preserved and the caller's value is appended, not replaced.
+        self.assertTrue(user_agent_extra.startswith('b2ai-mage-ai/'))
+        self.assertTrue(user_agent_extra.endswith(' custom-app/1.0'))
+
+    @mock.patch('mage_ai.io.s3.boto3.client')
+    def test_caller_config_user_agent_appended_and_other_settings_kept(
+        self, mock_boto_client,
+    ):
+        from botocore.config import Config
+
+        BackblazeB2(config=Config(user_agent_extra='custom-app/2.0', read_timeout=42))
+        _, kwargs = mock_boto_client.call_args
+        config = kwargs['config']
+        self.assertTrue(config.user_agent_extra.startswith('b2ai-mage-ai/'))
+        self.assertIn('custom-app/2.0', config.user_agent_extra)
+        # The caller's other Config settings survive the merge.
+        self.assertEqual(config.read_timeout, 42)
+
+    @mock.patch('mage_ai.io.s3.boto3.client')
+    def test_user_agent_extra_appends_both_kwarg_and_config(self, mock_boto_client):
+        from botocore.config import Config
+
+        BackblazeB2(
+            user_agent_extra='kwarg-app/1.0',
+            config=Config(user_agent_extra='config-app/2.0'),
+        )
+        _, kwargs = mock_boto_client.call_args
+        user_agent_extra = kwargs['config'].user_agent_extra
+        # When both channels are used, the base UA and both extras are present.
+        self.assertTrue(user_agent_extra.startswith('b2ai-mage-ai/'))
+        self.assertIn('config-app/2.0', user_agent_extra)
+        self.assertIn('kwarg-app/1.0', user_agent_extra)
+
+    @mock.patch('mage_ai.io.s3.boto3.client')
+    def test_custom_endpoint_url_overrides_default(self, mock_boto_client):
+        custom_endpoint = 'https://s3.us-east-005.backblazeb2.com'
+        BackblazeB2(endpoint_url=custom_endpoint)
+        _, kwargs = mock_boto_client.call_args
+        self.assertEqual(kwargs.get('endpoint_url'), custom_endpoint)
+
+    @mock.patch('mage_ai.io.s3.boto3.client')
+    def test_extra_kwargs_forwarded_to_boto_client(self, mock_boto_client):
+        BackblazeB2(
+            aws_access_key_id='id',
+            aws_secret_access_key='secret',
+            region_name='us-west-004',
+        )
+        _, kwargs = mock_boto_client.call_args
+        self.assertEqual(kwargs.get('aws_access_key_id'), 'id')
+        self.assertEqual(kwargs.get('aws_secret_access_key'), 'secret')
+        self.assertEqual(kwargs.get('region_name'), 'us-west-004')
+        self.assertEqual(kwargs.get('endpoint_url'), DEFAULT_B2_ENDPOINT_URL)
+
+
+class BackblazeB2WithConfigTests(TestCase):
+    @mock.patch('mage_ai.io.s3.boto3.client')
+    def test_with_config_uses_b2_keys(self, mock_boto_client):
+        config = _DictConfigLoader({
+            ConfigKey.B2_APPLICATION_KEY_ID: 'b2-key-id',
+            ConfigKey.B2_APPLICATION_KEY: 'b2-secret',
+            ConfigKey.B2_ENDPOINT_URL: None,
+            ConfigKey.AWS_ACCESS_KEY_ID: 'aws-key-id',
+            ConfigKey.AWS_SECRET_ACCESS_KEY: 'aws-secret',
+            ConfigKey.AWS_ENDPOINT: None,
+        })
+
+        BackblazeB2.with_config(config)
+
+        _, kwargs = mock_boto_client.call_args
+        self.assertEqual(kwargs.get('aws_access_key_id'), 'b2-key-id')
+        self.assertEqual(kwargs.get('aws_secret_access_key'), 'b2-secret')
+        self.assertEqual(kwargs.get('endpoint_url'), DEFAULT_B2_ENDPOINT_URL)
+
+    @mock.patch('mage_ai.io.s3.boto3.client')
+    def test_with_config_falls_back_to_aws_keys(self, mock_boto_client):
+        config = _DictConfigLoader({
+            ConfigKey.B2_APPLICATION_KEY_ID: None,
+            ConfigKey.B2_APPLICATION_KEY: None,
+            ConfigKey.B2_ENDPOINT_URL: None,
+            ConfigKey.AWS_ACCESS_KEY_ID: 'aws-key-id',
+            ConfigKey.AWS_SECRET_ACCESS_KEY: 'aws-secret',
+            ConfigKey.AWS_ENDPOINT: None,
+        })
+
+        BackblazeB2.with_config(config)
+
+        _, kwargs = mock_boto_client.call_args
+        self.assertEqual(kwargs.get('aws_access_key_id'), 'aws-key-id')
+        self.assertEqual(kwargs.get('aws_secret_access_key'), 'aws-secret')
+        self.assertEqual(kwargs.get('endpoint_url'), DEFAULT_B2_ENDPOINT_URL)
+
+    @mock.patch('mage_ai.io.s3.boto3.client')
+    def test_with_config_uses_aws_endpoint_when_present(self, mock_boto_client):
+        custom_endpoint = 'https://s3.eu-central-003.backblazeb2.com'
+        config = _DictConfigLoader({
+            ConfigKey.B2_APPLICATION_KEY_ID: 'b2-key-id',
+            ConfigKey.B2_APPLICATION_KEY: 'b2-secret',
+            ConfigKey.B2_ENDPOINT_URL: None,
+            ConfigKey.AWS_ACCESS_KEY_ID: None,
+            ConfigKey.AWS_SECRET_ACCESS_KEY: None,
+            ConfigKey.AWS_ENDPOINT: custom_endpoint,
+        })
+
+        BackblazeB2.with_config(config)
+
+        _, kwargs = mock_boto_client.call_args
+        self.assertEqual(kwargs.get('endpoint_url'), custom_endpoint)
+
+    @mock.patch('mage_ai.io.s3.boto3.client')
+    def test_with_config_b2_endpoint_url_takes_precedence_over_aws_endpoint(
+        self, mock_boto_client,
+    ):
+        b2_endpoint = 'https://s3.us-west-001.backblazeb2.com'
+        config = _DictConfigLoader({
+            ConfigKey.B2_APPLICATION_KEY_ID: 'b2-key-id',
+            ConfigKey.B2_APPLICATION_KEY: 'b2-secret',
+            ConfigKey.B2_ENDPOINT_URL: b2_endpoint,
+            ConfigKey.AWS_ENDPOINT: 'https://s3.us-east-005.backblazeb2.com',
+        })
+
+        BackblazeB2.with_config(config)
+
+        _, kwargs = mock_boto_client.call_args
+        self.assertEqual(kwargs.get('endpoint_url'), b2_endpoint)
+
+    @mock.patch('mage_ai.io.s3.boto3.client')
+    def test_with_config_b2_keys_take_precedence_over_aws(self, mock_boto_client):
+        config = _DictConfigLoader({
+            ConfigKey.B2_APPLICATION_KEY_ID: 'b2-key-id',
+            ConfigKey.B2_APPLICATION_KEY: 'b2-secret',
+            ConfigKey.B2_ENDPOINT_URL: None,
+            ConfigKey.AWS_ACCESS_KEY_ID: 'aws-key-id',
+            ConfigKey.AWS_SECRET_ACCESS_KEY: 'aws-secret',
+            ConfigKey.AWS_ENDPOINT: None,
+        })
+
+        BackblazeB2.with_config(config)
+
+        _, kwargs = mock_boto_client.call_args
+        self.assertEqual(kwargs.get('aws_access_key_id'), 'b2-key-id')
+        self.assertEqual(kwargs.get('aws_secret_access_key'), 'b2-secret')
+
+    @mock.patch('mage_ai.io.s3.boto3.client')
+    def test_with_config_forwards_region_but_not_config_session_token(
+        self, mock_boto_client,
+    ):
+        config = _DictConfigLoader({
+            ConfigKey.B2_APPLICATION_KEY_ID: 'b2-key-id',
+            ConfigKey.B2_APPLICATION_KEY: 'b2-secret',
+            ConfigKey.AWS_REGION: 'us-east-1',
+            ConfigKey.AWS_SESSION_TOKEN: 'session-token-value',
+        })
+
+        BackblazeB2.with_config(config)
+
+        _, kwargs = mock_boto_client.call_args
+        self.assertEqual(kwargs.get('region_name'), 'us-east-1')
+        # B2 does not support session tokens; AWS_SESSION_TOKEN from config is ignored.
+        self.assertIsNone(kwargs.get('aws_session_token'))
+
+    @mock.patch('mage_ai.io.s3.boto3.client')
+    def test_with_config_forwards_explicit_session_token(self, mock_boto_client):
+        config = _DictConfigLoader({
+            ConfigKey.B2_APPLICATION_KEY_ID: 'b2-key-id',
+            ConfigKey.B2_APPLICATION_KEY: 'b2-secret',
+            ConfigKey.AWS_SESSION_TOKEN: 'config-token-ignored',
+        })
+
+        BackblazeB2.with_config(config, aws_session_token='explicit-token')
+
+        _, kwargs = mock_boto_client.call_args
+        self.assertEqual(kwargs.get('aws_session_token'), 'explicit-token')
+
+    @mock.patch('mage_ai.io.s3.boto3.client')
+    def test_with_config_kwargs_override_config(self, mock_boto_client):
+        config = _DictConfigLoader({
+            ConfigKey.B2_APPLICATION_KEY_ID: 'b2-key-id',
+            ConfigKey.B2_APPLICATION_KEY: 'b2-secret',
+            ConfigKey.B2_ENDPOINT_URL: 'https://s3.us-west-004.backblazeb2.com',
+        })
+
+        # Passing a known key explicitly must override config, not raise TypeError.
+        BackblazeB2.with_config(
+            config,
+            endpoint_url='https://s3.eu-central-003.backblazeb2.com',
+            aws_access_key_id='override-id',
+        )
+
+        _, kwargs = mock_boto_client.call_args
+        self.assertEqual(
+            kwargs.get('endpoint_url'),
+            'https://s3.eu-central-003.backblazeb2.com',
+        )
+        self.assertEqual(kwargs.get('aws_access_key_id'), 'override-id')


### PR DESCRIPTION
# Description

Adds native Backblaze B2 support to `mage_ai.io` following the project's existing per-provider class pattern (one class per provider in `mage_ai/io/`, alongside `S3`, `BigQuery`, `Azure*`, etc.).

`BackblazeB2(S3)` is a thin subclass that defaults `endpoint_url` to the canonical Backblaze B2 region endpoint (`https://s3.us-west-004.backblazeb2.com`). Backblaze B2 exposes an S3-compatible API, so all of the parent class's `load`/`export`/`exists` operations work unchanged against a B2 bucket.

Closes #6101

**Files (5):**

- `mage_ai/io/backblaze_b2.py`: `BackblazeB2(S3)` subclass (~120 LOC).
- `mage_ai/io/config.py`: additive. 3 new `ConfigKey` entries (`B2_APPLICATION_KEY_ID`, `B2_APPLICATION_KEY`, `B2_ENDPOINT_URL`), 1 new `VerboseConfigKey` (`BACKBLAZE_B2 = 'Backblaze B2'`), 3 new `KEY_MAP` entries. AWS keys untouched.
- `mage_ai/tests/io/test_backblaze_b2.py`: 17 unit tests across 3 `TestCase` classes.
- `docs/integrations/databases/BackblazeB2.mdx`: docs page mirroring `S3.mdx` structure (Prerequisites, Add credentials, Using Python block, Endpoint override, Errors, Permissions).
- `docs/docs.json`: single-line alphabetic insertion under the Storage group.

`with_config` reads the B2-named keys first (`B2_APPLICATION_KEY_ID`, `B2_APPLICATION_KEY`, `B2_ENDPOINT_URL`) and falls back to the equivalent AWS keys (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT`) when a B2 key is not set, so existing AWS-style configurations continue to work unchanged. It does not inherit `AWS_SESSION_TOKEN` (B2's S3 auth is application key id + key only); a session token is sent only when the caller passes one explicitly.

Every B2 client sends a `b2ai-mage-ai/<version>` user agent. A caller-provided `user_agent_extra` (passed directly and/or via a botocore `Config`) is appended to it rather than replacing it, and other settings on a caller `Config` are preserved.

Packaging: `boto3`/`botocore` come from Mage's existing `s3` extra (present in Docker and full dev installs). Plain `pip install mage-ai` users install them with `mage-ai[s3]`, as noted in the docs Prerequisites. **No UI changes.** Verified via the 17 included unit tests (all passing locally).

A Singer destination at `mage_integrations/destinations/backblaze_b2/` mirroring `amazon_s3/` is intentionally out of scope here and will follow as a separate, smaller PR.

# How Has This Been Tested?

Ran `python -m unittest mage_ai.tests.io.test_backblaze_b2` locally on Python 3.10; 17/17 pass. Patches `mage_ai.io.s3.boto3.client` and asserts on `call_args` kwargs, so no live B2 credentials are needed in CI.

- [x] Endpoint defaults to `https://s3.us-west-004.backblazeb2.com`
- [x] Custom `endpoint_url` overrides the default
- [x] Extra kwargs forward to `boto3.client('s3', ...)`
- [x] `b2ai-mage-ai/<version>` user agent is sent
- [x] Caller `user_agent_extra` (direct and/or via `Config`) is appended, not replaced; other `Config` settings preserved
- [x] `with_config` uses B2 keys when present and falls back to `AWS_*` keys when unset
- [x] `B2_ENDPOINT_URL` takes precedence over `AWS_ENDPOINT`; B2 keys take precedence over `AWS_*`
- [x] `with_config` does not inherit `AWS_SESSION_TOKEN`; honors an explicit `aws_session_token`
- [x] `ConfigKey.B2_*` and `VerboseConfigKey.BACKBLAZE_B2` enum entries exist with expected values

# Checklist

- [ ] The PR is tagged with proper labels (bug, enhancement, feature, documentation)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

cc @wangxiaoyou1993. Does this shape match what you'd accept?
