### PR TITLE
omit cleared pipeline concurrency limits

### DIFF
--- a/mage_ai/frontend/components/PipelineDetail/Settings/index.tsx
+++ b/mage_ai/frontend/components/PipelineDetail/Settings/index.tsx
@@ -43,6 +43,29 @@ type PipelineSettingsProps = {
   updatePipeline: (pipeline: PipelineType) => void;
 };
 
+type ConcurrencyLimitKey =
+  | 'block_run_limit'
+  | 'pipeline_run_limit'
+  | 'pipeline_run_limit_all_triggers';
+
+function buildUpdatedConcurrencyConfig(
+  prev: PipelineType,
+  key: ConcurrencyLimitKey,
+  value: string,
+) {
+  const concurrencyConfig = {
+    ...prev?.concurrency_config,
+  };
+
+  if (value === '') {
+    delete concurrencyConfig[key];
+  } else {
+    concurrencyConfig[key] = Number(value);
+  }
+
+  return concurrencyConfig;
+}
+
 function PipelineSettings({
   isPipelineUpdating,
   pipeline,
@@ -260,14 +283,17 @@ function PipelineSettings({
               monospace: true,
               onChange: e => setPipelineAttributes(prev => ({
                 ...prev,
-                concurrency_config: {
-                  ...prev?.concurrency_config,
-                  pipeline_run_limit_all_triggers: Number(e.target.value),
-                },
+                concurrency_config: buildUpdatedConcurrencyConfig(
+                  prev,
+                  'pipeline_run_limit_all_triggers',
+                  e.target.value,
+                ),
               })),
               placeholder: 'e.g. 40',
               type: 'number',
-              value: String(pipelineAttributes?.concurrency_config?.pipeline_run_limit_all_triggers || ''),
+              value: String(
+                pipelineAttributes?.concurrency_config?.pipeline_run_limit_all_triggers ?? '',
+              ),
             }}
             title="Pipeline run limit across all triggers"
           />
@@ -284,14 +310,15 @@ function PipelineSettings({
               monospace: true,
               onChange: e => setPipelineAttributes(prev => ({
                 ...prev,
-                concurrency_config: {
-                  ...prev?.concurrency_config,
-                  pipeline_run_limit: Number(e.target.value),
-                },
+                concurrency_config: buildUpdatedConcurrencyConfig(
+                  prev,
+                  'pipeline_run_limit',
+                  e.target.value,
+                ),
               })),
               placeholder: 'e.g. 10',
               type: 'number',
-              value: String(pipelineAttributes?.concurrency_config?.pipeline_run_limit || ''),
+              value: String(pipelineAttributes?.concurrency_config?.pipeline_run_limit ?? ''),
             }}
             title="Pipeline run limit in 1 trigger"
           />
@@ -308,14 +335,15 @@ function PipelineSettings({
               monospace: true,
               onChange: e => setPipelineAttributes(prev => ({
                 ...prev,
-                concurrency_config: {
-                  ...prev?.concurrency_config,
-                  block_run_limit: Number(e.target.value),
-                },
+                concurrency_config: buildUpdatedConcurrencyConfig(
+                  prev,
+                  'block_run_limit',
+                  e.target.value,
+                ),
               })),
               placeholder: 'e.g. 20',
               type: 'number',
-              value: String(pipelineAttributes?.concurrency_config?.block_run_limit || ''),
+              value: String(pipelineAttributes?.concurrency_config?.block_run_limit ?? ''),
             }}
             title="Block run limit"
           />


### PR DESCRIPTION
## Summary
- Treat blank pipeline settings concurrency inputs as removed keys instead of coercing them to `0`.
- Preserve existing numeric values, including explicit zero if entered.
- Apply the same handling to pipeline, all-trigger, and block run limits.

Closes #5630

## Evidence
Pipeline settings page with cleared concurrency limit inputs. In this branch, blank input values delete the corresponding key from `concurrency_config` before the settings save payload is built:

<img src="https://github.com/BobbyWang0120/mage-ai/releases/download/pr-6149-concurrency-settings-assets/pr-6149-concurrency-settings.png" width="900" alt="Pipeline settings page showing blank pipeline concurrency limit inputs" />

Browser check on `http://localhost:3000/pipelines/example_pipeline/settings` confirmed the three concurrency number inputs are blank:

```json
{
  "values": ["", "", ""],
  "hasSection": true
}
```

Targeted lint for the changed settings component:

```text
$ yarn --cwd mage_ai/frontend lint --file components/PipelineDetail/Settings/index.tsx
Done in 4.46s.
```
