### PR TITLE
Report failed or empty ssh-keyscan results

### DIFF
--- a/mage_ai/data_preparation/git/utils.py
+++ b/mage_ai/data_preparation/git/utils.py
@@ -174,16 +174,20 @@ def add_host_to_known_hosts(remote_repo_link: str) -> bool:
     if known_hosts_dir:
         os.makedirs(known_hosts_dir, exist_ok=True)
 
-    # Use list-form subprocess + Python-managed file handle: shell metacharacters
-    # in `hostname` cannot reach a shell. Defense in depth on top of the regex
-    # check above.
+    # Use a list-form subprocess: shell metacharacters in `hostname` cannot reach
+    # a shell. Capture the key first so a failed scan cannot leave partial data in
+    # known_hosts or be reported as successful.
+    result = subprocess.run(
+        ['ssh-keyscan', '-t', 'rsa', hostname],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout:
+        return False
+
     with open(DEFAULT_KNOWN_HOSTS_FILE, 'ab') as known_hosts:
-        subprocess.run(
-            ['ssh-keyscan', '-t', 'rsa', hostname],
-            stdout=known_hosts,
-            stderr=subprocess.DEVNULL,
-            check=False,
-        )
+        known_hosts.write(result.stdout)
     return True
 
 

--- a/mage_ai/tests/data_preparation/git/test_add_host_to_known_hosts_security.py
+++ b/mage_ai/tests/data_preparation/git/test_add_host_to_known_hosts_security.py
@@ -26,8 +26,10 @@ class AddHostToKnownHostsSecurityTest(unittest.TestCase):
 
     def test_safe_hostname_accepted(self):
         with patch('subprocess.run') as mock_run, \
-             patch('builtins.open'), \
+             patch('builtins.open') as mock_open, \
              patch('os.makedirs'):
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = b'git.example.com ssh-rsa key\n'
             result = utils.add_host_to_known_hosts('ssh://git.example.com:22')
             self.assertTrue(result)
             args, kwargs = mock_run.call_args
@@ -37,13 +39,42 @@ class AddHostToKnownHostsSecurityTest(unittest.TestCase):
             self.assertEqual(args[0][0:3], ['ssh-keyscan', '-t', 'rsa'])
             self.assertEqual(args[0][3], 'git.example.com')
             self.assertNotIn('shell', kwargs)  # never run via /bin/sh
+            mock_open.return_value.__enter__.return_value.write.assert_called_once_with(
+                mock_run.return_value.stdout
+            )
 
     def test_no_scheme_added_automatically(self):
         with patch('subprocess.run') as mock_run, \
              patch('builtins.open'), \
              patch('os.makedirs'):
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = b'git.example.com ssh-rsa key\n'
             result = utils.add_host_to_known_hosts('git.example.com')
             self.assertTrue(result)
+
+    def test_keyscan_failure_is_reported(self):
+        with patch('subprocess.run') as mock_run, \
+             patch('builtins.open') as mock_open, \
+             patch('os.makedirs'):
+            mock_run.return_value.returncode = 1
+            mock_run.return_value.stdout = b''
+
+            result = utils.add_host_to_known_hosts('git.example.com')
+
+            self.assertFalse(result)
+            mock_open.assert_not_called()
+
+    def test_empty_keyscan_output_is_reported(self):
+        with patch('subprocess.run') as mock_run, \
+             patch('builtins.open') as mock_open, \
+             patch('os.makedirs'):
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = b''
+
+            result = utils.add_host_to_known_hosts('git.example.com')
+
+            self.assertFalse(result)
+            mock_open.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What

Capture the `ssh-keyscan` result before updating `known_hosts`, return `False` when the command fails or produces no key, and add regression coverage for both cases.

## Why

`add_host_to_known_hosts` previously returned `True` unconditionally. A failed scan therefore looked successful, leaving SSH cloning to fail later and allowing the caller's fallback path to hide the real host-key problem.

## Impact

Only a successful, non-empty scan is appended to `known_hosts`. Failed scans leave the file unchanged and are surfaced through the function's existing boolean contract.

Fixes #6166.

## Checks

- Isolated regression checks against the changed function
- `python3 -m compileall -q mage_ai/data_preparation/git/utils.py mage_ai/tests/data_preparation/git/test_add_host_to_known_hosts_security.py`
- `git diff --check`

The repository unittest module could not be imported in this environment because the optional `jwt` dependency is not installed.