### PR TITLE
flush Sentry after streaming worker errors

### DIFF
--- a/mage_ai/orchestration/queue/process_queue.py
+++ b/mage_ai/orchestration/queue/process_queue.py
@@ -28,6 +28,7 @@ from mage_ai.shared.enum import StrEnum
 from mage_ai.shared.logger import set_logging_format
 
 LIVENESS_TIMEOUT_SECONDS = 300
+SENTRY_FLUSH_TIMEOUT_SECONDS = 5
 
 
 class JobStatus(StrEnum):
@@ -291,7 +292,7 @@ class Worker(mp.Process):
                 server_name=SENTRY_SERVER_NAME,
             )
             import atexit
-            atexit.register(lambda: sentry_sdk.flush(timeout=5))
+            atexit.register(lambda: sentry_sdk.flush(timeout=SENTRY_FLUSH_TIMEOUT_SECONDS))
         initialize_new_relic()
 
         set_logging_format(
@@ -320,6 +321,7 @@ class Worker(mp.Process):
             except Exception as e:
                 if self.dsn:
                     capture_exception(e)
+                    sentry_sdk.flush(timeout=SENTRY_FLUSH_TIMEOUT_SECONDS)
                 raise
             finally:
                 self.job_dict[job_id] = JobStatus.COMPLETED

--- a/mage_ai/tests/orchestration/queue/test_process_queue.py
+++ b/mage_ai/tests/orchestration/queue/test_process_queue.py
@@ -1,7 +1,14 @@
+from contextlib import ExitStack
+from queue import Queue as InMemoryQueue
 from unittest.mock import patch
 
 from mage_ai.orchestration.queue.config import QueueConfig
-from mage_ai.orchestration.queue.process_queue import JobStatus, ProcessQueue
+from mage_ai.orchestration.queue.process_queue import (
+    SENTRY_FLUSH_TIMEOUT_SECONDS,
+    JobStatus,
+    ProcessQueue,
+    Worker,
+)
 from mage_ai.tests.base_test import TestCase
 
 
@@ -59,3 +66,62 @@ class ProcessQueueTests(TestCase):
         mock_pid_exists.return_value = False
         self.assertTrue(self.queue.has_job('block_run_1'))
         self.assertFalse(self.queue.has_job('block_run_2'))
+
+    def test_worker_flushes_sentry_after_capturing_exception(self):
+        (
+            mock_init,
+            mock_capture_exception,
+            mock_flush,
+            expected_error,
+        ) = self._run_worker_with_error(sentry_dsn='test-dsn')
+
+        mock_init.assert_called_once()
+        mock_capture_exception.assert_called_once_with(expected_error)
+        mock_flush.assert_called_once_with(timeout=SENTRY_FLUSH_TIMEOUT_SECONDS)
+
+    def test_worker_does_not_flush_sentry_when_not_configured(self):
+        mock_init, mock_capture_exception, mock_flush, _ = self._run_worker_with_error()
+
+        mock_init.assert_not_called()
+        mock_capture_exception.assert_not_called()
+        mock_flush.assert_not_called()
+
+    def _run_worker_with_error(self, sentry_dsn=None):
+        expected_error = RuntimeError('test worker error')
+        queue = InMemoryQueue()
+        job_dict = dict(block_run_1=JobStatus.QUEUED)
+        queue.put(['block_run_1', run_block, tuple(), dict()])
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch('mage_ai.orchestration.queue.process_queue.SENTRY_DSN', sentry_dsn),
+            )
+            mock_init = stack.enter_context(
+                patch('mage_ai.orchestration.queue.process_queue.sentry_sdk.init'),
+            )
+            stack.enter_context(patch('atexit.register'))
+            stack.enter_context(
+                patch('mage_ai.orchestration.queue.process_queue.initialize_new_relic'),
+            )
+            stack.enter_context(
+                patch('mage_ai.orchestration.queue.process_queue.set_logging_format'),
+            )
+            stack.enter_context(
+                patch(
+                    'mage_ai.orchestration.queue.process_queue.start_session_and_run',
+                    side_effect=expected_error,
+                ),
+            )
+            mock_capture_exception = stack.enter_context(
+                patch('mage_ai.orchestration.queue.process_queue.capture_exception'),
+            )
+            mock_flush = stack.enter_context(
+                patch('mage_ai.orchestration.queue.process_queue.sentry_sdk.flush'),
+            )
+
+            worker = Worker(queue, job_dict)
+
+            with self.assertRaises(RuntimeError):
+                worker.run()
+
+        return mock_init, mock_capture_exception, mock_flush, expected_error


### PR DESCRIPTION
Fixes #5666

## Summary
- Flush Sentry immediately after capturing streaming worker exceptions so short-lived worker processes have a chance to send the event.
- Share the existing Sentry shutdown timeout value between the atexit handler and the streaming-worker exception path.
- Add regression coverage for both configured and unconfigured Sentry clients.

## Evidence
- `PYTHONPATH=$PWD .venv/bin/python -m pytest mage_ai/tests/orchestration/queue/test_process_queue.py -q`
  - `5 passed, 1 warning in 2.37s`
