### PR TITLE
display object runtime variables as JSON

### DIFF
--- a/mage_ai/frontend/components/Triggers/Edit/index.tsx
+++ b/mage_ai/frontend/components/Triggers/Edit/index.tsx
@@ -354,7 +354,16 @@ function Edit({
     () => {
       if (overwriteVariables) {
         setRuntimeVariables(formattedVariables?.reduce(
-          (vars, { uuid, value }) => ({ ...vars, [uuid]: scheduleVariables[uuid] || value }),
+          (vars, { uuid, value }) => {
+            const runtimeVariableValue = Object.prototype.hasOwnProperty.call(scheduleVariables, uuid)
+              ? scheduleVariables[uuid]
+              : value;
+
+            return {
+              ...vars,
+              [uuid]: runtimeVariableValue,
+            };
+          },
           {},
         ));
       } else {

--- a/mage_ai/frontend/components/Triggers/OverwriteVariables/index.tsx
+++ b/mage_ai/frontend/components/Triggers/OverwriteVariables/index.tsx
@@ -22,7 +22,7 @@ type OverwriteVariablesProps = {
   enableVariablesOverwrite: boolean;
   originalVariables?: { [keyof: string]: any };
   runtimeVariables: { [keyof: string]: any };
-  setEnableVariablesOverwrite: (enableVariablesOverwrite: boolean) => void;
+  setEnableVariablesOverwrite?: (enableVariablesOverwrite: boolean) => void;
   setRuntimeVariables: (runtimeVariables: any) => void;
 };
 

--- a/mage_ai/frontend/components/Triggers/OverwriteVariables/index.tsx
+++ b/mage_ai/frontend/components/Triggers/OverwriteVariables/index.tsx
@@ -20,11 +20,45 @@ type OverwriteVariablesProps = {
   borderless?: boolean;
   compact?: boolean;
   enableVariablesOverwrite: boolean;
-  originalVariables?: { [keyof: string]: string };
-  runtimeVariables: { [keyof: string]: string };
+  originalVariables?: { [keyof: string]: any };
+  runtimeVariables: { [keyof: string]: any };
   setEnableVariablesOverwrite: (enableVariablesOverwrite: boolean) => void;
   setRuntimeVariables: (runtimeVariables: any) => void;
 };
+
+function formatRuntimeVariableValue(value: any): string {
+  if (typeof value === 'undefined') {
+    return '';
+  } else if (typeof value === 'string') {
+    return value;
+  } else if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+
+  return String(value);
+}
+
+function shouldUseTextAreaForValue(value: any): boolean {
+  if (value !== null && typeof value === 'object') {
+    return true;
+  }
+
+  if (typeof value !== 'string' || !isJsonString(value)) {
+    return false;
+  }
+
+  const parsedValue = JSON.parse(value);
+
+  return (
+    typeof parsedValue === 'object'
+    && !Array.isArray(parsedValue)
+    && parsedValue !== null
+  );
+}
 
 function OverwriteVariables({
   borderless,
@@ -43,14 +77,10 @@ function OverwriteVariables({
     const textAreaElementMappingInit = Object.entries(runtimeVariables || {})
       .reduce((acc, keyValPair) => {
         const [uuid, val] = keyValPair;
-        const isUsingTextAreaEl = isJsonString(val)
-          && typeof JSON.parse(val) === 'object'
-          && !Array.isArray(JSON.parse(val))
-          && JSON.parse(val) !== null;
 
         return {
           ...acc,
-          [uuid]: isUsingTextAreaEl,
+          [uuid]: shouldUseTextAreaForValue(val),
         };
       }, {});
 
@@ -64,7 +94,8 @@ function OverwriteVariables({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const buildValueRowEl = (uuid: string, value: string) => {
+  const buildValueRowEl = (uuid: string, value: any) => {
+    const formattedValue = formatRuntimeVariableValue(value);
     const sharedValueElProps = {
       borderless: true,
       key: `variable_uuid_input_${uuid}`,
@@ -78,7 +109,7 @@ function OverwriteVariables({
       },
       paddingHorizontal: 0,
       placeholder: 'Variable value',
-      value,
+      value: formattedValue,
     };
 
     if (textAreaElementMapping[uuid]) {
@@ -86,7 +117,7 @@ function OverwriteVariables({
         <TextArea
           {...sharedValueElProps}
           rows={1}
-          value={value}
+          value={formattedValue}
         />
       );
     }

--- a/mage_ai/frontend/components/Triggers/OverwriteVariables/index.tsx
+++ b/mage_ai/frontend/components/Triggers/OverwriteVariables/index.tsx
@@ -161,7 +161,7 @@ function OverwriteVariables({
             },
             {
               label: () => '',
-              uuid: 'Action'
+              uuid: 'Action',
             },
           ]}
           rows={Object.entries(runtimeVariables).map(([uuid, value]) => [
@@ -177,7 +177,7 @@ function OverwriteVariables({
               <Button
                 iconOnly
                 onClick={() => {
-                  setRuntimeVariables(prev => ignoreKeys(prev, [uuid]))
+                  setRuntimeVariables(prev => ignoreKeys(prev, [uuid]));
                 }}
               >
                 <Trash default />

--- a/mage_ai/frontend/components/Triggers/OverwriteVariables/index.tsx
+++ b/mage_ai/frontend/components/Triggers/OverwriteVariables/index.tsx
@@ -30,6 +30,10 @@ function formatRuntimeVariableValue(value: any): string {
   if (typeof value === 'undefined') {
     return '';
   } else if (typeof value === 'string') {
+    if (shouldUseTextAreaForValue(value)) {
+      return JSON.stringify(JSON.parse(value), null, 2);
+    }
+
     return value;
   } else if (typeof value === 'object') {
     try {
@@ -74,25 +78,31 @@ function OverwriteVariables({
   const [newVariableValue, setNewVariableValue] = useState(null);
 
   useEffect(() => {
-    const textAreaElementMappingInit = Object.entries(runtimeVariables || {})
-      .reduce((acc, keyValPair) => {
-        const [uuid, val] = keyValPair;
+    setTextAreaElementMapping(prev => {
+      let mappingChanged = false;
+      const runtimeVariableMapping = Object.entries(runtimeVariables || {})
+        .reduce((acc, [uuid, val]) => {
+          if (typeof prev?.[uuid] !== 'undefined') {
+            return {
+              ...acc,
+              [uuid]: prev[uuid],
+            };
+          }
 
-        return {
-          ...acc,
-          [uuid]: shouldUseTextAreaForValue(val),
-        };
-      }, {});
+          mappingChanged = true;
 
-    setTextAreaElementMapping(textAreaElementMappingInit);
+          return {
+            ...acc,
+            [uuid]: shouldUseTextAreaForValue(val),
+          };
+        }, {});
 
-  /*
-   * The runtimeVariables prop is intentionally excluded from the dependency array
-   * because adding it would convert the input element back to a normal TextInput
-   * component once the user edits the variable value.
-   */
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+      return mappingChanged
+        || Object.keys(prev || {}).length !== Object.keys(runtimeVariableMapping || {}).length
+        ? runtimeVariableMapping
+        : prev;
+    });
+  }, [runtimeVariables]);
 
   const buildValueRowEl = (uuid: string, value: any) => {
     const formattedValue = formatRuntimeVariableValue(value);
@@ -116,7 +126,7 @@ function OverwriteVariables({
       return (
         <TextArea
           {...sharedValueElProps}
-          rows={1}
+          rows={Math.min(formattedValue.split('\n').length, 6)}
           value={formattedValue}
         />
       );


### PR DESCRIPTION
## Summary
- Preserve saved runtime variable values like `false`, `0`, and objects instead of falling back with `||`.
- Render object runtime variable values as formatted JSON text in the trigger editor.
- Use text areas for object values so JSON stays readable on reopen, including values loaded after the editor mounts.

Closes #5764

## Evidence
Trigger editor showing object runtime variable values as formatted JSON while preserving `false` and `0` overrides:

<img src="https://github.com/BobbyWang0120/mage-ai/releases/download/pr-6152-runtime-variable-json-assets/pr-6152-runtime-variable-json-fixed.png" width="900" alt="Trigger editor showing runtime variable false, formatted JSON object, and zero value" />

Browser verification from `http://localhost:3000/pipelines/example_pipeline/triggers/1/edit`:

```json
{
  "inputs": ["false", "0", ""],
  "textareas": [
    "{\n  \"var\": \"value1\",\n  \"nested\": {\n    \"enabled\": true\n  }\n}"
  ]
}
```

Targeted check for the changed component:

```text
$ yarn --cwd mage_ai/frontend lint --file components/Triggers/OverwriteVariables/index.tsx
Done in 4.62s.
```

Note: running the broader pair of trigger editor files still hits an existing `react-hooks/exhaustive-deps` error in `components/Triggers/Edit/index.tsx` that is present on `master`.
