### PR TITLE
filter monitor stats to the current repo

### DIFF
--- a/mage_ai/orchestration/monitor/monitor_stats.py
+++ b/mage_ai/orchestration/monitor/monitor_stats.py
@@ -117,6 +117,8 @@ class MonitorStats:
             ).
             join(PipelineSchedule, PipelineRun.pipeline_schedule_id == PipelineSchedule.id)
         )
+        repo_pipeline_schedule_ids = PipelineSchedule.repo_query.with_entities(PipelineSchedule.id)
+        query = query.filter(PipelineRun.pipeline_schedule_id.in_(repo_pipeline_schedule_ids))
 
         query = self.__filter(
             query,

--- a/mage_ai/tests/orchestration/test_monitor_stats.py
+++ b/mage_ai/tests/orchestration/test_monitor_stats.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from mage_ai.orchestration.db import db_connection
+from mage_ai.orchestration.db.models.schedules import PipelineRun, PipelineSchedule
+from mage_ai.orchestration.monitor.monitor_stats import MonitorStats
+from mage_ai.tests.base_test import DBTestCase
+
+
+class MonitorStatsTest(DBTestCase):
+    def setUp(self):
+        super().setUp()
+        PipelineRun.query.delete()
+        PipelineSchedule.query.delete()
+        db_connection.session.commit()
+
+    def test_pipeline_run_count_filters_schedules_to_current_repo(self):
+        current_schedule = PipelineSchedule.create(
+            name='current repo schedule',
+            pipeline_uuid='current_pipeline',
+            repo_path=self.repo_path,
+        )
+        legacy_schedule = PipelineSchedule.create(
+            name='legacy schedule',
+            pipeline_uuid='legacy_pipeline',
+            repo_path=None,
+        )
+        other_schedule = PipelineSchedule.create(
+            name='other repo schedule',
+            pipeline_uuid='other_pipeline',
+            repo_path=f'{self.repo_path}_other',
+        )
+
+        created_at = datetime(2024, 1, 1)
+        for schedule in [current_schedule, legacy_schedule, other_schedule]:
+            PipelineRun.create(
+                create_block_runs=False,
+                pipeline_schedule_id=schedule.id,
+                pipeline_uuid=schedule.pipeline_uuid,
+                status=PipelineRun.PipelineRunStatus.COMPLETED,
+                created_at=created_at,
+            )
+
+        def build_pipeline(pipeline_uuid, **kwargs):
+            return SimpleNamespace(uuid=pipeline_uuid, type='python')
+
+        with patch(
+            'mage_ai.orchestration.monitor.monitor_stats.Pipeline.get',
+            side_effect=build_pipeline,
+        ) as mock_get_pipeline:
+            stats = MonitorStats().get_pipeline_run_count(
+                group_by_pipeline_type=True,
+            )
+
+        self.assertEqual({current_schedule.id, legacy_schedule.id}, set(stats.keys()))
+        self.assertNotIn(other_schedule.id, stats)
+        self.assertEqual(
+            {'current_pipeline', 'legacy_pipeline'},
+            {call.args[0] for call in mock_get_pipeline.call_args_list},
+        )
+        for call in mock_get_pipeline.call_args_list:
+            self.assertEqual(self.repo_path, call.kwargs['repo_path'])


### PR DESCRIPTION
## Summary
- Scope monitor stats pipeline-run queries to schedules visible in the current repo.
- Keep legacy schedules with no repo path included through the existing repo query behavior.
- Add regression coverage so runs from another repo are not loaded or counted.

Closes #6036

## Evidence
Backend/API change; screenshot is not useful here because the important behavior is query scoping. Focused regression tests pass from this branch:

```text
$ PYTHONPATH=$PWD .venv/bin/python -m pytest mage_ai/tests/orchestration/test_monitor_stats.py mage_ai/tests/api/endpoints/test_monitor_stats.py -q
....                                                                     [100%]
4 passed, 26 warnings in 5.15s
```
