### PR TITLE
Fix race condition in LoggerManager.create_log_filepath_dir

### DIFF
--- a/mage_ai/data_preparation/logging/logger_manager.py
+++ b/mage_ai/data_preparation/logging/logger_manager.py
@@ -138,8 +138,7 @@ class LoggerManager:
         Args:
             path (str): The path to create the directory.
         """
-        if not os.path.exists(path):
-            os.makedirs(path)
+        os.makedirs(path, exist_ok=True)
 
     def delete_old_logs(self):
         """


### PR DESCRIPTION
## Summary

- Fix TOCTOU race condition in `LoggerManager.create_log_filepath_dir()` by replacing `os.path.exists()` + `os.makedirs()` with `os.makedirs(path, exist_ok=True)`
- When multiple scheduler replicas share a filesystem (e.g. EFS), concurrent calls to `schedule_all()` race to create the same log directory, causing `FileExistsError: [Errno 17]`

## Problem

The current code at `mage_ai/data_preparation/logging/logger_manager.py:141-142`:

```python
if not os.path.exists(path):
    os.makedirs(path)
```

has a classic Time-Of-Check to Time-Of-Use (TOCTOU) race condition. Between the `os.path.exists()` check returning `False` and the `os.makedirs()` call executing, another process/pod can create the same directory, causing `os.makedirs()` to raise `FileExistsError`.

This is triggered in multi-replica scheduler deployments where all replicas share the same filesystem and call `PipelineScheduler.__init__()` → `LoggerManagerFactory.get_logger_manager()` → `LoggerManager.__init__()` → `create_log_filepath_dir()` for the same pipeline run concurrently.

## Fix

```python
os.makedirs(path, exist_ok=True)
```

The `exist_ok=True` parameter (available since Python 3.2) makes the operation idempotent — it succeeds whether the directory already exists or not, eliminating the race condition entirely.

## Test plan

- [x] Verified the change is a single-line fix with no behavioral difference for the success path
- [ ] Existing tests in `mage_ai/tests/data_preparation/logging/test_logger_manager.py` continue to pass
- [ ] Validated in production with 4 scheduler replicas on shared EFS — no more `FileExistsError` events


Made with [Cursor](https://cursor.com)