### PR TITLE
reject active time triggers with empty cron

### DIFF
--- a/mage_ai/orchestration/db/models/schedules.py
+++ b/mage_ai/orchestration/db/models/schedules.py
@@ -246,6 +246,50 @@ class PipelineSchedule(PipelineScheduleProjectPlatformMixin, BaseModel):
 
         return schedule_interval
 
+    def full_clean(self, **kwargs) -> None:
+        self.validate_active_time_schedule_interval()
+
+    def validate_active_time_schedule_interval(self) -> None:
+        if (
+            self.status != ScheduleStatus.ACTIVE
+            or self.schedule_type != ScheduleType.TIME
+            or self.schedule_interval is None
+        ):
+            return
+
+        if (
+            isinstance(self.schedule_interval, str)
+            and len(self.schedule_interval.strip()) == 0
+        ):
+            raise ValueError('Cron expression cannot be empty.')
+
+        if (
+            self.schedule_interval not in [e.value for e in ScheduleInterval]
+            and not croniter.is_valid(self.schedule_interval)
+        ):
+            raise ValueError('Cron expression is invalid.')
+
+    def save(self, commit=True) -> None:
+        try:
+            self.full_clean()
+            super().save(commit=commit)
+        except Exception as e:
+            if commit:
+                self.session.rollback()
+            raise e
+
+    def update(self, **kwargs) -> None:
+        commit = kwargs.pop('commit', True)
+        super().update(commit=False, **kwargs)
+        try:
+            self.full_clean()
+            if commit:
+                self.session.commit()
+        except Exception as e:
+            if commit:
+                self.session.rollback()
+            raise e
+
     @property
     def last_pipeline_run_status(self) -> str:
         if project_platform_activated():
@@ -400,8 +444,12 @@ class PipelineSchedule(PipelineScheduleProjectPlatformMixin, BaseModel):
                     kwargs['token'] = uuid.uuid4().hex
                 triggers_to_create.append(kwargs)
 
+        triggers = [PipelineSchedule(**data) for data in triggers_to_create]
+        for trigger in triggers:
+            trigger.full_clean()
+
         db_connection.session.bulk_save_objects(
-            [PipelineSchedule(**data) for data in triggers_to_create],
+            triggers,
             return_defaults=True,
         )
         db_connection.session.commit()

--- a/mage_ai/tests/api/operations/test_pipeline_schedules.py
+++ b/mage_ai/tests/api/operations/test_pipeline_schedules.py
@@ -47,6 +47,26 @@ class PipelineScheduleOperationTests(BaseApiTestCase):
         self.assertEqual(response['pipeline_schedule']['name'], 'test_schedule')
         self.assertEqual(response['pipeline_schedule']['repo_path'], get_repo_path())
 
+    async def test_execute_create_active_schedule_requires_cron_interval(self):
+        email = self.faker.email()
+        user = create_user(email=email, roles=1)
+        operation = self.build_create_operation(
+            dict(
+                name='test_schedule_empty_cron',
+                schedule_interval='',
+                schedule_type=ScheduleType.TIME,
+                status=ScheduleStatus.ACTIVE,
+                variables=[],
+            ),
+            resource_parent='pipeline',
+            resource_parent_id=self.pipeline.uuid,
+            user=user,
+        )
+
+        with self.assertRaises(ValueError) as context:
+            await operation.execute()
+        self.assertTrue('Cron expression cannot be empty.' in str(context.exception))
+
     async def test_execute_update_schedule_saved_in_code(self):
         email = self.faker.email()
         user = create_user(email=email, roles=1)
@@ -108,6 +128,30 @@ class PipelineScheduleOperationTests(BaseApiTestCase):
             updated_trigger_configs_by_name['test_schedule_2']['status'],
             ScheduleStatus.ACTIVE,
         )
+
+    async def test_execute_update_active_schedule_requires_cron_interval(self):
+        email = self.faker.email()
+        user = create_user(email=email, roles=1)
+        pipeline_schedule = PipelineSchedule.create(
+            name='test_schedule_update_empty_cron',
+            pipeline_uuid='test_pipeline',
+            schedule_interval='',
+            schedule_type=ScheduleType.TIME,
+            status=ScheduleStatus.INACTIVE,
+        )
+        operation = self.build_update_operation(
+            pipeline_schedule.id,
+            {
+                'pipeline_schedule': dict(
+                    status=ScheduleStatus.ACTIVE,
+                ),
+            },
+            user=user,
+        )
+
+        with self.assertRaises(ValueError) as context:
+            await operation.execute()
+        self.assertTrue('Cron expression cannot be empty.' in str(context.exception))
 
     async def test_execute_list(self):
         email = self.faker.email()

--- a/mage_ai/tests/orchestration/db/models/test_schedules.py
+++ b/mage_ai/tests/orchestration/db/models/test_schedules.py
@@ -15,6 +15,7 @@ from mage_ai.data_preparation.models.triggers import (
     Trigger,
 )
 from mage_ai.data_preparation.repo_manager import get_repo_config
+from mage_ai.orchestration.db import db_connection
 from mage_ai.orchestration.db.models.schedules import (
     BlockRun,
     PipelineRun,
@@ -189,6 +190,43 @@ class PipelineScheduleTests(DBTestCase):
                 schedule_interval='random_str',
             )
         self.assertTrue('Cron expression is invalid.' in str(context.exception))
+
+        PipelineSchedule.create(
+            name=self.faker.name(),
+            pipeline_uuid='test_pipeline',
+            schedule_interval='',
+            schedule_type=ScheduleType.TIME,
+            status=ScheduleStatus.INACTIVE,
+        )
+        PipelineSchedule.create(
+            name=self.faker.name(),
+            pipeline_uuid='test_pipeline',
+            schedule_interval='',
+            schedule_type=ScheduleType.API,
+            status=ScheduleStatus.ACTIVE,
+        )
+
+        with self.assertRaises(ValueError) as context:
+            PipelineSchedule.create(
+                name=self.faker.name(),
+                pipeline_uuid='test_pipeline',
+                schedule_interval='',
+                schedule_type=ScheduleType.TIME,
+                status=ScheduleStatus.ACTIVE,
+            )
+        self.assertTrue('Cron expression cannot be empty.' in str(context.exception))
+
+        pipeline_schedule = PipelineSchedule.create(
+            name=self.faker.name(),
+            pipeline_uuid='test_pipeline',
+            schedule_interval='',
+            schedule_type=ScheduleType.TIME,
+            status=ScheduleStatus.INACTIVE,
+        )
+        with self.assertRaises(ValueError) as context:
+            pipeline_schedule.update(status=ScheduleStatus.ACTIVE)
+        self.assertTrue('Cron expression cannot be empty.' in str(context.exception))
+        db_connection.session.rollback()
 
     def test_active_schedules(self):
         create_pipeline_with_blocks(


### PR DESCRIPTION
## Summary
- Add model-level validation that prevents active time triggers from being saved with blank or invalid cron expressions.
- Apply the validation through create, update, save, and bulk trigger creation paths.
- Add regression coverage for direct model usage and pipeline schedule API operations.

Closes #5769

## Evidence
Backend trigger validation change; screenshot is not useful here. Model-level schedule validation tests pass from this branch:

```text
$ ENV=test_mage PYTHONPATH=$PWD .venv/bin/python -m pytest mage_ai/tests/orchestration/db/models/test_schedules.py::PipelineScheduleTests -q
...................                                                      [100%]
19 passed, 41 warnings in 10.31s
```

Attempted API operation tests as well, but this local environment failed before reaching the assertions because SQLite opened the test database read-only while creating users:

```text
$ ENV=test_mage PYTHONPATH=$PWD .venv/bin/python -m pytest mage_ai/tests/api/operations/test_pipeline_schedules.py -q
sqlite3.OperationalError: attempt to write a readonly database
```
