### PR TITLE
support Zendesk lookup custom fields

### DIFF
--- a/mage_integrations/mage_integrations/sources/zendesk/tap_zendesk/streams.py
+++ b/mage_integrations/mage_integrations/sources/zendesk/tap_zendesk/streams.py
@@ -30,6 +30,7 @@ CUSTOM_TYPES = {
     'integer': 'integer',
     'decimal': 'number',
     'checkbox': 'boolean',
+    'lookup': 'string',
 }
 
 DEFAULT_SEARCH_WINDOW_SIZE = (60 * 60 * 24) * 30 # defined in seconds, default to a month (30 days)

--- a/mage_integrations/mage_integrations/sources/zendesk/test/unittests/test_custom_fields.py
+++ b/mage_integrations/mage_integrations/sources/zendesk/test/unittests/test_custom_fields.py
@@ -1,0 +1,34 @@
+import unittest
+from types import SimpleNamespace
+
+from tap_zendesk.streams import process_custom_field
+
+
+class TestProcessCustomField(unittest.TestCase):
+    def test_lookup_custom_field_is_nullable_string(self):
+        field = SimpleNamespace(
+            key='related_record',
+            title='Related record',
+            type='lookup',
+        )
+
+        self.assertEqual(
+            {'type': ['string', 'null']},
+            process_custom_field(field),
+        )
+
+    def test_unknown_custom_field_type_still_raises(self):
+        field = SimpleNamespace(
+            key='unsupported_field',
+            title='Unsupported field',
+            type='unsupported',
+        )
+
+        with self.assertRaises(Exception) as context:
+            process_custom_field(field)
+
+        self.assertIn(
+            'Discovered unsupported type for custom field Unsupported field '
+            '(key: unsupported_field): unsupported',
+            str(context.exception),
+        )


### PR DESCRIPTION
## Summary
- Map Zendesk custom field type `lookup` to nullable string in discovery schema generation.
- Preserve the existing error behavior for truly unsupported custom field types.
- Add focused custom-field unit coverage.

Closes #6008

## Evidence
Integration schema change; there is no useful browser screenshot. The focused custom-field tests pass locally when the unavailable legacy `singer`/`zenpy` imports are shimmed in memory so the changed `process_custom_field` code can be exercised:

```text
$ .venv/bin/python <in-memory shim runner for test_custom_fields.py>
test_lookup_custom_field_is_nullable_string (test_custom_fields.TestProcessCustomField) ... ok
test_unknown_custom_field_type_still_raises (test_custom_fields.TestProcessCustomField) ... ok

----------------------------------------------------------------------
Ran 2 tests in 0.000s

OK
```

The unshimmed local run is blocked by the existing environment missing the legacy `singer` package, matching the dependency limitation noted during implementation.
