### PR TITLE
skip dynamic child creation for empty parent output

### DIFF
--- a/mage_ai/data_preparation/models/block/dynamic/child.py
+++ b/mage_ai/data_preparation/models/block/dynamic/child.py
@@ -80,6 +80,8 @@ class DynamicChildController(DynamicBlockWrapperBase):
                             count = len(values.index)
                         else:
                             count = len(values)
+                        if count == 0:
+                            break
 
                     if count == 0:
                         time.sleep(10)

--- a/mage_ai/data_preparation/models/block/dynamic/counter.py
+++ b/mage_ai/data_preparation/models/block/dynamic/counter.py
@@ -99,6 +99,9 @@ class DynamicItemCounter:
     def item_count(self, downstream_block: Optional[Any] = None) -> int:
         return 0
 
+    def output_exists(self) -> bool:
+        return self.variable.data_exists()
+
 
 class DynamicBlockItemCounter(DynamicItemCounter):
     @property

--- a/mage_ai/data_preparation/models/block/dynamic/factory.py
+++ b/mage_ai/data_preparation/models/block/dynamic/factory.py
@@ -259,6 +259,10 @@ class DynamicBlockFactory(DynamicBlockWrapperBase):
                 )
 
                 if completed_count == spawn_count:
+                    counter = self.__counters.get(upstream_uuid)
+                    if counter is not None and counter.output_exists():
+                        return output_item_count
+
                     return 1
 
             # If no upstream block has been spawned and the upstream block runs are completed,
@@ -266,6 +270,10 @@ class DynamicBlockFactory(DynamicBlockWrapperBase):
             if spawn_count == 0:
                 upstream_block_runs = self.__upstream_block_runs()
                 if all(b.status == BlockRun.BlockRunStatus.COMPLETED for b in upstream_block_runs):
+                    counter = self.__counters.get(upstream_uuid)
+                    if counter is not None and counter.output_exists():
+                        return output_item_count
+
                     return 1
 
             return output_item_count

--- a/mage_ai/data_preparation/models/block/dynamic/utils.py
+++ b/mage_ai/data_preparation/models/block/dynamic/utils.py
@@ -599,7 +599,9 @@ def build_combinations_for_dynamic_child(
                 if arr is not None:
                     if not is_basic_iterable(arr) and not is_dataframe_or_series(arr):
                         arr = [0]
-            if arr is not None and hasattr(arr, '__len__') and len(arr) > 0:
+            if arr is None:
+                dynamic_counts.append([0])
+            elif hasattr(arr, '__len__'):
                 dynamic_counts.append([idx for idx in range(len(arr))])
             else:
                 dynamic_counts.append([0])

--- a/mage_ai/tests/data_preparation/executors/test_block_executor.py
+++ b/mage_ai/tests/data_preparation/executors/test_block_executor.py
@@ -469,6 +469,65 @@ class BlockExecutorTest(BaseApiTestCase):
                 verify_output=True,
             )
 
+    def test_dynamic_child_controller_skips_empty_dynamic_parent_output(self):
+        pipeline, blocks = create_pipeline_with_blocks(
+            'dynamic_child_empty_output',
+            self.repo_path,
+            return_blocks=True,
+        )
+
+        block1 = blocks[0]
+        block1.configuration = dict(dynamic=True)
+        block1.update_content(block1.get_typed_content("""
+def load_data(*args, **kwargs):
+    return [
+        [],
+        [],
+    ]
+""".strip()))
+
+        block2 = blocks[1]
+
+        pipeline_run = PipelineRun.create(
+            execution_date=datetime.utcnow(),
+            pipeline_schedule_id=0,
+            pipeline_uuid=pipeline.uuid,
+        )
+        BlockRun.create(
+            block_uuid=block1.uuid,
+            pipeline_run_id=pipeline_run.id,
+            status=BlockRun.BlockRunStatus.COMPLETED,
+        )
+        block_run = BlockRun.create(
+            block_uuid=block2.uuid,
+            pipeline_run_id=pipeline_run.id,
+        )
+
+        block1.execute_sync(execution_partition=pipeline_run.execution_partition)
+
+        executor = BlockExecutor(
+            pipeline,
+            block_run.block_uuid,
+            block_run_id=block_run.id,
+            execution_partition=pipeline_run.execution_partition,
+        )
+
+        self.assertEqual(executor.block.__class__, DynamicChildController)
+        self.assertEqual(
+            [],
+            executor.block.execute_sync(execution_partition=pipeline_run.execution_partition),
+        )
+        self.assertEqual(
+            [],
+            [
+                block_run.block_uuid
+                for block_run in BlockRun.query.filter(
+                    BlockRun.pipeline_run_id == pipeline_run.id,
+                ).all()
+                if block_run.block_uuid.startswith(f'{block2.uuid}:')
+            ],
+        )
+
     def test_block_run_for_dynamic_child_block_reduce_output(self):
         block1 = self.blocks[0]
         block2 = self.blocks[1]

--- a/mage_ai/tests/data_preparation/models/block/dynamic/test_combos.py
+++ b/mage_ai/tests/data_preparation/models/block/dynamic/test_combos.py
@@ -28,6 +28,13 @@ def load_data2(*args, **kwargs):
     ]
 
 
+def load_empty_data(*args, **kwargs):
+    return [
+        [],
+        [],
+    ]
+
+
 def transform_multiple(data1, data2, *args, **kwargs):
     return [data1, dict(upstream_data=data2)]
 
@@ -286,6 +293,21 @@ class DynamicBlockCombinationTest(BaseApiTestCase):
                     sum([len(arr) for arr in dynamic_spawn_2x_outputs]),
                 )
                 self.assertEqual(len(replica_outputs), 12)
+
+    def test_empty_dynamic_parent_output_has_no_combinations(self):
+        dynamic = self.create_block(
+            name='dynamic_empty',
+            func=load_empty_data,
+            configuration=dict(dynamic=True),
+        )
+        self.pipeline.add_block(dynamic)
+
+        child = self.create_block(name='child_empty', func=transform)
+        self.pipeline.add_block(child, upstream_block_uuids=[dynamic.uuid])
+
+        dynamic.execute_sync()
+
+        self.assertEqual([], build_combinations_for_dynamic_child(child))
 
     #             # Skip this one
     #             child_1x_childspawn_1x_reduce_outputs = []


### PR DESCRIPTION
## Summary
- Track whether a dynamic parent output exists separately from its item count.
- Avoid creating/executing synthetic child block `0` when a dynamic parent produced an empty output.
- Preserve existing fallback behavior when the parent output has not been materialized yet.
- Add regression coverage for empty dynamic parent combinations and child execution.

Closes #6045

## Evidence
Backend execution behavior change; screenshot is not useful here. Focused dynamic block and block executor regression tests pass from this branch:

```text
$ PYTHONPATH=$PWD .venv/bin/python -m pytest mage_ai/tests/data_preparation/models/block/dynamic/test_combos.py mage_ai/tests/data_preparation/models/block/dynamic/test_utils.py mage_ai/tests/data_preparation/models/block/dynamic/test_variables.py mage_ai/tests/data_preparation/executors/test_block_executor.py -q
....................                                                     [100%]
20 passed, 53236 warnings in 10.05s
```
