### PR TITLE
fix archive file downloads

### DIFF
--- a/mage_ai/server/api/downloads.py
+++ b/mage_ai/server/api/downloads.py
@@ -15,6 +15,25 @@ from mage_ai.settings import JWT_DOWNLOAD_SECRET, REQUIRE_USER_AUTHENTICATION
 from mage_ai.settings.repo import get_repo_path
 
 
+BINARY_DOWNLOAD_FILE_EXTENSIONS = (
+    '.7z',
+    '.rar',
+    '.tar',
+    '.tar.bz2',
+    '.tar.gz',
+    '.tar.xz',
+    '.tbz2',
+    '.tgz',
+    '.txz',
+    '.xlsx',
+    '.zip',
+)
+
+
+def should_open_download_in_binary_mode(file_path):
+    return file_path.lower().endswith(BINARY_DOWNLOAD_FILE_EXTENSIONS)
+
+
 class ApiDownloadHandler(BaseHandler):
     async def get(self, pipeline_uuid, block_uuid, **kwargs):
         self.set_header('Content-Type', 'text/csv')
@@ -118,8 +137,8 @@ class ApiResourceDownloadHandler(BaseHandler):
     # file pointer points to either a singular file or a temporary zip
     def get_file_pointer(self, file_list, relative_file_list):
         if len(file_list) == 1:
-            if file_list[0].endswith('.xlsx'):  # Check if it's an XLSX file
-                return open(file_list[0], 'rb')  # Open in binary mode for XLSX
+            if should_open_download_in_binary_mode(file_list[0]):
+                return open(file_list[0], 'rb')
             else:
                 return open(file_list[0])
         return self.zip_files(file_list, relative_file_list)

--- a/mage_ai/tests/server/test_downloads.py
+++ b/mage_ai/tests/server/test_downloads.py
@@ -1,0 +1,29 @@
+import os
+import tempfile
+from unittest import TestCase
+
+from mage_ai.server.api.downloads import ApiResourceDownloadHandler
+
+
+class ApiResourceDownloadHandlerTests(TestCase):
+
+    def assert_single_file_download_opens_as_binary(self, filename):
+        content = b'\xff\xfearchive-data'
+        handler = ApiResourceDownloadHandler.__new__(ApiResourceDownloadHandler)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_path = os.path.join(tmp_dir, filename)
+            with open(file_path, 'wb') as file:
+                file.write(content)
+
+            file_pointer = handler.get_file_pointer([file_path], [filename])
+            try:
+                self.assertEqual(content, file_pointer.read())
+            finally:
+                file_pointer.close()
+
+    def test_get_file_pointer_opens_zip_as_binary(self):
+        self.assert_single_file_download_opens_as_binary('archive.zip')
+
+    def test_get_file_pointer_opens_tar_gz_as_binary(self):
+        self.assert_single_file_download_opens_as_binary('archive.tar.gz')


### PR DESCRIPTION
Fixes #5682

## Summary
- Detect archive and binary extensions before serving single-file downloads.
- Open archive downloads such as `.zip` and `.tar.gz` in binary mode so the response is not corrupted.
- Add focused regression coverage for archive downloads.

## Evidence
- `PYTHONPATH=$PWD .venv/bin/python -m pytest mage_ai/tests/server/test_downloads.py -q`
  - `2 passed, 2 warnings in 3.74s`
