### PR TITLE
support array JSON bodies for API triggers

### DIFF
--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -1542,7 +1542,7 @@ class PipelineRun(PipelineRunProjectPlatformMixin, BaseModel):
             extra_variables = dict()
 
         pipeline_run_variables = self.variables or {}
-        event_variables = self.event_variables or {}
+        event_variables = self.event_variables if self.event_variables is not None else {}
 
         variables = merge_dict(
             merge_dict(
@@ -1552,17 +1552,26 @@ class PipelineRun(PipelineRunProjectPlatformMixin, BaseModel):
             pipeline_run_variables,
         )
 
-        # For backwards compatibility
-        for k, v in event_variables.items():
-            if k not in variables:
-                variables[k] = v
+        # For backwards compatibility, object event payloads are also exposed as top-level
+        # variables. Non-object payloads remain available through the event variable below.
+        if isinstance(event_variables, dict):
+            for k, v in event_variables.items():
+                if k not in variables:
+                    variables[k] = v
 
         if self.execution_date:
             variables['ds'] = self.execution_date.strftime('%Y-%m-%d')
             variables['hr'] = self.execution_date.strftime('%H')
 
         variables['env'] = ENV_PROD
-        variables['event'] = merge_dict(variables.get('event', {}), event_variables)
+        if isinstance(event_variables, dict):
+            event = variables.get('event', {})
+            variables['event'] = merge_dict(
+                event if isinstance(event, dict) else {},
+                event_variables,
+            )
+        else:
+            variables['event'] = event_variables
         variables['execution_date'] = self.execution_date
         variables['execution_partition'] = self.execution_partition
         variables['pipeline_run_id'] = self.id

--- a/mage_ai/orchestration/db/models/schedules_project_platform.py
+++ b/mage_ai/orchestration/db/models/schedules_project_platform.py
@@ -242,7 +242,7 @@ class PipelineRunProjectPlatformMixin:
             extra_variables = dict()
 
         pipeline_run_variables = self.variables or {}
-        event_variables = self.event_variables or {}
+        event_variables = self.event_variables if self.event_variables is not None else {}
 
         variables = merge_dict(
             merge_dict(
@@ -255,17 +255,26 @@ class PipelineRunProjectPlatformMixin:
             pipeline_run_variables,
         )
 
-        # For backwards compatibility
-        for k, v in event_variables.items():
-            if k not in variables:
-                variables[k] = v
+        # For backwards compatibility, object event payloads are also exposed as top-level
+        # variables. Non-object payloads remain available through the event variable below.
+        if isinstance(event_variables, dict):
+            for k, v in event_variables.items():
+                if k not in variables:
+                    variables[k] = v
 
         if self.execution_date:
             variables['ds'] = self.execution_date.strftime('%Y-%m-%d')
             variables['hr'] = self.execution_date.strftime('%H')
 
         variables['env'] = ENV_PROD
-        variables['event'] = merge_dict(variables.get('event', {}), event_variables)
+        if isinstance(event_variables, dict):
+            event = variables.get('event', {})
+            variables['event'] = merge_dict(
+                event if isinstance(event, dict) else {},
+                event_variables,
+            )
+        else:
+            variables['event'] = event_variables
         variables['execution_date'] = self.execution_date
         variables['execution_partition'] = self.execution_partition
 

--- a/mage_ai/server/api/triggers.py
+++ b/mage_ai/server/api/triggers.py
@@ -1,4 +1,5 @@
 import json
+from typing import Dict
 
 from mage_ai.api.errors import ApiError
 from mage_ai.data_preparation.models.pipeline import Pipeline
@@ -9,6 +10,30 @@ from mage_ai.orchestration.triggers.utils import create_and_start_pipeline_run
 from mage_ai.server.api.base import BaseHandler
 from mage_ai.server.api.errors import UnauthenticatedRequestException
 from mage_ai.shared.requests import get_bearer_auth_token_from_headers
+
+
+def build_api_trigger_payload(body: bytes) -> Dict:
+    payload = {}
+    request_payload = json.loads(body) if body else {}
+
+    if isinstance(request_payload, dict):
+        pipeline_run_payload = request_payload.get('pipeline_run') or {}
+        if isinstance(pipeline_run_payload, dict):
+            payload.update(pipeline_run_payload)
+
+        if body:
+            payload['event_variables'] = {
+                k: v
+                for k, v in request_payload.items()
+                if k != 'pipeline_run'
+            }
+    elif body:
+        payload['event_variables'] = request_payload
+
+    if 'variables' not in payload:
+        payload['variables'] = {}
+
+    return payload
 
 
 class ApiTriggerPipelineHandler(BaseHandler):
@@ -39,18 +64,7 @@ class ApiTriggerPipelineHandler(BaseHandler):
                 f'Invalid token for pipeline schedule ID {pipeline_schedule_id}.',
             )
 
-        payload = self.get_payload()
-        if 'variables' not in payload:
-            payload['variables'] = {}
-
-        body = self.request.body
-        if body:
-            payload['event_variables'] = {}
-
-            for k, v in json.loads(body).items():
-                if k == 'pipeline_run':
-                    continue
-                payload['event_variables'][k] = v
+        payload = build_api_trigger_payload(self.request.body)
 
         pipeline = Pipeline.get(
             pipeline_schedule.pipeline_uuid, repo_path=pipeline_schedule.repo_path

--- a/mage_ai/tests/server/test_api_triggers.py
+++ b/mage_ai/tests/server/test_api_triggers.py
@@ -1,0 +1,77 @@
+import json
+
+from mage_ai.data_preparation.models.triggers import ScheduleType
+from mage_ai.orchestration.db.models.schedules import PipelineRun, PipelineSchedule
+from mage_ai.orchestration.triggers.utils import create_and_start_pipeline_run
+from mage_ai.server.api.triggers import build_api_trigger_payload
+from mage_ai.tests.base_test import DBTestCase
+from mage_ai.tests.factory import create_pipeline_with_blocks
+
+
+class ApiTriggerPipelineHandlerTest(DBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.pipeline = create_pipeline_with_blocks(
+            self.faker.unique.name(),
+            self.repo_path,
+        )
+        self.pipeline_schedule = PipelineSchedule.create(
+            name=self.faker.unique.name(),
+            pipeline_uuid=self.pipeline.uuid,
+            schedule_type=ScheduleType.API,
+            token=self.faker.unique.uuid4(),
+        )
+
+    def tearDown(self):
+        PipelineRun.query.delete()
+        PipelineSchedule.query.delete()
+        self.pipeline.delete()
+        super().tearDown()
+
+    def test_array_body_creates_pipeline_run_with_event_payload(self):
+        request_body = [
+            dict(objectId=123, subscriptionType='contact.creation'),
+            dict(objectId=456, subscriptionType='contact.propertyChange'),
+        ]
+        payload = build_api_trigger_payload(json.dumps(request_body).encode())
+
+        pipeline_run = create_and_start_pipeline_run(
+            self.pipeline,
+            self.pipeline_schedule,
+            payload,
+            should_schedule=False,
+        )
+
+        self.assertEqual({}, pipeline_run.variables.get('event', {}))
+        self.assertEqual(request_body, pipeline_run.event_variables)
+        self.assertEqual(request_body, pipeline_run.get_variables()['event'])
+
+    def test_object_body_preserves_runtime_and_event_variables(self):
+        request_body = dict(
+            pipeline_run=dict(
+                variables=dict(target_env='staging'),
+            ),
+            schema='public',
+            table='contacts',
+        )
+        payload = build_api_trigger_payload(json.dumps(request_body).encode())
+
+        pipeline_run = create_and_start_pipeline_run(
+            self.pipeline,
+            self.pipeline_schedule,
+            payload,
+            should_schedule=False,
+        )
+
+        variables = pipeline_run.get_variables()
+        self.assertEqual('staging', variables['target_env'])
+        self.assertEqual('public', variables['schema'])
+        self.assertEqual('contacts', variables['table'])
+        self.assertEqual(
+            dict(schema='public', table='contacts'),
+            pipeline_run.event_variables,
+        )
+        self.assertEqual(
+            dict(schema='public', table='contacts'),
+            variables['event'],
+        )


### PR DESCRIPTION
Fixes #5414

## Summary
- Accept top-level JSON array bodies for API-triggered pipeline runs.
- Preserve the existing object-body behavior for `pipeline_run.variables` and event variables.
- Keep non-object webhook payloads available through `variables['event']`.
- Add regression coverage for array payloads and existing object payloads.

## Evidence
- `PYTHONPATH=$PWD .venv/bin/python -m pytest mage_ai/tests/server/test_api_triggers.py -q`
  - `2 passed, 25 warnings in 6.84s`
