### PR TITLE
Fix standalone ProOnly docs banner

### DIFF
--- a/docs/snippets/pro/only.mdx
+++ b/docs/snippets/pro/only.mdx
@@ -12,7 +12,7 @@ export const ProOnly = ({
         className="text-sm prose min-w-0 text-emerald-900 dark:text-emerald-200"
         style={{ flex: 1 }}
       >
-        <div className="font-semibold">{title}</div>
+        <span className="font-semibold">{title}</span>
         <p className="normal">{description}</p>
       </div>
 

--- a/docs/snippets/pro/only.mdx
+++ b/docs/snippets/pro/only.mdx
@@ -12,7 +12,7 @@ export const ProOnly = ({
         className="text-sm prose min-w-0 text-emerald-900 dark:text-emerald-200"
         style={{ flex: 1 }}
       >
-        {title}
+        <div className="font-semibold">{title}</div>
         <p className="normal">{description}</p>
       </div>
 

--- a/docs/snippets/pro/only.mdx
+++ b/docs/snippets/pro/only.mdx
@@ -1,15 +1,11 @@
-import { ProButton } from '/snippets/pro/button.mdx';
-
 export const ProOnly = ({
   button = 'Get started for free',
   description = 'Try our fully managed solution to access this advanced feature.',
   source = 'documentation',
   title = 'Only in Mage Pro.',
 }) => (
-  <a
-    href={`https://cloud.mage.ai/sign-up?source=${source}`}
+  <div
     className="block my-4 px-5 py-4 overflow-hidden rounded-xl flex gap-3 border border-emerald-500/20 bg-emerald-50/50 dark:border-emerald-500/30 dark:bg-emerald-500/10"
-    target="_blank"
   >
     <div style={{ display: 'flex', alignItems: 'center', width: '100%' }}>
       <div
@@ -22,9 +18,40 @@ export const ProOnly = ({
 
       <div>&nbsp;</div>
 
-      <div>
-        <ProButton label={button} href={`https://cloud.mage.ai/sign-up?source=${source}`} />
+      <div style={{ height: 32, position: 'relative' }}>
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group px-4 py-1.5 relative inline-flex items-center text-sm font-medium rounded-full"
+          href={`https://cloud.mage.ai/sign-up?source=${source}`}
+        >
+          <span
+            className="absolute inset-0 bg-primary-dark dark:bg-primary-light/10 border-primary-light/30 rounded-full dark:border group-hover:opacity-[0.9] dark:group-hover:border-primary-light/60"
+          >
+          </span>
+
+          <div className="mr-0.5 space-x-2.5 flex items-center">
+            <span className="z-10 text-white dark:text-primary-light">
+              {button}
+            </span>
+
+            <svg
+              width="3"
+              height="24"
+              viewBox="0 -9 3 24"
+              className="h-5 rotate-0 overflow-visible text-white/90 dark:text-primary-light"
+            >
+              <path
+                d="M0 0L3 3L0 6"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              ></path>
+            </svg>
+          </div>
+        </a>
       </div>
     </div>
-  </a>
+  </div>
 );


### PR DESCRIPTION
## What changed

- Make the `ProOnly` MDX component self-contained instead of relying on a nested import of `ProButton`.
- Preserve the existing call-to-action styling and destination.
- Replace the outer link wrapper with a `div` to avoid invalid nested anchor markup.
- Apply `font-semibold` explicitly to the title so it no longer depends on inherited link styling.
- Keep the title in an inline `span` to preserve the banner's original compact spacing inside Mintlify's `prose` container.
- Add `rel="noopener noreferrer"` to the external call-to-action link.

## Why

The docs MDX toolchain does not reliably preserve transitive imports between reusable `.mdx` snippets. As a result, pages that imported `ProOnly` without also importing `ProButton` could fail to render the banner because `ProButton` was unavailable in the page's compiled scope.

The previous outer anchor also supplied incidental font weight to the title. Making the component self-contained removed that inherited styling, so the title emphasis is now explicit. An inline element is used to avoid the extra vertical margins that Mintlify typography applies to block elements inside a `prose` container.

After this change, pages only need to import `ProOnly`, existing pages that import both components remain compatible, and the banner retains its original title emphasis and spacing.

## Validation

- `git diff --check`
- Repository pre-commit hooks run during each commit (all applicable checks passed; non-applicable Python checks were skipped)
- Compared the rendered preview against the previous banner appearance for title weight and vertical spacing

A full Mintlify build was not run because this repository does not configure a local documentation build script.