### PR TITLE
fix callback block rename from UI

### DIFF
--- a/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
+++ b/mage_ai/frontend/pages/pipelines/[pipeline]/edit.tsx
@@ -2143,7 +2143,7 @@ function PipelineDetailPage({
                 uuid: block.uuid,
               },
               pipeline: {
-                blocks: pipeline?.blocks || [],
+                blocks,
               },
             }).then(() => {
               setSelectedBlock(null);
@@ -2168,6 +2168,7 @@ function PipelineDetailPage({
   ), {
   }, [
     addNewBlockAtIndex,
+    blocks,
     pipeline,
   ], {
     background: true,


### PR DESCRIPTION
## Summary
- Fix callback block rename from the pipeline editor UI.
- Use the editor's full block state when saving from the configure-block modal so callback blocks are included in the save payload.

Fixes #6110

## Root cause
Callback blocks are stored separately from regular pipeline blocks. The rename modal was saving with only `pipeline.blocks`, so callback blocks were missing from the data that `savePipelineContent` uses to build the `callbacks` payload.

## Validation
- Verified manually in the browser that renaming a callback block from the UI now works.
- Ran `git diff --check`.
- Focused frontend lint was not run locally because `mage_ai/frontend/node_modules` is not installed in this checkout, so `next` is unavailable.

## Demo

https://github.com/user-attachments/assets/ead39cef-5032-461f-8203-301ee4707e8a
