### PR TITLE
Use uv for package installs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -64,11 +64,11 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install freetds-dev
-          python -m pip install --upgrade pip
-          pip install "git+https://github.com/mage-ai/sqlglot#egg=sqlglot"
-          pip install -r requirements.txt
-          pip install mage_integrations/
-          pip install "git+https://github.com/mage-ai/singer-python.git#egg=singer-python"
+          python -m pip install --upgrade pip uv
+          uv pip install --system "git+https://github.com/mage-ai/sqlglot#egg=sqlglot"
+          uv pip install --system -r requirements.txt
+          uv pip install --system mage_integrations/
+          uv pip install --system "git+https://github.com/mage-ai/singer-python.git#egg=singer-python"
       - name: Run unit tests
         run: |
           python3 -m unittest discover -s mage_ai --failfast
@@ -131,7 +131,8 @@ jobs:
           python -m venv venv3
           venv3/Scripts/Activate.ps1
           $env:PYTHONPATH = "${env:PYTHONPATH};${pwd}"
-          python -m pip install -r requirements.txt
+          python -m pip install --upgrade pip uv
+          uv pip install -r requirements.txt
           python mage_ai/cli/main.py init test_project
       - name: Build frontend, start server, and run Playwright tests
         run: |

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -21,8 +21,8 @@ jobs:
         python-version: 3.10.18
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install --user --upgrade setuptools wheel requests pkginfo
+        python -m pip install --upgrade pip uv
+        uv pip install --system --upgrade setuptools wheel requests pkginfo
     - name: Build stable distribution
       run: |
         rm -rf dist/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,27 +29,29 @@ RUN \
   R -e "install.packages('pacman', repos='http://cran.us.r-project.org')" && \
   R -e "install.packages('renv', repos='http://cran.us.r-project.org')"
 
+# Install uv for faster package installation
+RUN pip3 install --no-cache-dir uv
 
 ## Python Packages
 RUN \
-  pip3 install --no-cache-dir sparkmagic && \
+  uv pip install --system --no-cache-dir sparkmagic && \
   mkdir ~/.sparkmagic && \
   curl https://raw.githubusercontent.com/jupyter-incubator/sparkmagic/master/sparkmagic/example_config.json > ~/.sparkmagic/config.json && \
   sed -i 's/localhost:8998/host.docker.internal:9999/g' ~/.sparkmagic/config.json && \
-  jupyter-kernelspec install --user "$(pip3 show sparkmagic | grep Location | cut -d' ' -f2)/sparkmagic/kernels/pysparkkernel"
+  jupyter-kernelspec install --user "$(uv pip show sparkmagic | grep Location | cut -d' ' -f2)/sparkmagic/kernels/pysparkkernel"
 # Mage integrations and other related packages
 RUN \
-  pip3 install --no-cache-dir "git+https://github.com/wbond/oscrypto.git@d5f3437ed24257895ae1edd9e503cfb352e635a8" && \
-  pip3 install --no-cache-dir "git+https://github.com/dremio-hub/arrow-flight-client-examples.git#egg=dremio-flight&subdirectory=python/dremio-flight" && \
-  pip3 install --no-cache-dir "git+https://github.com/mage-ai/singer-python.git#egg=singer-python" && \
-  pip3 install --no-cache-dir "git+https://github.com/mage-ai/dbt-mysql.git#egg=dbt-mysql" && \
-  pip3 install --no-cache-dir "git+https://github.com/mage-ai/sqlglot#egg=sqlglot" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/wbond/oscrypto.git@d5f3437ed24257895ae1edd9e503cfb352e635a8" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/dremio-hub/arrow-flight-client-examples.git#egg=dremio-flight&subdirectory=python/dremio-flight" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/mage-ai/singer-python.git#egg=singer-python" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/mage-ai/dbt-mysql.git#egg=dbt-mysql" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/mage-ai/sqlglot#egg=sqlglot" && \
   # faster-fifo is not supported on Windows: https://github.com/alex-petrenko/faster-fifo/issues/17
-  pip3 install --no-cache-dir faster-fifo && \
+  uv pip install --system --no-cache-dir faster-fifo && \
   if [ -z "$FEATURE_BRANCH" ] || [ "$FEATURE_BRANCH" = "null" ]; then \
-  pip3 install --no-cache-dir "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations&subdirectory=mage_integrations"; \
+  uv pip install --system --no-cache-dir "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations&subdirectory=mage_integrations"; \
   else \
-  pip3 install --no-cache-dir "git+https://github.com/mage-ai/mage-ai.git@$FEATURE_BRANCH#egg=mage-integrations&subdirectory=mage_integrations"; \
+  uv pip install --system --no-cache-dir "git+https://github.com/mage-ai/mage-ai.git@$FEATURE_BRANCH#egg=mage-integrations&subdirectory=mage_integrations"; \
   fi
 
 # Mage
@@ -57,9 +59,9 @@ COPY ./mage_ai/server/constants.py /tmp/constants.py
 RUN if [ -z "$FEATURE_BRANCH" ] || [ "$FEATURE_BRANCH" = "null" ] ; then \
   tag=$(tail -n 1 /tmp/constants.py) && \
   VERSION=$(echo "$tag" | tr -d "'") && \
-  pip3 install --no-cache-dir "mage-ai[all]==$VERSION"; \
+  uv pip install --system --no-cache-dir "mage-ai[all]==$VERSION"; \
   else \
-  pip3 install --no-cache-dir "git+https://github.com/mage-ai/mage-ai.git@$FEATURE_BRANCH#egg=mage-ai[all]"; \
+  uv pip install --system --no-cache-dir "git+https://github.com/mage-ai/mage-ai.git@$FEATURE_BRANCH#egg=mage-ai[all]"; \
   fi
 
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.10-bookworm
 LABEL description="Mage data management platform"
-ARG PIP=pip3
 USER root
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -37,30 +36,33 @@ RUN apt-get update -y && \
 ## Node Packages
 RUN npm install --global yarn && yarn global add next
 
+# Install uv for faster package installation
+RUN pip3 install --no-cache-dir uv
+
 ## Python Packages
 RUN \
-  pip3 install --no-cache-dir sparkmagic && \
+  uv pip install --system --no-cache-dir sparkmagic && \
   mkdir ~/.sparkmagic && \
   curl https://raw.githubusercontent.com/jupyter-incubator/sparkmagic/master/sparkmagic/example_config.json > ~/.sparkmagic/config.json && \
   sed -i 's/localhost:8998/host.docker.internal:9999/g' ~/.sparkmagic/config.json && \
-  jupyter-kernelspec install --user "$(pip3 show sparkmagic | grep Location | cut -d' ' -f2)/sparkmagic/kernels/pysparkkernel"
+  jupyter-kernelspec install --user "$(uv pip show sparkmagic | grep Location | cut -d' ' -f2)/sparkmagic/kernels/pysparkkernel"
 # Mage integrations and other related packages
 RUN \
-  pip3 install --no-cache-dir "git+https://github.com/wbond/oscrypto.git@d5f3437ed24257895ae1edd9e503cfb352e635a8" && \
-  pip3 install --no-cache-dir "git+https://github.com/dremio-hub/arrow-flight-client-examples.git#egg=dremio-flight&subdirectory=python/dremio-flight" && \
-  pip3 install --no-cache-dir "git+https://github.com/mage-ai/singer-python.git#egg=singer-python" && \
-  pip3 install --no-cache-dir "git+https://github.com/mage-ai/dbt-mysql.git#egg=dbt-mysql" && \
-  pip3 install --no-cache-dir "git+https://github.com/mage-ai/sqlglot#egg=sqlglot" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/wbond/oscrypto.git@d5f3437ed24257895ae1edd9e503cfb352e635a8" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/dremio-hub/arrow-flight-client-examples.git#egg=dremio-flight&subdirectory=python/dremio-flight" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/mage-ai/singer-python.git#egg=singer-python" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/mage-ai/dbt-mysql.git#egg=dbt-mysql" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/mage-ai/sqlglot#egg=sqlglot" && \
   # faster-fifo is not supported on Windows: https://github.com/alex-petrenko/faster-fifo/issues/17
-  pip3 install --no-cache-dir faster-fifo
+  uv pip install --system --no-cache-dir faster-fifo
 COPY mage_integrations /tmp/mage_integrations
 RUN \
-  pip3 install --no-cache-dir /tmp/mage_integrations && \
+  uv pip install --system --no-cache-dir /tmp/mage_integrations && \
   rm -rf /tmp/mage_integrations
 # Mage Dependencies
 COPY requirements.txt /tmp/requirements.txt
 RUN \
-  pip3 install --no-cache-dir -r /tmp/requirements.txt && \
+  uv pip install --system --no-cache-dir -r /tmp/requirements.txt && \
   rm /tmp/requirements.txt
 
 ## Mage Frontend

--- a/dev.spark.Dockerfile
+++ b/dev.spark.Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.10-bookworm
 LABEL description="Mage data management platform"
-ARG PIP=pip3
 USER root
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -41,28 +40,31 @@ RUN \
 ## Node Packages
 RUN npm install --global yarn && yarn global add next
 
+# Install uv for faster package installation
+RUN pip3 install --no-cache-dir uv
+
 ## Python Packages
 RUN \
-  pip3 install --no-cache-dir sparkmagic && \
+  uv pip install --system --no-cache-dir sparkmagic && \
   mkdir ~/.sparkmagic && \
   curl https://raw.githubusercontent.com/jupyter-incubator/sparkmagic/master/sparkmagic/example_config.json > ~/.sparkmagic/config.json && \
   sed -i 's/localhost:8998/host.docker.internal:9999/g' ~/.sparkmagic/config.json && \
-  jupyter-kernelspec install --user "$(pip3 show sparkmagic | grep Location | cut -d' ' -f2)/sparkmagic/kernels/pysparkkernel"
+  jupyter-kernelspec install --user "$(uv pip show sparkmagic | grep Location | cut -d' ' -f2)/sparkmagic/kernels/pysparkkernel"
 # Mage integrations and other related packages
 RUN \
-  pip3 install --no-cache-dir "git+https://github.com/wbond/oscrypto.git@d5f3437ed24257895ae1edd9e503cfb352e635a8" && \
-  pip3 install --no-cache-dir "git+https://github.com/mage-ai/singer-python.git#egg=singer-python" && \
-  pip3 install --no-cache-dir "git+https://github.com/mage-ai/dbt-mysql.git#egg=dbt-mysql" && \
-  pip3 install --no-cache-dir "git+https://github.com/mage-ai/dbt-synapse.git#egg=dbt-synapse" && \
-  pip3 install --no-cache-dir pyspark
+  uv pip install --system --no-cache-dir "git+https://github.com/wbond/oscrypto.git@d5f3437ed24257895ae1edd9e503cfb352e635a8" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/mage-ai/singer-python.git#egg=singer-python" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/mage-ai/dbt-mysql.git#egg=dbt-mysql" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/mage-ai/dbt-synapse.git#egg=dbt-synapse" && \
+  uv pip install --system --no-cache-dir pyspark
 COPY mage_integrations /tmp/mage_integrations
 RUN \
-  pip3 install --no-cache-dir /tmp/mage_integrations && \
+  uv pip install --system --no-cache-dir /tmp/mage_integrations && \
   rm -rf /tmp/mage_integrations
 # Mage Dependencies
 COPY requirements.txt /tmp/requirements.txt
 RUN \
-  pip3 install --no-cache-dir -r /tmp/requirements.txt && \
+  uv pip install --system --no-cache-dir -r /tmp/requirements.txt && \
   rm /tmp/requirements.txt
 
 ## Mage Frontend

--- a/integrations/custom_spark/Dockerfile
+++ b/integrations/custom_spark/Dockerfile
@@ -38,7 +38,8 @@ RUN apt-get install screen unzip -y
 
 ADD hive-site.xml $SPARK_HOME/conf
 
-RUN pip3 install pandas numpy matplotlib seaborn scipy jupyter importlib_metadata spark-nlp
+RUN pip3 install --no-cache-dir uv
+RUN uv pip install --system --no-cache-dir pandas numpy matplotlib seaborn scipy jupyter importlib_metadata spark-nlp
 
 ENV SHELL /bin/bash
 

--- a/lsp.Dockerfile
+++ b/lsp.Dockerfile
@@ -3,14 +3,16 @@ FROM python:3.10-bookworm
 ENV PYTHONPATH="${PYTHONPATH}:/home/src"
 WORKDIR /home/src
 
-RUN pip3 install --no-cache-dir "python-lsp-server[all]" && \
-  pip3 install --no-cache-dir "python-lsp-server[websockets]" && \
-  pip3 install --no-cache-dir pyls-memestra && \
-  pip3 install --no-cache-dir pylsp-mypy && \
-  pip3 install --no-cache-dir pylsp-rope && \
-  pip3 install --no-cache-dir python-lsp-black && \
-  pip3 install --no-cache-dir python-lsp-isort && \
-  pip3 install --no-cache-dir python-lsp-ruff
+RUN pip3 install --no-cache-dir uv
+RUN uv pip install --system --no-cache-dir \
+  "python-lsp-server[all]" \
+  "python-lsp-server[websockets]" \
+  pyls-memestra \
+  pylsp-mypy \
+  pylsp-rope \
+  python-lsp-black \
+  python-lsp-isort \
+  python-lsp-ruff
 
 ENV PORT=8765
 EXPOSE ${PORT}

--- a/mage_ai/server/constants.py
+++ b/mage_ai/server/constants.py
@@ -9,7 +9,7 @@ DATA_PREP_SERVER_PORT = os.getenv('DATA_PREP_SERVER_PORT', 6789)
 DATAFRAME_OUTPUT_SAMPLE_COUNT = 10
 
 # The last line of this file must be the version number.
-# Dockerfile depends on it because it runs ./scripts/install_mage.sh and uses
+# Dockerfiles depend on it because install steps use
 # the last line to determine the version to install.
 VERSION = \
 '0.9.79'

--- a/scripts/pre-start/pre-start.Dockerfile
+++ b/scripts/pre-start/pre-start.Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.10-bookworm
 USER root
 
 RUN \
-  pip3 install --no-cache-dir kubernetes==25.3.0 && \
-  pip3 install --no-cache-dir Jinja2==3.1.2
+  pip3 install --no-cache-dir uv && \
+  uv pip install --system --no-cache-dir kubernetes==25.3.0 Jinja2==3.1.2
 
 COPY --chmod=+x ./scripts/pre-start /app/
 RUN chmod +x /app/pre-start.sh

--- a/test_branch.Dockerfile
+++ b/test_branch.Dockerfile
@@ -25,26 +25,29 @@ RUN \
   R -e "install.packages('pacman', repos='http://cran.us.r-project.org')" && \
   R -e "install.packages('renv', repos='http://cran.us.r-project.org')"
 
+# Install uv for faster package installation
+RUN pip3 install --no-cache-dir uv
+
 ## Python Packages
 RUN \
-  pip3 install --no-cache-dir sparkmagic && \
+  uv pip install --system --no-cache-dir sparkmagic && \
   mkdir ~/.sparkmagic && \
   curl https://raw.githubusercontent.com/jupyter-incubator/sparkmagic/master/sparkmagic/example_config.json > ~/.sparkmagic/config.json && \
   sed -i 's/localhost:8998/host.docker.internal:9999/g' ~/.sparkmagic/config.json && \
-  jupyter-kernelspec install --user "$(pip3 show sparkmagic | grep Location | cut -d' ' -f2)/sparkmagic/kernels/pysparkkernel"
+  jupyter-kernelspec install --user "$(uv pip show sparkmagic | grep Location | cut -d' ' -f2)/sparkmagic/kernels/pysparkkernel"
 # Mage integrations and other related packages
 RUN \
-  pip3 install --no-cache-dir "git+https://github.com/wbond/oscrypto.git@d5f3437ed24257895ae1edd9e503cfb352e635a8" && \
-  pip3 install --no-cache-dir "git+https://github.com/dremio-hub/arrow-flight-client-examples.git#egg=dremio-flight&subdirectory=python/dremio-flight" && \
-  pip3 install --no-cache-dir "git+https://github.com/mage-ai/singer-python.git#egg=singer-python" && \
-  pip3 install --no-cache-dir "git+https://github.com/mage-ai/google-ads-python.git#egg=google-ads" && \
-  pip3 install --no-cache-dir "git+https://github.com/mage-ai/dbt-mysql.git#egg=dbt-mysql" && \
-  pip3 install --no-cache-dir "git+https://github.com/mage-ai/dbt-synapse.git#egg=dbt-synapse" && \
-  pip3 install --no-cache-dir "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations&subdirectory=mage_integrations"
+  uv pip install --system --no-cache-dir "git+https://github.com/wbond/oscrypto.git@d5f3437ed24257895ae1edd9e503cfb352e635a8" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/dremio-hub/arrow-flight-client-examples.git#egg=dremio-flight&subdirectory=python/dremio-flight" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/mage-ai/singer-python.git#egg=singer-python" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/mage-ai/google-ads-python.git#egg=google-ads" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/mage-ai/dbt-mysql.git#egg=dbt-mysql" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/mage-ai/dbt-synapse.git#egg=dbt-synapse" && \
+  uv pip install --system --no-cache-dir "git+https://github.com/mage-ai/mage-ai.git#egg=mage-integrations&subdirectory=mage_integrations"
 # Mage
 COPY ./mage_ai/server/constants.py /tmp/constants.py
 RUN \
-  pip3 install --no-cache-dir git+https://github.com/mage-ai/mage-ai.git@alpha#egg="mage-ai[all]" && \
+  uv pip install --system --no-cache-dir git+https://github.com/mage-ai/mage-ai.git@alpha#egg="mage-ai[all]" && \
   rm /tmp/constants.py
 
 ## Startup Script


### PR DESCRIPTION
## Summary
- Install `uv` in Docker images that perform Python package installs, then switch those installs to `uv pip install --system --no-cache-dir`.
- Update GitHub Actions dependency setup to install `uv` and use `uv pip install` for backend tests and PyPI build dependencies.
- Add a small comment-only change under `mage_ai/**` so the existing `build_and_test.yml` path filters run CI for this Docker/workflow PR.

## Dockerfile coverage
- `Dockerfile`: main ECS image package installs now use uv, including `sparkmagic`, integration Git dependencies, `faster-fifo`, `mage-integrations`, and `mage-ai[all]`.
- `dev.Dockerfile` and `dev.spark.Dockerfile`: dev image Python dependencies, copied `mage_integrations`, and `requirements.txt` installs now use uv.
- `lsp.Dockerfile`: LSP server/plugin packages are installed in a single uv call.
- `test_branch.Dockerfile`: test branch image Python dependencies and `mage-ai[all]` install now use uv.
- `scripts/pre-start/pre-start.Dockerfile`: pre-start Python dependencies now use uv after bootstrapping it.
- `integrations/custom_spark/Dockerfile`: custom Spark Python packages now use uv.

## GitHub Actions coverage
- `.github/workflows/build_and_test.yml`: Linux backend dependency installs use `uv pip install --system`; Windows setup installs uv into the venv and uses `uv pip install -r requirements.txt`.
- `.github/workflows/publish_to_pypi.yml`: build/publish helper packages now install through uv.

## Notes
- `pip3 install --no-cache-dir uv` remains where needed to bootstrap uv inside Docker images.
- `uv pip show sparkmagic` replaces `pip3 show sparkmagic` where the Dockerfiles locate the installed Sparkmagic kernelspec.
- The `mage_ai/server/constants.py` change is comment-only and exists to trigger the watched `mage_ai/**` CI path for this PR.

## Tests
- `git diff --check HEAD~1..HEAD`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/build_and_test.yml .github/workflows/publish_to_pypi.yml`
- `rg --pcre2 -n "pip3? install --no-cache-dir (?!uv)|python -m pip install(?! --upgrade pip uv)|^[[:space:]]*pip install" -g '*Dockerfile*' -g '.github/workflows/*.yml' -g '.github/workflows/*.yaml'`
- pre-commit hooks from the local commits/pushes
