### PR TITLE
honor proxy environment variables for aiohttp sessions

### DIFF
--- a/docs/guides/tips-and-tricks.mdx
+++ b/docs/guides/tips-and-tricks.mdx
@@ -274,7 +274,7 @@ def load_data_sync(*args, **kwargs) -> Dict[str, Any]:
 
     async def fetch_data(url: str) -> Dict[str, Any]:
         # Create an aiohttp session and fetch the data
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.get(url) as response:
                 response.raise_for_status()
                 data: Dict[str, Any] = await response.json()

--- a/mage_ai/api/resources/ProjectResource.py
+++ b/mage_ai/api/resources/ProjectResource.py
@@ -32,7 +32,7 @@ from mage_ai.usage_statistics.logger import UsageStatisticLogger
 @async_ttl_cache(maxsize=1, ttl=600)
 async def get_latest_version() -> str:
     try:
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.get(
                 'https://pypi.org/pypi/mage-ai/json',
                 timeout=3,

--- a/mage_ai/authentication/providers/active_directory.py
+++ b/mage_ai/authentication/providers/active_directory.py
@@ -125,7 +125,7 @@ class ADProvider(SsoProvider, OauthProvider):
     async def get_access_token_response(self, code: str, **kwargs) -> Awaitable[Dict]:
         base_url = get_base_url(kwargs.get('redirect_uri'))
 
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.post(
                 f'{self.host}/organizations/oauth2/v2.0/token',
                 headers={
@@ -152,7 +152,7 @@ class ADProvider(SsoProvider, OauthProvider):
             raise Exception('Access token is required to fetch user info.')
 
         mage_roles = []
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.get(
                 f'{self.graph_api_host}/v1.0/me',
                 headers={

--- a/mage_ai/authentication/providers/bitbucket.py
+++ b/mage_ai/authentication/providers/bitbucket.py
@@ -61,7 +61,7 @@ class BitbucketProvider(OauthProvider):
     async def get_access_token_response(self, code: str, **kwargs) -> Awaitable[Dict]:
         base_url = get_base_url(kwargs.get('redirect_uri'))
         data = dict()
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.post(
                 f'{self.hostname}/site/oauth2/access_token',
                 headers={
@@ -82,7 +82,7 @@ class BitbucketProvider(OauthProvider):
     async def get_refresh_token_response(self, refresh_token: str) -> Awaitable[Dict]:
         data = dict()
 
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.post(
                 f'{self.hostname}/site/oauth2/access_token',
                 headers={

--- a/mage_ai/authentication/providers/ghe.py
+++ b/mage_ai/authentication/providers/ghe.py
@@ -59,7 +59,7 @@ class GHEProvider(OauthProvider):
 
     async def get_access_token_response(self, code: str, **kwargs) -> Awaitable[Dict]:
         data = dict()
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.post(
                 f'{self.hostname}/login/oauth/access_token',
                 headers={

--- a/mage_ai/authentication/providers/gitlab.py
+++ b/mage_ai/authentication/providers/gitlab.py
@@ -60,7 +60,7 @@ class GitlabProvider(OauthProvider):
         base_url = get_base_url(kwargs.get('redirect_uri'))
         data = dict()
 
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.post(
                 f'{self.hostname}/oauth/token',
                 headers={
@@ -82,7 +82,7 @@ class GitlabProvider(OauthProvider):
     async def get_refresh_token_response(self, refresh_token: str) -> Awaitable[Dict]:
         data = dict()
 
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.post(
                 f'{self.hostname}/oauth/token',
                 headers={

--- a/mage_ai/authentication/providers/google.py
+++ b/mage_ai/authentication/providers/google.py
@@ -56,7 +56,7 @@ class GoogleProvider(SsoProvider, OauthProvider):
         base_url = get_base_url(kwargs.get('redirect_uri'))
 
         data = dict()
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.post(
                 'https://oauth2.googleapis.com/token',
                 data=dict(
@@ -75,7 +75,7 @@ class GoogleProvider(SsoProvider, OauthProvider):
     async def get_user_info(self, access_token: str = None, **kwargs) -> Awaitable[Dict]:
         if access_token is None:
             raise Exception('Access token is required to fetch user info.')
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.get(
                 'https://www.googleapis.com/oauth2/v3/userinfo',
                 params=dict(access_token=access_token),

--- a/mage_ai/authentication/providers/oidc.py
+++ b/mage_ai/authentication/providers/oidc.py
@@ -111,7 +111,7 @@ class OidcProvider(OauthProvider, SsoProvider):
         if self.client_secret:
             payload['client_secret'] = self.client_secret
 
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.post(
                 self.token_endpoint,
                 headers={
@@ -128,7 +128,7 @@ class OidcProvider(OauthProvider, SsoProvider):
         if access_token is None:
             raise Exception('Access token is required to fetch user info.')
         mage_roles = []
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.get(
                 self.userinfo_endpoint,
                 headers={

--- a/mage_ai/server/api/projects.py
+++ b/mage_ai/server/api/projects.py
@@ -8,7 +8,7 @@ from mage_ai.settings.repo import get_repo_path
 class ApiProjectsHandler(BaseHandler):
     async def get(self):
         try:
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(trust_env=True) as session:
                 async with session.get(
                     'https://pypi.org/pypi/mage-ai/json',
                     timeout=3,

--- a/mage_ai/tests/shared/test_aiohttp_client_session.py
+++ b/mage_ai/tests/shared/test_aiohttp_client_session.py
@@ -1,0 +1,63 @@
+import ast
+import unittest
+from pathlib import Path
+
+
+class AiohttpClientSessionTest(unittest.TestCase):
+    def test_client_sessions_trust_environment_proxy_settings(self):
+        package_root = Path(__file__).resolve().parents[2]
+        tests_root = package_root / 'tests'
+        missing_trust_env = []
+        session_call_count = 0
+
+        for path in sorted(package_root.rglob('*.py')):
+            if tests_root in path.parents:
+                continue
+
+            source = path.read_text()
+            if 'aiohttp.ClientSession' not in source:
+                continue
+
+            tree = ast.parse(source)
+            for node in ast.walk(tree):
+                if not self.__is_aiohttp_client_session_call(node):
+                    continue
+
+                session_call_count += 1
+                trust_env_keyword = next(
+                    (
+                        keyword
+                        for keyword in node.keywords
+                        if keyword.arg == 'trust_env'
+                    ),
+                    None,
+                )
+
+                if not self.__is_true_constant(trust_env_keyword):
+                    missing_trust_env.append(
+                        f'{path.relative_to(package_root.parent)}:{node.lineno}'
+                    )
+
+        self.assertGreater(session_call_count, 0)
+        self.assertEqual(
+            [],
+            missing_trust_env,
+            'aiohttp.ClientSession must use trust_env=True so HTTP_PROXY, '
+            'HTTPS_PROXY, and NO_PROXY environment settings are honored.',
+        )
+
+    def __is_aiohttp_client_session_call(self, node):
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == 'ClientSession'
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == 'aiohttp'
+        )
+
+    def __is_true_constant(self, keyword):
+        return (
+            keyword is not None
+            and isinstance(keyword.value, ast.Constant)
+            and keyword.value.value is True
+        )

--- a/mage_ai/usage_statistics/logger.py
+++ b/mage_ai/usage_statistics/logger.py
@@ -487,7 +487,7 @@ class UsageStatisticLogger():
             data_to_send['project_uuid'] = project_uuid
 
         try:
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(trust_env=True) as session:
                 async with session.post(
                     API_ENDPOINT,
                     json=dict(


### PR DESCRIPTION
## Summary
- Set `trust_env=True` on Mage aiohttp `ClientSession` calls so `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` are honored.
- Add an AST-based regression test covering future aiohttp `ClientSession` calls.
- Update the aiohttp docs example to match the proxy-aware behavior.

Closes #5748

## Evidence
Backend/session behavior change; screenshot is not useful here. Focused regression tests pass from this branch:

```text
$ PYTHONPATH=$PWD .venv/bin/python -m pytest mage_ai/tests/shared/test_aiohttp_client_session.py mage_ai/tests/authentication/providers/test_active_directory.py mage_ai/tests/authentication/providers/test_oidc.py -q
...                                                                      [100%]
3 passed, 2 warnings in 2.16s
```
