### PR TITLE
Fix per-file format inference in FileIO.load

### DIFF
--- a/mage_ai/io/file.py
+++ b/mage_ai/io/file.py
@@ -43,9 +43,8 @@ class FileIO(BaseFile):
 
             dfs = []
             for fp in file_paths:
-                if format is None:
-                    format = self._get_file_format(fp)
-                df = self._read(fp, format, **kwargs)
+                file_format = format if format is not None else self._get_file_format(fp)
+                df = self._read(fp, file_format, **kwargs)
                 dfs.append(df)
 
             return pd.concat(dfs, axis=0, ignore_index=True)

--- a/mage_ai/tests/io/test_file.py
+++ b/mage_ai/tests/io/test_file.py
@@ -1,0 +1,36 @@
+import pandas as pd
+
+from mage_ai.io.file import FileIO
+
+
+def test_load_infers_format_for_each_file(tmp_path):
+    pd.DataFrame(
+        [
+            {
+                'id': 1,
+                'source': 'csv',
+            },
+        ],
+    ).to_csv(
+        tmp_path / 'records.csv',
+        index=False,
+    )
+
+    pd.DataFrame(
+        [
+            {
+                'id': 2,
+                'source': 'json',
+            },
+        ],
+    ).to_json(
+        tmp_path / 'records.json',
+        orient='records',
+    )
+
+    result = FileIO().load(
+        file_directories=[str(tmp_path)],
+    )
+
+    assert sorted(result['id'].tolist()) == [1, 2]
+    assert sorted(result['source'].tolist()) == ['csv', 'json']


### PR DESCRIPTION
## Description

Fixes #6160.

`FileIO.load()` previously stored the format inferred from the first file in the `format` parameter. As a result, every subsequent file in the directory was read using the first file's format.

This change preserves the original `format` parameter and uses a separate `file_format` variable for each file. When no format is explicitly provided, Mage now infers the format independently for every file.

## How Has This Been Tested?

* Added a regression test with CSV and JSON files in the same directory.
* Confirmed that both files are loaded and combined into the resulting DataFrame.
* Ran:

```bash
python -m pytest mage_ai/tests/io/test_file.py -v
```

Result:

```text
1 passed
```
The regression test covers mixed file formats in the same directory to prevent this behavior from being reintroduced.

## Checklist

* [ ] The PR is tagged with proper labels
* [x] I have performed a self-review of my own code
* [x] I have added unit tests that prove my fix is effective
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation

Documentation and additional comments were not required because this is a small internal bug fix and the updated logic is self-explanatory.
