### PR TITLE
[Fix] Render custom header media from design.yaml (customMediaSize was never set)

### DIFF
--- a/mage_ai/frontend/components/shared/Header/index.tsx
+++ b/mage_ai/frontend/components/shared/Header/index.tsx
@@ -260,24 +260,45 @@ function Header({
     width?: number;
   }>(null);
 
+  const customMediaUrl = useMemo(() => {
+    const media = design?.components?.header?.media;
+
+    return media?.url || media?.file_path;
+  }, [design]);
+
+  // Preload the custom header media (design.yaml: components.header.media) to
+  // measure its natural dimensions; customMediaSize gates rendering the custom
+  // logo and preserves its aspect ratio. Without this preload, customMediaSize
+  // stayed null forever, so the media configured in design.yaml was fetched
+  // from the API but never displayed.
+  useEffect(() => {
+    if (!customMediaUrl) {
+      return;
+    }
+
+    const img = new window.Image();
+    img.onload = () => setCustomMediaSize({
+      height: img.naturalHeight,
+      width: img.naturalWidth,
+    });
+    img.src = customMediaUrl;
+  }, [customMediaUrl]);
+
   const logoLink = useMemo(() => {
     let logoHeight = LOGO_HEIGHT;
     let logoEl = <GradientLogoIcon height={LOGO_HEIGHT} />;
 
-    if (design?.components?.header?.media) {
-      const media = design?.components?.header?.media;
-      if (customMediaSize !== null) {
-        const ratio = (customMediaSize?.width || 1) / (customMediaSize?.height || 1);
+    if (customMediaUrl && customMediaSize !== null) {
+      const ratio = (customMediaSize?.width || 1) / (customMediaSize?.height || 1);
 
-        logoHeight = CUSTOM_LOGO_HEIGHT;
-        logoEl = (
-          <MediaStyle
-            height={CUSTOM_LOGO_HEIGHT}
-            width={CUSTOM_LOGO_HEIGHT * ratio}
-            url={media?.url || media?.file_path}
-          />
-        );
-      }
+      logoHeight = CUSTOM_LOGO_HEIGHT;
+      logoEl = (
+        <MediaStyle
+          height={CUSTOM_LOGO_HEIGHT}
+          width={CUSTOM_LOGO_HEIGHT * ratio}
+          url={customMediaUrl}
+        />
+      );
     }
 
     return (
@@ -298,7 +319,7 @@ function Header({
     );
   }, [
     customMediaSize,
-    design,
+    customMediaUrl,
   ]);
 
   const userDropdown: FlyoutMenuItemType[] = hideActions


### PR DESCRIPTION
# Description

The custom design feature (`design.yaml` -> `components.header.media`) lets a project replace the header logo, and the backend serves it correctly via `CustomDesignResource`. But the frontend never displays it: rendering in `components/shared/Header/index.tsx` is gated on `customMediaSize !== null`, and `setCustomMediaSize` is never called anywhere in the codebase. The state stays `null` forever, so the media configured in `design.yaml` is fetched from the API but never shown — the default Mage logo always renders.

This PR preloads the configured media with an `Image()` in a `useEffect`, records its natural dimensions in `customMediaSize` on load (which is what the existing aspect-ratio math expects), and renders from there. If the URL fails to load, `onload` never fires and the header gracefully keeps the default Mage logo — same behavior as today.

Docs note: the `media.file_path` / `media.url` value is injected into `background-image: url(...)` (see `MediaStyle` in `index.style.tsx`), so it must be a browser-resolvable URL/path, not a server filesystem path.

# How Has This Been Tested?

- [x] Reproduced on 0.9.79: `features.custom_design: true` + valid `design.yaml` with `components.header.media`; the API returns the design payload; the logo never renders. Traced to the unset `customMediaSize` gate (`setCustomMediaSize` has zero call sites).
- [x] With this change, the media element renders once the image loads, sized `CUSTOM_LOGO_HEIGHT x (natural aspect ratio)`; a broken/unreachable URL falls back to the default Mage logo.

Repro config:

```yaml
# <project>/design.yaml
components:
  header:
    media:
      url: /images/custom-logo.png   # any browser-resolvable URL
```

```yaml
# <project>/metadata.yaml
features:
  custom_design: true
```

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas