### PR TITLE
Scope monitor stats to active project

### DIFF
--- a/mage_ai/orchestration/monitor/monitor_stats.py
+++ b/mage_ai/orchestration/monitor/monitor_stats.py
@@ -31,7 +31,7 @@ class MonitorStatsType(StrEnum):
 class MonitorStats:
     @property
     def repo_path(self) -> str:
-        return get_repo_path(root_project=True)
+        return get_repo_path(root_project=not project_platform_activated())
 
     def get_stats(
         self,
@@ -69,6 +69,7 @@ class MonitorStats:
         end_time: datetime = None,
         pipeline_schedule_id: int = None,
         pipeline_uuid: str = None,
+        repo_path: str = None,
         start_time: datetime = None,
     ) -> List:
         filter_statement = []
@@ -84,6 +85,9 @@ class MonitorStats:
 
         if pipeline_schedule_id is not None:
             filter_statement.append(PipelineRun.pipeline_schedule_id == int(pipeline_schedule_id))
+
+        if repo_path is not None:
+            filter_statement.append(PipelineSchedule.repo_path == repo_path)
 
         if filter_statement:
             return query.filter(*filter_statement)
@@ -123,6 +127,7 @@ class MonitorStats:
             end_time=end_time,
             pipeline_schedule_id=pipeline_schedule_id,
             pipeline_uuid=pipeline_uuid,
+            repo_path=self.repo_path if project_platform_activated() else None,
             start_time=start_time,
         )
 
@@ -138,7 +143,6 @@ class MonitorStats:
             try:
                 pipeline = Pipeline.get(
                     uuid,
-                    all_projects=project_platform_activated(),
                     check_if_exists=False,
                     repo_path=self.repo_path,
                 )
@@ -218,6 +222,7 @@ class MonitorStats:
             PipelineRun.select(*select),
             end_time=end_time,
             pipeline_uuid=pipeline_uuid,
+            repo_path=self.repo_path if project_platform_activated() else None,
             start_time=start_time,
         ).filter(PipelineRun.completed_at != None, PipelineRun.created_at != None)  # noqa: E711
 

--- a/mage_ai/orchestration/monitor/monitor_stats.py
+++ b/mage_ai/orchestration/monitor/monitor_stats.py
@@ -218,8 +218,15 @@ class MonitorStats:
         if start_time or end_time:
             select.append(PipelineRun.created_at)
 
+        query = PipelineRun.select(*select)
+        if project_platform_activated():
+            query = query.join(
+                PipelineSchedule,
+                PipelineRun.pipeline_schedule_id == PipelineSchedule.id,
+            )
+
         query = self.__filter(
-            PipelineRun.select(*select),
+            query,
             end_time=end_time,
             pipeline_uuid=pipeline_uuid,
             repo_path=self.repo_path if project_platform_activated() else None,

--- a/mage_ai/tests/orchestration/test_monitor_stats.py
+++ b/mage_ai/tests/orchestration/test_monitor_stats.py
@@ -1,0 +1,64 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from mage_ai.orchestration.monitor.monitor_stats import MonitorStats
+
+
+class QueryStub:
+    def __init__(self, results):
+        self.filter_calls = []
+        self.results = results
+
+    def join(self, *args, **kwargs):
+        return self
+
+    def filter(self, *args, **kwargs):
+        self.filter_calls.append(args)
+        return self
+
+    def all(self):
+        return self.results
+
+
+@patch('mage_ai.orchestration.monitor.monitor_stats.project_platform_activated', lambda: True)
+@patch('mage_ai.orchestration.monitor.monitor_stats.get_repo_path')
+@patch('mage_ai.orchestration.monitor.monitor_stats.Pipeline.get')
+@patch('mage_ai.orchestration.monitor.monitor_stats.PipelineRun.select')
+def test_pipeline_run_count_scopes_pipeline_lookup_to_active_project(
+    mock_select,
+    mock_pipeline_get,
+    mock_get_repo_path,
+):
+    repo_path = '/path/to/project'
+    mock_get_repo_path.return_value = repo_path
+    mock_pipeline_get.return_value = SimpleNamespace(type='python', uuid='demo_pipeline')
+    mock_select.return_value = QueryStub([
+        SimpleNamespace(
+            ds_created_at='2026-06-23',
+            name='Daily',
+            pipeline_schedule_id=1,
+            pipeline_uuid='demo_pipeline',
+            status='completed',
+        ),
+    ])
+
+    stats = MonitorStats().get_pipeline_run_count(group_by_pipeline_type=True)
+
+    assert stats == {
+        1: {
+            'data': {
+                '2026-06-23': {
+                    'python': {
+                        'completed': 1,
+                    },
+                },
+            },
+            'name': 'Daily',
+        },
+    }
+    mock_get_repo_path.assert_called_with(root_project=False)
+    mock_pipeline_get.assert_called_once_with(
+        'demo_pipeline',
+        check_if_exists=False,
+        repo_path=repo_path,
+    )

--- a/mage_ai/tests/orchestration/test_monitor_stats.py
+++ b/mage_ai/tests/orchestration/test_monitor_stats.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from unittest import TestCase
 from unittest.mock import patch
 
 from mage_ai.orchestration.monitor.monitor_stats import MonitorStats
@@ -7,9 +8,11 @@ from mage_ai.orchestration.monitor.monitor_stats import MonitorStats
 class QueryStub:
     def __init__(self, results):
         self.filter_calls = []
+        self.join_calls = []
         self.results = results
 
     def join(self, *args, **kwargs):
+        self.join_calls.append((args, kwargs))
         return self
 
     def filter(self, *args, **kwargs):
@@ -20,45 +23,66 @@ class QueryStub:
         return self.results
 
 
-@patch('mage_ai.orchestration.monitor.monitor_stats.project_platform_activated', lambda: True)
-@patch('mage_ai.orchestration.monitor.monitor_stats.get_repo_path')
-@patch('mage_ai.orchestration.monitor.monitor_stats.Pipeline.get')
-@patch('mage_ai.orchestration.monitor.monitor_stats.PipelineRun.select')
-def test_pipeline_run_count_scopes_pipeline_lookup_to_active_project(
-    mock_select,
-    mock_pipeline_get,
-    mock_get_repo_path,
-):
-    repo_path = '/path/to/project'
-    mock_get_repo_path.return_value = repo_path
-    mock_pipeline_get.return_value = SimpleNamespace(type='python', uuid='demo_pipeline')
-    mock_select.return_value = QueryStub([
-        SimpleNamespace(
-            ds_created_at='2026-06-23',
-            name='Daily',
-            pipeline_schedule_id=1,
-            pipeline_uuid='demo_pipeline',
-            status='completed',
-        ),
-    ])
+class MonitorStatsTest(TestCase):
+    @patch('mage_ai.orchestration.monitor.monitor_stats.project_platform_activated', lambda: True)
+    @patch('mage_ai.orchestration.monitor.monitor_stats.get_repo_path')
+    @patch('mage_ai.orchestration.monitor.monitor_stats.Pipeline.get')
+    @patch('mage_ai.orchestration.monitor.monitor_stats.PipelineRun.select')
+    def test_pipeline_run_count_scopes_pipeline_lookup_to_active_project(
+        self,
+        mock_select,
+        mock_pipeline_get,
+        mock_get_repo_path,
+    ):
+        repo_path = '/path/to/project'
+        mock_get_repo_path.return_value = repo_path
+        mock_pipeline_get.return_value = SimpleNamespace(type='python', uuid='demo_pipeline')
+        mock_select.return_value = QueryStub([
+            SimpleNamespace(
+                ds_created_at='2026-06-23',
+                name='Daily',
+                pipeline_schedule_id=1,
+                pipeline_uuid='demo_pipeline',
+                status='completed',
+            ),
+        ])
 
-    stats = MonitorStats().get_pipeline_run_count(group_by_pipeline_type=True)
+        stats = MonitorStats().get_pipeline_run_count(group_by_pipeline_type=True)
 
-    assert stats == {
-        1: {
-            'data': {
-                '2026-06-23': {
-                    'python': {
-                        'completed': 1,
+        self.assertEqual(
+            {
+                1: {
+                    'data': {
+                        '2026-06-23': {
+                            'python': {
+                                'completed': 1,
+                            },
+                        },
                     },
+                    'name': 'Daily',
                 },
             },
-            'name': 'Daily',
-        },
-    }
-    mock_get_repo_path.assert_called_with(root_project=False)
-    mock_pipeline_get.assert_called_once_with(
-        'demo_pipeline',
-        check_if_exists=False,
-        repo_path=repo_path,
-    )
+            stats,
+        )
+        mock_get_repo_path.assert_called_with(root_project=False)
+        mock_pipeline_get.assert_called_once_with(
+            'demo_pipeline',
+            check_if_exists=False,
+            repo_path=repo_path,
+        )
+
+    @patch('mage_ai.orchestration.monitor.monitor_stats.project_platform_activated', lambda: True)
+    @patch('mage_ai.orchestration.monitor.monitor_stats.get_repo_path')
+    @patch('mage_ai.orchestration.monitor.monitor_stats.PipelineRun.select')
+    def test_pipeline_run_time_joins_schedules_before_repo_filtering(
+        self,
+        mock_select,
+        mock_get_repo_path,
+    ):
+        mock_get_repo_path.return_value = '/path/to/project'
+        query = QueryStub([])
+        mock_select.return_value = query
+
+        MonitorStats().get_pipeline_run_time()
+
+        self.assertTrue(query.join_calls)


### PR DESCRIPTION
## Problem

`MonitorStats.get_pipeline_run_count` can try to load pipelines that belong to other workspaces/repositories in project-platform deployments. That produces noisy "pipeline does not exist" errors when monitor stats include pipeline runs whose schedule repo does not match the active workspace.

The problematic path queried pipeline runs, then looked up pipeline metadata with all-project behavior enabled. That made monitor stats cross workspace boundaries even when the UI was scoped to a specific project.

Fixes #6036.

## Changes

- Make `MonitorStats.repo_path` resolve to the active project repo when project platform is enabled.
- Add a repo-path filter to the shared pipeline-run monitor stats query in project-platform mode.
- Use the scoped repo path for pipeline type lookups instead of searching all project repos.
- Apply the same repo-path scoping to pipeline runtime stats, since it uses the same shared pipeline-run filter.
- Add a regression test that verifies project-platform monitor stats use the active repo path and do not call `Pipeline.get(..., all_projects=True)`.

## Impact

Pipeline monitor stats should only consider runs for the active workspace, avoiding cross-workspace metadata lookups and reducing noisy monitor logs. Standard non-project-platform behavior is unchanged.

## Validation Notes

The new regression test is included for CI, but local execution was blocked by missing Python dependencies in the temp worktree.

## Tests

- `python3 -m py_compile mage_ai/orchestration/monitor/monitor_stats.py mage_ai/tests/orchestration/test_monitor_stats.py`
- unit test could not run locally because this worktree is missing installed dependencies (`python-dateutil`)
- pre-commit hooks run during commit and push
