### PR TITLE
fix Azure Blob overwrite exports

### DIFF
--- a/mage_ai/io/azure_blob_storage.py
+++ b/mage_ai/io/azure_blob_storage.py
@@ -92,6 +92,15 @@ class AzureBlobStorage(BaseFile):
         """
 
         upload_kwargs = kwargs.pop('upload_kwargs', None)
+        if not isinstance(upload_kwargs, dict):
+            upload_kwargs = {}
+        else:
+            upload_kwargs = upload_kwargs.copy()
+
+        overwrite = kwargs.pop('overwrite', None)
+        if overwrite is not None:
+            upload_kwargs['overwrite'] = overwrite
+
         if format is None:
             format = self._get_file_format(blob_path)
 
@@ -105,7 +114,7 @@ class AzureBlobStorage(BaseFile):
             buffer = BytesIO()
             self._write(df, format, buffer, **kwargs)
             buffer.seek(0)
-            if upload_kwargs and isinstance(upload_kwargs, dict):
+            if upload_kwargs:
                 blob_client.upload_blob(buffer.read(), **upload_kwargs)
             else:
                 blob_client.upload_blob(buffer.read())

--- a/mage_ai/tests/io/test_azure_blob_storage.py
+++ b/mage_ai/tests/io/test_azure_blob_storage.py
@@ -1,0 +1,63 @@
+from unittest import mock
+
+from pandas import DataFrame
+
+from mage_ai.io.azure_blob_storage import AzureBlobStorage
+from mage_ai.tests.base_test import TestCase
+
+
+class AzureBlobStorageTests(TestCase):
+    @mock.patch('mage_ai.io.azure_blob_storage.DefaultAzureCredential')
+    @mock.patch('mage_ai.io.azure_blob_storage.BlobServiceClient')
+    def test_export_forwards_top_level_overwrite_to_blob_upload(
+        self,
+        mock_blob_service_client,
+        _mock_default_credential,
+    ):
+        blob_client = mock.Mock()
+        mock_blob_service_client.return_value.get_blob_client.return_value = blob_client
+
+        storage = AzureBlobStorage(storage_account_name='test-storage-account')
+        storage.export(
+            DataFrame({'value': [1]}),
+            'test-container',
+            'CSV/vehicles.csv',
+            overwrite=True,
+            index=False,
+        )
+
+        blob_client.upload_blob.assert_called_once()
+        data, = blob_client.upload_blob.call_args.args
+        self.assertEqual(b'value\n1\n', data)
+        self.assertEqual({'overwrite': True}, blob_client.upload_blob.call_args.kwargs)
+
+    @mock.patch('mage_ai.io.azure_blob_storage.DefaultAzureCredential')
+    @mock.patch('mage_ai.io.azure_blob_storage.BlobServiceClient')
+    def test_export_merges_overwrite_with_upload_kwargs(
+        self,
+        mock_blob_service_client,
+        _mock_default_credential,
+    ):
+        blob_client = mock.Mock()
+        mock_blob_service_client.return_value.get_blob_client.return_value = blob_client
+
+        storage = AzureBlobStorage(storage_account_name='test-storage-account')
+        upload_kwargs = {'content_settings': mock.sentinel.content_settings}
+
+        storage.export(
+            DataFrame({'value': [1]}),
+            'test-container',
+            'CSV/vehicles.csv',
+            upload_kwargs=upload_kwargs,
+            overwrite=True,
+            index=False,
+        )
+
+        self.assertEqual(
+            {
+                'content_settings': mock.sentinel.content_settings,
+                'overwrite': True,
+            },
+            blob_client.upload_blob.call_args.kwargs,
+        )
+        self.assertEqual({'content_settings': mock.sentinel.content_settings}, upload_kwargs)


### PR DESCRIPTION
Fixes #5335

## Summary
- Forward the top-level `overwrite` option from `AzureBlobStorage.export()` into Azure's `upload_blob()` call.
- Preserve any existing `upload_kwargs` by copying them before merging upload options.
- Add focused regression coverage for overwrite propagation and upload-kwargs preservation.

## Evidence
- `PYTHONPATH=$PWD .venv/bin/python -m pytest mage_ai/tests/io/test_azure_blob_storage.py -q`
  - `2 passed, 1 warning in 1.42s`
