### PR TITLE
Include callback blocks in pipeline save payload

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -1188,6 +1188,8 @@ function PipelineDetailPage({
     block?: BlockType;
     pipeline?: PipelineType | {
       blocks?: BlockType[];
+      callbacks?: BlockType[];
+      conditionals?: BlockType[];
       extensions?: PipelineExtensionsType;
       name?: string;
       type?: string;
@@ -1208,7 +1210,21 @@ function PipelineDetailPage({
     const callbacksByUUID = {};
     const conditionalsByUUID = {};
 
-    const blocksFinal = pipelineOverride?.blocks || blocks;
+    const blocksFinal = [];
+    const blocksFinalByUUID = {};
+
+    [
+      pipelineOverride?.blocks || blocks,
+      pipelineOverride?.callbacks || pipeline?.callbacks,
+      pipelineOverride?.conditionals || pipeline?.conditionals,
+    ].forEach((arr: BlockType[] = []) => {
+      arr?.forEach((block: BlockType) => {
+        if (!blocksFinalByUUID[block.uuid]) {
+          blocksFinalByUUID[block.uuid] = true;
+          blocksFinal.push(block);
+        }
+      });
+    });
 
     blocksFinal.forEach((block: BlockType) => {
       const {
@@ -1350,7 +1366,7 @@ function PipelineDetailPage({
     const conditionalsToSave = [];
 
     // @ts-ignore
-    (pipelineOverride?.blocks || blocks).forEach(({ uuid }) => {
+    blocksFinal.forEach(({ uuid }) => {
       const blockToSave = blocksByUUID[uuid];
       const callbackBlock = callbacksByUUID[uuid];
       const conditionalBlock = conditionalsByUUID[uuid];


### PR DESCRIPTION
## Problem

Renaming callback blocks from the UI can appear to do nothing. The update modal saves through `savePipelineContent`, but that function builds its save payload from regular pipeline blocks by default.

Callback and conditional blocks are stored separately on the pipeline object (`callbacks` and `conditionals`), so an update override for a callback block may never be applied when the save pass only iterates over `blocks`.

Fixes #6110.

## Changes

- Expand `savePipelineContent` to include regular blocks, callback blocks, and conditional blocks when constructing the save payload.
- Deduplicate by block UUID while preserving the existing save ordering behavior.
- Apply block overrides against this combined list so callback block updates, including renames, are included in the outgoing pipeline update.
- Keep the final payload separated into `blocks`, `callbacks`, and `conditionals` as expected by the backend.

## Impact

Callback block rename/update flows now use the same save path as regular block updates while preserving the pipeline payload structure. Conditional blocks are included too because they use the same add-on block storage pattern and would otherwise be vulnerable to the same omission.

## Validation Notes

Frontend dependencies are not installed in the temp worktree, so I could not run the full Next build/type check locally.

## Tests

- `git diff --check`
- frontend type/build check not run because `mage_ai/frontend/node_modules` is not installed in this worktree
- pre-commit hooks run during commit and push
