### PR TITLE
preserve empty DataFrame columns in parquet variables

### DIFF
--- a/mage_ai/data/tabular/writer.py
+++ b/mage_ai/data/tabular/writer.py
@@ -1,6 +1,8 @@
 import asyncio
 import glob
 import json
+import os
+from functools import partial
 from typing import Dict, List, Optional, Union
 
 import pandas as pd
@@ -101,14 +103,12 @@ def to_parquet_sync(
         partition_cols=partition_cols,
         settings=settings,
     ):
-        pq.write_to_dataset(
+        __write_to_dataset(
             table,
             basename_template=basename_template,
-            compression='snappy',
             existing_data_behavior=existing_data_behavior,
             partition_cols=partition_columns,
             root_path=output_dir,
-            use_dictionary=True,
         )
         total_rows += table.num_rows
         total_columns = max(len(table.schema.names), total_columns)
@@ -165,7 +165,25 @@ async def __write_to_dataset_async(
     loop = asyncio.get_event_loop()
     return await loop.run_in_executor(
         None,
-        pq.write_to_dataset,
+        partial(
+            __write_to_dataset,
+            table,
+            basename_template=basename_template,
+            existing_data_behavior=existing_data_behavior,
+            partition_cols=partition_cols,
+            root_path=root_path,
+        ),
+    )
+
+
+def __write_to_dataset(
+    table: pa.Table,
+    root_path: str,
+    basename_template: Optional[str] = None,
+    existing_data_behavior: Optional[str] = None,
+    partition_cols: Optional[List[str]] = None,
+):
+    pq.write_to_dataset(
         table,
         basename_template=basename_template,
         compression='snappy',
@@ -174,6 +192,30 @@ async def __write_to_dataset_async(
         root_path=root_path,
         use_dictionary=True,
     )
+    __write_empty_table_if_needed(table, root_path, basename_template)
+
+
+def __write_empty_table_if_needed(
+    table: pa.Table,
+    root_path: str,
+    basename_template: Optional[str] = None,
+) -> None:
+    if table.num_rows != 0:
+        return
+
+    if glob.glob(os.path.join(root_path, '**', '*.parquet'), recursive=True):
+        return
+
+    filename = '0-empty.parquet'
+    if basename_template:
+        try:
+            filename = basename_template.format(i=0)
+        except (IndexError, KeyError, ValueError):
+            pass
+
+    file_path = os.path.join(root_path, filename)
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    pq.write_table(table, file_path, compression='snappy', use_dictionary=True)
 
 
 def __prepare_data(

--- a/mage_ai/tests/data_preparation/models/test_variable.py
+++ b/mage_ai/tests/data_preparation/models/test_variable.py
@@ -16,6 +16,7 @@ from mage_ai.data_preparation.models.variables.constants import (
     VariableAggregateDataTypeFilename,
     VariableType,
 )
+from mage_ai.data_preparation.variable_manager import VariableManager
 from mage_ai.tests.base_test import DBTestCase
 from mage_ai.tests.factory import create_pipeline
 from mage_ai.tests.test_shared import (
@@ -102,6 +103,27 @@ class VariableTest(DBTestCase):
                 assert_frame_equal(variable1.read_data(sample=True, sample_count=1), df1.iloc[:1])
                 assert_frame_equal(variable2.read_data(), df2)
                 assert_frame_equal(variable2.read_data(sample=True, sample_count=1), df2.iloc[:1])
+
+    def test_write_and_read_empty_dataframe_with_columns_memory_manager_v2(self):
+        with patch.multiple(
+            'mage_ai.settings.server',
+            MEMORY_MANAGER_PANDAS_V2=True,
+            MEMORY_MANAGER_V2=True,
+        ):
+            variable_manager = VariableManager(variables_dir=self.repo_path)
+            df = pd.DataFrame(columns=['date', 'name', 'value'])
+
+            variable_manager.add_variable(
+                self.pipeline.uuid,
+                'transformer',
+                'output_0',
+                df,
+            )
+
+            assert_frame_equal(
+                variable_manager.get_variable(self.pipeline.uuid, 'transformer', 'output_0'),
+                df,
+            )
 
     def test_write_and_read_dataframe_analysis(self):
         pipeline = self.__create_pipeline('test pipeline 3')


### PR DESCRIPTION
## Summary
- Materialize an empty parquet file when a zero-row Arrow table has a schema but no dataset files are written.
- Preserve empty pandas DataFrame columns through memory manager v2 variable writes and reads.
- Add a regression test for empty DataFrames with defined headers.

Closes #5589

## Evidence
Storage/parquet behavior change; screenshot is not useful here. Focused variable regression tests pass from this branch:

```text
$ ENV=test_mage PYTHONPATH=$PWD .venv/bin/python -m pytest mage_ai/tests/data_preparation/models/test_variable.py::VariableTest::test_write_and_read_dataframe mage_ai/tests/data_preparation/models/test_variable.py::VariableTest::test_write_and_read_empty_dataframe_with_columns_memory_manager_v2 -q
..                                                                       [100%]
2 passed, 55 warnings in 4.71s
```
