### PR TITLE
Fix sklearn model warning checks

### DIFF
--- a/mage_ai/shared/complex.py
+++ b/mage_ai/shared/complex.py
@@ -7,11 +7,9 @@ def is_model_sklearn(data: Any) -> bool:
         return False
 
     try:
-        from sklearn.base import BaseEstimator, is_classifier, is_regressor
+        from sklearn.base import BaseEstimator
 
-        return (
-            is_classifier(data) or is_regressor(data) or isinstance(data, BaseEstimator)
-        )
+        return isinstance(data, BaseEstimator)
     except ImportError as err:
         print(f"Error importing sklearn: {err}")
         return False

--- a/mage_ai/tests/data_preparation/models/test_utils.py
+++ b/mage_ai/tests/data_preparation/models/test_utils.py
@@ -1,3 +1,4 @@
+import warnings
 from unittest.mock import patch
 
 import pandas as pd
@@ -54,6 +55,13 @@ class TestModelUtils(TestCase):
         data = LinearRegression()
         variable_type_use, basic_iterable = infer_variable_type(data)
         self.assertEqual(variable_type_use, VariableType.MODEL_SKLEARN)
+
+    def test_non_sklearn_values_do_not_emit_deprecation_warnings(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', DeprecationWarning)
+
+            for data in [{'a': 1}, [1, 2, 3], 'value', None]:
+                infer_variable_type(data)
 
     def test_list_complex(self):
         data = [TestCase(), TestCase()]


### PR DESCRIPTION
## Summary
- stop calling sklearn's `is_classifier` / `is_regressor` helpers while inferring variable types for arbitrary Python values
- keep sklearn model detection scoped to `BaseEstimator` instances, which covers the model objects Mage needs to classify without invoking sklearn's tag-resolution path on plain data
- add a regression test that turns `DeprecationWarning` into an error for representative non-model values (`dict`, `list`, `str`, and `None`)

## Why
Recent CI runs started printing thousands of sklearn warnings like:

```text
DeprecationWarning: The following error was raised: 'dict' object has no attribute '__sklearn_tags__'
```

Those warnings come from `mage_ai.shared.complex.is_model_sklearn`. During `infer_variable_type`, Mage checks many ordinary values to see whether they are sklearn models. Calling sklearn's classifier/regressor helpers on non-estimator objects now asks sklearn to resolve estimator tags, which emits deprecation warnings for plain containers and scalars. sklearn notes that this warning will become an error in a future release, so narrowing the check avoids both CI noise and a future compatibility break.

## Behavior
- sklearn estimators such as `LinearRegression()` are still inferred as `VariableType.MODEL_SKLEARN`
- ordinary values continue through the existing non-model inference paths
- plain values no longer trigger sklearn tag lookup warnings while being classified

## Tests
- `/Users/xiaoyou_wang/mage/repos/mage-ai/env/bin/python -m pytest mage_ai/tests/data_preparation/models/test_utils.py -q`
- `git diff --check`
