### PR TITLE
security: fix hardcoded SSL/TLS verification bypasses (CWE-295)

### DIFF
--- a/mage_ai/io/trino.py
+++ b/mage_ai/io/trino.py
@@ -4,7 +4,6 @@ from typing import IO, Dict, List, Mapping, Union
 
 import numpy as np
 import simplejson
-import urllib3
 from pandas import DataFrame, Series
 from trino.auth import BasicAuthentication
 from trino.dbapi import Connection
@@ -22,8 +21,6 @@ from mage_ai.shared.utils import (
     convert_pandas_dtype_to_python_type,
     convert_python_type_to_trino_type,
 )
-
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class Cursor(CursorParent):

--- a/mage_ai/services/spark/api/base.py
+++ b/mage_ai/services/spark/api/base.py
@@ -1,3 +1,4 @@
+import os
 import urllib.parse
 from abc import ABC, abstractmethod
 from typing import Dict, List
@@ -21,6 +22,10 @@ from mage_ai.services.spark.models.threads import Thread
 from mage_ai.services.spark.spark import get_spark_session
 from mage_ai.settings.repo import get_repo_path
 from mage_ai.shared.array import find
+
+# Default to verifying SSL certificates. Set SPARK_VERIFY_SSL=false to disable
+# (e.g., for self-signed certificates in development environments).
+SPARK_VERIFY_SSL = os.environ.get('SPARK_VERIFY_SSL', 'true').lower() not in ('false', '0', 'no')
 
 
 class BaseAPI(ABC):
@@ -209,7 +214,7 @@ class BaseAPI(ABC):
             data=payload,
             headers=headers,
             timeout=12,
-            verify=False,
+            verify=SPARK_VERIFY_SSL,
         )
 
     async def __build_request(self, *args, **kwargs):

--- a/mage_ai/streaming/sinks/opensearch.py
+++ b/mage_ai/streaming/sinks/opensearch.py
@@ -16,6 +16,8 @@ class OpensearchConfig(BaseConfig):
     host: str
     index_name: str
     verify_certs: bool = True
+    ssl_assert_hostname: bool = True
+    ssl_show_warn: bool = True
     http_auth: str = '@awsauth'
 
 
@@ -43,8 +45,8 @@ class OpenSearchSink(BaseSink):
                 http_auth=http_auth,
                 use_ssl=True,
                 verify_certs=self.config.verify_certs,
-                ssl_assert_hostname=False,
-                ssl_show_warn=False,
+                ssl_assert_hostname=self.config.ssl_assert_hostname,
+                ssl_show_warn=self.config.ssl_show_warn,
                 connection_class=RequestsHttpConnection,
         )
 


### PR DESCRIPTION
## Summary

Fix three instances of hardcoded SSL/TLS certificate verification bypasses that expose the application to man-in-the-middle (MITM) attacks.

## Security Impact

**CWE-295: Improper Certificate Validation**

### 1. OpenSearch Sink — `streaming/sinks/opensearch.py`

`ssl_assert_hostname=False` was hardcoded, completely disabling TLS hostname verification. An attacker on the network path could present any valid certificate (e.g., from a different domain) and intercept/modify data flowing to OpenSearch.

**Fix:** Made `ssl_assert_hostname` and `ssl_show_warn` configurable via `OpensearchConfig`, defaulting to `True`.

### 2. Spark API — `services/spark/api/base.py`

`verify=False` was hardcoded in all HTTP requests to the Spark API, disabling certificate verification entirely. This allows an attacker to intercept Spark API traffic, which may contain sensitive job data.

**Fix:** Made SSL verification configurable via `SPARK_VERIFY_SSL` environment variable, defaulting to `True`. Users with self-signed certificates can set `SPARK_VERIFY_SSL=false`.

### 3. Trino Connector — `io/trino.py`

`urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)` was called at module import time, globally suppressing SSL warnings across the entire application — not just Trino connections. This masks potential MITM vulnerabilities in any component using urllib3/requests.

**Fix:** Removed the global warning suppression.

## Backward Compatibility

All fixes maintain backward compatibility:
- OpenSearch: set `ssl_assert_hostname: false` in config to restore old behavior
- Spark: set `SPARK_VERIFY_SSL=false` env var to restore old behavior
- Trino: no behavior change if SSL is properly configured