### PR TITLE
feat: download dependency graph as image in pipeline editor (#6033)

### DIFF
--- a/mage_ai/frontend/components/DependencyGraph/ZoomControls/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/ZoomControls/index.tsx
@@ -6,13 +6,17 @@ import Tooltip from '@oracle/components/Tooltip';
 import { BORDER_RADIUS_PILL } from '@oracle/styles/units/borders';
 import { CanvasRef } from 'reaflow';
 import { ICON_SIZE_MEDIUM } from '@oracle/styles/units/icons';
-import { Recenter, ZoomIn, ZoomOut } from '@oracle/icons';
+import { Recenter, Save, ZoomIn, ZoomOut } from '@oracle/icons';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { ZoomControlsStyle, ZoomDisplayStyle } from './index.style';
+import { exportGraphAsImage } from '../exportGraph';
 
 type ZoomControlProps = {
+  allowDownload?: boolean;
+  backgroundColor?: string;
   canvasRef?: { current?: CanvasRef };
   containerRef?: { current?: any };
+  fileNamePrefix?: string;
   zoomLevel: number;
 };
 
@@ -38,8 +42,16 @@ const SHARED_ICON_PROPS = {
   size: ICON_SIZE_MEDIUM,
 };
 
-function ZoomControls({ canvasRef, containerRef, zoomLevel }: ZoomControlProps) {
+function ZoomControls({
+  allowDownload,
+  backgroundColor,
+  canvasRef,
+  containerRef,
+  fileNamePrefix,
+  zoomLevel,
+}: ZoomControlProps) {
   const [minimizeControls, setMinimizeControls] = useState<boolean>(false);
+  const [downloading, setDownloading] = useState<boolean>(false);
 
   useEffect(() => {
     if (!containerRef?.current) return;
@@ -53,14 +65,41 @@ function ZoomControls({ canvasRef, containerRef, zoomLevel }: ZoomControlProps) 
     return () => resizeObserver.disconnect();
   }, [containerRef]);
 
+  const handleDownload = async () => {
+    if (downloading) {
+      return;
+    }
+    setDownloading(true);
+    try {
+      await exportGraphAsImage({ backgroundColor, canvasRef, fileNamePrefix });
+    } finally {
+      setDownloading(false);
+    }
+  };
+
   return (
     <ZoomControlsStyle onDoubleClick={(event) => { event.stopPropagation(); }}>
+      {allowDownload && (
+        <Tooltip {...SHARED_TOOLTIP_PROPS} label="Download as image">
+          <Button
+            {...SHARED_BUTTON_PROPS}
+            borderRadius={`${BORDER_RADIUS_PILL}px 0 0 ${BORDER_RADIUS_PILL}px`}
+            disabled={downloading || !(canvasRef?.current?.layout?.width)}
+            onClick={handleDownload}
+            padding={`${UNIT * 1.5}px ${UNIT * 1.875}px ${UNIT * 1.5}px ${UNIT * 3.25}px`}
+          >
+            <Save {...SHARED_ICON_PROPS} />
+          </Button>
+        </Tooltip>
+      )}
       {!minimizeControls && (
         <>
           <Tooltip {...SHARED_TOOLTIP_PROPS} label="Reset (shortcut: double-click canvas)">
             <Button 
               {...SHARED_BUTTON_PROPS}
-              borderRadius={`${BORDER_RADIUS_PILL}px 0 0 ${BORDER_RADIUS_PILL}px`}
+              borderRadius={allowDownload
+                ? '0 0 0 0'
+                : `${BORDER_RADIUS_PILL}px 0 0 ${BORDER_RADIUS_PILL}px`}
               onClick={() => canvasRef?.current?.fitCanvas?.()}
               padding={`${UNIT * 1.5}px ${UNIT * 1.875}px ${UNIT * 1.5}px ${UNIT * 3.25}px`}
             >

--- a/mage_ai/frontend/components/DependencyGraph/exportGraph.ts
+++ b/mage_ai/frontend/components/DependencyGraph/exportGraph.ts
@@ -1,0 +1,125 @@
+import { CanvasRef } from 'reaflow';
+
+import { openSaveFileDialog } from '@components/PipelineDetail/utils';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const PIXEL_RATIO = 2;
+
+type ExportGraphOptions = {
+  backgroundColor?: string;
+  canvasRef?: { current?: CanvasRef };
+  fileNamePrefix?: string;
+};
+
+// The dependency graph renders block nodes as styled-components HTML inside SVG
+// <foreignObject> elements. Those styles live in <style> tags in the document
+// head and do not exist inside an isolated, rasterized SVG, so we embed the
+// document's CSS rules into the exported SVG to keep the nodes styled.
+function collectDocumentCss(): string {
+  const parts: string[] = [];
+
+  Array.from(document.styleSheets).forEach((sheet) => {
+    let rules: CSSRuleList | null = null;
+    try {
+      rules = sheet.cssRules;
+    } catch (err) {
+      // Cross-origin stylesheets throw on cssRules access; skip them.
+      return;
+    }
+    if (!rules) {
+      return;
+    }
+    Array.from(rules).forEach((rule) => parts.push(rule.cssText));
+  });
+
+  return parts.join('\n');
+}
+
+function rasterize(
+  svgDataUrl: string,
+  width: number,
+  height: number,
+  backgroundColor?: string,
+): Promise<Blob | null> {
+  return new Promise((resolve) => {
+    const image = new Image();
+
+    image.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = width * PIXEL_RATIO;
+      canvas.height = height * PIXEL_RATIO;
+
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        resolve(null);
+        return;
+      }
+
+      ctx.scale(PIXEL_RATIO, PIXEL_RATIO);
+      if (backgroundColor) {
+        ctx.fillStyle = backgroundColor;
+        ctx.fillRect(0, 0, width, height);
+      }
+      ctx.drawImage(image, 0, 0, width, height);
+
+      canvas.toBlob((blob) => resolve(blob), 'image/png');
+    };
+    image.onerror = () => resolve(null);
+    image.src = svgDataUrl;
+  });
+}
+
+export async function exportGraphAsImage({
+  backgroundColor,
+  canvasRef,
+  fileNamePrefix,
+}: ExportGraphOptions): Promise<void> {
+  const svg = canvasRef?.current?.svgRef?.current as SVGSVGElement | undefined;
+  const layout = canvasRef?.current?.layout as
+    | { height?: number; width?: number; x?: number; y?: number }
+    | undefined;
+
+  const width = Math.ceil(layout?.width || 0);
+  const height = Math.ceil(layout?.height || 0);
+
+  if (!svg || width <= 0 || height <= 0) {
+    return;
+  }
+
+  try {
+    // Operate on a clone so the live graph is never mutated (no flicker, no
+    // restore needed).
+    const clone = svg.cloneNode(true) as SVGSVGElement;
+    clone.setAttribute('xmlns', SVG_NS);
+    clone.setAttribute('width', String(width));
+    clone.setAttribute('height', String(height));
+    clone.setAttribute('viewBox', `0 0 ${width} ${height}`);
+
+    // Neutralize reaflow's pan/zoom (framer-motion transform on the inner <g>)
+    // so the export is the full tree at 1:1. Account for a non-zero ELK origin.
+    const group = clone.querySelector('g');
+    if (group) {
+      const offsetX = -(layout?.x || 0);
+      const offsetY = -(layout?.y || 0);
+      group.removeAttribute('transform');
+      group.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(1)`;
+    }
+
+    const styleEl = document.createElementNS(SVG_NS, 'style');
+    styleEl.textContent = collectDocumentCss();
+    clone.insertBefore(styleEl, clone.firstChild);
+
+    const xml = new XMLSerializer().serializeToString(clone);
+    const svgDataUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(xml)}`;
+
+    const blob = await rasterize(svgDataUrl, width, height, backgroundColor);
+    if (blob) {
+      openSaveFileDialog(blob, `${fileNamePrefix || 'pipeline'}_dependency_graph.png`);
+    }
+  } catch (error) {
+    // Matches existing client-side download helpers: no error UI. The live DOM
+    // is never touched, so a failed capture is non-destructive.
+    // eslint-disable-next-line no-console
+    console.error('Failed to export dependency graph image:', error);
+  }
+}

--- a/mage_ai/frontend/components/DependencyGraph/index.tsx
+++ b/mage_ai/frontend/components/DependencyGraph/index.tsx
@@ -42,6 +42,7 @@ import {
   SideEnum,
   ZOOMABLE_CANVAS_SIZE,
 } from './constants';
+import dark from '@oracle/styles/themes/dark';
 import { GraphContainerStyle, STROKE_WIDTH, inverseColorsMapping } from './index.style';
 import { RunStatus } from '@interfaces/BlockRunType';
 import { ThemeType } from '@oracle/styles/themes/constants';
@@ -219,10 +220,12 @@ export type DependencyGraphProps = {
   ) => void;
   treeRef?: { current?: CanvasRef };
   zoomable?: boolean;
+  allowGraphImageDownload?: boolean;
 } & SetEditingBlockType;
 
 function DependencyGraph({
   addNewBlockAtIndex,
+  allowGraphImageDownload,
   blockRefs,
   blockStatus,
   blocksOverride,
@@ -1770,8 +1773,11 @@ function DependencyGraph({
         onDoubleClick={() => canvasRef?.current?.fitCanvas?.()}
       >
         <ZoomControls
+          allowDownload={allowGraphImageDownload}
+          backgroundColor={(themeContext?.background || dark.background).panel}
           canvasRef={canvasRef}
           containerRef={containerRef}
+          fileNamePrefix={pipeline?.uuid}
           zoomLevel={zoomLevel}
         />
         <Canvas

--- a/mage_ai/frontend/components/Sidekick/index.tsx
+++ b/mage_ai/frontend/components/Sidekick/index.tsx
@@ -601,6 +601,7 @@ function Sidekick({
             <>
               <DependencyGraph
                 addNewBlockAtIndex={addNewBlockAtIndex}
+                allowGraphImageDownload
                 blockRefs={blockRefs}
                 blocks={blocks}
                 contentByBlockUUID={contentByBlockUUID}


### PR DESCRIPTION
# Description

Add a Download button to the dependency graph's bottom toolbox in the pipeline
editor. Clicking it exports the entire dependency tree as a 2x-resolution PNG
matching the current theme.

The graph is rendered by reaflow as an SVG whose block nodes are
styled-components HTML inside `<foreignObject>`. To capture it faithfully:
clone the live SVG, embed the document's CSS rules so the foreignObject nodes
keep their styling, resize to the tree's layout bounds and neutralize the
pan/zoom transform (full tree at 1:1), then rasterize onto a 2x canvas and
download. **No new dependencies.**

Gated behind an `allowGraphImageDownload` prop so only the pipeline editor shows
the button.

**Known limitation:** web fonts referenced by an external URL don't load inside
the isolated SVG image, so node text may fall back to a defau
readable, layout preserved).

Closes #6033

# How Has This Been Tested?

Manual testing in the pipeline editor (`/pipelines/<uuid>/edit`), dependency
graph view. The frontend has no unit-test framework (only Pla
this UI/canvas export feature was verified manually:

- [x] Clicking the new Download button in the graph's bottom toolbox saves
      `<pipeline_uuid>_dependency_graph.png`.
- [x] The exported PNG contains the **entire** tree (including all block nodes)
      even when the on-screen graph is zoomed in / scrolled t
- [x] Block nodes render with their styling (not just edges); image is 2x /
      high-resolution.
- [x] Background matches the current theme (verified in both dark and light).
- [x] The button only appears in the pipeline editor, not in
      (e.g. pipeline run detail).

# Checklist
- [x] The PR is tagged with proper labels (bug, enhancement,
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

cc:
<!-- Optionally mention someone to let them know about this pull request -->
