### PR TITLE
Use itertools.product in create_combinations

### DIFF
--- a/mage_ai/data_preparation/models/block/dynamic/utils.py
+++ b/mage_ai/data_preparation/models/block/dynamic/utils.py
@@ -1,6 +1,7 @@
 import json
 import os
 from dataclasses import dataclass, field
+from itertools import product
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
@@ -511,23 +512,9 @@ def transform_output_for_display_dynamic_child(
 
 
 def create_combinations(combinations: List[Any]) -> List[Any]:
-    def __create_combinations(combinations_inner: List[Any]) -> List[Any]:
-        combos = []
-
-        for idx, arr in enumerate(combinations_inner):
-            for value in arr:
-                combinations_next = combinations_inner[(idx + 1) :]
-                if len(combinations_next) >= 1:
-                    for combos_down in __create_combinations(combinations_next):
-                        combos.append([value] + combos_down)
-                else:
-                    combos.append([value])
-
-        return combos
-
-    count = len(combinations)
-    arr = __create_combinations(combinations)
-    return [combo for combo in arr if len(combo) == count]
+    if not combinations:
+        return []
+    return [list(combo) for combo in product(*combinations)]
 
 
 def build_combinations_for_dynamic_child(


### PR DESCRIPTION
# Description

`create_combinations()` builds the Cartesian product of a list of lists using a nested
recursive helper plus a final "keep full-length combinations" filter. That is exactly what
`itertools.product` does, so this replaces ~17 lines with a one-liner (no new dependency as
`itertools` is in the standard Python library):

```python
def create_combinations(combinations: List[Any]) -> List[Any]:
    if not combinations:
        return []
    return [list(combo) for combo in product(*combinations)]
```

Behavior is preserved, including element order and the empty-input case (the original returns
`[]` for an empty input, kept via the guard).

# How Has This Been Tested?

- [x] Existing suite: `mage_ai/tests/data_preparation/models/block/dynamic/test_combos.py`
  exercises `create_combinations` indirectly via `build_combinations_for_dynamic_child`.
- [x] Differential test: 20,000 randomized inputs plus edge cases (empty list, empty
  sub-array, single array, multi-array) compared against the original: 0 regressions.

# Checklist
- [x] The PR is tagged with proper labels (enhancement)
- [x] I have performed a self-review of my own code
- [x] I have added/relied on unit tests that prove the change works
- [x] I have commented my code where needed
- [ ] Documentation changes (None)