### PR TITLE
Fix Titanic example output path

### DIFF
--- a/mage_ai/data_preparation/templates/repo/data_exporters/export_titanic_clean.py
+++ b/mage_ai/data_preparation/templates/repo/data_exporters/export_titanic_clean.py
@@ -6,16 +6,12 @@ if 'data_exporter' not in globals():
     from mage_ai.data_preparation.decorators import data_exporter
 
 
-def project_root() -> Path:
-    return Path(__file__).resolve().parents[1]
-
-
 @data_exporter
 def export_data_to_file(df: DataFrame, **kwargs) -> None:
     """
     Save the cleaned Titanic dataset inside the Mage project folder.
     """
-    output_dir = project_root() / 'data' / 'processed' / 'titanic'
+    output_dir = Path(kwargs['repo_path']) / 'data' / 'processed' / 'titanic'
     output_dir.mkdir(parents=True, exist_ok=True)
 
     df.to_csv(output_dir / 'titanic_clean.csv', index=False)

--- a/mage_ai/data_preparation/templates/repo/data_exporters/export_titanic_clean.py
+++ b/mage_ai/data_preparation/templates/repo/data_exporters/export_titanic_clean.py
@@ -1,16 +1,21 @@
-from mage_ai.io.file import FileIO
+from pathlib import Path
+
 from pandas import DataFrame
 
 if 'data_exporter' not in globals():
     from mage_ai.data_preparation.decorators import data_exporter
 
 
+def project_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
 @data_exporter
 def export_data_to_file(df: DataFrame, **kwargs) -> None:
     """
-    Template for exporting data to filesystem.
-
-    Docs: https://docs.mage.ai/design/data-loading#example-loading-data-from-a-file
+    Save the cleaned Titanic dataset inside the Mage project folder.
     """
-    filepath = 'titanic_clean.csv'
-    FileIO().export(df, filepath)
+    output_dir = project_root() / 'data' / 'processed' / 'titanic'
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    df.to_csv(output_dir / 'titanic_clean.csv', index=False)


### PR DESCRIPTION
## Summary

Fixes #6137.

Updates the built-in Titanic example pipeline exporter so the generated cleaned CSV is written inside the generated Mage project folder instead of the process working directory.

The output now goes to:

```
data/processed/titanic/titanic_clean.csv
```

## Why

The previous template used a bare relative path, `titanic_clean.csv`, which can place tutorial output at the root of the Mage application checkout when Mage is started from that directory. Keeping the output under the project data folder is less surprising and matches the pattern used by project-level dataset outputs.

## Validation

- `.venv/bin/python -m py_compile mage_ai/data_preparation/templates/repo/data_exporters/export_titanic_clean.py`