### PR TITLE
Pin scipy for Docker startup compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,7 @@ redis~=5.0.1
 requests~=2.31.0
 ruamel.yaml==0.17.17
 scikit-learn<1.8
+scipy==1.14.1
 sentry-sdk>=2.0.0,<3.0.0
 setuptools==70.0.0
 simplejson


### PR DESCRIPTION
## Problem

Recent Docker images can resolve to a scipy/numpy combination that crashes during Mage startup on Python 3.10. The reported failure happens while importing scipy through the sklearn-related import chain before the server binds to a port.

The base dependency list currently pins neither scipy nor an upper numpy bound, so Docker/package installs can pick a scipy release that is incompatible with the numpy version installed in the image.

Fixes #6103.

## Changes

- Add `scipy==1.14.1` to the base `requirements.txt` dependency set.
- Keep the change in the base section so it is picked up by:
  - Docker image dependency installation
  - `setup.py` `install_requires`, since `setup.py` reads from `requirements.txt` until `# extras`

## Impact

This forces the image/package install to use the known-good scipy version suggested in the issue, avoiding the startup crash caused by resolving to the newer incompatible scipy version.

## Validation Notes

I did not run a full Docker build locally. The package metadata path was checked to make sure the edited requirements still parse through `setup.py`.

## Tests

- `python3 setup.py --name`
- pre-commit hooks run during commit and push
