### PR TITLE
add message search to pipeline logs page

### DIFF
--- a/mage_ai/frontend/components/Logs/Table/index.tsx
+++ b/mage_ai/frontend/components/Logs/Table/index.tsx
@@ -23,7 +23,7 @@ import { TabType } from '@oracle/components/Tabs/ButtonTabs';
 import { ThemeType } from '@oracle/styles/themes/constants';
 import { UNIT } from '@oracle/styles/units/spacing';
 import { WIDTH_OF_SINGLE_CHARACTER_MONOSPACE } from '@components/DataTable';
-import { formatTimestamp } from '@utils/models/log';
+import { formatTimestamp, getLogMessageText } from '@utils/models/log';
 import { get, set } from '@storage/localStorage';
 import { getColorsForBlockType } from '@components/CodeBlock/index.style';
 import { getLogScrollPositionLocalStorageKey } from '../utils';
@@ -140,22 +140,16 @@ function LogsTable({
       logs,
       themeContext,
     } = data;
-    const { content, data: logData, name } = logs[index];
+    const { data: logData, name } = logs[index];
     const {
       block_uuid: blockUUIDProp,
       level,
-      message,
       pipeline_uuid: pipelineUUID,
       timestamp,
       uuid,
     } = logData || {};
 
-    let displayText = message == null ? content : message;
-    if (Array.isArray(displayText)) {
-      displayText = displayText.join(' ');
-    } else if (typeof displayText === 'object') {
-      displayText = JSON.stringify(displayText);
-    }
+    const displayText = getLogMessageText(logs[index]);
 
     let idEl;
     const uuidInit = blockUUIDProp || name.split('.log')[0];

--- a/mage_ai/frontend/components/Logs/Toolbar/index.tsx
+++ b/mage_ai/frontend/components/Logs/Toolbar/index.tsx
@@ -134,7 +134,11 @@ function LogToolbar({
 
   return (
     <Spacing py={1}>
-      <FlexContainer alignItems="center">
+      <FlexContainer
+        alignItems="center"
+        flexWrap="wrap"
+        style={{ gap: UNIT }}
+      >
         <KeyboardShortcutButton
           {...SHARED_BUTTON_PROPS}
           disabled={allPastLogsLoaded}
@@ -147,8 +151,6 @@ function LogToolbar({
           {allPastLogsLoaded ? 'All past logs within range loaded' : 'Load older logs'}
         </KeyboardShortcutButton>
 
-        <Spacing mr={1} />
-
         <KeyboardShortcutButton
           {...SHARED_BUTTON_PROPS}
           disabled={q?._offset <= 0}
@@ -160,8 +162,6 @@ function LogToolbar({
         >
           Load newer logs
         </KeyboardShortcutButton>
-
-        <Spacing mr={2} />
 
         <Select
           compact
@@ -184,7 +184,7 @@ function LogToolbar({
           }}
           paddingRight={UNIT * 4}
           placeholder="Select time range"
-          value={selectedRange}
+          value={selectedRange || ''}
         >
           {Object.values(LogRangeEnum).map(range => (
             <option key={range} value={range}>
@@ -192,8 +192,6 @@ function LogToolbar({
             </option>
           ))}
         </Select>
-
-        <Spacing mr={1} />
 
         {selectedRange === LogRangeEnum.CUSTOM_RANGE && (
           <>

--- a/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/logs/index.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 
 import BlockType, { BlockTypeEnum } from '@interfaces/BlockType';
+import Button from '@oracle/elements/Button';
 import Divider from '@oracle/elements/Divider';
 import ErrorsType from '@interfaces/ErrorsType';
 import Filter, { FilterQueryType, FilterQueryParamEnum } from '@components/Logs/Filter';
@@ -26,6 +27,7 @@ import PrivateRoute from '@components/shared/PrivateRoute';
 import Spacing from '@oracle/elements/Spacing';
 import Spinner from '@oracle/components/Spinner';
 import Text from '@oracle/elements/Text';
+import TextInput from '@oracle/elements/Inputs/TextInput';
 import ToggleSwitch from '@oracle/elements/Inputs/ToggleSwitch';
 import api from '@api';
 import dark from '@oracle/styles/themes/dark';
@@ -38,18 +40,22 @@ import { LOCAL_STORAGE_KEY_AUTO_SCROLL_LOGS } from '@storage/constants';
 import { MetaQueryEnum } from '@api/constants';
 import { PageNameEnum } from '@components/PipelineDetailPage/constants';
 import { PADDING_UNITS, UNIT } from '@oracle/styles/units/spacing';
+import { SEARCH_INPUT_PROPS } from '@components/shared/Table/Toolbar/constants';
 import { TabType } from '@oracle/components/Tabs/ButtonTabs';
 import { calculateStartTimestamp } from '@utils/number';
 import { find, indexBy, sortByKey } from '@utils/array';
 import { get, set } from '@storage/localStorage';
 import { goToWithQuery } from '@utils/routing';
 import { ignoreKeys, isEmptyObject, isEqual } from '@utils/hash';
-import { initializeLogs } from '@utils/models/log';
+import { Close } from '@oracle/icons';
+import { getLogMessageText, initializeLogs } from '@utils/models/log';
 import { numberWithCommas } from '@utils/string';
 import { queryFromUrl } from '@utils/url';
 
 const PIPELINE_RUN_ID_PARAM = 'pipeline_run_id[]';
 const BLOCK_RUN_ID_PARAM = 'block_run_id[]';
+const LOG_SEARCH_INPUT_MAX_WIDTH = UNIT * 40;
+const LOG_SEARCH_INPUT_MIN_WIDTH = UNIT * 24;
 
 type PipelineLogsPageProp = {
   pipeline: {
@@ -62,6 +68,7 @@ function PipelineLogsPage({
 }: PipelineLogsPageProp) {
   const themeContext = useContext(ThemeContext);
   const tableInnerRef = useRef(null);
+  const logSearchInputRef = useRef(null);
   const pipelineUUID = pipelineProp.uuid;
 
   const [query, setQuery] = useState<FilterQueryType>(null);
@@ -70,6 +77,7 @@ function PipelineLogsPage({
   const [errors, setErrors] = useState<ErrorsType>(null);
   const [selectedTab, setSelectedTab] = useState<TabType>(TAB_DETAILS);
   const [autoScrollLogs, setAutoScrollLogs] = useState(get(LOCAL_STORAGE_KEY_AUTO_SCROLL_LOGS, true));
+  const [logSearchText, setLogSearchText] = useState<string>('');
 
   const { data: dataPipeline } = api.pipelines.detail(pipelineUUID, {
     includes_content: false,
@@ -226,6 +234,21 @@ function PipelineLogsPage({
       query,
   ]);
   const filteredLogCount = logsFiltered.length;
+  const logSearchQuery = useMemo(() => logSearchText.trim().toLowerCase(), [logSearchText]);
+  const logsDisplayed: LogType[] = useMemo(() => {
+    if (!logSearchQuery?.length) {
+      return logsFiltered;
+    }
+
+    return logsFiltered.filter((log: LogType) => (
+      getLogMessageText(log).toLowerCase().includes(logSearchQuery)
+    ));
+  }, [
+    logSearchQuery,
+    logsFiltered,
+  ]);
+  const displayedLogCount = logsDisplayed.length;
+  const hasLogSearch = logSearchQuery.length >= 1;
 
   const qPrev = usePrevious(q);
   useEffect(() => {
@@ -258,6 +281,17 @@ function PipelineLogsPage({
     q,
     selectedLog,
     selectedLogPrev,
+  ]);
+  useEffect(() => {
+    if (selectedLog?.data?.uuid
+      && !logsDisplayed.some(({ data }) => data?.uuid === selectedLog.data?.uuid)
+    ) {
+      goToWithQuery({ [LOG_UUID_PARAM]: null });
+      setSelectedLog(null);
+    }
+  }, [
+    logsDisplayed,
+    selectedLog,
   ]);
 
   const { _limit, _offset } = q;
@@ -306,7 +340,7 @@ function PipelineLogsPage({
     <LogsTable
       autoScrollLogs={autoScrollLogs}
       blocksByUUID={blocksByUUID}
-      logs={logsFiltered}
+      logs={logsDisplayed}
       onRowClick={setSelectedTab}
       pipeline={pipeline}
       query={query}
@@ -318,7 +352,7 @@ function PipelineLogsPage({
   ), [
     autoScrollLogs,
     blocksByUUID,
-    logsFiltered,
+    logsDisplayed,
     pipeline,
     query,
     saveScrollPosition,
@@ -361,10 +395,25 @@ function PipelineLogsPage({
       uuid="pipeline/logs"
     >
       <Spacing px={PADDING_UNITS} py={1}>
-        <Text>
-          {!isLoading && (
-            <>
-              {numberWithCommas(filteredLogCount)} logs found
+        {!isLoading && (
+          <FlexContainer
+            alignItems="center"
+            flexWrap="wrap"
+            justifyContent="space-between"
+            style={{ gap: UNIT }}
+          >
+            <Flex
+              alignItems="center"
+              flexWrap="wrap"
+              style={{ gap: UNIT }}
+            >
+              <Text>
+                {hasLogSearch
+                  ? `${numberWithCommas(displayedLogCount)} of ${numberWithCommas(filteredLogCount)} logs match`
+                  : `${numberWithCommas(filteredLogCount)} logs found`
+                }
+              </Text>
+
               <LogToolbar
                 allPastLogsLoaded={allPastLogsLoaded}
                 loadNewerLogInterval={loadNewerLogInterval}
@@ -373,10 +422,51 @@ function PipelineLogsPage({
                 selectedRange={selectedRange}
                 setSelectedRange={setSelectedRange}
               />
-            </>
-          )}
-          {isLoading && 'Searching...'}
-        </Text>
+            </Flex>
+
+            <Flex
+              alignItems="center"
+              flex="1 1 240px"
+              justifyContent="flex-end"
+              style={{
+                gap: UNIT,
+                maxWidth: LOG_SEARCH_INPUT_MAX_WIDTH + (UNIT * 5),
+                minWidth: LOG_SEARCH_INPUT_MIN_WIDTH,
+              }}
+            >
+              <TextInput
+                {...SEARCH_INPUT_PROPS}
+                maxWidth={LOG_SEARCH_INPUT_MAX_WIDTH}
+                minWidth={LOG_SEARCH_INPUT_MIN_WIDTH}
+                onChange={e => setLogSearchText(e.target.value)}
+                paddingVertical={6}
+                placeholder="Search messages"
+                ref={logSearchInputRef}
+                value={logSearchText}
+              />
+
+              {logSearchText && (
+                <Button
+                  iconOnly
+                  noBackground
+                  noBorder
+                  onClick={() => {
+                    setLogSearchText('');
+                    logSearchInputRef?.current?.focus();
+                  }}
+                  title="Clear search"
+                >
+                  <Close default size={2 * UNIT} />
+                </Button>
+              )}
+            </Flex>
+          </FlexContainer>
+        )}
+        {isLoading && (
+          <Text>
+            Searching...
+          </Text>
+        )}
       </Spacing>
 
       <Divider light />
@@ -387,7 +477,15 @@ function PipelineLogsPage({
         </Spacing>
       )}
 
-      {!isLoading && logsFiltered.length >= 1 && LogsTableMemo}
+      {!isLoading && logsDisplayed.length >= 1 && LogsTableMemo}
+
+      {!isLoading && logsDisplayed.length === 0 && (
+        <Spacing p={PADDING_UNITS}>
+          <Text muted>
+            {hasLogSearch ? 'No matching logs found.' : 'No logs found.'}
+          </Text>
+        </Spacing>
+      )}
 
       <Spacing p={`${UNIT * 1.5}px`}>
         <FlexContainer alignItems="center">

--- a/mage_ai/frontend/utils/models/log.ts
+++ b/mage_ai/frontend/utils/models/log.ts
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-import LogType, { LogDataType } from '@interfaces/LogType';
+import LogType from '@interfaces/LogType';
 import { isJsonString } from '@utils/string';
 
 const DATE_REGEX = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$/;
@@ -50,6 +50,24 @@ export function initializeLogs(log: LogType) {
     ...log,
     content: content2,
   }));
+}
+
+export function getLogMessageText(log: LogType): string {
+  const displayText: any = log?.data?.message == null ? log?.content : log?.data?.message;
+
+  if (displayText == null) {
+    return '';
+  } else if (Array.isArray(displayText)) {
+    return displayText.join(' ');
+  } else if (typeof displayText === 'object') {
+    try {
+      return JSON.stringify(displayText);
+    } catch {
+      return String(displayText);
+    }
+  }
+
+  return String(displayText);
 }
 
 export function formatTimestamp(


### PR DESCRIPTION
## Summary
- Add client-side text search for loaded pipeline log messages.
- Reuse the same message-text formatting for rendering and searching so arrays, objects, and raw content behave consistently.
- Update counts and empty states while preserving existing log filters and range controls.

Fixes #6105

## Screenshots
Default log list with the new message search input:

<img src="https://github.com/BobbyWang0120/mage-ai/releases/download/pr-6155-log-search-assets-v2/mage-log-search-default-normal.png" width="900" alt="Pipeline logs page showing the Search messages input with the normal filter panel width" />

Filtered log list after searching for `Warning`:

<img src="https://github.com/BobbyWang0120/mage-ai/releases/download/pr-6155-log-search-assets-v2/mage-log-search-filtered-normal.png" width="900" alt="Pipeline logs page filtered to matching warning log messages with the normal filter panel width" />

## Verification
- `yarn lint --file pages/pipelines/[pipeline]/logs/index.tsx --file components/Logs/Table/index.tsx --file components/Logs/Toolbar/index.tsx --file utils/models/log.ts`
- `git diff --check HEAD~1..HEAD`
- `agent-browser` on `http://localhost:3000/pipelines/example_pipeline/logs` for default, filtered, and clear-search states.
