### PR TITLE
Validate browser item paths are inside the project directory

### DIFF
--- a/mage_ai/api/resources/BrowserItemResource.py
+++ b/mage_ai/api/resources/BrowserItemResource.py
@@ -2,17 +2,31 @@ from __future__ import annotations
 
 import re
 import urllib.parse
-from typing import Dict
+from typing import Dict, Optional
 
 from mage_ai.api.errors import ApiError
 from mage_ai.api.resources.GenericResource import GenericResource
 from mage_ai.api.result_set import ResultSet
+from mage_ai.data_preparation.models.errors import FileNotInProjectError
+from mage_ai.data_preparation.models.file import ensure_file_is_in_project
 from mage_ai.settings.utils import base_repo_path
 from mage_ai.shared.files import get_absolute_paths_from_all_files
 from mage_ai.system.browser.models import Item
 
 
 class BrowserItemResource(GenericResource):
+    @classmethod
+    def check_item_is_in_project(cls, path: Optional[str]) -> None:
+        if not path:
+            return
+
+        try:
+            ensure_file_is_in_project(path)
+        except FileNotInProjectError:
+            error = ApiError.RESOURCE_INVALID.copy()
+            error.update(message=f'Item at path: {path} is not in the project directory.')
+            raise ApiError(error)
+
     @classmethod
     async def collection(cls, query, meta, user, **kwargs) -> ResultSet:
         paths = query.get('paths', [None])
@@ -45,9 +59,13 @@ class BrowserItemResource(GenericResource):
             absolute_path, _size, _modified_timestamp = tup
             return Item.load(path=absolute_path)
 
+        directories = [directory] + (paths or [])
+        for dir_path in directories:
+            cls.check_item_is_in_project(dir_path)
+
         items = []
 
-        for dir_path in [directory] + (paths or []):
+        for dir_path in directories:
             items += get_absolute_paths_from_all_files(
                 starting_full_path_directory=dir_path,
                 comparator=lambda path: (
@@ -69,6 +87,8 @@ class BrowserItemResource(GenericResource):
 
     @classmethod
     async def member(cls, pk, user, **kwargs) -> BrowserItemResource:
+        cls.check_item_is_in_project(urllib.parse.unquote(pk))
+
         item = cls.get_model(pk)
         if not await item.exists():
             raise ApiError({
@@ -81,6 +101,8 @@ class BrowserItemResource(GenericResource):
 
     @classmethod
     async def create(cls, payload: Dict, user, **kwargs) -> BrowserItemResource:
+        cls.check_item_is_in_project(payload.get('path'))
+
         model = Item.load(**payload)
         await model.create()
         return cls(model, user, **kwargs)
@@ -91,6 +113,8 @@ class BrowserItemResource(GenericResource):
     async def update(self, payload, **kwargs):
         if 'path' not in payload:
             payload['path'] = self.model.path
+
+        self.check_item_is_in_project(payload.get('path'))
 
         try:
             await self.model.synchronize(Item.load(**payload))

--- a/mage_ai/tests/api/resources/test_browser_item_resource.py
+++ b/mage_ai/tests/api/resources/test_browser_item_resource.py
@@ -1,0 +1,124 @@
+import os
+import shutil
+import tempfile
+import urllib.parse
+
+from mage_ai.api.errors import ApiError
+from mage_ai.api.resources.BrowserItemResource import BrowserItemResource
+from mage_ai.system.browser.models import Item
+from mage_ai.tests.base_test import AsyncDBTestCase
+
+
+class BrowserItemResourceTest(AsyncDBTestCase):
+    @classmethod
+    def setUpClass(self):
+        super().setUpClass()
+        self.original_path = os.getcwd()
+        os.chdir(self.repo_path)
+
+    @classmethod
+    def tearDownClass(self):
+        os.chdir(self.original_path)
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        self.outside_dir = tempfile.mkdtemp()
+        self.outside_file = os.path.join(self.outside_dir, 'outside.txt')
+        with open(self.outside_file, 'w') as f:
+            f.write('outside the project')
+
+    def tearDown(self):
+        shutil.rmtree(self.outside_dir, ignore_errors=True)
+        super().tearDown()
+
+    def build_file_in_project(self, filename: str, content: str) -> str:
+        file_path = os.path.join(self.repo_path, filename)
+        with open(file_path, 'w') as f:
+            f.write(content)
+        return file_path
+
+    async def test_member_file_outside_project(self):
+        with self.assertRaises(ApiError) as context:
+            await BrowserItemResource.member(
+                urllib.parse.quote(self.outside_file, safe=''),
+                None,
+            )
+
+        self.assertEqual(context.exception.type, ApiError.RESOURCE_INVALID['type'])
+
+    async def test_member_file_outside_project_using_relative_path(self):
+        relative_path = os.path.relpath(self.outside_file, self.repo_path)
+
+        with self.assertRaises(ApiError) as context:
+            await BrowserItemResource.member(
+                urllib.parse.quote(relative_path, safe=''),
+                None,
+            )
+
+        self.assertEqual(context.exception.type, ApiError.RESOURCE_INVALID['type'])
+
+    async def test_member_file_in_project(self):
+        file_path = self.build_file_in_project('browser_item.txt', 'in the project')
+
+        resource = await BrowserItemResource.member(
+            urllib.parse.quote(file_path, safe=''),
+            None,
+        )
+
+        self.assertEqual(resource.model.content, 'in the project')
+        os.remove(file_path)
+
+    async def test_create_file_outside_project(self):
+        file_path = os.path.join(self.outside_dir, 'created.txt')
+
+        with self.assertRaises(ApiError) as context:
+            await BrowserItemResource.create(
+                dict(path=file_path, content='written by the API'),
+                None,
+            )
+
+        self.assertEqual(context.exception.type, ApiError.RESOURCE_INVALID['type'])
+        self.assertFalse(os.path.exists(file_path))
+
+    async def test_create_file_in_project(self):
+        file_path = os.path.join(self.repo_path, 'created.txt')
+
+        await BrowserItemResource.create(
+            dict(path=file_path, content='written by the API'),
+            None,
+        )
+
+        self.assertTrue(os.path.exists(file_path))
+        os.remove(file_path)
+
+    async def test_update_file_outside_project(self):
+        file_path = self.build_file_in_project('moved.txt', 'in the project')
+        resource = BrowserItemResource(Item.load(path=file_path), None)
+
+        with self.assertRaises(ApiError) as context:
+            await resource.update(dict(path=os.path.join(self.outside_dir, 'moved.txt')))
+
+        self.assertEqual(context.exception.type, ApiError.RESOURCE_INVALID['type'])
+        self.assertTrue(os.path.exists(file_path))
+        os.remove(file_path)
+
+    async def test_collection_directory_outside_project(self):
+        with self.assertRaises(ApiError) as context:
+            await BrowserItemResource.collection(
+                dict(directory=[self.outside_dir]),
+                None,
+                None,
+            )
+
+        self.assertEqual(context.exception.type, ApiError.RESOURCE_INVALID['type'])
+
+    async def test_collection_paths_outside_project(self):
+        with self.assertRaises(ApiError) as context:
+            await BrowserItemResource.collection(
+                dict(paths=[self.outside_dir]),
+                None,
+                None,
+            )
+
+        self.assertEqual(context.exception.type, ApiError.RESOURCE_INVALID['type'])


### PR DESCRIPTION
This PR proposes validating that every user-supplied path reaching the `/api/browser_items` endpoint stays inside the project directory, closing the arbitrary file read and write reported in #6134. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/404. You can sign in with your GitHub ID to claim ownership of the project.

Fixes #6134.

## What is wrong

`BrowserItemResource` passes user-supplied paths straight to the filesystem helpers. `member()` unquotes the request `pk` and loads it, `create()` and `update()` read `path` out of the payload, and `collection()` reads `directory` and `paths` out of the query string. None of those went through `ensure_file_is_in_project`, which `FileContentResource`, `FileResource` and `FolderResource` each call before they touch a file. So this one endpoint could reach any path the server process could, while its neighbours could not.

I reproduced both halves on current `master` (`5640c790`), against a throwaway project directory: calling `BrowserItemResource.member()` with a URL-encoded absolute path to a file outside the project returned that file's contents, and `BrowserItemResource.create()` with a path outside the project wrote the file to disk. The write lands on disk first and the file-version bookkeeping raises afterwards, so the failure it reports hides the fact that the write already happened.

## What changed

`check_item_is_in_project` mirrors the existing `FolderResource.check_folder_is_in_project`: it calls the same `ensure_file_is_in_project` helper and converts `FileNotInProjectError` into the same `RESOURCE_INVALID` error the other file resources raise, so the endpoint's failure shape does not change. It is applied at the four points where a user-controlled path enters the resource: the detail `pk`, the `create` payload path, the `update` payload path (the move and rename destination), and the `directory` and `paths` query params, which are checked up front so no directory is listed before all of them are validated. `delete` needs no separate check because a delete resolves the member first, and that lookup is already validated.

Two things I deliberately did not do. I did not add a second, bespoke containment rule; reusing your existing helper means this endpoint follows whatever rule that helper enforces, including the change in your open #6133. And I left the project-platform behaviour exactly as the helper defines it today, so nothing changes for project-platform deployments in this PR.

The shipped front end is unaffected: it lists without a `directory` param and so keeps using the `base_repo_path()` default, and the editor reads and writes paths inside the project.

## How this was verified

New tests in `test_browser_item_resource.py` cover reading, listing by `directory`, listing by `paths`, creating, and moving with a target outside the project, plus a relative-path escape, and two controls that read and create inside the project. Each rejection asserts the containment error specifically, not merely that something was raised, so a plain "not found" cannot pass them.

Run from the package directory, on current `master` with only the test file added:

```
$ python3 -m unittest discover -s tests/api/resources -t .. -p 'test_browser_item_resource.py'
FAIL: test_member_file_outside_project
AssertionError: ApiError not raised
FAIL: test_member_file_outside_project_using_relative_path
AssertionError: ApiError not raised
FAIL: test_collection_directory_outside_project
AssertionError: ApiError not raised
FAIL: test_collection_paths_outside_project
AssertionError: ApiError not raised
FAIL: test_update_file_outside_project
AssertionError: False is not true
Ran 8 tests in 2.092s
FAILED (failures=5, errors=1)
```

With the change applied, the same command reports `Ran 8 tests in 2.060s` and `OK`.

I also ran the backend unit suite your Build and test workflow runs, minus `--failfast` so the whole set stays comparable, before and after the change from the same clean starting state. Both runs execute 4997 tests and the set of failing tests is identical except for the six new ones flipping from red to green, so the change introduces no new failure. My local environment does not have the optional extras installed, so a number of modules fail to import in both runs; none of them are touched here. `flake8` and `isort` are clean on both changed files.

## How this was managed

This work was tracked as [a story on our board](https://eastagiletracker.com/projects/404/stories/375789), on [a board built from this repo's own issues and pull requests](https://eastagiletracker.com/projects/404) — 6,101 stories imported, with issues as stories, pull requests as labelled stories and milestones as epics.

![board](https://raw.githubusercontent.com/eastagiletracker/mage-agile-board/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
