### PR TITLE
Fix project file path validation

### DIFF
--- a/mage_ai/data_preparation/models/file.py
+++ b/mage_ai/data_preparation/models/file.py
@@ -13,7 +13,6 @@ from mage_ai.data_preparation.models.errors import (
 )
 from mage_ai.data_preparation.models.project import Project
 from mage_ai.data_preparation.models.project.constants import FeatureUUID
-from mage_ai.settings.platform import project_platform_activated
 from mage_ai.settings.repo import get_repo_path
 from mage_ai.shared.environments import is_debug
 from mage_ai.shared.files import exists_async, rename_async, write_async
@@ -498,9 +497,6 @@ class File:
 
 
 def ensure_file_is_in_project(file_path: str) -> None:
-    if project_platform_activated():
-        return
-
     full_file_path = get_absolute_path(file_path)
     full_repo_path = get_absolute_path(get_repo_path(file_path=file_path))
     if full_repo_path != os.path.commonpath([full_file_path, full_repo_path]):

--- a/mage_ai/tests/data_preparation/models/test_file.py
+++ b/mage_ai/tests/data_preparation/models/test_file.py
@@ -228,14 +228,10 @@ class FileProjectPlatformTest(ProjectPlatformMixin, AsyncDBTestCase):
                 self.assertTrue(error)
 
             with patch(
-                'mage_ai.data_preparation.models.file.project_platform_activated',
+                'mage_ai.settings.repo.project_platform_activated',
                 lambda: True,
             ):
-                with patch(
-                    'mage_ai.settings.repo.project_platform_activated',
-                    lambda: True,
-                ):
-                    ensure_file_is_in_project(os.path.join(self.repo_path, 'file.txt'))
+                ensure_file_is_in_project(os.path.join(self.repo_path, 'file.txt'))
 
-                    with self.assertRaises(FileNotInProjectError):
-                        ensure_file_is_in_project('../file.txt')
+                with self.assertRaises(FileNotInProjectError):
+                    ensure_file_is_in_project('../file.txt')

--- a/mage_ai/tests/data_preparation/models/test_file.py
+++ b/mage_ai/tests/data_preparation/models/test_file.py
@@ -232,7 +232,10 @@ class FileProjectPlatformTest(ProjectPlatformMixin, AsyncDBTestCase):
                 lambda: True,
             ):
                 with patch(
-                    'mage_ai.data_preparation.models.file.project_platform_activated',
+                    'mage_ai.settings.repo.project_platform_activated',
                     lambda: True,
                 ):
-                    ensure_file_is_in_project('mage_data/demo/file.txt')
+                    ensure_file_is_in_project(os.path.join(self.repo_path, 'file.txt'))
+
+                    with self.assertRaises(FileNotInProjectError):
+                        ensure_file_is_in_project('../file.txt')


### PR DESCRIPTION
## Problem

`ensure_file_is_in_project` returned immediately whenever project platform was enabled. That meant API paths that rely on this helper skipped the existing project-directory validation entirely in project-platform mode.

This is the code path called by file and folder APIs before reading, writing, moving, or creating files. In project-platform deployments, the helper still needs to resolve the appropriate project repo for the incoming path, but it should not bypass the containment check.

Fixes #6063.

## Changes

- Remove the project-platform early return from `ensure_file_is_in_project`.
- Keep the existing `get_repo_path(file_path=...)` lookup so project-platform paths are still matched to the correct project repo.
- Continue using the existing absolute-path/commonpath validation to reject paths outside the resolved repo.
- Update the project-platform test coverage so:
  - a file inside the active project repo is accepted
  - a relative path escaping the project is rejected

## Impact

Project-platform file operations now follow the same path containment rule as standard OSS projects while preserving multi-project repo resolution. This should close the reported path-validation bypass without changing the intended behavior for valid in-project file paths.

## Notes

#6113 still requires a repository admin setting change: GitHub Private Vulnerability Reporting needs to be enabled under the repo security settings. That cannot be completed through this code PR.

## Tests

- `python3 -m py_compile mage_ai/data_preparation/models/file.py mage_ai/tests/data_preparation/models/test_file.py`
- `python3 -m unittest ...test_file...` could not run locally because this worktree is missing installed dependencies (`aiofiles`)
- pre-commit hooks run during commit and push
